### PR TITLE
fix: route --record proxy through the configured models gateway

### DIFF
--- a/cmd/root/record.go
+++ b/cmd/root/record.go
@@ -24,8 +24,10 @@ func setupFakeProxy(ctx context.Context, fakeResponses string, streamDelayMs int
 
 // setupRecordingProxy starts a recording proxy if recordPath is non-empty.
 // It configures the runtime config's ModelsGateway to point to the proxy.
+// Any models gateway already configured becomes the proxy's upstream, so
+// recording keeps routing (and auth) through the user's gateway.
 func setupRecordingProxy(ctx context.Context, recordPath string, runConfig *config.RuntimeConfig) (cassettePath string, cleanup func() error, err error) {
-	cassettePath, proxyURL, cleanupFn, err := recording.SetupRecordingProxy(ctx, recordPath)
+	cassettePath, proxyURL, cleanupFn, err := recording.SetupRecordingProxy(ctx, recordPath, runConfig.ModelsGateway)
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/fake/proxy.go
+++ b/pkg/fake/proxy.go
@@ -13,6 +13,7 @@ import (
 	"maps"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -21,6 +22,9 @@ import (
 	"github.com/labstack/echo/v4"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/cassette"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
+
+	"github.com/docker/docker-agent/pkg/desktop"
+	"github.com/docker/docker-agent/pkg/environment"
 )
 
 // ProxyOptions configures the fake proxy behavior.
@@ -30,6 +34,10 @@ type ProxyOptions struct {
 	// StreamChunkDelay is the delay between SSE chunks when SimulateStream is true.
 	// Defaults to 15ms if not set.
 	StreamChunkDelay time.Duration
+	// UpstreamGateway, when set, forwards requests to this models gateway
+	// instead of the provider's public endpoint. Used when recording a
+	// session that normally routes through a models gateway.
+	UpstreamGateway string
 }
 
 // ProxyOption is a function that configures ProxyOptions.
@@ -62,12 +70,18 @@ func StartProxy(ctx context.Context, cassettePath string, opts ...ProxyOption) (
 }
 
 // StartRecordingProxy starts a proxy that records AI API interactions to a cassette file.
-// It injects API keys from environment variables for the actual API calls.
+// Without an upstream gateway it forwards to the providers' public endpoints,
+// injecting API keys from environment variables. With an upstream gateway it
+// forwards through that gateway instead, so gateway-managed auth keeps working.
 // The recorded cassette can later be replayed using StartProxy.
 // This uses a streaming-aware recorder that allows responses to stream through
 // in real-time while being recorded, unlike the standard VCR recorder.
-func StartRecordingProxy(ctx context.Context, cassettePath string) (string, func() error, error) {
-	return StartStreamingRecordingProxy(ctx, cassettePath, APIKeyHeaderUpdater)
+func StartRecordingProxy(ctx context.Context, cassettePath, upstreamGateway string) (string, func() error, error) {
+	headerUpdater := APIKeyHeaderUpdater
+	if upstreamGateway != "" {
+		headerUpdater = gatewayAuthHeaderUpdater(upstreamGateway)
+	}
+	return StartStreamingRecordingProxy(ctx, cassettePath, upstreamGateway, headerUpdater)
 }
 
 // StartStreamingRecordingProxy starts a recording proxy with streaming support.
@@ -76,6 +90,7 @@ func StartRecordingProxy(ctx context.Context, cassettePath string) (string, func
 func StartStreamingRecordingProxy(
 	ctx context.Context,
 	cassettePath string,
+	upstreamGateway string,
 	headerUpdater func(host string, req *http.Request),
 ) (string, func() error, error) {
 	streamRec, err := NewStreamingRecorder(cassettePath)
@@ -86,7 +101,7 @@ func StartStreamingRecordingProxy(
 	e := echo.New()
 	e.HideBanner = true
 	e.HidePort = true
-	e.Any("/*", Handle(streamRec, headerUpdater, nil))
+	e.Any("/*", Handle(streamRec, headerUpdater, &ProxyOptions{UpstreamGateway: upstreamGateway}))
 
 	httpServer := httptest.NewServer(e)
 
@@ -119,19 +134,60 @@ func StartStreamingRecordingProxy(
 // APIKeyHeaderUpdater injects API keys from environment variables into request headers.
 // This is used when recording API interactions to ensure real API calls succeed.
 func APIKeyHeaderUpdater(host string, req *http.Request) {
+	key := envAPIKeyForHost(host)
 	switch host {
-	case "https://api.openai.com/v1":
-		req.Header.Set("Authorization", "Bearer "+os.Getenv("OPENAI_API_KEY"))
+	case "https://api.openai.com/v1", "https://api.mistral.ai/v1", "https://openrouter.ai/api/v1":
+		req.Header.Set("Authorization", "Bearer "+key)
 	case "https://api.anthropic.com":
 		req.Header.Del("Authorization")
-		req.Header.Set("X-Api-Key", os.Getenv("ANTHROPIC_API_KEY"))
+		req.Header.Set("X-Api-Key", key)
 	case "https://generativelanguage.googleapis.com":
 		req.Header.Del("Authorization")
-		req.Header.Set("X-Goog-Api-Key", os.Getenv("GOOGLE_API_KEY"))
+		req.Header.Set("X-Goog-Api-Key", key)
+	}
+}
+
+// envAPIKeyForHost returns the env-provided API key for a provider's public
+// endpoint, or "" for unknown hosts.
+func envAPIKeyForHost(host string) string {
+	switch host {
+	case "https://api.openai.com/v1":
+		return os.Getenv("OPENAI_API_KEY")
+	case "https://api.anthropic.com":
+		return os.Getenv("ANTHROPIC_API_KEY")
+	case "https://generativelanguage.googleapis.com":
+		return os.Getenv("GOOGLE_API_KEY")
 	case "https://api.mistral.ai/v1":
-		req.Header.Set("Authorization", "Bearer "+os.Getenv("MISTRAL_API_KEY"))
+		return os.Getenv("MISTRAL_API_KEY")
 	case "https://openrouter.ai/api/v1":
-		req.Header.Set("Authorization", "Bearer "+os.Getenv("OPENROUTER_API_KEY"))
+		return os.Getenv("OPENROUTER_API_KEY")
+	default:
+		return ""
+	}
+}
+
+// gatewayAuthHeaderUpdater re-authenticates requests forwarded to a models
+// gateway. The client authenticated against the localhost proxy URL — which
+// the Docker trust check matches — so it may have attached a Desktop token
+// instead of the credentials it would send to the real gateway.
+func gatewayAuthHeaderUpdater(gateway string) func(host string, req *http.Request) {
+	if environment.IsTrustedDockerURL(gateway) {
+		return func(_ string, req *http.Request) {
+			if token := desktop.GetToken(req.Context()); token != "" {
+				// Same headers gateway-mode provider clients set (Authorization
+				// for OpenAI-style, X-Api-Key for Anthropic-style).
+				req.Header.Set("Authorization", "Bearer "+token)
+				req.Header.Set("X-Api-Key", token)
+			}
+		}
+	}
+	// Custom gateways authenticate with the provider env keys the client
+	// would use when talking to them directly. Only re-apply when a key is
+	// configured; otherwise keep whatever the client attached.
+	return func(host string, req *http.Request) {
+		if envAPIKeyForHost(host) != "" {
+			APIKeyHeaderUpdater(host, req)
+		}
 	}
 }
 
@@ -298,9 +354,34 @@ func TargetURLForHost(host string) func(req *http.Request) string {
 	}
 }
 
+// GatewayTargetURL rewrites an incoming proxy request to target the upstream
+// models gateway, appending the request path to the gateway's path and
+// merging the gateway's own query parameters (e.g. plan tiers) with the
+// request's.
+func GatewayTargetURL(gateway string, req *http.Request) (string, error) {
+	base, err := url.Parse(strings.TrimSuffix(gateway, "/"))
+	if err != nil {
+		return "", fmt.Errorf("invalid gateway URL %q: %w", gateway, err)
+	}
+
+	target := *base
+	target.Path += req.URL.Path
+	target.RawPath = ""
+
+	query := base.Query()
+	for k, vs := range req.URL.Query() {
+		for _, v := range vs {
+			query.Add(k, v)
+		}
+	}
+	target.RawQuery = query.Encode()
+
+	return target.String(), nil
+}
+
 // Handle creates an echo handler that proxies requests through the VCR transport.
 // The headerUpdater is called with the host and request to update headers (e.g., for adding API keys).
-// The options parameter controls streaming simulation behavior.
+// The options parameter controls streaming simulation behavior and upstream gateway forwarding.
 func Handle(transport http.RoundTripper, headerUpdater func(host string, req *http.Request), options *ProxyOptions) echo.HandlerFunc {
 	if options == nil {
 		options = &ProxyOptions{}
@@ -312,11 +393,29 @@ func Handle(transport http.RoundTripper, headerUpdater func(host string, req *ht
 		host = strings.TrimSuffix(host, "/")
 
 		toTargetURL := TargetURLForHost(host)
-		if toTargetURL == nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "unknown service host "+host)
+
+		var targetURL, recordURL string
+		if options.UpstreamGateway != "" {
+			var err error
+			targetURL, err = GatewayTargetURL(options.UpstreamGateway, c.Request())
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+			}
+			// Record the canonical provider URL (what a gateway-less replay
+			// proxy would compute) so the cassette stays replayable.
+			if toTargetURL != nil {
+				recordURL = toTargetURL(c.Request())
+			}
+		} else {
+			if toTargetURL == nil {
+				return echo.NewHTTPError(http.StatusBadRequest, "unknown service host "+host)
+			}
+			targetURL = toTargetURL(c.Request())
 		}
 
-		targetURL := toTargetURL(c.Request())
+		if recordURL != "" {
+			ctx = WithRecordURL(ctx, recordURL)
+		}
 
 		req, err := http.NewRequestWithContext(ctx, c.Request().Method, targetURL, c.Request().Body)
 		if err != nil {

--- a/pkg/fake/proxy.go
+++ b/pkg/fake/proxy.go
@@ -23,7 +23,6 @@ import (
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/cassette"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 
-	"github.com/docker/docker-agent/pkg/desktop"
 	"github.com/docker/docker-agent/pkg/environment"
 )
 
@@ -36,7 +35,9 @@ type ProxyOptions struct {
 	StreamChunkDelay time.Duration
 	// UpstreamGateway, when set, forwards requests to this models gateway
 	// instead of the provider's public endpoint. Used when recording a
-	// session that normally routes through a models gateway.
+	// session that normally routes through a models gateway. Only honored
+	// by the streaming recording path (StartRecordingProxy); the go-vcr
+	// replay path never forwards upstream.
 	UpstreamGateway string
 }
 
@@ -93,6 +94,13 @@ func StartStreamingRecordingProxy(
 	upstreamGateway string,
 	headerUpdater func(host string, req *http.Request),
 ) (string, func() error, error) {
+	// Fail fast on a bad gateway URL instead of returning 500s per request.
+	if upstreamGateway != "" {
+		if u, err := url.Parse(upstreamGateway); err != nil || u.Scheme == "" || u.Host == "" {
+			return "", nil, fmt.Errorf("invalid upstream gateway URL %q", upstreamGateway)
+		}
+	}
+
 	streamRec, err := NewStreamingRecorder(cassettePath)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to create streaming recorder: %w", err)
@@ -167,24 +175,23 @@ func envAPIKeyForHost(host string) string {
 }
 
 // gatewayAuthHeaderUpdater re-authenticates requests forwarded to a models
-// gateway. The client authenticated against the localhost proxy URL — which
-// the Docker trust check matches — so it may have attached a Desktop token
-// instead of the credentials it would send to the real gateway.
+// gateway. The client authenticated against the localhost proxy URL, which
+// passes the same Docker trust check a trusted gateway does, so it attached
+// a fresh Desktop token to every request.
 func gatewayAuthHeaderUpdater(gateway string) func(host string, req *http.Request) {
 	if environment.IsTrustedDockerURL(gateway) {
-		return func(_ string, req *http.Request) {
-			if token := desktop.GetToken(req.Context()); token != "" {
-				// Same headers gateway-mode provider clients set (Authorization
-				// for OpenAI-style, X-Api-Key for Anthropic-style).
-				req.Header.Set("Authorization", "Bearer "+token)
-				req.Header.Set("X-Api-Key", token)
-			}
-		}
+		// The Desktop token the client attached is exactly what the gateway
+		// expects (localhost gateways are equally trusted in normal mode).
+		return func(string, *http.Request) {}
 	}
-	// Custom gateways authenticate with the provider env keys the client
-	// would use when talking to them directly. Only re-apply when a key is
-	// configured; otherwise keep whatever the client attached.
+	// Non-Docker gateways must never see the Desktop token. Strip the
+	// credential headers the client set and re-apply the provider env key
+	// it would have sent to the gateway directly (SDKs default to env keys
+	// when no gateway token is available).
 	return func(host string, req *http.Request) {
+		req.Header.Del("Authorization")
+		req.Header.Del("X-Api-Key")
+		req.Header.Del("X-Goog-Api-Key")
 		if envAPIKeyForHost(host) != "" {
 			APIKeyHeaderUpdater(host, req)
 		}
@@ -357,16 +364,17 @@ func TargetURLForHost(host string) func(req *http.Request) string {
 // GatewayTargetURL rewrites an incoming proxy request to target the upstream
 // models gateway, appending the request path to the gateway's path and
 // merging the gateway's own query parameters (e.g. plan tiers) with the
-// request's.
+// request's. Both query sets are kept side by side, matching how gateway-mode
+// clients merge them (httpclient.WithQuery uses Add too).
 func GatewayTargetURL(gateway string, req *http.Request) (string, error) {
 	base, err := url.Parse(strings.TrimSuffix(gateway, "/"))
 	if err != nil {
-		return "", fmt.Errorf("invalid gateway URL %q: %w", gateway, err)
+		return "", errors.New("invalid upstream gateway URL")
 	}
 
 	target := *base
-	target.Path += req.URL.Path
-	target.RawPath = ""
+	target.Path = base.Path + req.URL.Path
+	target.RawPath = base.EscapedPath() + req.URL.EscapedPath()
 
 	query := base.Query()
 	for k, vs := range req.URL.Query() {
@@ -402,9 +410,18 @@ func Handle(transport http.RoundTripper, headerUpdater func(host string, req *ht
 				return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 			}
 			// Record the canonical provider URL (what a gateway-less replay
-			// proxy would compute) so the cassette stays replayable.
+			// proxy would compute) so the cassette stays replayable and never
+			// contains the gateway URL, whose query may carry secrets.
 			if toTargetURL != nil {
 				recordURL = toTargetURL(c.Request())
+			} else {
+				hostURL, err := url.Parse(host)
+				if err != nil || hostURL.Scheme == "" || hostURL.Host == "" {
+					return echo.NewHTTPError(http.StatusBadRequest, "unknown service host "+host)
+				}
+				// Same shape as the TargetURLForHost builders: provider
+				// origin + request URI.
+				recordURL = hostURL.Scheme + "://" + hostURL.Host + c.Request().URL.Redacted()
 			}
 		} else {
 			if toTargetURL == nil {
@@ -435,7 +452,9 @@ func Handle(transport http.RoundTripper, headerUpdater func(host string, req *ht
 
 		resp, err := client.Do(req)
 		if err != nil {
-			slog.ErrorContext(ctx, "VCR proxy request failed", "url", targetURL, "error", err)
+			// Log host+path only: in gateway mode the full target URL may
+			// carry credentials in its query string.
+			slog.ErrorContext(ctx, "VCR proxy request failed", "url", req.URL.Scheme+"://"+req.URL.Host+req.URL.Path, "error", err)
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to run request: "+err.Error())
 		}
 		defer resp.Body.Close()

--- a/pkg/fake/proxy_gateway_test.go
+++ b/pkg/fake/proxy_gateway_test.go
@@ -1,0 +1,164 @@
+package fake
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/dnaeon/go-vcr.v4/pkg/cassette"
+)
+
+func TestGatewayTargetURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		gateway string
+		path    string
+		want    string
+	}{
+		{
+			name:    "root gateway",
+			gateway: "https://gateway.example.com",
+			path:    "/v1/messages",
+			want:    "https://gateway.example.com/v1/messages",
+		},
+		{
+			name:    "gateway with trailing slash",
+			gateway: "https://gateway.example.com/",
+			path:    "/v1/messages",
+			want:    "https://gateway.example.com/v1/messages",
+		},
+		{
+			name:    "gateway with path prefix",
+			gateway: "https://api.docker.com/models",
+			path:    "/v1/chat/completions",
+			want:    "https://api.docker.com/models/v1/chat/completions",
+		},
+		{
+			name:    "merges gateway and request query",
+			gateway: "https://api.docker.com/models?tier=pro",
+			path:    "/v1/chat/completions?stream=true",
+			want:    "https://api.docker.com/models/v1/chat/completions?stream=true&tier=pro",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, tt.path, http.NoBody)
+			got, err := GatewayTargetURL(tt.gateway, req)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGatewayAuthHeaderUpdater_NonDockerGateway(t *testing.T) {
+	updater := gatewayAuthHeaderUpdater("https://gateway.example.com")
+
+	t.Run("no env key keeps client headers", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_API_KEY", "")
+
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "https://gateway.example.com/v1/messages", http.NoBody)
+		require.NoError(t, err)
+		req.Header.Set("X-Api-Key", "client-key")
+
+		updater("https://api.anthropic.com", req)
+
+		assert.Equal(t, "client-key", req.Header.Get("X-Api-Key"))
+	})
+
+	t.Run("env key replaces the Desktop token the client attached", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_API_KEY", "env-key")
+
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "https://gateway.example.com/v1/messages", http.NoBody)
+		require.NoError(t, err)
+		req.Header.Set("X-Api-Key", "desktop-jwt")
+		req.Header.Set("Authorization", "Bearer desktop-jwt")
+
+		updater("https://api.anthropic.com", req)
+
+		assert.Equal(t, "env-key", req.Header.Get("X-Api-Key"))
+		assert.Empty(t, req.Header.Get("Authorization"))
+	})
+}
+
+// Recording through an upstream gateway must forward the request (with the
+// client's auth headers) to the gateway, not the provider's public endpoint,
+// and record the interaction under the canonical provider URL so the cassette
+// stays replayable.
+func TestStartRecordingProxy_UpstreamGateway(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	var gotPath, gotAPIKey, gotForward string
+	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAPIKey = r.Header.Get("X-Api-Key")
+		gotForward = r.Header.Get("X-Cagent-Forward")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer gateway.Close()
+
+	cassettePath := t.TempDir() + "/recording"
+	// gatewayAuthHeaderUpdater for a non-Docker gateway is a no-op; passed
+	// explicitly because the httptest gateway is localhost, which the Docker
+	// token trust check would otherwise match.
+	proxyURL, cleanup, err := StartStreamingRecordingProxy(t.Context(), cassettePath, gateway.URL,
+		gatewayAuthHeaderUpdater("https://gateway.example.com"))
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, proxyURL+"/v1/messages", strings.NewReader(`{"model":"claude"}`))
+	require.NoError(t, err)
+	req.Header.Set("X-Cagent-Forward", "https://api.anthropic.com")
+	req.Header.Set("X-Api-Key", "gateway-key")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.JSONEq(t, `{"ok":true}`, string(body))
+	assert.Equal(t, "/v1/messages", gotPath)
+	assert.Equal(t, "gateway-key", gotAPIKey, "gateway auth must reach the upstream gateway")
+	assert.Equal(t, "https://api.anthropic.com", gotForward, "forward header must reach the upstream gateway")
+
+	require.NoError(t, cleanup())
+
+	data, err := os.ReadFile(cassettePath + ".yaml")
+	require.NoError(t, err)
+	c, err := cassette.Load(cassettePath)
+	require.NoError(t, err)
+	require.Len(t, c.Interactions, 1)
+	assert.Equal(t, "https://api.anthropic.com/v1/messages", c.Interactions[0].Request.URL,
+		"cassette must record the canonical provider URL, not the gateway URL")
+	assert.NotContains(t, string(data), "gateway-key", "auth must not leak into the cassette")
+}
+
+// Without an upstream gateway the proxy keeps its historical behavior:
+// forward to the provider's public endpoint with env-provided API keys.
+func TestStartRecordingProxy_NoGatewayRejectsUnknownHost(t *testing.T) {
+	cassettePath := t.TempDir() + "/recording"
+	proxyURL, cleanup, err := StartRecordingProxy(t.Context(), cassettePath, "")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, cleanup()) }()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, proxyURL+"/v1/messages", http.NoBody)
+	require.NoError(t, err)
+	req.Header.Set("X-Cagent-Forward", "https://unknown.example.com")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}

--- a/pkg/fake/proxy_gateway_test.go
+++ b/pkg/fake/proxy_gateway_test.go
@@ -46,6 +46,12 @@ func TestGatewayTargetURL(t *testing.T) {
 			path:    "/v1/chat/completions?stream=true",
 			want:    "https://api.docker.com/models/v1/chat/completions?stream=true&tier=pro",
 		},
+		{
+			name:    "preserves percent-encoded path segments",
+			gateway: "https://gateway.example.com",
+			path:    "/v1/models/org%2Fmodel",
+			want:    "https://gateway.example.com/v1/models/org%2Fmodel",
+		},
 	}
 
 	for _, tt := range tests {
@@ -60,42 +66,60 @@ func TestGatewayTargetURL(t *testing.T) {
 	}
 }
 
-func TestGatewayAuthHeaderUpdater_NonDockerGateway(t *testing.T) {
-	updater := gatewayAuthHeaderUpdater("https://gateway.example.com")
-
-	t.Run("no env key keeps client headers", func(t *testing.T) {
-		t.Setenv("ANTHROPIC_API_KEY", "")
-
+func TestGatewayAuthHeaderUpdater(t *testing.T) {
+	newReq := func(t *testing.T) *http.Request {
+		t.Helper()
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "https://gateway.example.com/v1/messages", http.NoBody)
 		require.NoError(t, err)
-		req.Header.Set("X-Api-Key", "client-key")
+		return req
+	}
 
-		updater("https://api.anthropic.com", req)
+	t.Run("docker gateway keeps the Desktop token the client attached", func(t *testing.T) {
+		req := newReq(t)
+		req.Header.Set("Authorization", "Bearer desktop-jwt")
+		req.Header.Set("X-Api-Key", "desktop-jwt")
 
-		assert.Equal(t, "client-key", req.Header.Get("X-Api-Key"))
+		gatewayAuthHeaderUpdater("https://api.docker.com/models")("https://api.anthropic.com", req)
+
+		assert.Equal(t, "Bearer desktop-jwt", req.Header.Get("Authorization"))
+		assert.Equal(t, "desktop-jwt", req.Header.Get("X-Api-Key"))
 	})
 
-	t.Run("env key replaces the Desktop token the client attached", func(t *testing.T) {
+	t.Run("non-docker gateway strips the Desktop token", func(t *testing.T) {
+		t.Setenv("ANTHROPIC_API_KEY", "")
+
+		req := newReq(t)
+		req.Header.Set("Authorization", "Bearer desktop-jwt")
+		req.Header.Set("X-Api-Key", "desktop-jwt")
+		req.Header.Set("X-Goog-Api-Key", "desktop-jwt")
+
+		gatewayAuthHeaderUpdater("https://gateway.example.com")("https://api.anthropic.com", req)
+
+		assert.Empty(t, req.Header.Get("Authorization"), "Desktop token must not leak to non-Docker gateways")
+		assert.Empty(t, req.Header.Get("X-Api-Key"))
+		assert.Empty(t, req.Header.Get("X-Goog-Api-Key"))
+	})
+
+	t.Run("non-docker gateway re-applies the provider env key", func(t *testing.T) {
 		t.Setenv("ANTHROPIC_API_KEY", "env-key")
 
-		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "https://gateway.example.com/v1/messages", http.NoBody)
-		require.NoError(t, err)
-		req.Header.Set("X-Api-Key", "desktop-jwt")
+		req := newReq(t)
 		req.Header.Set("Authorization", "Bearer desktop-jwt")
+		req.Header.Set("X-Api-Key", "desktop-jwt")
 
-		updater("https://api.anthropic.com", req)
+		gatewayAuthHeaderUpdater("https://gateway.example.com")("https://api.anthropic.com", req)
 
 		assert.Equal(t, "env-key", req.Header.Get("X-Api-Key"))
 		assert.Empty(t, req.Header.Get("Authorization"))
 	})
 }
 
-// Recording through an upstream gateway must forward the request (with the
-// client's auth headers) to the gateway, not the provider's public endpoint,
-// and record the interaction under the canonical provider URL so the cassette
-// stays replayable.
+// Recording through an upstream gateway must forward the request to the
+// gateway (with the auth the client would send to it directly), not the
+// provider's public endpoint, and record the interaction under the canonical
+// provider URL so the cassette stays replayable.
 func TestStartRecordingProxy_UpstreamGateway(t *testing.T) {
-	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "env-key")
 
 	var gotPath, gotAPIKey, gotForward string
 	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -108,17 +132,18 @@ func TestStartRecordingProxy_UpstreamGateway(t *testing.T) {
 	defer gateway.Close()
 
 	cassettePath := t.TempDir() + "/recording"
-	// gatewayAuthHeaderUpdater for a non-Docker gateway is a no-op; passed
-	// explicitly because the httptest gateway is localhost, which the Docker
-	// token trust check would otherwise match.
+	// gatewayAuthHeaderUpdater for a non-Docker gateway; passed explicitly
+	// because the httptest gateway is localhost, which the Docker token
+	// trust check would otherwise match.
 	proxyURL, cleanup, err := StartStreamingRecordingProxy(t.Context(), cassettePath, gateway.URL,
 		gatewayAuthHeaderUpdater("https://gateway.example.com"))
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = cleanup() }) // idempotent; defensive if asserts fail early
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, proxyURL+"/v1/messages", strings.NewReader(`{"model":"claude"}`))
 	require.NoError(t, err)
 	req.Header.Set("X-Cagent-Forward", "https://api.anthropic.com")
-	req.Header.Set("X-Api-Key", "gateway-key")
+	req.Header.Set("X-Api-Key", "desktop-jwt")
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -129,7 +154,7 @@ func TestStartRecordingProxy_UpstreamGateway(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.JSONEq(t, `{"ok":true}`, string(body))
 	assert.Equal(t, "/v1/messages", gotPath)
-	assert.Equal(t, "gateway-key", gotAPIKey, "gateway auth must reach the upstream gateway")
+	assert.Equal(t, "env-key", gotAPIKey, "gateway must receive the provider env key, not the Desktop token")
 	assert.Equal(t, "https://api.anthropic.com", gotForward, "forward header must reach the upstream gateway")
 
 	require.NoError(t, cleanup())
@@ -141,7 +166,73 @@ func TestStartRecordingProxy_UpstreamGateway(t *testing.T) {
 	require.Len(t, c.Interactions, 1)
 	assert.Equal(t, "https://api.anthropic.com/v1/messages", c.Interactions[0].Request.URL,
 		"cassette must record the canonical provider URL, not the gateway URL")
-	assert.NotContains(t, string(data), "gateway-key", "auth must not leak into the cassette")
+	assert.NotContains(t, string(data), "env-key", "auth must not leak into the cassette")
+	assert.NotContains(t, string(data), "desktop-jwt", "auth must not leak into the cassette")
+}
+
+// Unknown forward hosts (custom base_url models) recorded through a gateway
+// must be saved under the forwarded host, never under the gateway URL whose
+// query may carry secrets.
+func TestStartRecordingProxy_UpstreamGateway_UnknownHost(t *testing.T) {
+	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer gateway.Close()
+
+	cassettePath := t.TempDir() + "/recording"
+	proxyURL, cleanup, err := StartStreamingRecordingProxy(t.Context(), cassettePath, gateway.URL+"?api_key=gateway-secret",
+		gatewayAuthHeaderUpdater("https://gateway.example.com"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cleanup() })
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, proxyURL+"/v1/chat/completions", strings.NewReader(`{}`))
+	require.NoError(t, err)
+	req.Header.Set("X-Cagent-Forward", "https://custom.example.com/v1")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.NoError(t, cleanup())
+
+	data, err := os.ReadFile(cassettePath + ".yaml")
+	require.NoError(t, err)
+	c, err := cassette.Load(cassettePath)
+	require.NoError(t, err)
+	require.Len(t, c.Interactions, 1)
+	assert.Equal(t, "https://custom.example.com/v1/chat/completions", c.Interactions[0].Request.URL)
+	assert.NotContains(t, string(data), "gateway-secret", "gateway query secrets must not leak into the cassette")
+}
+
+// A missing forward header in gateway mode is rejected rather than blindly
+// forwarded and recorded.
+func TestStartRecordingProxy_UpstreamGateway_MissingForwardHeader(t *testing.T) {
+	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer gateway.Close()
+
+	cassettePath := t.TempDir() + "/recording"
+	proxyURL, cleanup, err := StartStreamingRecordingProxy(t.Context(), cassettePath, gateway.URL,
+		gatewayAuthHeaderUpdater("https://gateway.example.com"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cleanup() })
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, proxyURL+"/v1/messages", http.NoBody)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestStartStreamingRecordingProxy_InvalidGatewayURL(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := StartStreamingRecordingProxy(t.Context(), t.TempDir()+"/recording", "not a url", nil)
+	require.ErrorContains(t, err, "invalid upstream gateway URL")
 }
 
 // Without an upstream gateway the proxy keeps its historical behavior:

--- a/pkg/fake/streaming_recorder.go
+++ b/pkg/fake/streaming_recorder.go
@@ -2,6 +2,7 @@ package fake
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"sync"
@@ -9,6 +10,15 @@ import (
 	"github.com/goccy/go-yaml"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/cassette"
 )
+
+type recordURLKey struct{}
+
+// WithRecordURL overrides the URL stored in the cassette for a request.
+// Used when recording through an upstream models gateway so interactions are
+// saved under the canonical provider URL and stay replayable.
+func WithRecordURL(ctx context.Context, url string) context.Context {
+	return context.WithValue(ctx, recordURLKey{}, url)
+}
 
 // StreamingRecorder wraps an http.RoundTripper to record interactions while
 // allowing streaming responses to pass through in real-time.
@@ -88,6 +98,11 @@ func (r *StreamingRecorder) addInteraction(req *http.Request, reqBody []byte, re
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	recordedURL := req.URL.String()
+	if override, ok := req.Context().Value(recordURLKey{}).(string); ok && override != "" {
+		recordedURL = override
+	}
+
 	interaction := cassette.Interaction{
 		Request: cassette.Request{
 			Proto:         req.Proto,
@@ -96,7 +111,7 @@ func (r *StreamingRecorder) addInteraction(req *http.Request, reqBody []byte, re
 			ContentLength: req.ContentLength,
 			Host:          req.Host,
 			Method:        req.Method,
-			URL:           req.URL.String(),
+			URL:           recordedURL,
 			Body:          string(reqBody),
 			// Headers intentionally omitted for security
 		},

--- a/pkg/recording/recording.go
+++ b/pkg/recording/recording.go
@@ -43,9 +43,11 @@ func SetupFakeProxy(ctx context.Context, fakeResponses string, streamDelayMs int
 // SetupRecordingProxy starts a recording proxy if recordPath is non-empty.
 // It handles auto-generating a filename when recordPath is "true" (from NoOptDefVal),
 // and normalizes the path by stripping any .yaml suffix.
+// When upstreamGateway is non-empty, recorded requests are forwarded through
+// that models gateway instead of the providers' public endpoints.
 // Returns the cassette path (with .yaml extension), the proxy URL, and a cleanup function.
 // The cleanup function must be called when done (typically via defer).
-func SetupRecordingProxy(ctx context.Context, recordPath string) (cassettePath, proxyURL string, cleanup func() error, err error) {
+func SetupRecordingProxy(ctx context.Context, recordPath, upstreamGateway string) (cassettePath, proxyURL string, cleanup func() error, err error) {
 	if recordPath == "" {
 		return "", "", noop, nil
 	}
@@ -57,7 +59,7 @@ func SetupRecordingProxy(ctx context.Context, recordPath string) (cassettePath, 
 		recordPath = strings.TrimSuffix(recordPath, ".yaml")
 	}
 
-	proxyURL, cleanupFn, err := fake.StartRecordingProxy(ctx, recordPath)
+	proxyURL, cleanupFn, err := fake.StartRecordingProxy(ctx, recordPath, upstreamGateway)
 	if err != nil {
 		return "", "", nil, fmt.Errorf("failed to start recording proxy: %w", err)
 	}


### PR DESCRIPTION
When `docker agent run <agent> --record` was used with a models gateway configured, the recording proxy bypassed the gateway entirely and forwarded requests directly to providers' public endpoints. This caused HTTP 401 errors (e.g. Anthropic "invalid x-api-key") because the gateway's managed credentials were never used, and environment API keys that happened to be set were injected instead.

The recording proxy now chains through the configured upstream gateway. `GatewayTargetURL` preserves the gateway's path prefix, query parameters, and percent-encoded paths when rewriting request targets. Cassette entries are stored under the canonical provider URL (via `WithRecordURL`) so existing `--fake` replay continues to work without modification.

The second commit hardens the forwarding path against credential leakage: the Docker Desktop token is never forwarded to non-Docker gateways (credential headers are stripped and provider env keys are re-applied instead); requests with an unknown or missing `X-Cagent-Forward` host are rejected rather than silently misrouted; the gateway URL is validated at startup; and full target URLs are kept out of logs and cassettes so gateway query parameters that may carry secrets are never recorded. New tests in `pkg/fake/proxy_gateway_test.go` cover forwarding, auth handling, cassette contents, and credential-leakage prevention.