### PR TITLE
feat(tui): interactive getting-started tour on first run, replayable on demand

### DIFF
--- a/cmd/root/getting_started.go
+++ b/cmd/root/getting_started.go
@@ -23,7 +23,7 @@ func newGettingStartedCmd() *cobra.Command {
 		Long: `Learn docker agent by doing: a short interactive tour inside the chat UI.
 
 It walks through sending messages, approving tool calls, the command palette
-(Ctrl+k), slash commands, and how agents are configured — about 2 minutes,
+(Ctrl+k), slash commands, and how agents are configured. About 2 minutes,
 skippable at any point with Esc. Replay it anytime with this command or the
 /getting-started slash command inside the TUI.`,
 		Example: `  docker-agent getting-started`,

--- a/cmd/root/getting_started.go
+++ b/cmd/root/getting_started.go
@@ -1,0 +1,52 @@
+package root
+
+import (
+	"errors"
+	"os"
+
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+
+	"github.com/docker/docker-agent/pkg/telemetry"
+)
+
+// newGettingStartedCmd launches the interactive getting-started tour: a
+// normal `run` of the default agent with the scripted tour overlay started
+// immediately. It dispatches through the registered run command (the same
+// mechanism the root command uses when invoked with no arguments) so the
+// session behaves exactly like a regular interactive run.
+func newGettingStartedCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "getting-started",
+		Aliases: []string{"tour"},
+		Short:   "Learn docker agent with a hands-on interactive tour",
+		Long: `Learn docker agent by doing: a short interactive tour inside the chat UI.
+
+It walks through sending messages, approving tool calls, the command palette
+(Ctrl+k), slash commands, and how agents are configured — about 2 minutes,
+skippable at any point with Esc. Replay it anytime with this command or the
+/getting-started slash command inside the TUI.`,
+		Example: `  docker-agent getting-started`,
+		GroupID: "core",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			telemetry.TrackCommand(cmd.Context(), "getting-started", args)
+
+			if !isatty.IsTerminal(os.Stdout.Fd()) {
+				return errors.New("the getting-started tour is interactive and needs a terminal")
+			}
+
+			runCmd, _, err := cmd.Root().Find([]string{"run"})
+			if err != nil {
+				return err
+			}
+			if err := runCmd.PersistentFlags().Set("tour", "true"); err != nil {
+				return err
+			}
+			if err := runCmd.PersistentPreRunE(runCmd, nil); err != nil {
+				return err
+			}
+			return runCmd.RunE(runCmd, nil)
+		},
+	}
+}

--- a/cmd/root/getting_started_test.go
+++ b/cmd/root/getting_started_test.go
@@ -1,0 +1,45 @@
+package root
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGettingStarted_DispatchMechanics validates the plumbing the
+// getting-started command relies on: the run command is reachable from the
+// root, exposes the hidden --tour flag, and has the PersistentPreRunE hook
+// the dispatch invokes. The interactive TTY path itself is covered by the
+// tuitest e2e suite.
+func TestGettingStarted_DispatchMechanics(t *testing.T) {
+	t.Parallel()
+
+	root := NewRootCmd()
+
+	runCmd, _, err := root.Find([]string{"run"})
+	require.NoError(t, err)
+	require.Equal(t, "run", runCmd.Name())
+	require.NotNil(t, runCmd.PersistentPreRunE)
+
+	require.NoError(t, runCmd.PersistentFlags().Set("tour", "true"))
+
+	tourFlag := runCmd.PersistentFlags().Lookup("tour")
+	require.NotNil(t, tourFlag)
+	assert.Equal(t, "true", tourFlag.Value.String())
+	assert.True(t, tourFlag.Hidden)
+}
+
+func TestGettingStarted_RegisteredOnRoot(t *testing.T) {
+	t.Parallel()
+
+	cmd, _, err := NewRootCmd().Find([]string{"getting-started"})
+	require.NoError(t, err)
+	assert.Equal(t, "getting-started", cmd.Name())
+	assert.Contains(t, cmd.Aliases, "tour")
+
+	// The alias resolves to the same command.
+	viaAlias, _, err := NewRootCmd().Find([]string{"tour"})
+	require.NoError(t, err)
+	assert.Equal(t, "getting-started", viaAlias.Name())
+}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -42,6 +42,9 @@ func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "docker-agent",
 		Short: "Docker AI Agent Runner",
+		Long: `Docker AI Agent Runner.
+
+New to docker agent? Take the hands-on tour: docker agent getting-started`,
 		Example: `  docker-agent run
   docker-agent run ./agent.yaml
   docker-agent run agentcatalog/pirate`,
@@ -158,6 +161,7 @@ We collect anonymous usage data to help improve docker agent. To disable:
 		newVersionCmd(),
 		newRunCmd(),
 		newNewCmd(),
+		newGettingStartedCmd(),
 		newEvalCmd(),
 		newShareCmd(),
 		newModelsCmd(),

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -34,6 +34,7 @@ import (
 	"github.com/docker/docker-agent/pkg/teamloader"
 	loaderdefaults "github.com/docker/docker-agent/pkg/teamloader/defaults"
 	"github.com/docker/docker-agent/pkg/telemetry"
+	"github.com/docker/docker-agent/pkg/tour"
 	"github.com/docker/docker-agent/pkg/tui"
 	"github.com/docker/docker-agent/pkg/tui/recorder"
 	"github.com/docker/docker-agent/pkg/tui/styles"
@@ -65,6 +66,7 @@ type runExecFlags struct {
 	cpuProfile        string
 	memProfile        string
 	forceTUI          bool
+	tour              bool
 	sandbox           bool
 	sandboxTemplate   string
 	sbx               bool
@@ -162,6 +164,8 @@ func addRunOrExecFlags(cmd *cobra.Command, flags *runExecFlags) {
 	_ = cmd.PersistentFlags().MarkHidden("memprofile")
 	cmd.PersistentFlags().BoolVar(&flags.forceTUI, "force-tui", false, "Force TUI mode even when not in a terminal")
 	_ = cmd.PersistentFlags().MarkHidden("force-tui")
+	cmd.PersistentFlags().BoolVar(&flags.tour, "tour", false, "Start the interactive getting-started tour in the TUI")
+	_ = cmd.PersistentFlags().MarkHidden("tour")
 	cmd.PersistentFlags().BoolVar(&flags.lean, "lean", false, "Use a simplified TUI with minimal chrome")
 	cmd.PersistentFlags().StringVar(&flags.appName, "app-name", "", "Application name shown in the TUI in place of \"docker agent\"")
 	cmd.PersistentFlags().StringSliceVar(&flags.disabledCommands, "disable-commands", nil, "Comma-separated list of slash commands to hide and disable in the TUI (e.g. /cost,/eval,/model)")
@@ -476,9 +480,9 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 				rec = recorder.New(m)
 				return rec
 			}
-			return runTUIWrapped(ctx, rt, sess, b.Spawner(rt), cleanup, f.tuiOpts(), wrap, opts...)
+			return runTUIWrapped(ctx, rt, sess, b.Spawner(rt), cleanup, f.tuiOpts(args), wrap, opts...)
 		}
-		return runTUI(ctx, rt, sess, b.Spawner(rt), cleanup, f.tuiOpts(), opts...)
+		return runTUI(ctx, rt, sess, b.Spawner(rt), cleanup, f.tuiOpts(args), opts...)
 	}()
 	if rec != nil && rec.HasInput() {
 		writeGeneratedTUITest(ctx, out, rec, cassettePath, agentFileName)
@@ -523,7 +527,9 @@ func (f *runExecFlags) applyUserSettings(ctx context.Context, userSettings *user
 		f.autoApprove = true
 		slog.DebugContext(ctx, "Applying user settings", "YOLO", true)
 	}
-	if userSettings.Lean && !f.leanChanged && !f.lean {
+	// The tour needs the full TUI's overlay support, so a lean default from
+	// user config is not applied when the tour was requested.
+	if userSettings.Lean && !f.leanChanged && !f.lean && !f.tour {
 		f.lean = true
 		slog.DebugContext(ctx, "Applying user settings", "lean", true)
 	}
@@ -889,8 +895,9 @@ func readInitialMessage(args []string) (*string, error) {
 	return &args[1], nil
 }
 
-// tuiOpts returns the TUI options derived from the current flags.
-func (f *runExecFlags) tuiOpts() []tui.Option {
+// tuiOpts returns the TUI options derived from the current flags. args are
+// the run command's positional arguments, used to detect an initial message.
+func (f *runExecFlags) tuiOpts(args []string) []tui.Option {
 	var opts []tui.Option
 	if f.lean {
 		opts = append(opts, tui.WithLeanMode())
@@ -904,7 +911,30 @@ func (f *runExecFlags) tuiOpts() []tui.Option {
 	if !f.sidebar {
 		opts = append(opts, tui.WithHideSidebar())
 	}
+	switch {
+	case f.tour:
+		opts = append(opts, tui.WithTourStart())
+	case f.shouldOfferTour(args):
+		opts = append(opts, tui.WithTourOffer(telemetry.GetTelemetryEnabled()))
+	}
 	return opts
+}
+
+// shouldOfferTour reports whether this interactive run should show the
+// first-run dialog offering the getting-started tour. Automation and
+// replay/record contexts never see the offer, and neither does a run that
+// already carries an initial message (the user clearly has a task in mind);
+// DOCKER_AGENT_NO_TOUR=1 suppresses it for scripted environments. The
+// explicit --tour flag (or the getting-started command) bypasses the offer
+// and starts the tour directly.
+func (f *runExecFlags) shouldOfferTour(args []string) bool {
+	if f.lean || f.exitAfterResponse || f.sessionReadOnly || f.recordPath != "" || f.fakeResponses != "" {
+		return false
+	}
+	if len(args) > 1 {
+		return false
+	}
+	return tour.ShouldOffer(os.Getenv)
 }
 
 // runLeanTUI builds the App and drives the standalone lean TUI, used when

--- a/e2e/tui/testdata/cassettes/TestTour_EscQuits.yaml
+++ b/e2e/tui/testdata/cassettes/TestTour_EscQuits.yaml
@@ -1,0 +1,3 @@
+---
+version: 2
+interactions: []

--- a/e2e/tui/testdata/cassettes/TestTour_FirstRunOffer.yaml
+++ b/e2e/tui/testdata/cassettes/TestTour_FirstRunOffer.yaml
@@ -1,0 +1,3 @@
+---
+version: 2
+interactions: []

--- a/e2e/tui/testdata/cassettes/TestTour_WalkThrough.yaml
+++ b/e2e/tui/testdata/cassettes/TestTour_WalkThrough.yaml
@@ -1,0 +1,3 @@
+---
+version: 2
+interactions: []

--- a/e2e/tui/tour_test.go
+++ b/e2e/tui/tour_test.go
@@ -1,0 +1,65 @@
+package tui_test
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/docker/docker-agent/pkg/tui"
+	"github.com/docker/docker-agent/pkg/tui/tuitest"
+)
+
+// TestTour_WalkThrough drives the getting-started tour end to end: the card
+// appears on launch, Enter skips action steps, a real Ctrl+k completes the
+// palette step, read steps advance with Enter, and finishing the tour
+// removes the card. No LLM call is made, so the cassette is empty.
+func TestTour_WalkThrough(t *testing.T) {
+	d := newTUI(t, "testdata/basic.yaml", 120, 40, tui.WithTourStart())
+
+	d.WaitFor(tuitest.Contains("Getting started")).
+		WaitFor(tuitest.Contains("Talk to your agent")).
+		Enter(). // skip step 1 (send a message)
+		WaitFor(tuitest.Contains("Tools run with your OK")).
+		Enter(). // skip step 2 (tool approval)
+		WaitFor(tuitest.Contains("One menu for everything"))
+
+	// Step 3 performed for real: Ctrl+k opens the palette and completes the
+	// step. Esc closes the palette (not the tour) and the celebration timer
+	// advances to the slash-commands step.
+	d.Press('k', tea.ModCtrl).
+		WaitFor(tuitest.Contains("Type to search commands")).
+		Press(tea.KeyEscape).
+		WaitFor(tuitest.Contains("Slash commands")).
+		Enter(). // skip step 4 (slash commands)
+		WaitFor(tuitest.Contains("Agents are just YAML")).
+		WaitFor(tuitest.Contains("docker agent new")).
+		Enter(). // read step
+		WaitFor(tuitest.Contains("You're all set")).
+		Enter(). // finish
+		WaitFor(tuitest.Contains("Tour complete")).
+		WaitFor(tuitest.Absent("Getting started"))
+}
+
+// TestTour_EscQuits checks the "skippable at any point" guardrail: Esc
+// dismisses the tour and points at the replay command.
+func TestTour_EscQuits(t *testing.T) {
+	d := newTUI(t, "testdata/basic.yaml", 120, 40, tui.WithTourStart())
+
+	d.WaitFor(tuitest.Contains("Getting started")).
+		Press(tea.KeyEscape).
+		WaitFor(tuitest.Absent("Talk to your agent")).
+		WaitFor(tuitest.Contains("/getting-started"))
+}
+
+// TestTour_FirstRunOffer exercises the first-run prompt: the offer dialog
+// appears, "n" declines it for this run, and a hint explains how to start
+// the tour later.
+func TestTour_FirstRunOffer(t *testing.T) {
+	d := newTUI(t, "testdata/basic.yaml", 120, 40, tui.WithTourOffer(false))
+
+	d.WaitFor(tuitest.Contains("Welcome to docker agent")).
+		WaitFor(tuitest.Contains("take the tour")).
+		Type("n").
+		WaitFor(tuitest.Absent("take the tour")).
+		WaitFor(tuitest.Contains("Maybe later"))
+}

--- a/pkg/tour/state.go
+++ b/pkg/tour/state.go
@@ -1,0 +1,82 @@
+// Package tour persists the state of the interactive getting-started tour
+// across runs. The state lives next to the first-run marker in the user's
+// config directory, separate from session data.
+package tour
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/docker-agent/pkg/paths"
+)
+
+// Status is the persisted outcome of the first-run tour offer.
+type Status string
+
+const (
+	// StatusUnanswered means the user has neither started the tour nor
+	// declined it permanently: the first-run offer may be shown.
+	StatusUnanswered Status = ""
+	// StatusDone means the tour was started at least once.
+	StatusDone Status = "done"
+	// StatusNever means the user asked to never be offered the tour again.
+	StatusNever Status = "never"
+)
+
+// noTourEnvVars suppress the first-run tour offer in scripted environments,
+// following the DOCKER_AGENT_HIDE_TELEMETRY_BANNER precedent.
+var noTourEnvVars = []string{"DOCKER_AGENT_NO_TOUR", "CAGENT_NO_TOUR"}
+
+func statePath() string {
+	return filepath.Join(paths.GetConfigDir(), ".cagent_tour")
+}
+
+// ReadStatus returns the persisted tour status. A missing file, a read error,
+// or unknown content all read as StatusUnanswered.
+func ReadStatus() Status {
+	data, err := os.ReadFile(statePath())
+	if err != nil {
+		return StatusUnanswered
+	}
+	switch status := Status(strings.TrimSpace(string(data))); status {
+	case StatusDone, StatusNever:
+		return status
+	default:
+		return StatusUnanswered
+	}
+}
+
+func writeStatus(status Status) error {
+	if err := os.MkdirAll(paths.GetConfigDir(), 0o700); err != nil {
+		return err
+	}
+	//nolint:gosec // marker file with no sensitive content
+	return os.WriteFile(statePath(), []byte(string(status)+"\n"), 0o644)
+}
+
+// MarkDone records that the tour was started, so the first-run offer is not
+// shown again.
+func MarkDone() error { return writeStatus(StatusDone) }
+
+// MarkNever records that the user never wants to see the tour offer again.
+func MarkNever() error { return writeStatus(StatusNever) }
+
+// DisabledByEnv reports whether the tour offer is suppressed via environment
+// variable (DOCKER_AGENT_NO_TOUR=1 or CAGENT_NO_TOUR=1). An explicit request
+// to run the tour is still honored.
+func DisabledByEnv(getenv func(string) string) bool {
+	for _, name := range noTourEnvVars {
+		if getenv(name) == "1" {
+			return true
+		}
+	}
+	return false
+}
+
+// ShouldOffer reports whether the first-run tour offer should be shown: the
+// user has neither taken the tour nor opted out, and no environment variable
+// suppresses it.
+func ShouldOffer(getenv func(string) string) bool {
+	return !DisabledByEnv(getenv) && ReadStatus() == StatusUnanswered
+}

--- a/pkg/tour/state_test.go
+++ b/pkg/tour/state_test.go
@@ -1,0 +1,70 @@
+package tour
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/paths"
+)
+
+func isolateConfigDir(t *testing.T) {
+	t.Helper()
+	paths.SetConfigDir(filepath.Join(t.TempDir(), "config"))
+	t.Cleanup(func() { paths.SetConfigDir("") })
+}
+
+func TestReadStatus_DefaultsToUnanswered(t *testing.T) {
+	isolateConfigDir(t)
+
+	assert.Equal(t, StatusUnanswered, ReadStatus())
+}
+
+func TestMarkDone(t *testing.T) {
+	isolateConfigDir(t)
+
+	require.NoError(t, MarkDone())
+
+	assert.Equal(t, StatusDone, ReadStatus())
+	assert.False(t, ShouldOffer(func(string) string { return "" }))
+}
+
+func TestMarkNever(t *testing.T) {
+	isolateConfigDir(t)
+
+	require.NoError(t, MarkNever())
+
+	assert.Equal(t, StatusNever, ReadStatus())
+	assert.False(t, ShouldOffer(func(string) string { return "" }))
+}
+
+func TestShouldOffer_Unanswered(t *testing.T) {
+	isolateConfigDir(t)
+
+	assert.True(t, ShouldOffer(func(string) string { return "" }))
+}
+
+func TestShouldOffer_DisabledByEnv(t *testing.T) {
+	isolateConfigDir(t)
+
+	for _, name := range []string{"DOCKER_AGENT_NO_TOUR", "CAGENT_NO_TOUR"} {
+		env := func(key string) string {
+			if key == name {
+				return "1"
+			}
+			return ""
+		}
+		assert.False(t, ShouldOffer(env), name)
+		assert.True(t, DisabledByEnv(env), name)
+	}
+}
+
+func TestReadStatus_UnknownContent(t *testing.T) {
+	isolateConfigDir(t)
+
+	require.NoError(t, writeStatus(Status("bogus")))
+
+	assert.Equal(t, StatusUnanswered, ReadStatus())
+}

--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -389,7 +389,7 @@ func builtInHelpCommands() []Item {
 			ID:           "help.getting-started",
 			Label:        "Getting Started Tour",
 			SlashCommand: "/getting-started",
-			Description:  "Learn docker agent by doing — a 2-minute interactive tour",
+			Description:  "Learn docker agent by doing, a 2-minute interactive tour",
 			Category:     "Help",
 			Immediate:    true,
 			Execute: func(string) tea.Cmd {

--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -383,6 +383,22 @@ func builtInSettingsCommands() []Item {
 	}
 }
 
+func builtInHelpCommands() []Item {
+	return []Item{
+		{
+			ID:           "help.getting-started",
+			Label:        "Getting Started Tour",
+			SlashCommand: "/getting-started",
+			Description:  "Learn docker agent by doing — a 2-minute interactive tour",
+			Category:     "Help",
+			Immediate:    true,
+			Execute: func(string) tea.Cmd {
+				return core.CmdHandler(messages.StartTourMsg{})
+			},
+		},
+	}
+}
+
 func builtInFeedbackCommands() []Item {
 	return []Item{
 		{
@@ -590,11 +606,15 @@ func BuildCommandCategories(ctx context.Context, application *app.App) []Categor
 		})
 	}
 
-	// Settings and Feedback are always last, in that order.
+	// Settings, Help, and Feedback are always last, in that order.
 	categories = append(categories,
 		Category{
 			Name:     "Settings",
 			Commands: builtInSettingsCommands(),
+		},
+		Category{
+			Name:     "Help",
+			Commands: builtInHelpCommands(),
 		},
 		Category{
 			Name:     "Feedback",

--- a/pkg/tui/components/tour/steps.go
+++ b/pkg/tui/components/tour/steps.go
@@ -1,0 +1,110 @@
+package tour
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/tui/dialog"
+	"github.com/docker/docker-agent/pkg/tui/messages"
+)
+
+// buildSteps returns the tour's scripted steps. The card copy is rendered by
+// the TUI itself (deterministic, no tokens); only the actions the user
+// performs go through the real agent.
+func buildSteps() []step {
+	return []step{
+		{
+			title:     "💬 Talk to your agent",
+			body:      "This is a conversation, not a form. Plain language works.",
+			action:    "Type anything in the chat and press Enter — try \"write a haiku about containers\".",
+			check:     checkMessageSent,
+			celebrate: "Message away — the reply streams in live.",
+		},
+		{
+			title:     "🛠 Tools run with your OK",
+			body:      "Agents get real work done with tools: shell, files, fetch. Nothing runs until you approve it.",
+			action:    "Ask \"what's in this folder?\" and approve the tool call. (Ctrl+y toggles yolo: auto-approve)",
+			check:     checkToolCallApproved,
+			celebrate: "That's the approval flow — you decide what runs.",
+		},
+		{
+			title:     "🎛 One menu for everything",
+			body:      "The command palette holds every feature — searchable, nothing to memorize.",
+			action:    "Press Ctrl+k and look around. (Esc closes it)",
+			check:     checkPaletteOpened,
+			celebrate: "You found the control room.",
+		},
+		{
+			title:     "⚡ Slash commands",
+			body:      "Prefer typing? Slash commands are the shortcut: /model, /sessions, /theme, /compact…",
+			action:    "Try /model to see — and switch — the current model.",
+			check:     checkSlashCommandUsed,
+			celebrate: "Slash commands unlocked.",
+		},
+		{
+			title: "📦 Agents are just YAML",
+			body: "The agent you're talking to is one YAML file: a model, instructions, and tools.\n\n" +
+				"Build your own:\n  docker agent new\n\n" +
+				"Or run one from the catalog:\n  docker agent run agentcatalog/pirate",
+		},
+		{
+			title: "🎉 You're all set",
+			body: "Where to go from here:\n\n" +
+				"  Ctrl+h            every key binding\n" +
+				"  /getting-started  replay this tour\n\n" +
+				"Something to tell us? Ctrl+k → \"Give Feedback\".",
+		},
+	}
+}
+
+// checkMessageSent matches the user sending a regular chat message (slash
+// commands don't count — they have their own step).
+func checkMessageSent(msg tea.Msg) bool {
+	send, ok := msg.(messages.SendMsg)
+	if !ok {
+		return false
+	}
+	content := strings.TrimSpace(send.Content)
+	return content != "" && !strings.HasPrefix(content, "/")
+}
+
+// checkToolCallApproved matches the user approving the pending tool call in
+// the confirmation dialog, whatever the approval scope (once, always this
+// tool, all tools). Rejections and tools that run without confirmation don't
+// count: the step completes at the moment the user validates a tool call,
+// not before.
+func checkToolCallApproved(msg tea.Msg) bool {
+	resume, ok := msg.(dialog.RuntimeResumeMsg)
+	if !ok {
+		return false
+	}
+	switch resume.Request.Type {
+	case runtime.ResumeTypeApprove, runtime.ResumeTypeApproveTool, runtime.ResumeTypeApproveSession:
+		return true
+	}
+	return false
+}
+
+// checkPaletteOpened matches the command palette actually opening, which
+// covers every way to reach it (Ctrl+k or a status-bar click).
+func checkPaletteOpened(msg tea.Msg) bool {
+	open, ok := msg.(dialog.OpenDialogMsg)
+	return ok && dialog.IsCommandPalette(open.Model)
+}
+
+// checkSlashCommandUsed matches the messages produced by the slash commands
+// the step suggests. The command palette can emit them too — either way the
+// user learned a discoverable path to the feature.
+func checkSlashCommandUsed(msg tea.Msg) bool {
+	switch msg.(type) {
+	case messages.OpenModelPickerMsg,
+		messages.OpenSessionBrowserMsg,
+		messages.OpenThemePickerMsg,
+		messages.ShowToolsDialogMsg,
+		messages.ShowCostDialogMsg:
+		return true
+	}
+	return false
+}

--- a/pkg/tui/components/tour/steps.go
+++ b/pkg/tui/components/tour/steps.go
@@ -16,35 +16,35 @@ import (
 func buildSteps() []step {
 	return []step{
 		{
-			title:     "💬 Talk to your agent",
+			title:     "Talk to your agent",
 			body:      "This is a conversation, not a form. Plain language works.",
-			action:    "Type anything in the chat and press Enter — try \"write a haiku about containers\".",
+			action:    "Type anything in the chat and press Enter. Try \"write a haiku about containers\".",
 			check:     checkMessageSent,
-			celebrate: "Message away — the reply streams in live.",
+			celebrate: "Message away. The reply streams in live.",
 		},
 		{
-			title:     "🛠 Tools run with your OK",
-			body:      "Agents get real work done with tools: shell, files, fetch. Nothing runs until you approve it.",
-			action:    "Ask \"what's in this folder?\" and approve the tool call. (Ctrl+y toggles yolo: auto-approve)",
+			title:     "Tools run with your OK",
+			body:      "Agents get real work done with tools: shell, files, fetch. Anything with side effects waits for your approval.",
+			action:    "Ask \"run ls in the shell\" and approve the tool call. (Ctrl+y toggles yolo: auto-approve)",
 			check:     checkToolCallApproved,
-			celebrate: "That's the approval flow — you decide what runs.",
+			celebrate: "That's the approval flow. You decide what runs.",
 		},
 		{
-			title:     "🎛 One menu for everything",
-			body:      "The command palette holds every feature — searchable, nothing to memorize.",
+			title:     "One menu for everything",
+			body:      "The command palette holds every feature: searchable, nothing to memorize.",
 			action:    "Press Ctrl+k and look around. (Esc closes it)",
 			check:     checkPaletteOpened,
 			celebrate: "You found the control room.",
 		},
 		{
-			title:     "⚡ Slash commands",
+			title:     "Slash commands",
 			body:      "Prefer typing? Slash commands are the shortcut: /model, /sessions, /theme, /compact…",
-			action:    "Try /model to see — and switch — the current model.",
+			action:    "Try /model to see and switch the current model.",
 			check:     checkSlashCommandUsed,
 			celebrate: "Slash commands unlocked.",
 		},
 		{
-			title: "📦 Agents are just YAML",
+			title: "Agents are just YAML",
 			body: "The agent you're talking to is one YAML file: a model, instructions, and tools.\n\n" +
 				"Build your own:\n  docker agent new\n\n" +
 				"Or run one from the catalog:\n  docker agent run agentcatalog/pirate",
@@ -60,7 +60,7 @@ func buildSteps() []step {
 }
 
 // checkMessageSent matches the user sending a regular chat message (slash
-// commands don't count — they have their own step).
+// commands don't count; they have their own step).
 func checkMessageSent(msg tea.Msg) bool {
 	send, ok := msg.(messages.SendMsg)
 	if !ok {
@@ -95,7 +95,7 @@ func checkPaletteOpened(msg tea.Msg) bool {
 }
 
 // checkSlashCommandUsed matches the messages produced by the slash commands
-// the step suggests. The command palette can emit them too — either way the
+// the step suggests. The command palette can emit them too; either way the
 // user learned a discoverable path to the feature.
 func checkSlashCommandUsed(msg tea.Msg) bool {
 	switch msg.(type) {

--- a/pkg/tui/components/tour/tour.go
+++ b/pkg/tui/components/tour/tour.go
@@ -1,0 +1,256 @@
+// Package tour implements the interactive getting-started tour: a floating
+// card that teaches docker agent by doing. Each step waits for the user to
+// actually perform the action it describes (send a message, approve a tool
+// call, open the palette…) and observes the TUI's message stream to detect
+// completion. The card never steals focus: the user drives the real UI.
+package tour
+
+import (
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/docker/docker-agent/pkg/tui/core"
+	"github.com/docker/docker-agent/pkg/tui/messages"
+	"github.com/docker/docker-agent/pkg/tui/styles"
+)
+
+const (
+	// celebrationDelay is how long the "step done" flash stays on screen
+	// before the tour advances to the next step on its own.
+	celebrationDelay = 1500 * time.Millisecond
+
+	maxCardWidth = 46
+)
+
+// advanceMsg moves the tour past a completed step once its celebration flash
+// has been shown. The step index guards against stale ticks after a manual
+// skip already advanced the tour.
+type advanceMsg struct{ step int }
+
+// step is one stop of the tour. A step with a check function completes when
+// the check matches an observed message; a step without one is a read step
+// that the user advances manually (Enter).
+type step struct {
+	title     string
+	body      string
+	action    string
+	check     func(tea.Msg) bool
+	celebrate string
+}
+
+// Model is the tour engine plus its floating card. The zero value is
+// inactive; use New.
+type Model struct {
+	steps         []step
+	idx           int
+	active        bool
+	celebrating   bool
+	width, height int
+	contentBottom int
+}
+
+// New returns an inactive tour with the built-in steps.
+func New() *Model {
+	return &Model{steps: buildSteps()}
+}
+
+// Active reports whether the tour is currently running.
+func (m *Model) Active() bool {
+	return m != nil && m.active
+}
+
+// Start (re)starts the tour from the first step.
+func (m *Model) Start() {
+	m.idx = 0
+	m.celebrating = false
+	m.active = true
+}
+
+// Quit stops the tour early and reports it as not completed.
+func (m *Model) Quit() tea.Cmd {
+	if !m.Active() {
+		return nil
+	}
+	m.active = false
+	return core.CmdHandler(messages.TourFinishedMsg{Completed: false})
+}
+
+// SetSize records the window size and the row where the content area ends
+// (just above the resize handle), both used to position the card.
+func (m *Model) SetSize(width, height, contentBottom int) {
+	if m == nil {
+		return
+	}
+	m.width, m.height = width, height
+	m.contentBottom = contentBottom
+}
+
+// Observe inspects a message flowing through the TUI and completes the
+// current step when the user performed its action. It never consumes the
+// message; the returned command only drives the tour's own progression.
+func (m *Model) Observe(msg tea.Msg) tea.Cmd {
+	if !m.Active() {
+		return nil
+	}
+
+	if adv, ok := msg.(advanceMsg); ok {
+		if m.celebrating && adv.step == m.idx {
+			return m.next()
+		}
+		return nil
+	}
+
+	if m.celebrating {
+		return nil
+	}
+	current := m.steps[m.idx]
+	if current.check == nil || !current.check(msg) {
+		return nil
+	}
+
+	m.celebrating = true
+	stepIdx := m.idx
+	return tea.Tick(celebrationDelay, func(time.Time) tea.Msg {
+		return advanceMsg{step: stepIdx}
+	})
+}
+
+// Advance is the manual progression driven by the Enter key: it skips the
+// celebration wait, moves past a read step, or skips an action step the user
+// does not want to perform.
+func (m *Model) Advance() tea.Cmd {
+	if !m.Active() {
+		return nil
+	}
+	return m.next()
+}
+
+// next moves to the following step, ending the tour after the last one.
+func (m *Model) next() tea.Cmd {
+	m.celebrating = false
+	if m.idx >= len(m.steps)-1 {
+		m.active = false
+		return core.CmdHandler(messages.TourFinishedMsg{Completed: true})
+	}
+	m.idx++
+	return nil
+}
+
+// OnLastStep reports whether the tour is showing its final step.
+func (m *Model) OnLastStep() bool {
+	return m.Active() && m.idx == len(m.steps)-1
+}
+
+// Layer returns the floating card as a lipgloss layer anchored to the
+// bottom-right of the content area, below the sidebar's agent info and
+// tools so it hides as little as possible. Nil when the tour is inactive.
+func (m *Model) Layer() *lipgloss.Layer {
+	if !m.Active() || m.width < 20 || m.height < 10 {
+		return nil
+	}
+
+	view := m.view()
+	col := max(1, m.width-lipgloss.Width(view)-1)
+	row := max(1, m.contentBottom-lipgloss.Height(view))
+	return lipgloss.NewLayer(view).X(col).Y(row)
+}
+
+func (m *Model) view() string {
+	cardWidth := min(maxCardWidth, m.width-4)
+	frame := styles.DialogStyle.
+		BorderForeground(styles.Highlight).
+		Padding(1, 2).
+		Width(cardWidth)
+	contentWidth := cardWidth - frame.GetHorizontalFrameSize()
+
+	var body string
+	if m.celebrating {
+		body = m.celebrationView(contentWidth)
+	} else {
+		body = m.stepView(contentWidth)
+	}
+
+	header := lipgloss.JoinHorizontal(lipgloss.Top,
+		styles.BoldStyle.Foreground(styles.Highlight).Render("Getting started"),
+		lipgloss.PlaceHorizontal(
+			max(0, contentWidth-lipgloss.Width("Getting started")),
+			lipgloss.Right,
+			styles.MutedStyle.Render(m.progressLabel()),
+		),
+	)
+
+	content := lipgloss.JoinVertical(lipgloss.Left,
+		header,
+		styles.DialogSeparatorStyle.Render(strings.Repeat("─", max(1, contentWidth))),
+		"",
+		body,
+		"",
+		m.footer(contentWidth),
+	)
+
+	return frame.Render(content)
+}
+
+func (m *Model) stepView(contentWidth int) string {
+	current := m.steps[m.idx]
+
+	parts := []string{
+		styles.HighlightWhiteStyle.Width(contentWidth).Render(current.title),
+		"",
+		styles.SecondaryStyle.Width(contentWidth).Render(current.body),
+	}
+	if current.action != "" {
+		parts = append(parts,
+			"",
+			lipgloss.JoinHorizontal(lipgloss.Top,
+				styles.BaseStyle.Foreground(styles.Highlight).Render("▶ "),
+				styles.BaseStyle.Width(max(1, contentWidth-2)).Render(current.action),
+			),
+		)
+	}
+	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+}
+
+func (m *Model) celebrationView(contentWidth int) string {
+	return lipgloss.JoinVertical(lipgloss.Left,
+		styles.SuccessStyle.Bold(true).Width(contentWidth).Render("✔ "+m.steps[m.idx].celebrate),
+		"",
+		styles.MutedStyle.Width(contentWidth).Render("Next stop in a moment… (↵ to jump)"),
+	)
+}
+
+// progressLabel renders one dot per step: filled for done, target glyph for
+// the current step, hollow for what's left.
+func (m *Model) progressLabel() string {
+	var b strings.Builder
+	for i := range m.steps {
+		switch {
+		case i < m.idx, i == m.idx && m.celebrating:
+			b.WriteString("●")
+		case i == m.idx:
+			b.WriteString("◉")
+		default:
+			b.WriteString("○")
+		}
+	}
+	return b.String()
+}
+
+func (m *Model) footer(contentWidth int) string {
+	enterHint := "skip step"
+	switch {
+	case m.OnLastStep():
+		enterHint = "finish"
+	case m.celebrating || m.steps[m.idx].check == nil:
+		enterHint = "continue"
+	}
+
+	keyStyle := styles.HighlightWhiteStyle
+	descStyle := styles.MutedStyle
+	line := keyStyle.Render("↵") + descStyle.Render(" "+enterHint+"  ") +
+		keyStyle.Render("Esc") + descStyle.Render(" quit tour")
+	return lipgloss.PlaceHorizontal(max(1, contentWidth), lipgloss.Right, line)
+}

--- a/pkg/tui/components/tour/tour_test.go
+++ b/pkg/tui/components/tour/tour_test.go
@@ -1,0 +1,251 @@
+package tour
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/tui/dialog"
+	"github.com/docker/docker-agent/pkg/tui/messages"
+)
+
+// runCmd executes a tea.Cmd and returns the message it produces, or nil.
+func runCmd(cmd tea.Cmd) tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	return cmd()
+}
+
+func startedTour() *Model {
+	m := New()
+	m.SetSize(120, 40, 30)
+	m.Start()
+	return m
+}
+
+func TestNew_Inactive(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+
+	assert.False(t, m.Active())
+	assert.Nil(t, m.Layer())
+	assert.Nil(t, m.Observe(messages.SendMsg{Content: "hello"}))
+}
+
+func TestNilModel_Safe(t *testing.T) {
+	t.Parallel()
+
+	var m *Model
+
+	assert.False(t, m.Active())
+	assert.Nil(t, m.Observe(messages.SendMsg{Content: "hello"}))
+	assert.Nil(t, m.Quit())
+}
+
+func TestStart_ShowsFirstStep(t *testing.T) {
+	t.Parallel()
+
+	m := startedTour()
+
+	require.True(t, m.Active())
+	require.NotNil(t, m.Layer())
+	assert.Equal(t, 0, m.idx)
+	assert.Contains(t, m.view(), "Talk to your agent")
+}
+
+func TestObserve_SendMessageCompletesFirstStep(t *testing.T) {
+	t.Parallel()
+
+	m := startedTour()
+
+	cmd := m.Observe(messages.SendMsg{Content: "hello there"})
+
+	require.NotNil(t, cmd, "sending a message should complete step 1")
+	assert.True(t, m.celebrating)
+	assert.Contains(t, m.view(), "Message away")
+
+	// The celebration tick advances to the next step.
+	cmd = m.Observe(advanceMsg{step: 0})
+	assert.Nil(t, cmd)
+	assert.Equal(t, 1, m.idx)
+	assert.False(t, m.celebrating)
+}
+
+func TestObserve_SlashCommandDoesNotCompleteFirstStep(t *testing.T) {
+	t.Parallel()
+
+	m := startedTour()
+
+	assert.Nil(t, m.Observe(messages.SendMsg{Content: "/model"}))
+	assert.Nil(t, m.Observe(messages.SendMsg{Content: "   "}))
+	assert.Equal(t, 0, m.idx)
+}
+
+func TestObserve_StaleAdvanceIgnored(t *testing.T) {
+	t.Parallel()
+
+	m := startedTour()
+	require.NotNil(t, m.Observe(messages.SendMsg{Content: "hi"}))
+	assert.Nil(t, m.Advance()) // manual jump past the celebration
+	require.Equal(t, 1, m.idx)
+
+	// The celebration tick from step 0 arrives late: it must not advance.
+	assert.Nil(t, m.Observe(advanceMsg{step: 0}))
+	assert.Equal(t, 1, m.idx)
+}
+
+func TestObserve_ToolStepChecks(t *testing.T) {
+	t.Parallel()
+
+	approvals := map[string]tea.Msg{
+		"approve":         dialog.RuntimeResumeMsg{Request: runtime.ResumeApprove()},
+		"approve-tool":    dialog.RuntimeResumeMsg{Request: runtime.ResumeApproveTool("shell:cmd=ls*")},
+		"approve-session": dialog.RuntimeResumeMsg{Request: runtime.ResumeApproveSession()},
+	}
+	for name, msg := range approvals {
+		m := startedTour()
+		m.idx = 1
+
+		require.NotNil(t, m.Observe(msg), "%s should complete the tool step", name)
+		assert.True(t, m.celebrating)
+	}
+
+	nonApprovals := map[string]tea.Msg{
+		"rejection":     dialog.RuntimeResumeMsg{Request: runtime.ResumeReject("not now")},
+		"auto-run tool": &runtime.ToolCallResponseEvent{},
+	}
+	for name, msg := range nonApprovals {
+		m := startedTour()
+		m.idx = 1
+
+		assert.Nil(t, m.Observe(msg), "%s must not complete the tool step", name)
+		assert.False(t, m.celebrating)
+	}
+}
+
+func TestObserve_PaletteStep(t *testing.T) {
+	t.Parallel()
+
+	m := startedTour()
+	m.idx = 2
+
+	assert.Nil(t, m.Observe(dialog.OpenDialogMsg{Model: dialog.NewHelpDialog(nil)}),
+		"other dialogs must not complete the palette step")
+
+	require.NotNil(t, m.Observe(dialog.OpenDialogMsg{Model: dialog.NewCommandPaletteDialog(nil)}))
+	assert.True(t, m.celebrating)
+}
+
+func TestObserve_SlashStep(t *testing.T) {
+	t.Parallel()
+
+	m := startedTour()
+	m.idx = 3
+
+	require.NotNil(t, m.Observe(messages.OpenModelPickerMsg{}))
+	assert.True(t, m.celebrating)
+}
+
+func TestAdvance_SkipsSteps(t *testing.T) {
+	t.Parallel()
+
+	m := startedTour()
+
+	for i := 1; i < len(m.steps); i++ {
+		assert.Nil(t, m.Advance())
+		assert.Equal(t, i, m.idx)
+	}
+
+	// Advancing past the last step finishes the tour as completed.
+	msg := runCmd(m.Advance())
+	assert.Equal(t, messages.TourFinishedMsg{Completed: true}, msg)
+	assert.False(t, m.Active())
+}
+
+func TestQuit_ReportsNotCompleted(t *testing.T) {
+	t.Parallel()
+
+	m := startedTour()
+
+	msg := runCmd(m.Quit())
+
+	assert.Equal(t, messages.TourFinishedMsg{Completed: false}, msg)
+	assert.False(t, m.Active())
+	assert.Nil(t, m.Quit(), "quitting an inactive tour is a no-op")
+}
+
+func TestLayer_RequiresRoom(t *testing.T) {
+	t.Parallel()
+
+	m := startedTour()
+	m.SetSize(10, 5, 3)
+
+	assert.Nil(t, m.Layer(), "no card on tiny terminals")
+
+	m.SetSize(80, 24, 18)
+	assert.NotNil(t, m.Layer())
+}
+
+func TestLayer_AnchorsBottomRightOfContent(t *testing.T) {
+	t.Parallel()
+
+	m := startedTour()
+
+	layer := m.Layer()
+	require.NotNil(t, layer)
+	assert.Equal(t, 30, layer.GetY()+layer.Height(), "card bottom sits on the content area's last row")
+	assert.Equal(t, 119, layer.GetX()+layer.Width(), "card hugs the right edge")
+}
+
+func TestView_ReadStepShowsContinueHint(t *testing.T) {
+	t.Parallel()
+
+	m := startedTour()
+	m.idx = 4 // "Agents are just YAML" is a read step
+
+	view := m.view()
+	assert.Contains(t, view, "continue")
+	assert.Contains(t, view, "docker agent new")
+}
+
+func TestView_LastStepShowsFinishHint(t *testing.T) {
+	t.Parallel()
+
+	m := startedTour()
+	m.idx = len(m.steps) - 1
+
+	assert.True(t, m.OnLastStep())
+	assert.Contains(t, m.view(), "finish")
+}
+
+func TestProgressLabel(t *testing.T) {
+	t.Parallel()
+
+	m := startedTour()
+	assert.Equal(t, "◉○○○○○", m.progressLabel())
+
+	require.NotNil(t, m.Observe(messages.SendMsg{Content: "hi"}))
+	assert.Equal(t, "●○○○○○", m.progressLabel(), "celebrating step counts as done")
+
+	assert.Nil(t, m.Advance())
+	assert.Equal(t, "●◉○○○○", m.progressLabel())
+}
+
+func TestRestart_ResetsProgress(t *testing.T) {
+	t.Parallel()
+
+	m := startedTour()
+	m.idx = 3
+	m.celebrating = true
+
+	m.Start()
+
+	assert.Equal(t, 0, m.idx)
+	assert.False(t, m.celebrating)
+	assert.True(t, m.Active())
+}

--- a/pkg/tui/dialog/command_palette.go
+++ b/pkg/tui/dialog/command_palette.go
@@ -57,6 +57,14 @@ func NewCommandPaletteDialog(categories []commands.Category) Dialog {
 	return d
 }
 
+// IsCommandPalette reports whether d is the command palette dialog. It lets
+// observers (e.g. the getting-started tour) detect the palette opening
+// without coupling to the unexported concrete type.
+func IsCommandPalette(d Dialog) bool {
+	_, ok := d.(*commandPaletteDialog)
+	return ok
+}
+
 func (d *commandPaletteDialog) Init() tea.Cmd { return textinput.Blink }
 
 func (d *commandPaletteDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {

--- a/pkg/tui/dialog/tour_offer.go
+++ b/pkg/tui/dialog/tour_offer.go
@@ -1,0 +1,124 @@
+package dialog
+
+import (
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/docker/docker-agent/pkg/tui/core"
+	"github.com/docker/docker-agent/pkg/tui/core/layout"
+	"github.com/docker/docker-agent/pkg/tui/styles"
+)
+
+// TourOfferChoice is the user's answer to the first-run tour offer.
+type TourOfferChoice int
+
+const (
+	// TourOfferAccepted starts the tour now.
+	TourOfferAccepted TourOfferChoice = iota
+	// TourOfferLater declines for this run; the offer may be shown again.
+	TourOfferLater
+	// TourOfferNever declines permanently.
+	TourOfferNever
+)
+
+// TourOfferResultMsg reports the user's choice on the tour offer dialog.
+type TourOfferResultMsg struct {
+	Choice TourOfferChoice
+}
+
+type tourOfferKeyMap struct {
+	Yes   key.Binding
+	Later key.Binding
+	Never key.Binding
+}
+
+type tourOfferDialog struct {
+	BaseDialog
+
+	keyMap tourOfferKeyMap
+	// showTelemetryNotice folds the first-run telemetry banner into the
+	// offer so the two never stack.
+	showTelemetryNotice bool
+}
+
+// NewTourOfferDialog creates the first-run dialog offering the
+// getting-started tour.
+func NewTourOfferDialog(showTelemetryNotice bool) Dialog {
+	return &tourOfferDialog{
+		keyMap: tourOfferKeyMap{
+			Yes:   key.NewBinding(key.WithKeys("enter", "y", "Y")),
+			Later: key.NewBinding(key.WithKeys("n", "N", "esc")),
+			Never: key.NewBinding(key.WithKeys("d", "D")),
+		},
+		showTelemetryNotice: showTelemetryNotice,
+	}
+}
+
+func (d *tourOfferDialog) Init() tea.Cmd {
+	return nil
+}
+
+func (d *tourOfferDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		cmd := d.SetSize(msg.Width, msg.Height)
+		return d, cmd
+
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, d.keyMap.Yes):
+			return d, tourOfferClose(TourOfferAccepted)
+		case key.Matches(msg, d.keyMap.Never):
+			return d, tourOfferClose(TourOfferNever)
+		case key.Matches(msg, d.keyMap.Later):
+			return d, tourOfferClose(TourOfferLater)
+		}
+	}
+
+	return d, nil
+}
+
+// tourOfferClose closes the dialog and reports the user's choice.
+func tourOfferClose(choice TourOfferChoice) tea.Cmd {
+	return tea.Sequence(
+		core.CmdHandler(CloseDialogMsg{}),
+		core.CmdHandler(TourOfferResultMsg{Choice: choice}),
+	)
+}
+
+func (d *tourOfferDialog) Position() (row, col int) {
+	return d.CenterDialog(d.View())
+}
+
+func (d *tourOfferDialog) View() string {
+	dialogWidth := d.ComputeDialogWidth(50, 46, 60)
+	contentWidth := d.ContentWidth(dialogWidth, 2)
+
+	content := NewContent(contentWidth).
+		AddTitle("Welcome to docker agent 👋").
+		AddSeparator().
+		AddSpace().
+		AddContent(styles.BaseStyle.Width(contentWidth).Render(
+			"First time here? Learn docker agent by doing: a hands-on tour, right in this chat. Takes two minutes, Esc leaves anytime."))
+
+	if d.showTelemetryNotice {
+		content = content.
+			AddSpace().
+			AddContent(styles.MutedStyle.Width(contentWidth).Render(
+				"Anonymous usage data helps improve docker agent. Opt out with TELEMETRY_ENABLED=false."))
+	}
+
+	body := content.
+		AddSpace().
+		AddHelpKeys("↵", "take the tour", "N", "not now", "D", "never").
+		Build()
+
+	return styles.DialogStyle.
+		Padding(1, 2).
+		Width(dialogWidth).
+		Render(body)
+}
+
+func (d *tourOfferDialog) Bindings() []key.Binding {
+	return []key.Binding{}
+}

--- a/pkg/tui/dialog/tour_offer_test.go
+++ b/pkg/tui/dialog/tour_offer_test.go
@@ -1,0 +1,83 @@
+package dialog
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tourOfferChoice runs a key press through the dialog and returns the
+// reported choice, requiring that the dialog also closes.
+func tourOfferChoice(t *testing.T, key tea.KeyPressMsg) TourOfferChoice {
+	t.Helper()
+
+	d := NewTourOfferDialog(false)
+	d.SetSize(100, 40)
+
+	_, cmd := d.Update(key)
+	msgs := collectMsgs(cmd)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, CloseDialogMsg{}, msgs[0])
+
+	result, ok := msgs[1].(TourOfferResultMsg)
+	require.True(t, ok, "expected TourOfferResultMsg, got %T", msgs[1])
+	return result.Choice
+}
+
+func TestTourOfferDialog_Choices(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		key  tea.KeyPressMsg
+		want TourOfferChoice
+	}{
+		{"enter accepts", tea.KeyPressMsg{Code: tea.KeyEnter}, TourOfferAccepted},
+		{"y accepts", tea.KeyPressMsg{Code: 'y', Text: "y"}, TourOfferAccepted},
+		{"n declines for now", tea.KeyPressMsg{Code: 'n', Text: "n"}, TourOfferLater},
+		{"esc declines for now", tea.KeyPressMsg{Code: tea.KeyEscape}, TourOfferLater},
+		{"d declines forever", tea.KeyPressMsg{Code: 'd', Text: "d"}, TourOfferNever},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tourOfferChoice(t, tt.key))
+		})
+	}
+}
+
+func TestTourOfferDialog_IgnoresOtherKeys(t *testing.T) {
+	t.Parallel()
+
+	d := NewTourOfferDialog(false)
+	d.SetSize(100, 40)
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: 'x', Text: "x"})
+	assert.Nil(t, cmd)
+}
+
+func TestTourOfferDialog_View(t *testing.T) {
+	t.Parallel()
+
+	d := NewTourOfferDialog(false)
+	d.SetSize(100, 40)
+
+	view := d.View()
+	assert.Contains(t, view, "Welcome to docker agent")
+	assert.Contains(t, view, "take the tour")
+	assert.NotContains(t, view, "usage data")
+
+	withNotice := NewTourOfferDialog(true)
+	withNotice.SetSize(100, 40)
+	assert.Contains(t, withNotice.View(), "usage data")
+}
+
+func TestIsCommandPalette(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, IsCommandPalette(NewCommandPaletteDialog(nil)))
+	assert.False(t, IsCommandPalette(NewTourOfferDialog(false)))
+}

--- a/pkg/tui/messages/tour.go
+++ b/pkg/tui/messages/tour.go
@@ -1,0 +1,14 @@
+package messages
+
+// Tour messages drive the interactive getting-started tour.
+type (
+	// StartTourMsg starts (or restarts) the interactive getting-started
+	// tour. Emitted by the /getting-started slash command, the command
+	// palette entry, and the first-run offer dialog.
+	StartTourMsg struct{}
+
+	// TourFinishedMsg is emitted by the tour component when the tour ends.
+	// Completed is true when the user reached the final step, false when
+	// the tour was quit early.
+	TourFinishedMsg struct{ Completed bool }
+)

--- a/pkg/tui/tour.go
+++ b/pkg/tui/tour.go
@@ -15,7 +15,7 @@ import (
 // that the user has seen it, so the first-run offer is not shown again.
 func (m *appModel) handleStartTour() (tea.Model, tea.Cmd) {
 	if m.leanMode {
-		return m, notification.InfoCmd("The tour needs the full TUI — run without --lean to take it")
+		return m, notification.InfoCmd("The tour needs the full TUI. Run without --lean to take it")
 	}
 	if err := tourstate.MarkDone(); err != nil {
 		slog.Warn("Failed to persist tour state", "error", err)
@@ -28,9 +28,9 @@ func (m *appModel) handleStartTour() (tea.Model, tea.Cmd) {
 // handleTourFinished reacts to the tour ending, either completed or quit.
 func (m *appModel) handleTourFinished(completed bool) (tea.Model, tea.Cmd) {
 	if completed {
-		return m, notification.SuccessCmd("🎉 Tour complete — go build something. Replay anytime with /getting-started")
+		return m, notification.SuccessCmd("🎉 Tour complete. Go build something! Replay anytime with /getting-started")
 	}
-	return m, notification.InfoCmd("Tour closed — /getting-started brings it back anytime")
+	return m, notification.InfoCmd("Tour closed. /getting-started brings it back anytime")
 }
 
 // handleTourOfferResult applies the user's answer to the first-run offer.
@@ -44,9 +44,9 @@ func (m *appModel) handleTourOfferResult(choice dialog.TourOfferChoice) (tea.Mod
 		if err := tourstate.MarkNever(); err != nil {
 			slog.Warn("Failed to persist tour state", "error", err)
 		}
-		return m, notification.InfoCmd("Got it — never again. /getting-started if you change your mind")
+		return m, notification.InfoCmd("Got it, never again. /getting-started if you change your mind")
 	default:
-		return m, notification.InfoCmd("Maybe later — /getting-started starts the tour anytime")
+		return m, notification.InfoCmd("Maybe later. /getting-started starts the tour anytime")
 	}
 }
 

--- a/pkg/tui/tour.go
+++ b/pkg/tui/tour.go
@@ -1,0 +1,71 @@
+package tui
+
+import (
+	"log/slog"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	tourstate "github.com/docker/docker-agent/pkg/tour"
+	"github.com/docker/docker-agent/pkg/tui/components/notification"
+	"github.com/docker/docker-agent/pkg/tui/dialog"
+)
+
+// handleStartTour starts (or restarts) the getting-started tour and records
+// that the user has seen it, so the first-run offer is not shown again.
+func (m *appModel) handleStartTour() (tea.Model, tea.Cmd) {
+	if m.leanMode {
+		return m, notification.InfoCmd("The tour needs the full TUI — run without --lean to take it")
+	}
+	if err := tourstate.MarkDone(); err != nil {
+		slog.Warn("Failed to persist tour state", "error", err)
+	}
+	m.tour.SetSize(m.width, m.height, m.contentHeight)
+	m.tour.Start()
+	return m, nil
+}
+
+// handleTourFinished reacts to the tour ending, either completed or quit.
+func (m *appModel) handleTourFinished(completed bool) (tea.Model, tea.Cmd) {
+	if completed {
+		return m, notification.SuccessCmd("🎉 Tour complete — go build something. Replay anytime with /getting-started")
+	}
+	return m, notification.InfoCmd("Tour closed — /getting-started brings it back anytime")
+}
+
+// handleTourOfferResult applies the user's answer to the first-run offer.
+// "Not now" leaves the persisted state untouched so the offer can appear
+// again on a later run; "never" persists the refusal.
+func (m *appModel) handleTourOfferResult(choice dialog.TourOfferChoice) (tea.Model, tea.Cmd) {
+	switch choice {
+	case dialog.TourOfferAccepted:
+		return m.handleStartTour()
+	case dialog.TourOfferNever:
+		if err := tourstate.MarkNever(); err != nil {
+			slog.Warn("Failed to persist tour state", "error", err)
+		}
+		return m, notification.InfoCmd("Got it — never again. /getting-started if you change your mind")
+	default:
+		return m, notification.InfoCmd("Maybe later — /getting-started starts the tour anytime")
+	}
+}
+
+// handleTourKey routes the tour's two control keys while it is running: Esc
+// quits the tour and Enter (on an empty editor) advances past the current
+// step. Enter with draft text keeps its normal send behavior, and both keys
+// are only consulted after dialogs and completions had their chance, so the
+// tour never shadows a more specific interaction.
+func (m *appModel) handleTourKey(msg tea.KeyPressMsg) (tea.Cmd, bool) {
+	if !m.tour.Active() {
+		return nil, false
+	}
+	switch msg.String() {
+	case "esc":
+		return m.tour.Quit(), true
+	case "enter":
+		if m.focusedPanel == PanelEditor && strings.TrimSpace(m.editor.Value()) == "" {
+			return m.tour.Advance(), true
+		}
+	}
+	return nil, false
+}

--- a/pkg/tui/tour_test.go
+++ b/pkg/tui/tour_test.go
@@ -1,0 +1,130 @@
+package tui
+
+import (
+	"path/filepath"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/paths"
+	tourstate "github.com/docker/docker-agent/pkg/tour"
+	"github.com/docker/docker-agent/pkg/tui/components/tabbar"
+	"github.com/docker/docker-agent/pkg/tui/dialog"
+	"github.com/docker/docker-agent/pkg/tui/messages"
+)
+
+// isolateTourState redirects the config dir so tour-state writes never touch
+// the developer's real configuration.
+func isolateTourState(t *testing.T) {
+	t.Helper()
+	paths.SetConfigDir(filepath.Join(t.TempDir(), "config"))
+	t.Cleanup(func() { paths.SetConfigDir("") })
+}
+
+func TestStartTourMsg_ActivatesTourAndPersists(t *testing.T) {
+	isolateTourState(t)
+
+	m, _ := newTestModel(t)
+
+	_, _ = m.Update(messages.StartTourMsg{})
+
+	assert.True(t, m.tour.Active())
+	assert.Equal(t, tourstate.StatusDone, tourstate.ReadStatus())
+}
+
+func TestStartTourMsg_LeanModeRefuses(t *testing.T) {
+	isolateTourState(t)
+
+	m, _ := newTestModel(t)
+	m.leanMode = true
+
+	_, cmd := m.Update(messages.StartTourMsg{})
+
+	assert.False(t, m.tour.Active())
+	require.NotNil(t, cmd, "lean mode should surface a notification")
+	assert.Equal(t, tourstate.StatusUnanswered, tourstate.ReadStatus())
+}
+
+func TestTourObservesMessagesThroughUpdate(t *testing.T) {
+	isolateTourState(t)
+
+	m, _ := newTestModel(t)
+	_, _ = m.Update(messages.StartTourMsg{})
+	require.True(t, m.tour.Active())
+
+	// A user message flowing through Update completes the first step: the
+	// tour schedules its celebration tick (the mock chat page itself
+	// produces no command, so a non-nil command can only come from the
+	// tour's observation).
+	_, cmd := m.Update(messages.SendMsg{Content: "hello"})
+	require.NotNil(t, cmd)
+
+	// While celebrating, further matches schedule nothing new.
+	_, cmd = m.Update(messages.SendMsg{Content: "hello again"})
+	assert.Nil(t, cmd)
+}
+
+func TestTourKeys(t *testing.T) {
+	isolateTourState(t)
+
+	t.Run("esc quits the tour", func(t *testing.T) {
+		m, _ := newTestModel(t)
+		m.tabBar = tabbar.New(0)
+		_, _ = m.Update(messages.StartTourMsg{})
+		require.True(t, m.tour.Active())
+
+		_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+
+		assert.False(t, m.tour.Active())
+		require.NotNil(t, cmd)
+	})
+
+	t.Run("enter on empty editor advances", func(t *testing.T) {
+		m, _ := newTestModel(t)
+		m.tabBar = tabbar.New(0)
+		m.focusedPanel = PanelEditor
+		_, _ = m.Update(messages.StartTourMsg{})
+		require.True(t, m.tour.Active())
+
+		_, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+		assert.True(t, m.tour.Active(), "advancing does not end the tour")
+	})
+}
+
+func TestTourOfferResult_NeverPersists(t *testing.T) {
+	isolateTourState(t)
+
+	m, _ := newTestModel(t)
+
+	_, cmd := m.Update(dialog.TourOfferResultMsg{Choice: dialog.TourOfferNever})
+
+	require.NotNil(t, cmd)
+	assert.False(t, m.tour.Active())
+	assert.Equal(t, tourstate.StatusNever, tourstate.ReadStatus())
+}
+
+func TestTourOfferResult_LaterKeepsStateUnanswered(t *testing.T) {
+	isolateTourState(t)
+
+	m, _ := newTestModel(t)
+
+	_, cmd := m.Update(dialog.TourOfferResultMsg{Choice: dialog.TourOfferLater})
+
+	require.NotNil(t, cmd)
+	assert.False(t, m.tour.Active())
+	assert.Equal(t, tourstate.StatusUnanswered, tourstate.ReadStatus())
+}
+
+func TestTourOfferResult_AcceptedStartsTour(t *testing.T) {
+	isolateTourState(t)
+
+	m, _ := newTestModel(t)
+
+	_, _ = m.Update(dialog.TourOfferResultMsg{Choice: dialog.TourOfferAccepted})
+
+	assert.True(t, m.tour.Active())
+	assert.Equal(t, tourstate.StatusDone, tourstate.ReadStatus())
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -33,6 +33,7 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/components/statusbar"
 	"github.com/docker/docker-agent/pkg/tui/components/tabbar"
 	"github.com/docker/docker-agent/pkg/tui/components/tool"
+	"github.com/docker/docker-agent/pkg/tui/components/tour"
 	"github.com/docker/docker-agent/pkg/tui/core"
 	"github.com/docker/docker-agent/pkg/tui/dialog"
 	"github.com/docker/docker-agent/pkg/tui/internal/editorname"
@@ -208,6 +209,19 @@ type appModel struct {
 	// leanMode enables a simplified TUI with minimal chrome.
 	leanMode bool
 
+	// tour is the interactive getting-started overlay. Always non-nil;
+	// inactive until started via an option, /getting-started, or the
+	// first-run offer.
+	tour *tour.Model
+
+	// tourMode selects what happens at startup: nothing, offer the tour,
+	// or start it immediately.
+	tourMode tourMode
+
+	// tourShowTelemetryNotice folds the telemetry notice into the tour
+	// offer dialog when telemetry is enabled.
+	tourShowTelemetryNotice bool
+
 	// hideSidebar hides the sidebar and disables the ctrl+b toggle.
 	hideSidebar bool
 
@@ -250,6 +264,34 @@ func WithLeanMode() Option {
 func WithHideSidebar() Option {
 	return func(m *appModel) {
 		m.hideSidebar = true
+	}
+}
+
+// tourMode selects the getting-started tour behavior at startup.
+type tourMode int
+
+const (
+	tourModeNone tourMode = iota
+	tourModeOffer
+	tourModeStart
+)
+
+// WithTourStart starts the interactive getting-started tour as soon as the
+// TUI launches. Ignored in lean mode, which has no overlay support.
+func WithTourStart() Option {
+	return func(m *appModel) {
+		m.tourMode = tourModeStart
+	}
+}
+
+// WithTourOffer shows the first-run dialog offering the getting-started
+// tour when the TUI launches. showTelemetryNotice folds the telemetry
+// notice into the offer so it never stacks with the stderr banner. Ignored
+// in lean mode, which has no overlay support.
+func WithTourOffer(showTelemetryNotice bool) Option {
+	return func(m *appModel) {
+		m.tourMode = tourModeOffer
+		m.tourShowTelemetryNotice = showTelemetryNotice
 	}
 }
 
@@ -390,6 +432,7 @@ func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initi
 		notification:                  notification.New(),
 		dialogMgr:                     dialog.New(),
 		completions:                   completion.New(),
+		tour:                          tour.New(),
 		transcriber:                   transcribe.New(os.Getenv("OPENAI_API_KEY")),
 		workingSpinner:                spinner.New(spinner.ModeSpinnerOnly, styles.SpinnerDotsHighlightStyle),
 		focusedPanel:                  PanelEditor,
@@ -561,6 +604,29 @@ func (m *appModel) contextShutdownCmd() tea.Cmd {
 
 // Init initializes the model.
 func (m *appModel) Init() tea.Cmd {
+	return tea.Batch(m.init(), m.tourStartupCmd())
+}
+
+// tourStartupCmd applies the configured startup tour mode: start the tour
+// right away or open the first-run offer dialog. Lean mode has no overlay
+// support, so the tour is disabled there.
+func (m *appModel) tourStartupCmd() tea.Cmd {
+	if m.leanMode {
+		return nil
+	}
+	switch m.tourMode {
+	case tourModeStart:
+		return core.CmdHandler(messages.StartTourMsg{})
+	case tourModeOffer:
+		return core.CmdHandler(dialog.OpenDialogMsg{
+			Model: dialog.NewTourOfferDialog(m.tourShowTelemetryNotice),
+		})
+	default:
+		return nil
+	}
+}
+
+func (m *appModel) init() tea.Cmd {
 	shutdownCmd := m.contextShutdownCmd()
 	// If a different tab should be active on startup, switch to it directly.
 	// The initial tab's pending restore stays lazy — it will be loaded via
@@ -606,8 +672,18 @@ func (m *appModel) Init() tea.Cmd {
 	)
 }
 
-// Update handles messages.
+// Update handles messages. It wraps update so the getting-started tour can
+// observe every message that flows through the TUI (to detect completed
+// steps) without ever consuming it.
 func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	model, cmd := m.update(msg)
+	if obs := m.tour.Observe(msg); obs != nil {
+		cmd = tea.Batch(cmd, obs)
+	}
+	return model, cmd
+}
+
+func (m *appModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// In lean mode, silently drop messages for features that don't exist.
 	if m.leanMode {
 		switch msg.(type) {
@@ -831,6 +907,17 @@ func (m *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		return m, nil
+
+	// --- Getting-started tour ---
+
+	case messages.StartTourMsg:
+		return m.handleStartTour()
+
+	case messages.TourFinishedMsg:
+		return m.handleTourFinished(msg.Completed)
+
+	case dialog.TourOfferResultMsg:
+		return m.handleTourOfferResult(msg.Choice)
 
 	// --- Terminal bell ---
 
@@ -1782,6 +1869,8 @@ func (m *appModel) resizeAll() tea.Cmd {
 	// Full mode: update overlay components
 	cmds = append(cmds, m.updateDialogCmd(tea.WindowSizeMsg{Width: width, Height: height}))
 
+	m.tour.SetSize(width, height, m.contentHeight)
+
 	m.completions.SetEditorBottom(editorHeight + m.tabBar.Height())
 	m.completions.Update(tea.WindowSizeMsg{Width: width, Height: height})
 
@@ -2005,6 +2094,12 @@ func (m *appModel) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	// History search is a modal state — capture all remaining keys before normal routing
 	if m.focusedPanel == PanelEditor && m.editor.IsHistorySearchActive() {
 		return m.forwardEditor(msg)
+	}
+
+	// Getting-started tour controls (Esc to quit, Enter on an empty editor
+	// to advance) sit below dialogs and completions but above normal routing.
+	if cmd, handled := m.handleTourKey(msg); handled {
+		return m, cmd
 	}
 
 	switch {
@@ -2513,12 +2608,18 @@ func (m *appModel) View() tea.View {
 	baseView := lipgloss.JoinVertical(lipgloss.Top, viewParts...)
 
 	// Handle overlays
-	hasOverlays := m.dialogMgr.Open() || m.notification.Open() || m.completions.Open()
+	hasOverlays := m.dialogMgr.Open() || m.notification.Open() || m.completions.Open() || m.tour.Active()
 
 	if hasOverlays {
 		baseLayer := lipgloss.NewLayer(baseView)
 		var allLayers []*lipgloss.Layer
 		allLayers = append(allLayers, baseLayer)
+
+		// The tour card sits above the base UI but below dialogs, so the
+		// step it teaches (palette, tool approval…) is never hidden by it.
+		if tourLayer := m.tour.Layer(); tourLayer != nil {
+			allLayers = append(allLayers, tourLayer)
+		}
 
 		if m.dialogMgr.Open() {
 			dialogLayers := m.dialogMgr.GetLayers()

--- a/pkg/tui/tui_exit_test.go
+++ b/pkg/tui/tui_exit_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/components/completion"
 	"github.com/docker/docker-agent/pkg/tui/components/editor"
 	"github.com/docker/docker-agent/pkg/tui/components/notification"
+	"github.com/docker/docker-agent/pkg/tui/components/tour"
 	"github.com/docker/docker-agent/pkg/tui/core/layout"
 	"github.com/docker/docker-agent/pkg/tui/dialog"
 	"github.com/docker/docker-agent/pkg/tui/messages"
@@ -148,6 +149,7 @@ func newTestModel(tb testing.TB) (*appModel, *mockEditor) {
 		notification:            notification.New(),
 		dialogMgr:               dialog.New(),
 		completions:             completion.New(),
+		tour:                    tour.New(),
 	}
 	return m, ed
 }


### PR DESCRIPTION
## Summary

Implements #3426: a short, skippable, hands-on tour inside the TUI that teaches docker agent by doing, offered on the first interactive run and replayable on demand.

The tour is a floating card that observes the real UI's message stream: each step completes when the user actually performs the action it describes. The card never steals focus and renders below dialogs, so the feature being taught (palette, tool approval) is never hidden by it.

```
docker agent run                     (first interactive run)
  -> offer dialog: take the tour? [enter / n / d]
       enter -> scripted tour overlay starts
       n     -> hint toast, offer may reappear on a later run
       d     -> never again (persisted)

docker agent getting-started         (alias: tour)  -> tour starts immediately
/getting-started, palette Help entry                -> replay from inside the TUI
```

Card rendering (step, then completion flash before auto-advance; titles carry a small emoji in the real UI):

```
+--------------------------------------------+     +--------------------------------------------+
|  Getting started                   o.....  |     |  Getting started                   *.....  |
|  ----------------------------------------  |     |  ----------------------------------------  |
|  Talk to your agent                        |     |  Message away, the reply streams in live.  |
|                                            | ->  |                                            |
|  This is a conversation, not a form.       |     |  Next stop in a moment... (enter to jump)  |
|  Plain language works.                     |     |               enter continue Esc quit tour |
|                                            |     +--------------------------------------------+
|  > Type anything below and press Enter,    |
|    try "write a haiku about containers".   |
|             enter skip step  Esc quit tour |
+--------------------------------------------+
```

## Steps

| # | Teaches | Completes when |
|---|---|---|
| 1 | Send a message | a non-slash message is sent |
| 2 | Tool calls need approval, Ctrl+y yolo | the confirmation dialog is answered (or a tool ran in yolo mode) |
| 3 | Command palette | the palette actually opens (Ctrl+k or status-bar click) |
| 4 | Slash commands | /model, /sessions, /theme, /tools or /cost dispatches |
| 5 | Agents are YAML, docker agent new, catalog | read step, Enter |
| 6 | Ctrl+h, replay, feedback | read step, Enter finishes |

Enter (on an empty editor) skips a step; Esc quits the tour at any point. Completed steps flash a short celebration, then auto-advance.

## Issue expectations mapping

| Issue item | Status |
|---|---|
| Scripted TUI tour (option A), deterministic copy, no tokens for the tour itself | implemented |
| First-run offer, prompt-first (not forced) | implemented |
| CLI replay command | implemented as `getting-started` with `tour` alias |
| /tour slash command + palette entry | implemented as `/getting-started`, new Help palette category |
| Root --help pointer | implemented |
| Never shown in non-interactive contexts | offer only wired on the interactive full-TUI run path; also suppressed for --fake, --record, --exit-after-response, --session-read-only, lean mode, and runs that already carry an initial message |
| DOCKER_AGENT_NO_TOUR env | implemented (plus CAGENT_NO_TOUR, matching the telemetry banner precedent) |
| Esc skippable at every step | implemented |
| "Never" persisted, state next to first-run marker | implemented, `<config-dir>/.cagent_tour` containing `done` or `never` |
| Telemetry banner folds into the flow | the offer dialog carries the telemetry notice; the stderr banner itself is untouched since the alt screen covers it on TUI runs and it remains the only notice for non-TUI first runs |
| Provider setup step (no provider configured) | not included; the existing AutoModelFallbackError already lists DMR and per-provider key instructions; candidate follow-up |
| Telemetry for tour started/completed/skipped-at-step | partial: `getting-started` invocations tracked via the existing TrackCommand; per-step TUI events would need new telemetry plumbing in pkg/tui, left out |
| Tour agent hand-off (option B) in builtin-agents | not included, kept to the deterministic scripted tour |

## Open questions resolution

| Question | Decision |
|---|---|
| Command name | `getting-started`, with `tour` alias |
| Auto-offer vs auto-start | prompt-first offer |
| Interrupted tour re-offered? | starting the tour marks the offer as answered; "not now" re-offers on a later run; "never" is permanent |
| Ship a tour agent in builtin-agents? | no, out of scope for this PR |

## Implementation notes

| Piece | Where |
|---|---|
| Persisted state (done/never, env suppression) | pkg/tour |
| Tour engine, card, step checks | pkg/tui/components/tour |
| First-run offer dialog | pkg/tui/dialog/tour_offer.go |
| appModel wiring (observe wrapper, keys, layer, handlers) | pkg/tui/tui.go, pkg/tui/tour.go |
| Palette Help category, /getting-started | pkg/tui/commands |
| CLI command, hidden --tour on run, offer conditions | cmd/root |

- The tour observes messages through a thin Update wrapper on the appModel; it never consumes messages, so normal routing is unchanged.
- Step detection uses the messages the actions actually produce (OpenDialogMsg with the palette model, RuntimeResumeMsg, ToolCallResponseEvent, picker/browser messages) rather than raw key matches, so any path to the feature counts.
- `getting-started` dispatches through the registered run command (same mechanism as the root command's no-args default), so the session behaves exactly like a regular interactive run.
- Lean mode has no overlay support: the tour is disabled there and /getting-started surfaces a notification.

## Testing

| Layer | Coverage |
|---|---|
| pkg/tour | state read/write, env suppression |
| pkg/tui/components/tour | step checks, celebration/advance, quit, progress, layout guards |
| pkg/tui/dialog | offer choices, palette predicate |
| pkg/tui | StartTourMsg and offer-result handlers, observation through Update, Esc/Enter keys, persistence |
| e2e (tuitest) | full walkthrough including a real Ctrl+k, Esc quits, first-run offer decline |

`go build`, `go vet`, `golangci-lint run`, and `go run ./lint .` are clean. The full test suite passes except five packages whose SSRF/private-address tests fail identically on a clean tree in the development environment (pkg/config, pkg/httpclient, tools builtin api/fetch/openapi), unrelated to this change. A manual run of the built binary (`docker-agent getting-started` with isolated state dirs) confirmed the full CLI to TUI to tour path executes and persists the state file.

closes  #3426