### PR TITLE
fix: show proper toolset names in /tools dialog for loader-created toolsets

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1030,23 +1030,30 @@ func (r *LocalRuntime) AgentToolsetStatuses(name string) []tools.ToolsetStatus {
 //   - no toolset matches name (matching uses the same logic as the
 //     /tools dialog: the toolset's Name() if any, otherwise its
 //     description),
-//   - the toolset is not supervisor-backed (no Restartable capability),
+//   - no matching toolset is supervisor-backed (no Restartable capability),
 //   - the supervisor itself returned an error (timeout, classified
 //     transport failure, etc.).
+//
+// Display names are not guaranteed unique (a YAML name: can shadow a
+// built-in), so non-restartable matches are skipped rather than aborting:
+// the first restartable toolset with the given name wins.
 func (r *LocalRuntime) RestartToolset(ctx context.Context, name string) error {
 	a := r.CurrentAgent()
 	if a == nil {
 		return errors.New("no active agent")
 	}
+	found := false
 	for _, ts := range a.ToolSets() {
 		if nameFor(ts, tools.DescribeToolSet(ts)) != name {
 			continue
 		}
-		restartable, ok := tools.As[tools.Restartable](ts)
-		if !ok {
-			return fmt.Errorf("toolset %q does not support restart", name)
+		found = true
+		if restartable, ok := tools.As[tools.Restartable](ts); ok {
+			return restartable.Restart(ctx)
 		}
-		return restartable.Restart(ctx)
+	}
+	if found {
+		return fmt.Errorf("toolset %q does not support restart", name)
 	}
 	return fmt.Errorf("toolset %q not found", name)
 }

--- a/pkg/tools/builtin/deferred/deferred.go
+++ b/pkg/tools/builtin/deferred/deferred.go
@@ -36,6 +36,7 @@ var (
 	_ tools.ToolSet      = (*ToolSet)(nil)
 	_ tools.Startable    = (*ToolSet)(nil)
 	_ tools.Instructable = (*ToolSet)(nil)
+	_ tools.Named        = (*ToolSet)(nil)
 )
 
 type deferredSource struct {
@@ -49,6 +50,11 @@ func New() *ToolSet {
 		deferredTools:  make(map[string]deferredToolEntry),
 		activatedTools: make(map[string]tools.Tool),
 	}
+}
+
+// Name implements tools.Named; loader-created, so no registry WithName wrapper.
+func (d *ToolSet) Name() string {
+	return "deferred"
 }
 
 func (d *ToolSet) AddSource(toolset tools.ToolSet, deferAll bool, toolNames []string) {

--- a/pkg/tools/builtin/handoff/handoff.go
+++ b/pkg/tools/builtin/handoff/handoff.go
@@ -10,7 +10,10 @@ const ToolNameHandoff = "handoff"
 
 type ToolSet struct{}
 
-var _ tools.ToolSet = (*ToolSet)(nil)
+var (
+	_ tools.ToolSet = (*ToolSet)(nil)
+	_ tools.Named   = (*ToolSet)(nil)
+)
 
 type Args struct {
 	Agent string `json:"agent" jsonschema:"The name of the agent to hand off the conversation to."`
@@ -18,6 +21,11 @@ type Args struct {
 
 func New() *ToolSet {
 	return &ToolSet{}
+}
+
+// Name implements tools.Named; loader-created, so no registry WithName wrapper.
+func (t *ToolSet) Name() string {
+	return ToolNameHandoff
 }
 
 func (t *ToolSet) Tools(context.Context) ([]tools.Tool, error) {

--- a/pkg/tools/builtin/skills/skills.go
+++ b/pkg/tools/builtin/skills/skills.go
@@ -20,6 +20,7 @@ const (
 var (
 	_ tools.ToolSet      = (*ToolSet)(nil)
 	_ tools.Instructable = (*ToolSet)(nil)
+	_ tools.Named        = (*ToolSet)(nil)
 )
 
 // BuildSkillUserMessage formats a PreparedSkillFork as the implicit user
@@ -94,6 +95,11 @@ func New(loadedSkills []skills.Skill, workingDir string) *ToolSet {
 // after resolving the skills' declared toolset names.
 func (s *ToolSet) SetForkToolSets(m map[string][]tools.ToolSet) {
 	s.forkToolSets = m
+}
+
+// Name implements tools.Named; loader-created, so no registry WithName wrapper.
+func (s *ToolSet) Name() string {
+	return "skills"
 }
 
 // Skills returns the loaded skills (used by the app layer for slash commands).

--- a/pkg/tools/builtin/transfertask/transfertask.go
+++ b/pkg/tools/builtin/transfertask/transfertask.go
@@ -10,7 +10,10 @@ const ToolNameTransferTask = "transfer_task"
 
 type ToolSet struct{}
 
-var _ tools.ToolSet = (*ToolSet)(nil)
+var (
+	_ tools.ToolSet = (*ToolSet)(nil)
+	_ tools.Named   = (*ToolSet)(nil)
+)
 
 type Args struct {
 	Agent          string `json:"agent" jsonschema:"The name of the agent to transfer the task to."`
@@ -20,6 +23,11 @@ type Args struct {
 
 func New() *ToolSet {
 	return &ToolSet{}
+}
+
+// Name implements tools.Named; loader-created, so no registry WithName wrapper.
+func (t *ToolSet) Name() string {
+	return ToolNameTransferTask
 }
 
 func (t *ToolSet) Tools(context.Context) ([]tools.Tool, error) {

--- a/pkg/tools/codemode/codemode.go
+++ b/pkg/tools/codemode/codemode.go
@@ -42,7 +42,13 @@ type codeModeTool struct {
 var (
 	_ tools.ToolSet   = (*codeModeTool)(nil)
 	_ tools.Startable = (*codeModeTool)(nil)
+	_ tools.Named     = (*codeModeTool)(nil)
 )
+
+// Name implements tools.Named; loader-created, so no registry WithName wrapper.
+func (c *codeModeTool) Name() string {
+	return "code_mode"
+}
 
 type RunToolsWithJavascriptArgs struct {
 	Script string `json:"script" jsonschema:"Script to execute"`


### PR DESCRIPTION
Toolsets created directly by the team loader — `skills`, `transfer_task`, `handoff`, `deferred`, and `code_mode` — bypass the registry's `tools.WithName` wrapper. Because they implemented neither `tools.Named` nor `tools.Describer`, the `/tools` TUI dialog fell back to Go type names such as `*skills.ToolSet`, which made the picker hard to read and navigate.

Each of those toolset types now implements `tools.Named`, returning a stable, human-readable name. The `transfer_task` and `handoff` implementations reuse their existing `ToolName` constants so the name is defined in exactly one place. `RestartToolset` in the runtime was also tightened: it now skips non-restartable name matches rather than aborting on the first hit, since display names are not guaranteed to be unique across toolsets.

No behaviour changes outside the `/tools` dialog display names.