### PR TITLE
feat(tui): group /sessions browser by current workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 
 
+## [Unreleased]
+
+## What's New
+
+- Groups the `/sessions` browser by workspace: sessions started in the current directory are listed first under "This workspace", everything else under "Other locations" with its originating directory shown next to each entry; `ctrl+g` cycles a filter between all, current-directory only, and other-directory views
+
+
 ## [v1.97.0] - 2026-07-02
 
 This release adds global hook support in user config, expands environment variable references in hook and script-shell fields, and fixes hook field merging.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,52 @@
 All notable changes to this project will be documented in this file.
 
 
-## [Unreleased]
+## [v1.98.0] - 2026-07-03
+
+This release adds several new TUI features including an interactive getting-started tour, an effort picker dialog, and Lean Mode support in the agent picker, along with stability fixes for startup, shutdown, and proxy recovery.
 
 ## What's New
 
-- Groups the `/sessions` browser by workspace: sessions started in the current directory are listed first under "This workspace", everything else under "Other locations" with its originating directory shown next to each entry; `ctrl+g` cycles a filter between all, current-directory only, and other-directory views
+- Adds an interactive getting-started tour offered on first run and replayable on demand, implemented as a floating card that observes the real UI's message stream
+- Opens an effort picker dialog when `/effort` is used with no argument, instead of printing a usage hint
+- Adds a Lean Mode checkbox to the agent picker panel, toggleable with the `l` key or mouse click
+- Agent picker now discovers `~/.agents` config files (`.yaml`, `.yml`, `.hcl`) when no explicit list is given, in addition to the built-in `default` and `coder` agents
+- Adds cross-process locking and atomic writes for SQLite memory storage
+
+## Bug Fixes
+
+- Fixes toolset `Start` during startup so the sidebar tools spinner can no longer animate forever when Docker is wedged
+- Fixes TUI exit being blocked by a wedged resource cleanup
+- Fixes `--record` proxy bypassing the configured models gateway, which caused HTTP 401 errors when gateway-managed credentials were expected
+- Hardens gateway forwarding in record mode against credential leakage
+- Fixes proxy recovery after cooldown — previously a socket error would permanently latch the transport to direct connections for the lifetime of the process
+- Fixes `/tools` dialog showing Go type names (e.g. `*skills.ToolSet`) instead of human-readable names for loader-created toolsets
+- Fixes telemetry incorrectly recording an error on a chat span after a successful LLM completion
+- Fixes agent picker hardening: windowing, escapes, FIFO skip, sentinel, and description guard
+- Keeps agent picker panel geometry stable and windowing math in sync
+
+## Technical Changes
+
+- Fixes flaky frame synchronization in TUI test driver `sendSync`
+- Fixes file descriptor double-close corrupting parallel tests in `TestListen_FD`
+- Guards `fdOwnershipPin` with a mutex to fix a data race in server tests
+- Trims comments in the fallback transport
+### Pull Requests
+
+- [#3114](https://github.com/docker/docker-agent/pull/3114) - feat(memory): add cross-process locking and atomic writes for sqlite
+- [#3281](https://github.com/docker/docker-agent/pull/3281) - telemetry: don't record error on chat span after successful LLM completion
+- [#3412](https://github.com/docker/docker-agent/pull/3412) - feat(tui): generate a TUI e2e test from a `--record` session
+- [#3420](https://github.com/docker/docker-agent/pull/3420) - test: fix flaky tuitest frame sync and TestListen_FD fd double-close
+- [#3423](https://github.com/docker/docker-agent/pull/3423) - fix: bound toolset startup and never block the TUI exit when Docker is wedged
+- [#3424](https://github.com/docker/docker-agent/pull/3424) - docs: update CHANGELOG.md for v1.97.0
+- [#3425](https://github.com/docker/docker-agent/pull/3425) - feat(tui): open effort picker when /effort has no argument
+- [#3427](https://github.com/docker/docker-agent/pull/3427) - feat(tui): interactive getting-started tour on first run, replayable on demand
+- [#3428](https://github.com/docker/docker-agent/pull/3428) - fix: route --record proxy through the configured models gateway
+- [#3430](https://github.com/docker/docker-agent/pull/3430) - docs: sync documentation with recent merges
+- [#3431](https://github.com/docker/docker-agent/pull/3431) - fix(remote): recover proxy after cooldown instead of latching to direct
+- [#3441](https://github.com/docker/docker-agent/pull/3441) - fix: show proper toolset names in /tools dialog for loader-created toolsets
+- [#3443](https://github.com/docker/docker-agent/pull/3443) - feat(picker): add Lean Mode checkbox to agent picker
+- [#3444](https://github.com/docker/docker-agent/pull/3444) - feat: agent picker discovers ~/.agents configs when no list is given
 
 
 ## [v1.97.0] - 2026-07-02
@@ -4338,3 +4379,5 @@ This release improves the terminal user interface with better error handling and
 [v1.96.0]: https://github.com/docker/docker-agent/releases/tag/v1.96.0
 
 [v1.97.0]: https://github.com/docker/docker-agent/releases/tag/v1.97.0
+
+[v1.98.0]: https://github.com/docker/docker-agent/releases/tag/v1.98.0

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -211,6 +211,7 @@ Each error message includes a clickable **↻ retry** button. Clicking it resume
 docker-agent automatically saves your sessions. Use `/sessions` to browse past conversations:
 
 - **Browse** past sessions with search and filtering
+- **Workspace grouping**: sessions started in the current directory are listed first under "This workspace", everything else under "Other locations" with its originating directory shown next to each entry; press <kbd>Ctrl</kbd>+<kbd>G</kbd> in the browser to cycle between all, current-directory only, and other-directory views. Restoring a session reopens it in its original directory, so the label always matches where a restore will land
 - **Star** important sessions with `/star`
 - **Branch** conversations by editing any previous user message — preserving the original session history
 - **Resume** sessions with `docker agent run config.yaml --session <id>`

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -82,6 +82,7 @@ type Summary struct {
 	CreatedAt   time.Time
 	Starred     bool
 	NumMessages int
+	WorkingDir  string
 }
 
 // Store defines the interface for session storage
@@ -182,6 +183,7 @@ func (s *InMemorySessionStore) GetSessionSummaries(_ context.Context) ([]Summary
 			CreatedAt:   value.CreatedAt,
 			Starred:     value.Starred,
 			NumMessages: value.MessageCount(),
+			WorkingDir:  value.WorkingDir,
 		})
 		return true
 	})
@@ -853,7 +855,7 @@ func (s *SQLiteSessionStore) GetSessions(ctx context.Context) ([]*Session, error
 // This is much faster than GetSessions as it doesn't load message content.
 func (s *SQLiteSessionStore) GetSessionSummaries(ctx context.Context) ([]Summary, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT s.id, s.title, s.created_at, s.starred,
+		`SELECT s.id, s.title, s.created_at, s.starred, s.working_dir,
 		        (SELECT COUNT(*) FROM session_items si WHERE si.session_id = s.id AND si.item_type = 'message')
 		 FROM sessions s
 		 WHERE s.parent_id IS NULL OR s.parent_id = ''
@@ -868,14 +870,16 @@ func (s *SQLiteSessionStore) GetSessionSummaries(ctx context.Context) ([]Summary
 		var (
 			summary      Summary
 			createdAtStr string
+			workingDir   sql.NullString
 		)
-		if err := rows.Scan(&summary.ID, &summary.Title, &createdAtStr, &summary.Starred, &summary.NumMessages); err != nil {
+		if err := rows.Scan(&summary.ID, &summary.Title, &createdAtStr, &summary.Starred, &workingDir, &summary.NumMessages); err != nil {
 			return nil, err
 		}
 		summary.CreatedAt, err = time.Parse(time.RFC3339, createdAtStr)
 		if err != nil {
 			return nil, err
 		}
+		summary.WorkingDir = workingDir.String
 		summaries = append(summaries, summary)
 	}
 

--- a/pkg/session/store_test.go
+++ b/pkg/session/store_test.go
@@ -193,7 +193,8 @@ func TestGetSessionSummaries(t *testing.T) {
 				Content: "A very long message that should not be loaded when getting summaries",
 			})),
 		},
-		CreatedAt: session1Time,
+		CreatedAt:  session1Time,
+		WorkingDir: "/work/project",
 	}
 
 	session2 := &Session{
@@ -224,11 +225,32 @@ func TestGetSessionSummaries(t *testing.T) {
 	assert.Equal(t, "Second Session", summaries[0].Title)
 	assert.Equal(t, session2Time, summaries[0].CreatedAt)
 	assert.Equal(t, 1, summaries[0].NumMessages)
+	assert.Empty(t, summaries[0].WorkingDir)
 
 	assert.Equal(t, "session-1", summaries[1].ID)
 	assert.Equal(t, "First Session", summaries[1].Title)
 	assert.Equal(t, session1Time, summaries[1].CreatedAt)
 	assert.Equal(t, 1, summaries[1].NumMessages)
+	assert.Equal(t, "/work/project", summaries[1].WorkingDir)
+}
+
+func TestGetSessionSummaries_InMemory_WorkingDir(t *testing.T) {
+	t.Parallel()
+
+	store := NewInMemorySessionStore()
+
+	err := store.AddSession(t.Context(), &Session{
+		ID:         "session-1",
+		Title:      "First Session",
+		CreatedAt:  time.Now(),
+		WorkingDir: "/work/project",
+	})
+	require.NoError(t, err)
+
+	summaries, err := store.GetSessionSummaries(t.Context())
+	require.NoError(t, err)
+	require.Len(t, summaries, 1)
+	assert.Equal(t, "/work/project", summaries[0].WorkingDir)
 }
 
 func TestBranchSessionCopiesPrefix(t *testing.T) {

--- a/pkg/tui/dialog/session_browser.go
+++ b/pkg/tui/dialog/session_browser.go
@@ -2,6 +2,9 @@ package dialog
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -13,6 +16,7 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/atotto/clipboard"
 
+	"github.com/docker/docker-agent/pkg/paths"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tui/components/notification"
 	"github.com/docker/docker-agent/pkg/tui/components/scrollview"
@@ -24,21 +28,105 @@ import (
 
 // sessionBrowserKeyMap defines key bindings for the session browser
 type sessionBrowserKeyMap struct {
-	Up         key.Binding
-	Down       key.Binding
-	Enter      key.Binding
-	Escape     key.Binding
-	Star       key.Binding
-	FilterStar key.Binding
-	CopyID     key.Binding
-	Delete     key.Binding
+	Up              key.Binding
+	Down            key.Binding
+	Enter           key.Binding
+	Escape          key.Binding
+	Star            key.Binding
+	FilterStar      key.Binding
+	FilterWorkspace key.Binding
+	CopyID          key.Binding
+	Delete          key.Binding
 }
 
 // Session browser dialog dimension constants
 const (
 	sessionBrowserListOverhead = 12 // title(1) + space(1) + input(1) + separator(1) + separator(1) + id(1) + space(1) + help(1) + borders(2) + extra(2)
 	sessionBrowserListStartY   = 6  // border(1) + padding(1) + title(1) + space(1) + input(1) + separator(1)
+	sessionBrowserDirMaxLen    = 28 // max display length of a session's working dir in a list row
 )
+
+const (
+	sessionBrowserHeaderWorkspace = "This workspace"
+	sessionBrowserHeaderElsewhere = "Other locations"
+)
+
+// browserRow is one visual line of the session list: either a section
+// header (header != "") or the session at filtered[sessionIdx].
+type browserRow struct {
+	header     string
+	sessionIdx int
+}
+
+// workspaceMatcher reports whether a session's working directory belongs to
+// the workspace the browser was opened from. Paths are normalized with
+// filepath.Clean and EvalSymlinks so symlinked variants of the same
+// directory (e.g. /tmp vs /private/tmp on macOS) compare equal.
+// Normalization results are cached because many sessions share the same
+// directory and EvalSymlinks touches the filesystem.
+type workspaceMatcher struct {
+	current string
+	cache   map[string]string
+}
+
+func newWorkspaceMatcher(workspaceDir string) *workspaceMatcher {
+	m := &workspaceMatcher{cache: make(map[string]string)}
+	m.current = m.normalize(workspaceDir)
+	return m
+}
+
+func (m *workspaceMatcher) enabled() bool { return m.current != "" }
+
+func (m *workspaceMatcher) matches(dir string) bool {
+	if !m.enabled() {
+		return false
+	}
+	normalized := m.normalize(dir)
+	if normalized == "" {
+		return false
+	}
+	return workspacePathsEqual(normalized, m.current)
+}
+
+func (m *workspaceMatcher) normalize(dir string) string {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return ""
+	}
+	if cached, ok := m.cache[dir]; ok {
+		return cached
+	}
+	normalized := filepath.Clean(dir)
+	// Best effort: the recorded directory may no longer exist.
+	if resolved, err := filepath.EvalSymlinks(normalized); err == nil {
+		normalized = resolved
+	}
+	m.cache[dir] = normalized
+	return normalized
+}
+
+// workspacePathsEqual compares normalized paths, ignoring case on platforms
+// whose filesystems are typically case-insensitive.
+func workspacePathsEqual(a, b string) bool {
+	if goruntime.GOOS == "darwin" || goruntime.GOOS == "windows" {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
+}
+
+// abbreviateHome replaces a $HOME prefix with "~" for compact display.
+func abbreviateHome(dir string) string {
+	home := paths.GetHomeDir()
+	if home == "" || !strings.HasPrefix(dir, home) {
+		return dir
+	}
+	rest := dir[len(home):]
+	// Reject prefix matches that fall inside a path component (/home/bob2).
+	if rest != "" && rest[0] != os.PathSeparator {
+		return dir
+	}
+	return "~" + rest
+}
 
 type sessionBrowserDialog struct {
 	BaseDialog
@@ -52,13 +140,24 @@ type sessionBrowserDialog struct {
 	openedAt   time.Time // when dialog was opened, for stable time display
 	starFilter int       // 0 = all, 1 = starred only, 2 = unstarred only
 
+	// Workspace grouping state
+	workspace       *workspaceMatcher
+	workspaceDir    string // raw directory the browser was opened from, for display
+	workspaceFilter int    // 0 = all, 1 = this workspace only, 2 = other locations only
+	rows            []browserRow
+	rowForSession   []int // filtered index -> row index
+	workspaceCount  int
+	elsewhereCount  int
+
 	// Double-click detection
 	lastClickTime  time.Time
 	lastClickIndex int
 }
 
-// NewSessionBrowserDialog creates a new session browser dialog
-func NewSessionBrowserDialog(sessions []session.Summary) Dialog {
+// NewSessionBrowserDialog creates a new session browser dialog.
+// workspaceDir is the directory of the active session; sessions started
+// there are grouped first and can be filtered with the workspace filter.
+func NewSessionBrowserDialog(sessions []session.Summary, workspaceDir string) Dialog {
 	ti := textinput.New()
 	ti.Placeholder = "Type to search sessions…"
 	ti.Focus()
@@ -74,18 +173,21 @@ func NewSessionBrowserDialog(sessions []session.Summary) Dialog {
 	}
 
 	d := &sessionBrowserDialog{
-		textInput:  ti,
-		sessions:   nonEmptySessions,
-		scrollview: scrollview.New(scrollview.WithReserveScrollbarSpace(true)),
+		textInput:    ti,
+		sessions:     nonEmptySessions,
+		scrollview:   scrollview.New(scrollview.WithReserveScrollbarSpace(true)),
+		workspace:    newWorkspaceMatcher(workspaceDir),
+		workspaceDir: strings.TrimSpace(workspaceDir),
 		keyMap: sessionBrowserKeyMap{
-			Up:         key.NewBinding(key.WithKeys("up", "ctrl+k")),
-			Down:       key.NewBinding(key.WithKeys("down", "ctrl+j")),
-			Enter:      key.NewBinding(key.WithKeys("enter")),
-			Escape:     key.NewBinding(key.WithKeys("esc")),
-			Star:       key.NewBinding(key.WithKeys("ctrl+s")),
-			FilterStar: key.NewBinding(key.WithKeys("ctrl+f")),
-			CopyID:     key.NewBinding(key.WithKeys("ctrl+y")),
-			Delete:     key.NewBinding(key.WithKeys("ctrl+d")),
+			Up:              key.NewBinding(key.WithKeys("up", "ctrl+k")),
+			Down:            key.NewBinding(key.WithKeys("down", "ctrl+j")),
+			Enter:           key.NewBinding(key.WithKeys("enter")),
+			Escape:          key.NewBinding(key.WithKeys("esc")),
+			Star:            key.NewBinding(key.WithKeys("ctrl+s")),
+			FilterStar:      key.NewBinding(key.WithKeys("ctrl+f")),
+			FilterWorkspace: key.NewBinding(key.WithKeys("ctrl+g")),
+			CopyID:          key.NewBinding(key.WithKeys("ctrl+y")),
+			Delete:          key.NewBinding(key.WithKeys("ctrl+d")),
 		},
 		openedAt: time.Now(),
 	}
@@ -147,14 +249,14 @@ func (d *sessionBrowserDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		case key.Matches(msg, d.keyMap.Up):
 			if d.selected > 0 {
 				d.selected--
-				d.scrollview.EnsureLineVisible(d.selected)
+				d.ensureSelectedVisible()
 			}
 			return d, nil
 
 		case key.Matches(msg, d.keyMap.Down):
 			if d.selected < len(d.filtered)-1 {
 				d.selected++
-				d.scrollview.EnsureLineVisible(d.selected)
+				d.ensureSelectedVisible()
 			}
 			return d, nil
 
@@ -191,6 +293,13 @@ func (d *sessionBrowserDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 			d.filterSessions()
 			return d, nil
 
+		case key.Matches(msg, d.keyMap.FilterWorkspace):
+			if d.workspace.enabled() {
+				d.workspaceFilter = (d.workspaceFilter + 1) % 3
+				d.filterSessions()
+			}
+			return d, nil
+
 		case key.Matches(msg, d.keyMap.CopyID):
 			if d.selected >= 0 && d.selected < len(d.filtered) {
 				sessionID := d.filtered[d.selected].ID
@@ -224,7 +333,7 @@ func (d *sessionBrowserDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 func (d *sessionBrowserDialog) filterSessions() {
 	query := strings.ToLower(strings.TrimSpace(d.textInput.Value()))
 
-	d.filtered = nil
+	var workspace, elsewhere []session.Summary
 	for _, sess := range d.sessions {
 		switch d.starFilter {
 		case 1:
@@ -233,6 +342,18 @@ func (d *sessionBrowserDialog) filterSessions() {
 			}
 		case 2:
 			if sess.Starred {
+				continue
+			}
+		}
+
+		inWorkspace := d.workspace.matches(sess.WorkingDir)
+		switch d.workspaceFilter {
+		case 1:
+			if !inWorkspace {
+				continue
+			}
+		case 2:
+			if inWorkspace {
 				continue
 			}
 		}
@@ -247,20 +368,77 @@ func (d *sessionBrowserDialog) filterSessions() {
 			}
 		}
 
-		d.filtered = append(d.filtered, sess)
+		if inWorkspace {
+			workspace = append(workspace, sess)
+		} else {
+			elsewhere = append(elsewhere, sess)
+		}
 	}
+
+	// Current-workspace sessions come first; each group keeps its recency order.
+	d.workspaceCount = len(workspace)
+	d.elsewhereCount = len(elsewhere)
+	d.filtered = append(workspace, elsewhere...)
+	d.rebuildRows()
 
 	if d.selected >= len(d.filtered) {
 		d.selected = max(0, len(d.filtered)-1)
 	}
 	// Keep the scrollview's totalHeight in sync so EnsureLineVisible and the
 	// scrollbar clamp correctly even before View() runs.
-	d.scrollview.SetContent(nil, len(d.filtered))
+	d.scrollview.SetContent(nil, len(d.rows))
 	d.scrollview.SetScrollOffset(0)
 }
 
+// rebuildRows lays out the filtered sessions as visual rows. Section headers
+// are added only in the ungrouped-filter view, when the workspace is known
+// and both groups are non-empty; otherwise the list stays flat.
+func (d *sessionBrowserDialog) rebuildRows() {
+	d.rows = d.rows[:0]
+	d.rowForSession = d.rowForSession[:0]
+
+	showHeaders := d.workspaceFilter == 0 && d.workspace.enabled() &&
+		d.workspaceCount > 0 && d.elsewhereCount > 0
+
+	appendSession := func(i int) {
+		d.rowForSession = append(d.rowForSession, len(d.rows))
+		d.rows = append(d.rows, browserRow{sessionIdx: i})
+	}
+
+	if !showHeaders {
+		for i := range d.filtered {
+			appendSession(i)
+		}
+		return
+	}
+
+	d.rows = append(d.rows, browserRow{header: sessionBrowserHeaderWorkspace, sessionIdx: -1})
+	for i := range d.workspaceCount {
+		appendSession(i)
+	}
+	d.rows = append(d.rows, browserRow{header: sessionBrowserHeaderElsewhere, sessionIdx: -1})
+	for i := d.workspaceCount; i < len(d.filtered); i++ {
+		appendSession(i)
+	}
+}
+
+// ensureSelectedVisible scrolls so the selected session is on screen. When
+// the row just above it is a section header, the header is kept visible too
+// so reaching the first session of a group reveals its title.
+func (d *sessionBrowserDialog) ensureSelectedVisible() {
+	if d.selected < 0 || d.selected >= len(d.rowForSession) {
+		return
+	}
+	row := d.rowForSession[d.selected]
+	start := row
+	if row > 0 && d.rows[row-1].header != "" {
+		start = row - 1
+	}
+	d.scrollview.EnsureRangeVisible(start, row)
+}
+
 // mouseYToSessionIndex converts a mouse Y position to a session index in the filtered list.
-// Returns -1 if the position is not on a session.
+// Returns -1 if the position is not on a session (outside the list or on a section header).
 func (d *sessionBrowserDialog) mouseYToSessionIndex(y int) int {
 	dialogRow, _ := d.Position()
 	visLines := d.scrollview.VisibleHeight()
@@ -270,11 +448,11 @@ func (d *sessionBrowserDialog) mouseYToSessionIndex(y int) int {
 		return -1
 	}
 	lineInView := y - listStartY
-	idx := d.scrollview.ScrollOffset() + lineInView
-	if idx < 0 || idx >= len(d.filtered) {
+	rowIdx := d.scrollview.ScrollOffset() + lineInView
+	if rowIdx < 0 || rowIdx >= len(d.rows) {
 		return -1
 	}
-	return idx
+	return d.rows[rowIdx].sessionIdx
 }
 
 func (d *sessionBrowserDialog) dialogSize() (dialogWidth, maxHeight, contentWidth int) {
@@ -300,7 +478,7 @@ func (d *sessionBrowserDialog) View() string {
 	// on every keystroke is the dominant cost when there are many sessions.
 	// The follow-up SetScrollOffset call re-clamps the offset against the
 	// (possibly shrunk) total — it is intentionally not a no-op.
-	total := len(d.filtered)
+	total := len(d.rows)
 	d.scrollview.SetContent(nil, total)
 	d.scrollview.SetScrollOffset(d.scrollview.ScrollOffset())
 
@@ -319,13 +497,18 @@ func (d *sessionBrowserDialog) View() string {
 		end := min(offset+visibleLines, total)
 		windowLines := make([]string, 0, end-offset)
 		for i := offset; i < end; i++ {
-			windowLines = append(windowLines, d.renderSession(d.filtered[i], i == d.selected, contentWidth))
+			row := d.rows[i]
+			if row.header != "" {
+				windowLines = append(windowLines, d.renderSectionHeader(row.header, contentWidth))
+			} else {
+				windowLines = append(windowLines, d.renderSession(d.filtered[row.sessionIdx], row.sessionIdx == d.selected, contentWidth))
+			}
 		}
 		scrollableContent = d.scrollview.ViewWithLines(windowLines)
 	}
 
-	// Build title with session count and optional star-filter indicator.
-	// Show "filtered/total" when a search or star filter reduces the list.
+	// Build title with session count and optional filter indicators.
+	// Show "filtered/total" when a search or filter reduces the list.
 	var countLabel string
 	if len(d.filtered) == len(d.sessions) {
 		countLabel = strconv.Itoa(len(d.sessions))
@@ -338,6 +521,12 @@ func (d *sessionBrowserDialog) View() string {
 		title += " " + styles.StarredStyle.Render("★")
 	case 2:
 		title += " " + styles.UnstarredStyle.Render("☆")
+	}
+	switch d.workspaceFilter {
+	case 1:
+		title += " " + styles.StarredStyle.Render("⌂")
+	case 2:
+		title += " " + styles.UnstarredStyle.Render("⌂")
 	}
 
 	var filterDesc string
@@ -355,6 +544,21 @@ func (d *sessionBrowserDialog) View() string {
 		idFooter = styles.MutedStyle.Render("ID: ") + styles.SecondaryStyle.Render(d.filtered[d.selected].ID)
 	}
 
+	secondHelpLine := []string{"enter", "load"}
+	if d.workspace.enabled() {
+		var workspaceDesc string
+		switch d.workspaceFilter {
+		case 0:
+			workspaceDesc = "all dirs"
+		case 1:
+			workspaceDesc = "this dir"
+		case 2:
+			workspaceDesc = "other dirs"
+		}
+		secondHelpLine = append(secondHelpLine, "ctrl+g", workspaceDesc)
+	}
+	secondHelpLine = append(secondHelpLine, "esc", "close")
+
 	content := NewContent(regionWidth).
 		AddTitle(title).
 		AddSpace().
@@ -365,7 +569,7 @@ func (d *sessionBrowserDialog) View() string {
 		AddContent(idFooter).
 		AddSpace().
 		AddHelpKeys("↑/↓", "navigate", "ctrl+s", "star", "ctrl+f", filterDesc, "ctrl+y", "copy id", "ctrl+d", "delete").
-		AddHelpKeys("enter", "load", "esc", "close").
+		AddHelpKeys(secondHelpLine...).
 		Build()
 
 	return styles.DialogStyle.Width(dialogWidth).Render(content)
@@ -393,14 +597,49 @@ func (d *sessionBrowserDialog) renderSession(sess session.Summary, selected bool
 	}
 
 	suffix := fmt.Sprintf(" • (%d msg) • %s", sess.NumMessages, d.timeAgo(sess.CreatedAt))
+	if dir := d.sessionDirLabel(sess); dir != "" {
+		suffix += " • " + dir
+	}
 
 	starWidth := 3
-	maxTitleLen := max(1, maxWidth-len(suffix)-starWidth)
+	maxTitleLen := max(1, maxWidth-lipgloss.Width(suffix)-starWidth)
 	if r := []rune(title); len(r) > maxTitleLen {
 		title = string(r[:maxTitleLen-1]) + "…"
 	}
 
 	return styles.StarIndicator(sess.Starred) + titleStyle.Render(title) + timeStyle.Render(suffix)
+}
+
+// sessionDirLabel returns the abbreviated directory shown next to sessions
+// that belong to a different workspace than the current one. Sessions from
+// the current workspace need no label, and sessions with no recorded
+// directory (pre-migration or API-created) have none to show.
+func (d *sessionBrowserDialog) sessionDirLabel(sess session.Summary) string {
+	dir := strings.TrimSpace(sess.WorkingDir)
+	if dir == "" || d.workspace.matches(dir) {
+		return ""
+	}
+	return truncatePath(abbreviateHome(dir), sessionBrowserDirMaxLen)
+}
+
+// renderSectionHeader renders a workspace group header. The current-workspace
+// header includes the abbreviated directory when it fits.
+func (d *sessionBrowserDialog) renderSectionHeader(header string, maxWidth int) string {
+	count := d.elsewhereCount
+	if header == sessionBrowserHeaderWorkspace {
+		count = d.workspaceCount
+	}
+	label := fmt.Sprintf("%s (%d)", header, count)
+
+	var dir string
+	if header == sessionBrowserHeaderWorkspace && d.workspaceDir != "" {
+		available := maxWidth - lipgloss.Width(label) - 3 // " · " separator
+		if available >= 8 {
+			dir = " · " + truncatePath(abbreviateHome(d.workspaceDir), available)
+		}
+	}
+
+	return styles.MutedStyle.Bold(true).Render(label) + styles.MutedStyle.Render(dir)
 }
 
 func (d *sessionBrowserDialog) timeAgo(t time.Time) string {

--- a/pkg/tui/dialog/session_browser_test.go
+++ b/pkg/tui/dialog/session_browser_test.go
@@ -2,6 +2,9 @@ package dialog
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -10,6 +13,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/paths"
 	"github.com/docker/docker-agent/pkg/session"
 )
 
@@ -21,7 +25,7 @@ func TestSessionBrowserNavigation(t *testing.T) {
 		{ID: "3", Title: "Session 3", CreatedAt: time.Now()},
 	}
 
-	dialog := NewSessionBrowserDialog(sessions)
+	dialog := NewSessionBrowserDialog(sessions, "")
 	d := dialog.(*sessionBrowserDialog)
 
 	// Initialize and set window size like the TUI does
@@ -70,7 +74,7 @@ func TestSessionBrowserNavigationWithCtrl(t *testing.T) {
 		{ID: "3", Title: "Session 3", CreatedAt: time.Now()},
 	}
 
-	dialog := NewSessionBrowserDialog(sessions)
+	dialog := NewSessionBrowserDialog(sessions, "")
 	d := dialog.(*sessionBrowserDialog)
 	d.Init()
 	d.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
@@ -106,7 +110,7 @@ func TestSessionBrowserViewShowsSelection(t *testing.T) {
 		{ID: "3", Title: "Session 3", CreatedAt: time.Now()},
 	}
 
-	dialog := NewSessionBrowserDialog(sessions)
+	dialog := NewSessionBrowserDialog(sessions, "")
 	d := dialog.(*sessionBrowserDialog)
 	d.Init()
 	d.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
@@ -137,7 +141,7 @@ func TestSessionBrowserFiltersEmptySessions(t *testing.T) {
 		{ID: "5", Title: "Session 5", CreatedAt: time.Now()},
 	}
 
-	dialog := NewSessionBrowserDialog(sessions)
+	dialog := NewSessionBrowserDialog(sessions, "")
 	d := dialog.(*sessionBrowserDialog)
 
 	// Should only have non-empty sessions
@@ -157,7 +161,7 @@ func TestSessionBrowserAllEmptySessions(t *testing.T) {
 		{ID: "2", Title: "", CreatedAt: time.Now()},
 	}
 
-	dialog := NewSessionBrowserDialog(sessions)
+	dialog := NewSessionBrowserDialog(sessions, "")
 	d := dialog.(*sessionBrowserDialog)
 
 	// Should have no sessions
@@ -177,7 +181,7 @@ func TestSessionBrowserScrolling(t *testing.T) {
 		}
 	}
 
-	dialog := NewSessionBrowserDialog(sessions)
+	dialog := NewSessionBrowserDialog(sessions, "")
 	d := dialog.(*sessionBrowserDialog)
 	d.Init()
 	// Set a small window size to force scrolling
@@ -218,7 +222,7 @@ func TestSessionBrowserMouseClickSelectsSession(t *testing.T) {
 		{ID: "3", Title: "Session 3", CreatedAt: time.Now()},
 	}
 
-	dialog := NewSessionBrowserDialog(sessions)
+	dialog := NewSessionBrowserDialog(sessions, "")
 	d := dialog.(*sessionBrowserDialog)
 	d.Init()
 	d.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
@@ -265,7 +269,7 @@ func TestSessionBrowserDoubleClickOpensSession(t *testing.T) {
 		{ID: "sess-3", Title: "Session 3", CreatedAt: time.Now()},
 	}
 
-	dialog := NewSessionBrowserDialog(sessions)
+	dialog := NewSessionBrowserDialog(sessions, "")
 	d := dialog.(*sessionBrowserDialog)
 	d.Init()
 	d.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
@@ -297,7 +301,7 @@ func TestSessionBrowserClickOutsideListIgnored(t *testing.T) {
 		{ID: "2", Title: "Session 2", CreatedAt: time.Now()},
 	}
 
-	dialog := NewSessionBrowserDialog(sessions)
+	dialog := NewSessionBrowserDialog(sessions, "")
 	d := dialog.(*sessionBrowserDialog)
 	d.Init()
 	d.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
@@ -314,4 +318,253 @@ func TestSessionBrowserClickOutsideListIgnored(t *testing.T) {
 	// Selection should remain at 0
 	require.Equal(t, 0, d.selected, "click outside list should not change selection")
 	require.Nil(t, cmd, "click outside list should not produce a command")
+}
+
+func workspaceTestSessions() []session.Summary {
+	return []session.Summary{
+		{ID: "here-1", Title: "Newest here", CreatedAt: time.Now(), WorkingDir: "/work/project"},
+		{ID: "away-1", Title: "Away one", CreatedAt: time.Now().Add(-1 * time.Hour), WorkingDir: "/work/other"},
+		{ID: "here-2", Title: "Older here", CreatedAt: time.Now().Add(-2 * time.Hour), WorkingDir: "/work/project"},
+		{ID: "nodir", Title: "No dir recorded", CreatedAt: time.Now().Add(-3 * time.Hour)},
+	}
+}
+
+func filteredIDs(d *sessionBrowserDialog) []string {
+	ids := make([]string, 0, len(d.filtered))
+	for _, s := range d.filtered {
+		ids = append(ids, s.ID)
+	}
+	return ids
+}
+
+func TestSessionBrowserWorkspaceGrouping(t *testing.T) {
+	t.Parallel()
+	dialog := NewSessionBrowserDialog(workspaceTestSessions(), "/work/project")
+	d := dialog.(*sessionBrowserDialog)
+	d.Init()
+	d.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
+
+	// Workspace sessions come first (keeping recency order), then the rest.
+	require.Equal(t, []string{"here-1", "here-2", "away-1", "nodir"}, filteredIDs(d))
+	require.Equal(t, 2, d.workspaceCount)
+	require.Equal(t, 2, d.elsewhereCount)
+
+	// Rows carry two section headers around the groups.
+	require.Len(t, d.rows, 6, "4 sessions + 2 headers")
+	require.Equal(t, sessionBrowserHeaderWorkspace, d.rows[0].header)
+	require.Equal(t, -1, d.rows[0].sessionIdx)
+	require.Equal(t, sessionBrowserHeaderElsewhere, d.rows[3].header)
+	require.Equal(t, -1, d.rows[3].sessionIdx)
+
+	// rowForSession maps every session to its visual row.
+	require.Equal(t, []int{1, 2, 4, 5}, d.rowForSession)
+
+	view := d.View()
+	require.Contains(t, view, sessionBrowserHeaderWorkspace)
+	require.Contains(t, view, sessionBrowserHeaderElsewhere)
+	require.Contains(t, view, "/work/other", "sessions from another workspace should show their directory")
+}
+
+func TestSessionBrowserWorkspaceGroupingFlatWithoutWorkspace(t *testing.T) {
+	t.Parallel()
+	dialog := NewSessionBrowserDialog(workspaceTestSessions(), "")
+	d := dialog.(*sessionBrowserDialog)
+
+	// Unknown workspace: original order, no headers.
+	require.Equal(t, []string{"here-1", "away-1", "here-2", "nodir"}, filteredIDs(d))
+	require.Len(t, d.rows, 4)
+	for i, row := range d.rows {
+		require.Empty(t, row.header)
+		require.Equal(t, i, row.sessionIdx)
+	}
+}
+
+func TestSessionBrowserNoHeadersWhenSingleGroup(t *testing.T) {
+	t.Parallel()
+	sessions := []session.Summary{
+		{ID: "1", Title: "Session 1", CreatedAt: time.Now(), WorkingDir: "/work/project"},
+		{ID: "2", Title: "Session 2", CreatedAt: time.Now(), WorkingDir: "/work/project"},
+	}
+
+	dialog := NewSessionBrowserDialog(sessions, "/work/project")
+	d := dialog.(*sessionBrowserDialog)
+
+	require.Len(t, d.rows, 2, "headers should not appear when every session is in the workspace")
+	for _, row := range d.rows {
+		require.Empty(t, row.header)
+	}
+}
+
+func TestSessionBrowserWorkspaceFilterCycle(t *testing.T) {
+	t.Parallel()
+	dialog := NewSessionBrowserDialog(workspaceTestSessions(), "/work/project")
+	d := dialog.(*sessionBrowserDialog)
+	d.Init()
+	d.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
+
+	ctrlG := tea.KeyPressMsg{Code: 'g', Mod: tea.ModCtrl}
+	require.True(t, key.Matches(ctrlG, d.keyMap.FilterWorkspace), "ctrl+g should match keyMap.FilterWorkspace")
+
+	// 1: this workspace only
+	updated, _ := d.Update(ctrlG)
+	d = updated.(*sessionBrowserDialog)
+	require.Equal(t, 1, d.workspaceFilter)
+	require.Equal(t, []string{"here-1", "here-2"}, filteredIDs(d))
+	require.Len(t, d.rows, 2, "no headers in filtered views")
+
+	// 2: other locations only, including sessions without a recorded dir
+	updated, _ = d.Update(ctrlG)
+	d = updated.(*sessionBrowserDialog)
+	require.Equal(t, 2, d.workspaceFilter)
+	require.Equal(t, []string{"away-1", "nodir"}, filteredIDs(d))
+
+	// 0: back to all
+	updated, _ = d.Update(ctrlG)
+	d = updated.(*sessionBrowserDialog)
+	require.Equal(t, 0, d.workspaceFilter)
+	require.Len(t, d.filtered, 4)
+}
+
+func TestSessionBrowserWorkspaceFilterNoopWithoutWorkspace(t *testing.T) {
+	t.Parallel()
+	dialog := NewSessionBrowserDialog(workspaceTestSessions(), "")
+	d := dialog.(*sessionBrowserDialog)
+	d.Init()
+	d.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
+
+	updated, _ := d.Update(tea.KeyPressMsg{Code: 'g', Mod: tea.ModCtrl})
+	d = updated.(*sessionBrowserDialog)
+	require.Equal(t, 0, d.workspaceFilter, "workspace filter should be inert when the workspace is unknown")
+	require.Len(t, d.filtered, 4)
+}
+
+func TestSessionBrowserWorkspaceFilterCombinesWithStarAndSearch(t *testing.T) {
+	t.Parallel()
+	sessions := workspaceTestSessions()
+	sessions[0].Starred = true // here-1
+	sessions[1].Starred = true // away-1
+
+	dialog := NewSessionBrowserDialog(sessions, "/work/project")
+	d := dialog.(*sessionBrowserDialog)
+	d.Init()
+	d.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
+
+	// Workspace-only + starred-only
+	d.Update(tea.KeyPressMsg{Code: 'g', Mod: tea.ModCtrl})
+	updated, _ := d.Update(tea.KeyPressMsg{Code: 'f', Mod: tea.ModCtrl})
+	d = updated.(*sessionBrowserDialog)
+	require.Equal(t, []string{"here-1"}, filteredIDs(d))
+
+	// Adding a non-matching search empties the list without panicking.
+	d.textInput.SetValue("zzz")
+	d.filterSessions()
+	require.Empty(t, d.filtered)
+	require.Empty(t, d.rows)
+	require.NotEmpty(t, d.View())
+}
+
+func TestSessionBrowserWorkspacePathNormalization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		sessionDir   string
+		workspaceDir string
+	}{
+		{name: "identical", sessionDir: "/work/project", workspaceDir: "/work/project"},
+		{name: "trailing slash", sessionDir: "/work/project/", workspaceDir: "/work/project"},
+		{name: "redundant segments", sessionDir: "/work/./project/sub/..", workspaceDir: "/work/project"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			m := newWorkspaceMatcher(tc.workspaceDir)
+			require.True(t, m.matches(tc.sessionDir))
+		})
+	}
+
+	require.False(t, newWorkspaceMatcher("/work/project").matches(""), "empty session dir never matches")
+	require.False(t, newWorkspaceMatcher("").matches("/work/project"), "unknown workspace never matches")
+}
+
+func TestSessionBrowserWorkspaceSymlinkNormalization(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires privileges on Windows")
+	}
+	t.Parallel()
+
+	realDir := t.TempDir()
+	link := filepath.Join(t.TempDir(), "link")
+	require.NoError(t, os.Symlink(realDir, link))
+
+	m := newWorkspaceMatcher(realDir)
+	require.True(t, m.matches(link), "a symlinked session dir should match its resolved workspace")
+}
+
+func TestSessionBrowserHeaderRowsNotSelectable(t *testing.T) {
+	t.Parallel()
+	dialog := NewSessionBrowserDialog(workspaceTestSessions(), "/work/project")
+	d := dialog.(*sessionBrowserDialog)
+	d.Init()
+	d.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
+
+	dialogRow, _ := d.Position()
+	listStartY := dialogRow + sessionBrowserListStartY
+
+	// Row 0 is the "This workspace" header: clicking it must not change the
+	// selection or produce a command.
+	clickMsg := tea.MouseClickMsg{X: 20, Y: listStartY, Button: tea.MouseLeft}
+	updated, cmd := d.Update(clickMsg)
+	d = updated.(*sessionBrowserDialog)
+	require.Equal(t, 0, d.selected)
+	require.Nil(t, cmd)
+
+	// Row 1 is the first session.
+	clickMsg = tea.MouseClickMsg{X: 20, Y: listStartY + 1, Button: tea.MouseLeft}
+	updated, _ = d.Update(clickMsg)
+	d = updated.(*sessionBrowserDialog)
+	require.Equal(t, 0, d.selected, "first session row should map to filtered index 0")
+
+	// Row 4 is the first "Other locations" session (after the second header).
+	clickMsg = tea.MouseClickMsg{X: 20, Y: listStartY + 4, Button: tea.MouseLeft}
+	updated, _ = d.Update(clickMsg)
+	d = updated.(*sessionBrowserDialog)
+	require.Equal(t, 2, d.selected)
+}
+
+func TestSessionBrowserNavigationSkipsHeaders(t *testing.T) {
+	t.Parallel()
+	dialog := NewSessionBrowserDialog(workspaceTestSessions(), "/work/project")
+	d := dialog.(*sessionBrowserDialog)
+	d.Init()
+	d.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
+
+	downKey := tea.KeyPressMsg{Code: tea.KeyDown}
+	for range 3 {
+		d.Update(downKey)
+	}
+	require.Equal(t, 3, d.selected, "selection moves across groups, headers are not selectable stops")
+
+	// Further downs stay clamped at the last session.
+	d.Update(downKey)
+	require.Equal(t, 3, d.selected)
+
+	upKey := tea.KeyPressMsg{Code: tea.KeyUp}
+	for range 5 {
+		d.Update(upKey)
+	}
+	require.Equal(t, 0, d.selected)
+}
+
+func TestAbbreviateHome(t *testing.T) {
+	home := paths.GetHomeDir()
+	if home == "" {
+		t.Skip("home directory unknown")
+	}
+
+	require.Equal(t, "~", abbreviateHome(home))
+	require.Equal(t, filepath.Join("~", "code"), abbreviateHome(filepath.Join(home, "code")))
+	require.Equal(t, home+"2", abbreviateHome(home+"2"), "sibling dirs sharing the prefix must not be abbreviated")
+	require.Equal(t, "/somewhere/else", abbreviateHome("/somewhere/else"))
 }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1290,8 +1290,19 @@ func (m *appModel) handleOpenSessionBrowser() (tea.Model, tea.Cmd) {
 		return m, notification.InfoCmd("No previous sessions found")
 	}
 
+	// Resolve the active workspace so the browser can group sessions started
+	// in the current directory. This mirrors where a restore would land: the
+	// same WorkingDir field drives replaceActiveSession.
+	var workspaceDir string
+	if runner := m.supervisor.GetRunner(m.supervisor.ActiveID()); runner != nil {
+		workspaceDir = runner.WorkingDir
+	}
+	if workspaceDir == "" {
+		workspaceDir, _ = os.Getwd()
+	}
+
 	return m, core.CmdHandler(dialog.OpenDialogMsg{
-		Model: dialog.NewSessionBrowserDialog(sessions),
+		Model: dialog.NewSessionBrowserDialog(sessions, workspaceDir),
 	})
 }
 


### PR DESCRIPTION
Closes #3440

The `/sessions` browser now surfaces sessions from the current workspace instead of a flat global list. Grouping uses the same `WorkingDir` field that drives restore, so the label always matches where a restore actually lands.

## Issue expectations, mapped

| Issue item | Status | Where |
| --- | --- | --- |
| `WorkingDir` in `session.Summary`, selected in both stores | yes | `pkg/session/store.go` |
| Active runner's `WorkingDir` (fallback `os.Getwd()`) passed to the browser | yes | `pkg/tui/tui.go` |
| "This workspace" group first, with section headers | yes | `pkg/tui/dialog/session_browser.go` |
| Workspace filter cycle key | yes | `ctrl+g`: all dirs, this dir, other dirs (`ctrl+w` is taken by close-tab; inside a dialog `ctrl+g` shadows nothing) |
| Abbreviated working dir (`$HOME` to `~`) | yes | shown on rows outside the workspace (truncated, tail-preserving) and in the "This workspace" header |
| Path normalization | yes | `filepath.Clean` + `filepath.EvalSymlinks` (best effort), case-insensitive compare on darwin/windows |
| Empty-`WorkingDir` sessions stay reachable | yes | grouped under "Other locations", included in the "other dirs" filter |
| Tests + docs | yes | 11 new dialog tests, 2 store tests, `docs/features/tui/index.md`, `CHANGELOG.md` |

## Behaviour

```text
Sessions (7)
  This workspace (2) . ~/code/proj
    Fix flaky retry test      . (12 msg) . 2h ago
    Add CI cache              . (5 msg)  . 1d ago
  Other locations (5)
    Refactor parser           . (40 msg) . 3d ago . ~/code/other
    Untitled import           . (3 msg)  . 5d ago
    ...
```

- Headers appear only when the workspace is known and both groups are non-empty; otherwise the list stays flat (no behaviour change when opened without a workspace).
- Headers are not selectable and not clickable; selection, enter/star/delete/copy-id and double-click semantics are unchanged.
- The workspace filter combines with the existing star filter and text search, and is inert when the workspace is unknown.
- Title shows a `⌂` indicator when the workspace filter is active, mirroring the star filter indicator.
- Remote mode is unaffected (`RemoteSessionStore.GetSessionSummaries` still returns unsupported).

## Implementation notes

- The list is modeled as rows (section header or index into the filtered sessions); rendering stays windowed to the visible lines, so large session stores keep the existing per-keystroke cost.
- Path normalization is memoized per unique raw path, so `EvalSymlinks` runs once per directory instead of on every keystroke; deleted directories fall back to the cleaned path.
- `abbreviateHome` only abbreviates on a path component boundary (`/home/bob2` is not abbreviated for home `/home/bob`).
- Scrolling to the first session of a group also reveals the group header (`EnsureRangeVisible`).
- Read path + UI only, no schema migration.

## Validation

| Check | Result |
| --- | --- |
| `go build ./...`, `go vet` | pass |
| `go test` on `pkg/session`, `pkg/tui/...`, `pkg/acp`, `pkg/runtime`, `cmd` | pass |
| Full `go test ./...` | only pre-existing SSRF network-test failures, also failing on pristine main in the sandbox used |
| `golangci-lint run`, `go run ./lint .` | 0 issues |
| markdownlint (docs) | 0 errors |

## Follow-ups (out of scope)

- Worktree sessions record the worktree dir and will not match the parent checkout; subtree/git-root matching remains a follow-up, as noted in the issue.
- `acp.ListSessions` still loads each full session to read its cwd; it could now read `Summary.WorkingDir` instead.
- Remote summaries: mapping `GET /api/sessions` into summaries remains a possible follow-up.
