### PR TITLE
fix(remote): recover proxy after cooldown instead of latching to direct

### DIFF
--- a/pkg/remote/transport.go
+++ b/pkg/remote/transport.go
@@ -17,10 +17,9 @@ import (
 
 var memoizer = memoize.New[bool](1 * time.Minute)
 
-// NewTransport returns an HTTP transport that uses Docker Desktop proxy if
-// available. If the proxy becomes unavailable during the session, it falls
-// back to direct connections and re-probes the proxy after a short cooldown,
-// so a long-lived process recovers automatically once the proxy is back.
+// NewTransport returns an HTTP transport that uses the Docker Desktop proxy
+// if available, and falls back to direct connections while re-probing the
+// proxy after a cooldown so long-lived processes recover on their own.
 func NewTransport(ctx context.Context) http.RoundTripper {
 	t, ok := http.DefaultTransport.(*http.Transport)
 	if !ok {
@@ -55,27 +54,17 @@ func NewTransport(ctx context.Context) http.RoundTripper {
 	return transport
 }
 
-// proxyRetryCooldown is how long we skip the proxy after a socket failure
-// before probing it again. Keeps the request path cheap when the proxy is
-// down for an extended period (one dial per cooldown rather than per
-// request) while still recovering automatically when the proxy comes back.
+// Bounded backoff: one probe per cooldown, not per request.
 const proxyRetryCooldown = 30 * time.Second
 
-// fallbackTransport wraps a proxy transport and falls back to a direct transport
-// when the proxy socket becomes unavailable (e.g., Docker Desktop proxy dies).
-//
-// Failures are treated as temporary: after a proxy socket error we skip the
-// proxy for proxyRetryCooldown, then probe it again on the next request. This
-// lets a long-lived agent process recover automatically once the proxy is
-// available again, instead of latching into direct mode for the rest of its
-// lifetime.
+// fallbackTransport tries the proxy first, direct second. A socket error
+// disables the proxy for proxyRetryCooldown, so a stale error can't latch
+// the transport into direct mode for the rest of the process's lifetime.
 type fallbackTransport struct {
 	proxy  *http.Transport
 	direct *http.Transport
 
-	// disabledUntilUnixNano holds the earliest wall-clock time at which the
-	// proxy may be tried again, encoded as time.Time.UnixNano(). Zero means
-	// the proxy is currently enabled.
+	// Zero = enabled. Non-zero = disabled until this UnixNano deadline.
 	disabledUntilUnixNano atomic.Int64
 }
 
@@ -94,9 +83,6 @@ func (f *fallbackTransport) DisableCompression() {
 	f.direct.DisableCompression = true
 }
 
-// proxyEnabled reports whether the proxy should be tried on this request. It
-// also clears an expired cooldown so the next caller in the cooldown-expired
-// state re-enters the "enabled" branch cleanly.
 func (f *fallbackTransport) proxyEnabled() bool {
 	until := f.disabledUntilUnixNano.Load()
 	if until == 0 {
@@ -105,57 +91,48 @@ func (f *fallbackTransport) proxyEnabled() bool {
 	if time.Now().UnixNano() < until {
 		return false
 	}
+	// CAS (not Store) so a concurrent disableProxy() can't be stomped.
 	f.disabledUntilUnixNano.CompareAndSwap(until, 0)
 	return true
 }
 
-// disableProxy marks the proxy as unavailable for proxyRetryCooldown.
 func (f *fallbackTransport) disableProxy() {
 	f.disabledUntilUnixNano.Store(time.Now().Add(proxyRetryCooldown).UnixNano())
 }
 
-// RoundTrip implements http.RoundTripper.
 func (f *fallbackTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	// If the proxy is currently on cooldown, skip straight to direct.
 	if !f.proxyEnabled() {
 		return f.direct.RoundTrip(req)
 	}
 
-	// Try the proxy first
 	resp, err := f.proxy.RoundTrip(req)
 	if err == nil {
 		return resp, nil
 	}
-
-	// Check if this is a proxy socket error (socket gone, connection refused, etc.)
-	if isProxySocketError(err) {
-		slog.Warn("Docker Desktop proxy unavailable, falling back to direct connection",
-			"error", err.Error(),
-			"url", req.URL.String(),
-			"retry_after", proxyRetryCooldown)
-
-		// Skip the proxy on subsequent requests until the cooldown expires.
-		f.disableProxy()
-
-		// Clone the request for retry (the body may have been partially read)
-		// For requests without a body or with GetBody set, we can retry
-		if req.Body == nil || req.GetBody != nil {
-			retryReq := req.Clone(req.Context())
-			if req.GetBody != nil {
-				var bodyErr error
-				retryReq.Body, bodyErr = req.GetBody()
-				if bodyErr != nil {
-					return nil, err // Return original error if we can't get the body
-				}
-			}
-			return f.direct.RoundTrip(retryReq)
-		}
-
-		// Can't retry requests with consumed bodies
+	if !isProxySocketError(err) {
 		return nil, err
 	}
 
-	return nil, err
+	slog.Warn("Docker Desktop proxy unavailable, falling back to direct connection",
+		"error", err.Error(),
+		"url", req.URL.String(),
+		"retry_after", proxyRetryCooldown)
+	f.disableProxy()
+
+	// Retry direct only when the body is safe to replay; otherwise the
+	// proxy may have already consumed it.
+	if req.Body != nil && req.GetBody == nil {
+		return nil, err
+	}
+	retryReq := req.Clone(req.Context())
+	if req.GetBody != nil {
+		body, bodyErr := req.GetBody()
+		if bodyErr != nil {
+			return nil, err
+		}
+		retryReq.Body = body
+	}
+	return f.direct.RoundTrip(retryReq)
 }
 
 // isProxySocketError checks if the error indicates the proxy socket is unavailable.

--- a/pkg/remote/transport.go
+++ b/pkg/remote/transport.go
@@ -17,9 +17,10 @@ import (
 
 var memoizer = memoize.New[bool](1 * time.Minute)
 
-// NewTransport returns an HTTP transport that uses Docker Desktop proxy if available.
-// If the proxy becomes unavailable during the session, it automatically falls back
-// to direct connections.
+// NewTransport returns an HTTP transport that uses Docker Desktop proxy if
+// available. If the proxy becomes unavailable during the session, it falls
+// back to direct connections and re-probes the proxy after a short cooldown,
+// so a long-lived process recovers automatically once the proxy is back.
 func NewTransport(ctx context.Context) http.RoundTripper {
 	t, ok := http.DefaultTransport.(*http.Transport)
 	if !ok {
@@ -54,15 +55,28 @@ func NewTransport(ctx context.Context) http.RoundTripper {
 	return transport
 }
 
+// proxyRetryCooldown is how long we skip the proxy after a socket failure
+// before probing it again. Keeps the request path cheap when the proxy is
+// down for an extended period (one dial per cooldown rather than per
+// request) while still recovering automatically when the proxy comes back.
+const proxyRetryCooldown = 30 * time.Second
+
 // fallbackTransport wraps a proxy transport and falls back to a direct transport
 // when the proxy socket becomes unavailable (e.g., Docker Desktop proxy dies).
+//
+// Failures are treated as temporary: after a proxy socket error we skip the
+// proxy for proxyRetryCooldown, then probe it again on the next request. This
+// lets a long-lived agent process recover automatically once the proxy is
+// available again, instead of latching into direct mode for the rest of its
+// lifetime.
 type fallbackTransport struct {
 	proxy  *http.Transport
 	direct *http.Transport
 
-	// proxyDisabled is set to true when the proxy socket becomes unavailable.
-	// Once set, all subsequent requests go directly without trying the proxy.
-	proxyDisabled atomic.Bool
+	// disabledUntilUnixNano holds the earliest wall-clock time at which the
+	// proxy may be tried again, encoded as time.Time.UnixNano(). Zero means
+	// the proxy is currently enabled.
+	disabledUntilUnixNano atomic.Int64
 }
 
 // newFallbackTransport creates a transport that tries the proxy first, then falls back to direct.
@@ -80,10 +94,30 @@ func (f *fallbackTransport) DisableCompression() {
 	f.direct.DisableCompression = true
 }
 
+// proxyEnabled reports whether the proxy should be tried on this request. It
+// also clears an expired cooldown so the next caller in the cooldown-expired
+// state re-enters the "enabled" branch cleanly.
+func (f *fallbackTransport) proxyEnabled() bool {
+	until := f.disabledUntilUnixNano.Load()
+	if until == 0 {
+		return true
+	}
+	if time.Now().UnixNano() < until {
+		return false
+	}
+	f.disabledUntilUnixNano.CompareAndSwap(until, 0)
+	return true
+}
+
+// disableProxy marks the proxy as unavailable for proxyRetryCooldown.
+func (f *fallbackTransport) disableProxy() {
+	f.disabledUntilUnixNano.Store(time.Now().Add(proxyRetryCooldown).UnixNano())
+}
+
 // RoundTrip implements http.RoundTripper.
 func (f *fallbackTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	// If proxy is already known to be disabled, go direct
-	if f.proxyDisabled.Load() {
+	// If the proxy is currently on cooldown, skip straight to direct.
+	if !f.proxyEnabled() {
 		return f.direct.RoundTrip(req)
 	}
 
@@ -97,10 +131,11 @@ func (f *fallbackTransport) RoundTrip(req *http.Request) (*http.Response, error)
 	if isProxySocketError(err) {
 		slog.Warn("Docker Desktop proxy unavailable, falling back to direct connection",
 			"error", err.Error(),
-			"url", req.URL.String())
+			"url", req.URL.String(),
+			"retry_after", proxyRetryCooldown)
 
-		// Disable proxy for future requests
-		f.proxyDisabled.Store(true)
+		// Skip the proxy on subsequent requests until the cooldown expires.
+		f.disableProxy()
 
 		// Clone the request for retry (the body may have been partially read)
 		// For requests without a body or with GetBody set, we can retry

--- a/pkg/remote/transport_test.go
+++ b/pkg/remote/transport_test.go
@@ -147,8 +147,6 @@ func (e *testError) Error() string {
 	return e.msg
 }
 
-// countingRoundTripper is a test http.RoundTripper that records how many
-// times it was called and returns a fixed response or error.
 type countingRoundTripper struct {
 	calls atomic.Int32
 	err   error
@@ -166,9 +164,8 @@ func (c *countingRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 	}, nil
 }
 
-// fakeFallback drives the same enabled/cooldown state machine as
-// fallbackTransport but against http.RoundTripper fakes instead of real
-// *http.Transport instances, so tests don't have to stand up a Unix socket.
+// fakeFallback drives the fallbackTransport state machine against RoundTripper
+// fakes so tests don't need a real Unix socket.
 type fakeFallback struct {
 	*fallbackTransport
 
@@ -208,28 +205,26 @@ func TestFallbackTransport_ProxyRecoversAfterCooldown(t *testing.T) {
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.invalid/", http.NoBody)
 	require.NoError(t, err)
 
-	// First request: proxy fails with a socket error, falls back to direct.
+	// 1st request: proxy fails → direct.
 	resp, err := ft.RoundTrip(req)
 	require.NoError(t, err)
 	_ = resp.Body.Close()
 	require.Equal(t, int32(1), ft.fakeProxy.calls.Load())
 	require.Equal(t, int32(1), ft.fakeDirect.calls.Load())
 
-	// Second request while still on cooldown: skips the proxy entirely.
+	// 2nd request: still on cooldown, proxy is skipped.
 	resp, err = ft.RoundTrip(req)
 	require.NoError(t, err)
 	_ = resp.Body.Close()
 	require.Equal(t, int32(1), ft.fakeProxy.calls.Load(), "proxy should be skipped during cooldown")
 	require.Equal(t, int32(2), ft.fakeDirect.calls.Load())
 
-	// Simulate the cooldown expiring by pushing the deadline into the past.
-	// This exercises the CompareAndSwap clear branch inside proxyEnabled(),
-	// rather than short-circuiting via a zero value. Also swap the proxy to
-	// a healthy variant so the retry succeeds.
+	// Push the deadline into the past to exercise the CAS clear branch in
+	// proxyEnabled (Store(0) would short-circuit it).
 	ft.disabledUntilUnixNano.Store(time.Now().Add(-time.Second).UnixNano())
 	ft.fakeProxy = &countingRoundTripper{}
 
-	// Third request: cooldown has elapsed, proxy is probed again and succeeds.
+	// 3rd request: cooldown elapsed, proxy re-probed and succeeds.
 	resp, err = ft.RoundTrip(req)
 	require.NoError(t, err)
 	_ = resp.Body.Close()
@@ -237,12 +232,11 @@ func TestFallbackTransport_ProxyRecoversAfterCooldown(t *testing.T) {
 	assert.Equal(t, int32(2), ft.fakeDirect.calls.Load(), "direct should not be hit once proxy recovers")
 }
 
+// Non-socket errors (e.g. upstream timeouts) must not trip the cooldown,
+// otherwise a transient upstream problem would look like a proxy outage.
 func TestFallbackTransport_NonSocketErrorDoesNotDisableProxy(t *testing.T) {
 	t.Parallel()
 
-	// A non-socket error (e.g. a plain network timeout) must not trip the
-	// cooldown — otherwise a transient upstream problem would look like a
-	// proxy outage and route every subsequent request direct.
 	upstreamErr := &testError{msg: "read tcp 10.0.0.1:443: i/o timeout"}
 	ft := newFakeFallback(upstreamErr, nil)
 
@@ -262,17 +256,12 @@ func TestFallbackTransport_ProxyEnabledAfterCooldownExpires(t *testing.T) {
 
 	ft := newFallbackTransport(&http.Transport{}, &http.Transport{})
 
-	// Nothing disabled yet.
 	require.True(t, ft.proxyEnabled())
 
-	// Disable with a past deadline: proxyEnabled must observe the expiry
-	// and clear the marker back to zero.
 	ft.disabledUntilUnixNano.Store(time.Now().Add(-time.Second).UnixNano())
 	require.True(t, ft.proxyEnabled(), "expired cooldown should re-enable the proxy")
 	require.Equal(t, int64(0), ft.disabledUntilUnixNano.Load(), "expired cooldown should be cleared")
 
-	// Disable with a future deadline: proxyEnabled must return false and
-	// leave the marker untouched.
 	future := time.Now().Add(time.Hour).UnixNano()
 	ft.disabledUntilUnixNano.Store(future)
 	require.False(t, ft.proxyEnabled())

--- a/pkg/remote/transport_test.go
+++ b/pkg/remote/transport_test.go
@@ -1,9 +1,12 @@
 package remote
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -142,4 +145,135 @@ type testError struct {
 
 func (e *testError) Error() string {
 	return e.msg
+}
+
+// countingRoundTripper is a test http.RoundTripper that records how many
+// times it was called and returns a fixed response or error.
+type countingRoundTripper struct {
+	calls atomic.Int32
+	err   error
+}
+
+func (c *countingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.calls.Add(1)
+	if c.err != nil {
+		return nil, c.err
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       http.NoBody,
+		Request:    req,
+	}, nil
+}
+
+// fakeFallback drives the same enabled/cooldown state machine as
+// fallbackTransport but against http.RoundTripper fakes instead of real
+// *http.Transport instances, so tests don't have to stand up a Unix socket.
+type fakeFallback struct {
+	*fallbackTransport
+
+	fakeProxy  *countingRoundTripper
+	fakeDirect *countingRoundTripper
+}
+
+func (f *fakeFallback) RoundTrip(req *http.Request) (*http.Response, error) {
+	if !f.proxyEnabled() {
+		return f.fakeDirect.RoundTrip(req)
+	}
+	resp, err := f.fakeProxy.RoundTrip(req)
+	if err == nil {
+		return resp, nil
+	}
+	if isProxySocketError(err) {
+		f.disableProxy()
+		return f.fakeDirect.RoundTrip(req)
+	}
+	return nil, err
+}
+
+func newFakeFallback(proxyErr, directErr error) *fakeFallback {
+	return &fakeFallback{
+		fallbackTransport: newFallbackTransport(&http.Transport{}, &http.Transport{}),
+		fakeProxy:         &countingRoundTripper{err: proxyErr},
+		fakeDirect:        &countingRoundTripper{err: directErr},
+	}
+}
+
+func TestFallbackTransport_ProxyRecoversAfterCooldown(t *testing.T) {
+	t.Parallel()
+
+	proxySocketErr := &testError{msg: "proxyconnect tcp: dial unix /path/to/httpproxy.sock: connect: no such file or directory"}
+	ft := newFakeFallback(proxySocketErr, nil)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.invalid/", http.NoBody)
+	require.NoError(t, err)
+
+	// First request: proxy fails with a socket error, falls back to direct.
+	resp, err := ft.RoundTrip(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, int32(1), ft.fakeProxy.calls.Load())
+	require.Equal(t, int32(1), ft.fakeDirect.calls.Load())
+
+	// Second request while still on cooldown: skips the proxy entirely.
+	resp, err = ft.RoundTrip(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, int32(1), ft.fakeProxy.calls.Load(), "proxy should be skipped during cooldown")
+	require.Equal(t, int32(2), ft.fakeDirect.calls.Load())
+
+	// Simulate the cooldown expiring by clearing the disabled marker directly
+	// (equivalent to time.Now() advancing past disabledUntilUnixNano). Also
+	// swap the proxy to a healthy variant so the retry succeeds.
+	ft.disabledUntilUnixNano.Store(0)
+	ft.fakeProxy = &countingRoundTripper{}
+
+	// Third request: cooldown has elapsed, proxy is probed again and succeeds.
+	resp, err = ft.RoundTrip(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	assert.Equal(t, int32(1), ft.fakeProxy.calls.Load(), "healthy proxy should be tried again once cooldown expires")
+	assert.Equal(t, int32(2), ft.fakeDirect.calls.Load(), "direct should not be hit once proxy recovers")
+}
+
+func TestFallbackTransport_NonSocketErrorDoesNotDisableProxy(t *testing.T) {
+	t.Parallel()
+
+	// A non-socket error (e.g. a plain network timeout) must not trip the
+	// cooldown — otherwise a transient upstream problem would look like a
+	// proxy outage and route every subsequent request direct.
+	upstreamErr := &testError{msg: "read tcp 10.0.0.1:443: i/o timeout"}
+	ft := newFakeFallback(upstreamErr, nil)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.invalid/", http.NoBody)
+	require.NoError(t, err)
+
+	resp, err := ft.RoundTrip(req) //nolint:bodyclose // resp is nil on error, checked below
+	require.Error(t, err)
+	require.Nil(t, resp)
+	assert.True(t, errors.Is(err, upstreamErr) || err.Error() == upstreamErr.Error())
+	assert.True(t, ft.proxyEnabled(), "proxy must stay enabled after a non-socket error")
+	assert.Equal(t, int32(0), ft.fakeDirect.calls.Load(), "direct must not be tried on non-socket errors")
+}
+
+func TestFallbackTransport_ProxyEnabledAfterCooldownExpires(t *testing.T) {
+	t.Parallel()
+
+	ft := newFallbackTransport(&http.Transport{}, &http.Transport{})
+
+	// Nothing disabled yet.
+	require.True(t, ft.proxyEnabled())
+
+	// Disable with a past deadline: proxyEnabled must observe the expiry
+	// and clear the marker back to zero.
+	ft.disabledUntilUnixNano.Store(time.Now().Add(-time.Second).UnixNano())
+	require.True(t, ft.proxyEnabled(), "expired cooldown should re-enable the proxy")
+	require.Equal(t, int64(0), ft.disabledUntilUnixNano.Load(), "expired cooldown should be cleared")
+
+	// Disable with a future deadline: proxyEnabled must return false and
+	// leave the marker untouched.
+	future := time.Now().Add(time.Hour).UnixNano()
+	ft.disabledUntilUnixNano.Store(future)
+	require.False(t, ft.proxyEnabled())
+	require.Equal(t, future, ft.disabledUntilUnixNano.Load())
 }

--- a/pkg/remote/transport_test.go
+++ b/pkg/remote/transport_test.go
@@ -222,10 +222,11 @@ func TestFallbackTransport_ProxyRecoversAfterCooldown(t *testing.T) {
 	require.Equal(t, int32(1), ft.fakeProxy.calls.Load(), "proxy should be skipped during cooldown")
 	require.Equal(t, int32(2), ft.fakeDirect.calls.Load())
 
-	// Simulate the cooldown expiring by clearing the disabled marker directly
-	// (equivalent to time.Now() advancing past disabledUntilUnixNano). Also
-	// swap the proxy to a healthy variant so the retry succeeds.
-	ft.disabledUntilUnixNano.Store(0)
+	// Simulate the cooldown expiring by pushing the deadline into the past.
+	// This exercises the CompareAndSwap clear branch inside proxyEnabled(),
+	// rather than short-circuiting via a zero value. Also swap the proxy to
+	// a healthy variant so the retry succeeds.
+	ft.disabledUntilUnixNano.Store(time.Now().Add(-time.Second).UnixNano())
 	ft.fakeProxy = &countingRoundTripper{}
 
 	// Third request: cooldown has elapsed, proxy is probed again and succeeds.


### PR DESCRIPTION
## Motivation

`fallbackTransport` was designed to gracefully degrade when the HTTP proxy socket that docker-agent optionally routes through disappears mid-session. In practice the "graceful degradation" is a one-way trap: the first socket error flips a `proxyDisabled` flag that is never cleared, so every subsequent request in that process goes direct forever — even after the proxy comes back.

For short-lived CLI invocations this is fine. For a long-lived process (any interactive session, server, or agent host that outlives a single proxy outage) it means the proxy stops being used the first time the socket blips, and the only way to get it back is to restart the process.

```
Before                                     After
------                                     -----

t0  proxy up                               t0  proxy up
    request -> proxy: OK                       request -> proxy: OK

t1  proxy stops                            t1  proxy stops
    request -> proxy: error                    request -> proxy: error
    proxyDisabled = true (permanent)           proxy disabled until t1+30s
    fallback to direct                         fallback to direct

t2  proxy back up                          t2  proxy back up (still in cooldown)
    request -> direct forever                  request -> direct

    ...                                    t1+30s+ cooldown expires
                                               next request -> proxy: OK
                                               back to normal
```

## Why a cooldown rather than always retrying

Always re-probing on every request would add a dial round-trip to every hot-path request while the proxy is down. A short cooldown (30s) keeps the request path cheap during an extended outage while still recovering automatically — one dial per cooldown, not per request.

## Why not just remove the fallback altogether

Some traffic through this transport (OCI push/pull, catalog lookups) works fine on a direct connection when the proxy is unavailable. Auth-required traffic doesn't, and callers already own that concern. This PR changes only the recovery behaviour, not the routing decision.
