### PR TITLE
feat(picker): add Lean Mode checkbox to agent picker

### DIFF
--- a/cmd/root/agent_picker.go
+++ b/cmd/root/agent_picker.go
@@ -78,15 +78,16 @@ func loadAgentChoices(ctx context.Context, refs []string, env environment.Provid
 	return choices
 }
 
-// selectAgentRef shows a full-screen picker and returns the chosen agent ref.
-// When only a single ref is supplied there is nothing to choose, so it is
-// returned directly without showing any UI.
-func selectAgentRef(ctx context.Context, refs []string, env environment.Provider) (string, error) {
+// selectAgentRef shows a full-screen picker and returns the chosen agent ref
+// along with whether the user ticked the "Lean Mode" checkbox. When only a
+// single ref is supplied there is nothing to choose, so it is returned
+// directly without showing any UI.
+func selectAgentRef(ctx context.Context, refs []string, env environment.Provider) (ref string, lean bool, err error) {
 	if len(refs) == 0 {
-		return "", errors.New("no agent refs to choose from")
+		return "", false, errors.New("no agent refs to choose from")
 	}
 	if len(refs) == 1 {
-		return refs[0], nil
+		return refs[0], false, nil
 	}
 
 	choices := loadAgentChoices(ctx, refs, env)
@@ -95,14 +96,14 @@ func selectAgentRef(ctx context.Context, refs []string, env environment.Provider
 	p := tea.NewProgram(m, tea.WithContext(ctx))
 	final, err := p.Run()
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 
 	result, ok := final.(*agentPickerModel)
 	if !ok || result.cancelled {
-		return "", errAgentPickerCancelled
+		return "", false, errAgentPickerCancelled
 	}
-	return result.choices[result.cursor].ref, nil
+	return result.choices[result.cursor].ref, result.leanMode, nil
 }
 
 // agentPickerKeyMap holds the key bindings for the agent picker.
@@ -111,6 +112,7 @@ type agentPickerKeyMap struct {
 	Down    key.Binding
 	Choose  key.Binding
 	Details key.Binding
+	Lean    key.Binding
 	Quit    key.Binding
 }
 
@@ -131,6 +133,10 @@ var agentPickerKeys = agentPickerKeyMap{
 		key.WithKeys("?"),
 		key.WithHelp("?", "view yaml"),
 	),
+	Lean: key.NewBinding(
+		key.WithKeys("l"),
+		key.WithHelp("l", "toggle lean mode"),
+	),
 	Quit: key.NewBinding(
 		key.WithKeys("esc", "ctrl+c", "q"),
 		key.WithHelp("esc", "cancel"),
@@ -144,6 +150,10 @@ type agentPickerModel struct {
 	width     int
 	height    int
 	cancelled bool
+
+	// leanMode mirrors the "Lean Mode" checkbox: when ticked the chosen
+	// agent runs in the lean TUI instead of the full one. Off by default.
+	leanMode bool
 
 	// showDetails toggles the scrollable YAML dialog overlay for the
 	// currently selected agent.
@@ -223,6 +233,9 @@ func (m *agentPickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case key.Matches(msg, agentPickerKeys.Details):
 			m.openDetails()
 			return m, nil
+		case key.Matches(msg, agentPickerKeys.Lean):
+			m.leanMode = !m.leanMode
+			return m, nil
 		case key.Matches(msg, agentPickerKeys.Choose):
 			return m, tea.Quit
 		}
@@ -252,6 +265,11 @@ func (m *agentPickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // selection. Clicks are ignored while the YAML dialog is open.
 func (m *agentPickerModel) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 	if m.showDetails || msg.Button != tea.MouseLeft {
+		return m, nil
+	}
+	if m.leanCheckboxAt(msg.X, msg.Y) {
+		m.leanMode = !m.leanMode
+		m.lastClickIndex = -1
 		return m, nil
 	}
 	i, ok := m.cardAt(msg.X, msg.Y)
@@ -495,6 +513,32 @@ func (m *agentPickerModel) cardAt(x, y int) (int, bool) {
 	return i, true
 }
 
+// leanCheckboxAt reports whether terminal coordinates land on the "Lean
+// Mode" checkbox row. It mirrors the layout produced by render: the checkbox
+// sits one blank row below the last card, at the cards' left offset.
+func (m *agentPickerModel) leanCheckboxAt(x, y int) bool {
+	panelWidth, panelHeight := m.panelSize()
+	originX := max((m.width-panelWidth)/2, 0)
+	originY := max((m.height-panelHeight)/2, 0)
+
+	cardRows := len(m.choices)*agentPickerCardHeight + max(len(m.choices)-1, 0)*agentPickerCardGap
+	checkboxY := originY + agentPickerCardsTop + cardRows + 1
+	if y != checkboxY {
+		return false
+	}
+	relX := x - originX - agentPickerCardsLeft
+	return relX >= 0 && relX < lipgloss.Width(m.leanCheckbox())
+}
+
+// leanCheckbox renders the "Lean Mode" checkbox line.
+func (m *agentPickerModel) leanCheckbox() string {
+	box := "[ ]"
+	if m.leanMode {
+		box = styles.SuccessStyle.Render("[x]")
+	}
+	return box + " " + styles.SecondaryStyle.Render("Lean Mode")
+}
+
 // panelSize returns the outer dimensions of the rendered picker panel without
 // rendering every card. cardAt relies on it to place hit zones, and it is
 // called on every mouse-motion event, so it must stay cheap: cards all share
@@ -510,9 +554,9 @@ func (m *agentPickerModel) panelSize() (w, h int) {
 	// Horizontal chrome: border (1) + padding (4) on each side.
 	w = contentWidth + 2*(1+4)
 	// Content rows: title + blank + subtitle + blank + cards (with gaps) +
-	// blank + help.
+	// blank + lean checkbox + blank + help.
 	cardRows := len(m.choices)*agentPickerCardHeight + max(len(m.choices)-1, 0)*agentPickerCardGap
-	rows := 4 + cardRows + 2
+	rows := 4 + cardRows + 4
 	// Vertical chrome: border (2) + padding (2).
 	h = rows + 4
 	return w, h
@@ -529,6 +573,7 @@ func (m *agentPickerModel) headerText() (title, subtitle, help string) {
 			"double-click select",
 			agentPickerKeys.Choose.Help().Key + " " + agentPickerKeys.Choose.Help().Desc,
 			agentPickerKeys.Details.Help().Key + " " + agentPickerKeys.Details.Help().Desc,
+			agentPickerKeys.Lean.Help().Key + " " + agentPickerKeys.Lean.Help().Desc,
 			agentPickerKeys.Quit.Help().Key + " " + agentPickerKeys.Quit.Help().Desc,
 		}, "   "),
 	)
@@ -555,6 +600,8 @@ func (m *agentPickerModel) render() string {
 		subtitle,
 		"",
 		list,
+		"",
+		m.leanCheckbox(),
 		"",
 		help,
 	)

--- a/cmd/root/agent_picker.go
+++ b/cmd/root/agent_picker.go
@@ -79,19 +79,22 @@ func loadAgentChoices(ctx context.Context, refs []string, env environment.Provid
 }
 
 // selectAgentRef shows a full-screen picker and returns the chosen agent ref
-// along with whether the user ticked the "Lean Mode" checkbox. When only a
-// single ref is supplied there is nothing to choose, so it is returned
-// directly without showing any UI.
-func selectAgentRef(ctx context.Context, refs []string, env environment.Provider) (ref string, lean bool, err error) {
+// along with whether the user wants lean mode. The "Lean Mode" checkbox is
+// seeded with initialLean (the effective lean state from flags/user config)
+// so what the user sees always matches what will run; the returned value is
+// authoritative. When only a single ref is supplied there is nothing to
+// choose, so it is returned directly without showing any UI.
+func selectAgentRef(ctx context.Context, refs []string, env environment.Provider, initialLean bool) (ref string, lean bool, err error) {
 	if len(refs) == 0 {
 		return "", false, errors.New("no agent refs to choose from")
 	}
 	if len(refs) == 1 {
-		return refs[0], false, nil
+		return refs[0], initialLean, nil
 	}
 
 	choices := loadAgentChoices(ctx, refs, env)
 	m := newAgentPickerModel(choices)
+	m.leanMode = initialLean
 
 	p := tea.NewProgram(m, tea.WithContext(ctx))
 	final, err := p.Run()
@@ -152,7 +155,8 @@ type agentPickerModel struct {
 	cancelled bool
 
 	// leanMode mirrors the "Lean Mode" checkbox: when ticked the chosen
-	// agent runs in the lean TUI instead of the full one. Off by default.
+	// agent runs in the lean TUI instead of the full one. Seeded by the
+	// caller with the effective lean state (off by default).
 	leanMode bool
 
 	// showDetails toggles the scrollable YAML dialog overlay for the
@@ -269,7 +273,7 @@ func (m *agentPickerModel) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, t
 	}
 	if m.leanCheckboxAt(msg.X, msg.Y) {
 		m.leanMode = !m.leanMode
-		m.lastClickIndex = -1
+		m.resetClickTracking()
 		return m, nil
 	}
 	i, ok := m.cardAt(msg.X, msg.Y)
@@ -485,14 +489,24 @@ func (m *agentPickerModel) cardWidth() int {
 	return w
 }
 
+// panelOrigin returns the top-left corner of the centered picker panel.
+func (m *agentPickerModel) panelOrigin() (x, y int) {
+	panelWidth, panelHeight := m.panelSize()
+	return max((m.width-panelWidth)/2, 0), max((m.height-panelHeight)/2, 0)
+}
+
+// cardRows returns the number of rows occupied by the stacked cards,
+// including the gaps between them.
+func (m *agentPickerModel) cardRows() int {
+	return len(m.choices)*agentPickerCardHeight + max(len(m.choices)-1, 0)*agentPickerCardGap
+}
+
 // cardAt maps terminal coordinates to the index of the agent card under them.
 // It mirrors the layout produced by render: the panel is centered, and cards
 // are stacked with no gaps below the title/subtitle. The bool is false when
 // the point is outside every card.
 func (m *agentPickerModel) cardAt(x, y int) (int, bool) {
-	panelWidth, panelHeight := m.panelSize()
-	originX := max((m.width-panelWidth)/2, 0)
-	originY := max((m.height-panelHeight)/2, 0)
+	originX, originY := m.panelOrigin()
 
 	cardWidth := m.cardWidth()
 	relX := x - originX - agentPickerCardsLeft
@@ -517,12 +531,9 @@ func (m *agentPickerModel) cardAt(x, y int) (int, bool) {
 // Mode" checkbox row. It mirrors the layout produced by render: the checkbox
 // sits one blank row below the last card, at the cards' left offset.
 func (m *agentPickerModel) leanCheckboxAt(x, y int) bool {
-	panelWidth, panelHeight := m.panelSize()
-	originX := max((m.width-panelWidth)/2, 0)
-	originY := max((m.height-panelHeight)/2, 0)
+	originX, originY := m.panelOrigin()
 
-	cardRows := len(m.choices)*agentPickerCardHeight + max(len(m.choices)-1, 0)*agentPickerCardGap
-	checkboxY := originY + agentPickerCardsTop + cardRows + 1
+	checkboxY := originY + agentPickerCardsTop + m.cardRows() + 1
 	if y != checkboxY {
 		return false
 	}
@@ -532,7 +543,7 @@ func (m *agentPickerModel) leanCheckboxAt(x, y int) bool {
 
 // leanCheckbox renders the "Lean Mode" checkbox line.
 func (m *agentPickerModel) leanCheckbox() string {
-	box := "[ ]"
+	box := styles.MutedStyle.Render("[ ]")
 	if m.leanMode {
 		box = styles.SuccessStyle.Render("[x]")
 	}
@@ -555,8 +566,7 @@ func (m *agentPickerModel) panelSize() (w, h int) {
 	w = contentWidth + 2*(1+4)
 	// Content rows: title + blank + subtitle + blank + cards (with gaps) +
 	// blank + lean checkbox + blank + help.
-	cardRows := len(m.choices)*agentPickerCardHeight + max(len(m.choices)-1, 0)*agentPickerCardGap
-	rows := 4 + cardRows + 4
+	rows := 4 + m.cardRows() + 4
 	// Vertical chrome: border (2) + padding (2).
 	h = rows + 4
 	return w, h

--- a/cmd/root/agent_picker_test.go
+++ b/cmd/root/agent_picker_test.go
@@ -451,6 +451,70 @@ func TestAgentPickerWheelIgnoredWithoutDetails(t *testing.T) {
 	assert.Equal(t, 0, m.cursor)
 }
 
+func TestAgentPickerLeanCheckboxDefaultsUnticked(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPickerModel([]agentChoice{{ref: "default"}, {ref: "coder"}})
+	m.width = 120
+	m.height = 40
+
+	assert.False(t, m.leanMode, "lean mode must be off by default")
+	assert.Contains(t, ansi.Strip(m.render()), "[ ] Lean Mode", "checkbox renders unticked by default")
+}
+
+func TestAgentPickerLeanCheckboxKeyToggle(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPickerModel([]agentChoice{{ref: "default"}, {ref: "coder"}})
+	m.width = 120
+	m.height = 40
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 'l', Text: "l"})
+	assert.Nil(t, cmd)
+	assert.True(t, m.leanMode)
+	assert.Contains(t, ansi.Strip(m.render()), "[x] Lean Mode")
+
+	_, _ = m.Update(tea.KeyPressMsg{Code: 'l', Text: "l"})
+	assert.False(t, m.leanMode)
+}
+
+func TestAgentPickerLeanCheckboxClickToggle(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPickerModel([]agentChoice{{ref: "default"}, {ref: "coder"}})
+	m.width = 120
+	m.height = 40
+
+	// Locate the checkbox on the rendered screen and click it.
+	screen := ansi.Strip(lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, m.render()))
+	lines := strings.Split(screen, "\n")
+	var x, y int
+	found := false
+	for row, line := range lines {
+		if col := strings.Index(line, "[ ] Lean Mode"); col >= 0 {
+			x, y, found = col, row, true
+			break
+		}
+	}
+	assert.True(t, found, "checkbox not found on screen")
+	assert.True(t, m.leanCheckboxAt(x, y), "hit zone must match the rendered checkbox")
+
+	click := tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft}
+	_, cmd := m.Update(click)
+	assert.Nil(t, cmd, "clicking the checkbox must not quit")
+	assert.True(t, m.leanMode)
+
+	// A second click within the double-click threshold toggles back rather
+	// than being treated as a card double-click.
+	_, cmd = m.Update(click)
+	assert.Nil(t, cmd)
+	assert.False(t, m.leanMode)
+
+	// The checkbox row must not hit any card.
+	_, ok := m.cardAt(x, y)
+	assert.False(t, ok, "checkbox row must not resolve to a card")
+}
+
 // firstCardPoint scans the grid for a coordinate that maps to card index want.
 func firstCardPoint(t *testing.T, m *agentPickerModel, want int) (int, int) {
 	t.Helper()

--- a/cmd/root/agent_picker_test.go
+++ b/cmd/root/agent_picker_test.go
@@ -462,6 +462,19 @@ func TestAgentPickerLeanCheckboxDefaultsUnticked(t *testing.T) {
 	assert.Contains(t, ansi.Strip(m.render()), "[ ] Lean Mode", "checkbox renders unticked by default")
 }
 
+func TestAgentPickerLeanCheckboxSeeded(t *testing.T) {
+	t.Parallel()
+
+	// When the run would already be lean (--lean or user config), the
+	// checkbox must reflect it instead of lying about the run mode.
+	m := newAgentPickerModel([]agentChoice{{ref: "default"}, {ref: "coder"}})
+	m.leanMode = true
+	m.width = 120
+	m.height = 40
+
+	assert.Contains(t, ansi.Strip(m.render()), "[x] Lean Mode")
+}
+
 func TestAgentPickerLeanCheckboxKeyToggle(t *testing.T) {
 	t.Parallel()
 
@@ -485,19 +498,30 @@ func TestAgentPickerLeanCheckboxClickToggle(t *testing.T) {
 	m.width = 120
 	m.height = 40
 
-	// Locate the checkbox on the rendered screen and click it.
+	// Locate the checkbox on the rendered screen and click it. Note:
+	// strings.Index returns a byte offset; convert the prefix to display
+	// columns because border runes (│) are multi-byte.
 	screen := ansi.Strip(lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, m.render()))
 	lines := strings.Split(screen, "\n")
 	var x, y int
 	found := false
 	for row, line := range lines {
-		if col := strings.Index(line, "[ ] Lean Mode"); col >= 0 {
-			x, y, found = col, row, true
+		if prefix, _, ok := strings.Cut(line, "[ ] Lean Mode"); ok {
+			x, y, found = lipgloss.Width(prefix), row, true
 			break
 		}
 	}
 	assert.True(t, found, "checkbox not found on screen")
 	assert.True(t, m.leanCheckboxAt(x, y), "hit zone must match the rendered checkbox")
+
+	// Hit-zone boundaries: both edges are inside; one cell beyond each edge
+	// and the adjacent rows are outside.
+	checkboxWidth := len("[ ] Lean Mode")
+	assert.True(t, m.leanCheckboxAt(x+checkboxWidth-1, y), "right edge must be inside")
+	assert.False(t, m.leanCheckboxAt(x-1, y), "left of the checkbox must miss")
+	assert.False(t, m.leanCheckboxAt(x+checkboxWidth, y), "right of the checkbox must miss")
+	assert.False(t, m.leanCheckboxAt(x, y-1), "row above must miss")
+	assert.False(t, m.leanCheckboxAt(x, y+1), "row below must miss")
 
 	click := tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft}
 	_, cmd := m.Update(click)

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -246,13 +246,18 @@ func (f *runExecFlags) runRunCommand(cmd *cobra.Command, args []string) (command
 		}
 		refs := parseAgentPickerRefs(f.agentPickerSpec)
 		applyTheme(f.theme)
-		chosen, err := selectAgentRef(ctx, refs, f.runConfig.EnvProvider())
+		chosen, lean, err := selectAgentRef(ctx, refs, f.runConfig.EnvProvider())
 		if err != nil {
 			if errors.Is(err, errAgentPickerCancelled) {
 				cli.NewPrinter(cmd.OutOrStdout()).Println("Agent selection cancelled.")
 				return nil
 			}
 			return err
+		}
+		// The picker's "Lean Mode" checkbox opts into the lean TUI; unticked
+		// keeps the normal run mode (whatever the flags/user config decide).
+		if lean {
+			f.lean = true
 		}
 		// With --agent-picker the agent comes from the picker, so any
 		// positional args are messages. Prepend the chosen ref so the rest

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -234,6 +234,7 @@ func (f *runExecFlags) runRunCommand(cmd *cobra.Command, args []string) (command
 	}
 
 	useTUI := !f.exec && (f.forceTUI || isatty.IsTerminal(os.Stdout.Fd()))
+	f.leanChanged = cmd.Flags().Changed("lean")
 
 	// When --agent-picker is set, show a full-screen picker up front and use
 	// the chosen ref as the agent to run. Resolving it here (before sandbox
@@ -246,7 +247,11 @@ func (f *runExecFlags) runRunCommand(cmd *cobra.Command, args []string) (command
 		}
 		refs := parseAgentPickerRefs(f.agentPickerSpec)
 		applyTheme(f.theme)
-		chosen, lean, err := selectAgentRef(ctx, refs, f.runConfig.EnvProvider())
+		// Seed the picker's "Lean Mode" checkbox with the lean state the run
+		// would otherwise use (--lean, or the user-config default applied in
+		// applyUserSettings) so the checkbox never lies about the run mode.
+		initialLean := f.lean || (!f.leanChanged && userconfig.Get().Lean && !f.tour)
+		chosen, lean, err := selectAgentRef(ctx, refs, f.runConfig.EnvProvider(), initialLean)
 		if err != nil {
 			if errors.Is(err, errAgentPickerCancelled) {
 				cli.NewPrinter(cmd.OutOrStdout()).Println("Agent selection cancelled.")
@@ -254,11 +259,10 @@ func (f *runExecFlags) runRunCommand(cmd *cobra.Command, args []string) (command
 			}
 			return err
 		}
-		// The picker's "Lean Mode" checkbox opts into the lean TUI; unticked
-		// keeps the normal run mode (whatever the flags/user config decide).
-		if lean {
-			f.lean = true
-		}
+		// The checkbox is the user's explicit choice: it wins over both the
+		// --lean flag and the user-config lean default.
+		f.lean = lean
+		f.leanChanged = true
 		// With --agent-picker the agent comes from the picker, so any
 		// positional args are messages. Prepend the chosen ref so the rest
 		// of the pipeline (which expects args[0] to be the agent) is happy.
@@ -294,7 +298,6 @@ func (f *runExecFlags) runRunCommand(cmd *cobra.Command, args []string) (command
 	if f.worktreeBase != "" && !f.worktree {
 		return errors.New("--worktree-base requires --worktree")
 	}
-	f.leanChanged = cmd.Flags().Changed("lean")
 
 	out := cli.NewPrinter(cmd.OutOrStdout())
 


### PR DESCRIPTION
The full-screen agent picker (`--agent-picker`) had no way to control the TUI mode at launch time, forcing users to know in advance whether they wanted the lean interface and pass `--lean` on the command line before the picker even appeared.

This adds a "Lean Mode" checkbox to the bottom of the picker panel. It is off by default and can be toggled with the `l` key or by clicking it with the mouse. When ticked, the chosen agent launches in the lean TUI; when unticked, it launches in the full one. The checkbox is seeded with the *effective* lean state derived from `--lean` and the user-config lean default, so it never shows a value that disagrees with what would actually run. The returned value is authoritative: unticking the checkbox overrides a lean default from user config, and ticking it enables lean even if no flag was passed.

The follow-up commit tightens the seeding logic, extracts `panelOrigin` and `cardRows` helpers to remove duplication between the hit-test and render paths, and replaces an open-coded `lastClickIndex = -1` reset with `resetClickTracking`. Tests cover the default state, `l`-key and mouse-click toggling, hit-zone boundaries (including just-inside and just-outside the checkbox row), and layout consistency between the render and hit-test helpers.