### PR TITLE
docs: point rel=canonical at the docs.docker.com mirrored pages

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -18,10 +18,12 @@ on:
     paths:
       - ".github/workflows/docs-lint.yml"
       - "docs/**"
+      - "scripts/docs-check-canonical.sh"
   pull_request:
     paths:
       - ".github/workflows/docs-lint.yml"
       - "docs/**"
+      - "scripts/docs-check-canonical.sh"
 
 jobs:
   markdownlint:
@@ -35,6 +37,17 @@ jobs:
       - name: Lint Markdown
         run: npx --yes markdownlint-cli2@0.22.1
         working-directory: docs
+
+  canonical-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Mounted pages must canonicalize to their docs.docker.com URL
+      # (STYLE.md "Canonical URLs"); catches pages added without one.
+      - name: Check canonical front matter
+        run: ./scripts/docs-check-canonical.sh
 
   link-check:
     runs-on: ubuntu-latest

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -73,6 +73,26 @@ render hook) resolve these to the right URL. Never use Liquid
 (`relative_url`) or absolute `/path/` links in `docs/**` content —
 they break when the page is mounted on docs.docker.com.
 
+## Canonical URLs
+
+Every content page is mounted on docs.docker.com, and this site
+tracks `main` while docs.docker.com is pinned to a release — so the
+stable page is the authoritative copy. Each
+`docs/<section>/<page>/index.md` sets `canonical:` in its front
+matter (after `weight:`), derived from its path:
+
+```yaml
+canonical: https://docs.docker.com/ai/docker-agent/<section>/<page>/
+```
+
+The Jekyll layout renders it as the page's `rel=canonical` link;
+docs.docker.com ignores the value and self-canonicalizes. CI
+(`docs-lint` / `scripts/docs-check-canonical.sh`) fails when the
+value is missing or doesn't match the page path — mind it when
+scaffolding a new page from an existing one. The homepage, `404.md`
+and section `_index.md` files are not mirrored pages and don't set
+one.
+
 ## Availability badges
 
 When a page documents a feature that is merged on `main` but not yet

--- a/docs/community/contributing/index.md
+++ b/docs/community/contributing/index.md
@@ -3,6 +3,7 @@ title: "Contributing"
 description: "docker-agent is open source. Here's how to set up your development environment and contribute."
 keywords: docker agent, ai agents, community, contributing
 weight: 10
+canonical: https://docs.docker.com/ai/docker-agent/community/contributing/
 ---
 
 _docker-agent is open source. Here's how to set up your development environment and contribute._

--- a/docs/community/opentelemetry/index.md
+++ b/docs/community/opentelemetry/index.md
@@ -3,6 +3,7 @@ title: "OpenTelemetry Tracing"
 description: "Export docker-agent traces to any OTLP backend, including Langfuse and LangSmith, for debugging agentic workflows."
 keywords: docker agent, ai agents, community, opentelemetry tracing
 weight: 40
+canonical: https://docs.docker.com/ai/docker-agent/community/opentelemetry/
 ---
 
 _docker-agent can export OpenTelemetry traces of an agent run to any OTLP/HTTP backend. This is separate from [product-analytics telemetry](../telemetry/index.md) and is opt-in via the `--otel` flag._

--- a/docs/community/telemetry/index.md
+++ b/docs/community/telemetry/index.md
@@ -3,6 +3,7 @@ title: "Telemetry"
 description: "docker-agent collects anonymous usage data to help improve the tool. Telemetry can be disabled at any time."
 keywords: docker agent, ai agents, community, telemetry
 weight: 30
+canonical: https://docs.docker.com/ai/docker-agent/community/telemetry/
 ---
 
 _docker-agent collects anonymous usage data to help improve the tool. Telemetry can be disabled at any time._

--- a/docs/community/troubleshooting/index.md
+++ b/docs/community/troubleshooting/index.md
@@ -3,6 +3,7 @@ title: "Troubleshooting"
 description: "Common issues and how to resolve them when working with docker-agent."
 keywords: docker agent, ai agents, community, troubleshooting
 weight: 20
+canonical: https://docs.docker.com/ai/docker-agent/community/troubleshooting/
 ---
 
 _Common issues and how to resolve them when working with docker-agent._

--- a/docs/concepts/agents/index.md
+++ b/docs/concepts/agents/index.md
@@ -3,6 +3,7 @@ title: "Agents"
 description: "Agents are the core building blocks of docker-agent. Each agent is an AI-powered entity with a model, instructions, tools, and optional sub-agents."
 keywords: docker agent, ai agents, concepts, agents
 weight: 10
+canonical: https://docs.docker.com/ai/docker-agent/concepts/agents/
 ---
 
 _Agents are the core building blocks of docker-agent. Each agent is an AI-powered entity with a model, instructions, tools, and optional sub-agents._

--- a/docs/concepts/distribution/index.md
+++ b/docs/concepts/distribution/index.md
@@ -3,6 +3,7 @@ title: "Agent Distribution"
 description: "Package, share, and run agents via OCI-compatible registries — just like container images."
 keywords: docker agent, ai agents, concepts, agent distribution
 weight: 50
+canonical: https://docs.docker.com/ai/docker-agent/concepts/distribution/
 aliases:
   - /ai/docker-agent/sharing-agents/
 ---

--- a/docs/concepts/models/index.md
+++ b/docs/concepts/models/index.md
@@ -3,6 +3,7 @@ title: "Models"
 description: "Models are the AI brains behind your agents. docker-agent supports multiple providers and flexible configuration."
 keywords: docker agent, ai agents, concepts, models
 weight: 20
+canonical: https://docs.docker.com/ai/docker-agent/concepts/models/
 ---
 
 _Models are the AI brains behind your agents. docker-agent supports multiple providers and flexible configuration._

--- a/docs/concepts/multi-agent/index.md
+++ b/docs/concepts/multi-agent/index.md
@@ -4,6 +4,7 @@ description: "Build teams of specialized agents that collaborate and delegate ta
 keywords: docker agent, ai agents, concepts, multi-agent systems
 linkTitle: "Multi-Agent"
 weight: 40
+canonical: https://docs.docker.com/ai/docker-agent/concepts/multi-agent/
 ---
 
 _Build teams of specialized agents that collaborate and delegate tasks to each other._

--- a/docs/concepts/tools/index.md
+++ b/docs/concepts/tools/index.md
@@ -3,6 +3,7 @@ title: "Tools"
 description: "Tools give agents the ability to interact with the world — read files, run commands, search the web, query databases, and more."
 keywords: docker agent, ai agents, concepts, tools
 weight: 30
+canonical: https://docs.docker.com/ai/docker-agent/concepts/tools/
 ---
 
 _Tools give agents the ability to interact with the world — read files, run commands, search the web, query databases, and more._

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -4,6 +4,7 @@ description: "Complete reference for defining agents in your YAML configuration.
 keywords: docker agent, ai agents, configuration, yaml, agent configuration
 linkTitle: "Agent Config"
 weight: 30
+canonical: https://docs.docker.com/ai/docker-agent/configuration/agents/
 ---
 
 _Complete reference for defining agents in your YAML configuration._

--- a/docs/configuration/hcl/index.md
+++ b/docs/configuration/hcl/index.md
@@ -3,6 +3,7 @@ title: "HCL Configuration"
 description: "Write docker-agent configs in HCL instead of YAML, using labeled blocks, heredocs, and the same underlying schema."
 keywords: docker agent, ai agents, configuration, yaml, hcl configuration
 weight: 20
+canonical: https://docs.docker.com/ai/docker-agent/configuration/hcl/
 ---
 
 _Write docker-agent configs in HCL instead of YAML. It maps to the same docker-agent schema and validation rules._

--- a/docs/configuration/hooks/index.md
+++ b/docs/configuration/hooks/index.md
@@ -3,6 +3,7 @@ title: "Hooks"
 description: "Run shell commands at various points during agent execution for deterministic control over behavior."
 keywords: docker agent, ai agents, configuration, yaml, hooks
 weight: 60
+canonical: https://docs.docker.com/ai/docker-agent/configuration/hooks/
 ---
 
 _Run shell commands at various points during agent execution for deterministic control over behavior._

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -4,6 +4,7 @@ description: "Complete reference for defining models with providers, parameters,
 keywords: docker agent, ai agents, configuration, yaml, model configuration
 linkTitle: "Model Config"
 weight: 40
+canonical: https://docs.docker.com/ai/docker-agent/configuration/models/
 ---
 
 _Complete reference for defining models with providers, parameters, and reasoning settings._

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -4,6 +4,7 @@ description: "docker-agent uses YAML or HCL configuration files to define agents
 keywords: docker agent, ai agents, configuration, yaml, configuration overview
 linkTitle: "Overview"
 weight: 10
+canonical: https://docs.docker.com/ai/docker-agent/configuration/overview/
 aliases:
   - /ai/docker-agent/reference/config/
 ---

--- a/docs/configuration/permissions/index.md
+++ b/docs/configuration/permissions/index.md
@@ -3,6 +3,7 @@ title: "Permissions"
 description: "Control which tools can execute automatically, require confirmation, or are blocked entirely."
 keywords: docker agent, ai agents, configuration, yaml, permissions
 weight: 70
+canonical: https://docs.docker.com/ai/docker-agent/configuration/permissions/
 ---
 
 _Control which tools can execute automatically, require confirmation, or are blocked entirely._

--- a/docs/configuration/routing/index.md
+++ b/docs/configuration/routing/index.md
@@ -3,6 +3,7 @@ title: "Model Routing"
 description: "Route requests to different models based on the content of user messages."
 keywords: docker agent, ai agents, configuration, yaml, model routing
 weight: 100
+canonical: https://docs.docker.com/ai/docker-agent/configuration/routing/
 ---
 
 _Route requests to different models based on the content of user messages._

--- a/docs/configuration/sandbox/index.md
+++ b/docs/configuration/sandbox/index.md
@@ -3,6 +3,7 @@ title: "Sandbox Mode"
 description: "Run agents in an isolated Docker sandbox VM for enhanced security."
 keywords: docker agent, ai agents, configuration, yaml, sandbox mode
 weight: 80
+canonical: https://docs.docker.com/ai/docker-agent/configuration/sandbox/
 ---
 
 _Run agents in an isolated Docker sandbox VM for enhanced security._

--- a/docs/configuration/structured-output/index.md
+++ b/docs/configuration/structured-output/index.md
@@ -3,6 +3,7 @@ title: "Structured Output"
 description: "Force the agent to respond with JSON matching a specific schema."
 keywords: docker agent, ai agents, configuration, yaml, structured output
 weight: 90
+canonical: https://docs.docker.com/ai/docker-agent/configuration/structured-output/
 ---
 
 _Force the agent to respond with JSON matching a specific schema._

--- a/docs/configuration/tools/index.md
+++ b/docs/configuration/tools/index.md
@@ -4,6 +4,7 @@ description: "Complete reference for configuring built-in tools, MCP tools, and 
 keywords: docker agent, ai agents, configuration, yaml, tool configuration
 linkTitle: "Tool Config"
 weight: 50
+canonical: https://docs.docker.com/ai/docker-agent/configuration/tools/
 aliases:
   - /ai/docker-agent/reference/toolsets/
 ---

--- a/docs/features/a2a/index.md
+++ b/docs/features/a2a/index.md
@@ -3,6 +3,7 @@ title: "A2A Protocol"
 description: "Expose docker-agent agents via Google's Agent-to-Agent (A2A) protocol for interoperability with other agent frameworks."
 keywords: docker agent, ai agents, features, a2a protocol
 weight: 60
+canonical: https://docs.docker.com/ai/docker-agent/features/a2a/
 aliases:
   - /ai/docker-agent/integrations/a2a/
 ---

--- a/docs/features/acp/index.md
+++ b/docs/features/acp/index.md
@@ -4,6 +4,7 @@ description: "Expose docker-agent agents via the Agent Client Protocol for integ
 keywords: docker agent, ai agents, features, acp (agent client protocol)
 linkTitle: "ACP"
 weight: 70
+canonical: https://docs.docker.com/ai/docker-agent/features/acp/
 aliases:
   - /ai/docker-agent/integrations/acp/
 ---

--- a/docs/features/api-server/index.md
+++ b/docs/features/api-server/index.md
@@ -3,6 +3,7 @@ title: "API Server"
 description: "Expose your agents via an HTTP API for programmatic access, web frontends, and integrations."
 keywords: docker agent, ai agents, features, api server
 weight: 80
+canonical: https://docs.docker.com/ai/docker-agent/features/api-server/
 ---
 
 _Expose your agents via an HTTP API for programmatic access, web frontends, and integrations._

--- a/docs/features/chat-server/index.md
+++ b/docs/features/chat-server/index.md
@@ -3,6 +3,7 @@ title: "Chat Server"
 description: "Expose your agents through an OpenAI-compatible Chat Completions API so any tool that already speaks OpenAI can drive a docker-agent agent."
 keywords: docker agent, ai agents, features, chat server
 weight: 90
+canonical: https://docs.docker.com/ai/docker-agent/features/chat-server/
 ---
 
 _Expose your agents through an OpenAI-compatible Chat Completions API so any tool that already speaks OpenAI can drive a docker-agent agent._

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -3,6 +3,7 @@ title: "CLI Reference"
 description: "Complete reference for all docker-agent command-line commands and flags."
 keywords: docker agent, ai agents, features, cli reference
 weight: 30
+canonical: https://docs.docker.com/ai/docker-agent/features/cli/
 aliases:
   - /ai/docker-agent/reference/cli/
 ---

--- a/docs/features/evaluation/index.md
+++ b/docs/features/evaluation/index.md
@@ -3,6 +3,7 @@ title: "Evaluation"
 description: "Measure agent quality with automated evaluations — tool call accuracy, response relevance, output size, and more."
 keywords: docker agent, ai agents, features, evaluation
 weight: 100
+canonical: https://docs.docker.com/ai/docker-agent/features/evaluation/
 aliases:
   - /ai/docker-agent/evals/
 ---

--- a/docs/features/harnesses/index.md
+++ b/docs/features/harnesses/index.md
@@ -3,6 +3,7 @@ title: "Coding Harnesses"
 description: "Delegate coding tasks to external AI coding CLIs (Claude Code, Codex, opencode) as sub-agents."
 keywords: docker agent, ai agents, features, coding harnesses
 weight: 50
+canonical: https://docs.docker.com/ai/docker-agent/features/harnesses/
 ---
 
 _Delegate coding tasks to external AI coding CLIs (Claude Code, Codex, opencode) as sub-agents._

--- a/docs/features/mcp-mode/index.md
+++ b/docs/features/mcp-mode/index.md
@@ -3,6 +3,7 @@ title: "MCP Mode"
 description: "Expose your docker-agent agents as MCP tools for use in Claude Desktop, Claude Code, and other MCP-compatible applications."
 keywords: docker agent, ai agents, features, mcp mode
 weight: 40
+canonical: https://docs.docker.com/ai/docker-agent/features/mcp-mode/
 ---
 
 _Expose your docker-agent agents as MCP tools for use in Claude Desktop, Claude Code, and other MCP-compatible applications._

--- a/docs/features/remote-mcp/index.md
+++ b/docs/features/remote-mcp/index.md
@@ -3,6 +3,7 @@ title: "Remote MCP Servers"
 description: "Connect docker-agent to cloud services via remote MCP servers with built-in OAuth authentication."
 keywords: docker agent, ai agents, features, remote mcp servers
 weight: 120
+canonical: https://docs.docker.com/ai/docker-agent/features/remote-mcp/
 ---
 
 _Connect docker-agent to cloud services via remote MCP servers with built-in OAuth authentication._

--- a/docs/features/skills/index.md
+++ b/docs/features/skills/index.md
@@ -3,6 +3,7 @@ title: "Skills"
 description: "Skills provide specialized instructions that agents can load on demand when a task matches a skill's description."
 keywords: docker agent, ai agents, features, skills
 weight: 110
+canonical: https://docs.docker.com/ai/docker-agent/features/skills/
 ---
 
 _Skills provide specialized instructions that agents can load on demand when a task matches a skill's description._

--- a/docs/features/snapshots/index.md
+++ b/docs/features/snapshots/index.md
@@ -3,6 +3,7 @@ title: "Snapshots"
 description: "Shadow-git snapshots capture your workspace at turn boundaries so you can review what an agent changed and undo it without touching your real git history."
 keywords: docker agent, ai agents, features, snapshots
 weight: 20
+canonical: https://docs.docker.com/ai/docker-agent/features/snapshots/
 ---
 
 _Shadow-git snapshots capture your workspace at turn boundaries so you can review what an agent changed and undo it without touching your real git history._

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -4,6 +4,7 @@ description: "docker-agent's default interface is a rich, interactive terminal U
 keywords: docker agent, ai agents, features, terminal ui (tui)
 linkTitle: "Terminal UI"
 weight: 10
+canonical: https://docs.docker.com/ai/docker-agent/features/tui/
 ---
 
 _docker-agent's default interface is a rich, interactive terminal UI with file attachments, themes, session management, and more._

--- a/docs/getting-started/installation/index.md
+++ b/docs/getting-started/installation/index.md
@@ -3,6 +3,7 @@ title: "Installation"
 description: "Get docker-agent running on your system in minutes."
 keywords: docker agent, ai agents, getting started, installation
 weight: 20
+canonical: https://docs.docker.com/ai/docker-agent/getting-started/installation/
 ---
 
 _Get docker-agent running on your system in minutes._

--- a/docs/getting-started/introduction/index.md
+++ b/docs/getting-started/introduction/index.md
@@ -3,6 +3,7 @@ title: "Introduction"
 description: "Docker Agent is a multi-agent runtime that lets you build, run, and share AI agents with a YAML or HCL config — no glue code required."
 keywords: docker agent, ai agents, getting started, introduction
 weight: 10
+canonical: https://docs.docker.com/ai/docker-agent/getting-started/introduction/
 ---
 
 _Docker Agent is a multi-agent runtime that lets you build, run, and share AI agents with a YAML or HCL config — no glue code required._

--- a/docs/getting-started/quickstart/index.md
+++ b/docs/getting-started/quickstart/index.md
@@ -3,6 +3,7 @@ title: "Quick Start"
 description: "Get up and running with Docker Agent in under 5 minutes. Pick whichever path suits you best."
 keywords: docker agent, ai agents, getting started, quick start
 weight: 30
+canonical: https://docs.docker.com/ai/docker-agent/getting-started/quickstart/
 aliases:
   - /ai/docker-agent/tutorial/
 ---

--- a/docs/guides/go-sdk/index.md
+++ b/docs/guides/go-sdk/index.md
@@ -3,6 +3,7 @@ title: "Go SDK"
 description: "Use docker-agent as a Go library to embed AI agents in your applications."
 keywords: docker agent, ai agents, guides, go sdk
 weight: 40
+canonical: https://docs.docker.com/ai/docker-agent/guides/go-sdk/
 ---
 
 _Use docker-agent as a Go library to embed AI agents in your applications._

--- a/docs/guides/secrets/index.md
+++ b/docs/guides/secrets/index.md
@@ -3,6 +3,7 @@ title: "Managing Secrets"
 description: "How to securely provide API keys and credentials to docker-agent using environment variables, env files, Docker Compose secrets, macOS Keychain, pass, and 1Password references."
 keywords: docker agent, ai agents, guides, managing secrets
 weight: 30
+canonical: https://docs.docker.com/ai/docker-agent/guides/secrets/
 ---
 
 _How to securely provide API keys and credentials to docker-agent._

--- a/docs/guides/thinking/index.md
+++ b/docs/guides/thinking/index.md
@@ -3,6 +3,7 @@ title: "Thinking / Reasoning"
 description: "Control how much a model reasons before responding. Works across OpenAI, Anthropic, Google Gemini, AWS Bedrock, and Docker Model Runner."
 keywords: docker agent, ai agents, guides, thinking / reasoning
 weight: 20
+canonical: https://docs.docker.com/ai/docker-agent/guides/thinking/
 ---
 
 _Control how much a model reasons before responding. Works across OpenAI, Anthropic, Google Gemini, AWS Bedrock, and Docker Model Runner._

--- a/docs/guides/tips/index.md
+++ b/docs/guides/tips/index.md
@@ -3,6 +3,7 @@ title: "Tips & Best Practices"
 description: "Expert guidance for building effective, efficient, and secure agents."
 keywords: docker agent, ai agents, guides, tips & best practices
 weight: 10
+canonical: https://docs.docker.com/ai/docker-agent/guides/tips/
 aliases:
   - /ai/docker-agent/best-practices/
 ---

--- a/docs/providers/anthropic/index.md
+++ b/docs/providers/anthropic/index.md
@@ -3,6 +3,7 @@ title: "Anthropic"
 description: "Use Claude Sonnet 4, Claude Sonnet 4.5, and other Anthropic models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, anthropic
 weight: 20
+canonical: https://docs.docker.com/ai/docker-agent/providers/anthropic/
 ---
 
 _Use Claude Sonnet 4, Claude Sonnet 4.5, and other Anthropic models with docker-agent._

--- a/docs/providers/baseten/index.md
+++ b/docs/providers/baseten/index.md
@@ -3,6 +3,7 @@ title: "Baseten"
 description: "Use Baseten AI models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, baseten
 weight: 40
+canonical: https://docs.docker.com/ai/docker-agent/providers/baseten/
 ---
 
 _Use Baseten AI models with docker-agent._

--- a/docs/providers/bedrock/index.md
+++ b/docs/providers/bedrock/index.md
@@ -3,6 +3,7 @@ title: "AWS Bedrock"
 description: "Access Claude, Nova, Llama, and more through AWS infrastructure with enterprise-grade security and compliance."
 keywords: docker agent, ai agents, model providers, llm, aws bedrock
 weight: 30
+canonical: https://docs.docker.com/ai/docker-agent/providers/bedrock/
 ---
 
 _Access Claude, Nova, Llama, and more through AWS infrastructure with enterprise-grade security and compliance._

--- a/docs/providers/cerebras/index.md
+++ b/docs/providers/cerebras/index.md
@@ -3,6 +3,7 @@ title: "Cerebras"
 description: "Use Cerebras models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, cerebras
 weight: 50
+canonical: https://docs.docker.com/ai/docker-agent/providers/cerebras/
 ---
 
 _Use Cerebras models with docker-agent._

--- a/docs/providers/cloudflare-ai-gateway/index.md
+++ b/docs/providers/cloudflare-ai-gateway/index.md
@@ -3,6 +3,7 @@ title: "Cloudflare AI Gateway"
 description: "Use Cloudflare AI Gateway models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, cloudflare ai gateway
 weight: 60
+canonical: https://docs.docker.com/ai/docker-agent/providers/cloudflare-ai-gateway/
 ---
 
 _Use Cloudflare AI Gateway models with docker-agent._

--- a/docs/providers/cloudflare-workers-ai/index.md
+++ b/docs/providers/cloudflare-workers-ai/index.md
@@ -3,6 +3,7 @@ title: "Cloudflare Workers AI"
 description: "Use Cloudflare Workers AI models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, cloudflare workers ai
 weight: 70
+canonical: https://docs.docker.com/ai/docker-agent/providers/cloudflare-workers-ai/
 ---
 
 _Use Cloudflare Workers AI models with docker-agent._

--- a/docs/providers/custom/index.md
+++ b/docs/providers/custom/index.md
@@ -3,6 +3,7 @@ title: "Provider Definitions"
 description: "Define reusable provider configurations with shared defaults for any provider type — OpenAI, Anthropic, Google, Bedrock, and more."
 keywords: docker agent, ai agents, model providers, llm, provider definitions
 weight: 280
+canonical: https://docs.docker.com/ai/docker-agent/providers/custom/
 ---
 
 _Define reusable provider configurations with shared defaults for any provider type — OpenAI, Anthropic, Google, Bedrock, and more._

--- a/docs/providers/deepseek/index.md
+++ b/docs/providers/deepseek/index.md
@@ -3,6 +3,7 @@ title: "DeepSeek"
 description: "Use DeepSeek models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, deepseek
 weight: 80
+canonical: https://docs.docker.com/ai/docker-agent/providers/deepseek/
 ---
 
 _Use DeepSeek models with docker-agent._

--- a/docs/providers/dmr/index.md
+++ b/docs/providers/dmr/index.md
@@ -3,6 +3,7 @@ title: "Docker Model Runner"
 description: "Run AI models locally with Docker — no API keys, no costs, full data privacy."
 keywords: docker agent, ai agents, model providers, llm, docker model runner
 weight: 90
+canonical: https://docs.docker.com/ai/docker-agent/providers/dmr/
 ---
 
 _Run AI models locally with Docker — no API keys, no costs, full data privacy._

--- a/docs/providers/fireworks/index.md
+++ b/docs/providers/fireworks/index.md
@@ -3,6 +3,7 @@ title: "Fireworks AI"
 description: "Use Fireworks AI models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, fireworks ai
 weight: 100
+canonical: https://docs.docker.com/ai/docker-agent/providers/fireworks/
 ---
 
 _Use Fireworks AI models with docker-agent._

--- a/docs/providers/github-copilot/index.md
+++ b/docs/providers/github-copilot/index.md
@@ -3,6 +3,7 @@ title: "GitHub Copilot"
 description: "Use GitHub Copilot's hosted models (GPT-4o, Claude, Gemini, and more) with docker-agent through your GitHub subscription."
 keywords: docker agent, ai agents, model providers, llm, github copilot
 weight: 110
+canonical: https://docs.docker.com/ai/docker-agent/providers/github-copilot/
 ---
 
 _Use GitHub Copilot's hosted models with docker-agent through your existing GitHub subscription._

--- a/docs/providers/google/index.md
+++ b/docs/providers/google/index.md
@@ -3,6 +3,7 @@ title: "Google Gemini"
 description: "Use Gemini 2.5 Flash, Gemini 3 Pro, and other Google models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, google gemini
 weight: 120
+canonical: https://docs.docker.com/ai/docker-agent/providers/google/
 ---
 
 _Use Gemini 2.5 Flash, Gemini 3 Pro, and other Google models with docker-agent._

--- a/docs/providers/groq/index.md
+++ b/docs/providers/groq/index.md
@@ -3,6 +3,7 @@ title: "Groq"
 description: "Use Groq fast-inference models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, groq
 weight: 130
+canonical: https://docs.docker.com/ai/docker-agent/providers/groq/
 ---
 
 _Use Groq models with docker-agent._

--- a/docs/providers/huggingface/index.md
+++ b/docs/providers/huggingface/index.md
@@ -3,6 +3,7 @@ title: "Hugging Face"
 description: "Use Hugging Face Inference Providers with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, hugging face
 weight: 140
+canonical: https://docs.docker.com/ai/docker-agent/providers/huggingface/
 ---
 
 _Use Hugging Face Inference Providers with docker-agent._

--- a/docs/providers/local/index.md
+++ b/docs/providers/local/index.md
@@ -4,6 +4,7 @@ description: "Run docker-agent with locally hosted models for privacy, offline u
 keywords: docker agent, ai agents, model providers, llm, local models (ollama, vllm, localai)
 linkTitle: "Local Models"
 weight: 150
+canonical: https://docs.docker.com/ai/docker-agent/providers/local/
 aliases:
   - /ai/docker-agent/local-models/
 ---

--- a/docs/providers/minimax/index.md
+++ b/docs/providers/minimax/index.md
@@ -3,6 +3,7 @@ title: "MiniMax"
 description: "Use MiniMax AI models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, minimax
 weight: 160
+canonical: https://docs.docker.com/ai/docker-agent/providers/minimax/
 ---
 
 _Use MiniMax AI models with docker-agent._

--- a/docs/providers/mistral/index.md
+++ b/docs/providers/mistral/index.md
@@ -3,6 +3,7 @@ title: "Mistral"
 description: "Use Mistral AI models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, mistral
 weight: 170
+canonical: https://docs.docker.com/ai/docker-agent/providers/mistral/
 ---
 
 _Use Mistral AI models with docker-agent._

--- a/docs/providers/moonshot/index.md
+++ b/docs/providers/moonshot/index.md
@@ -3,6 +3,7 @@ title: "Moonshot AI"
 description: "Use Moonshot AI (Kimi) models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, moonshot ai
 weight: 180
+canonical: https://docs.docker.com/ai/docker-agent/providers/moonshot/
 ---
 
 _Use Moonshot AI (Kimi) models with docker-agent._

--- a/docs/providers/nebius/index.md
+++ b/docs/providers/nebius/index.md
@@ -3,6 +3,7 @@ title: "Nebius"
 description: "Use Nebius AI models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, nebius
 weight: 190
+canonical: https://docs.docker.com/ai/docker-agent/providers/nebius/
 ---
 
 _Use Nebius AI models with docker-agent._

--- a/docs/providers/openai/index.md
+++ b/docs/providers/openai/index.md
@@ -3,6 +3,7 @@ title: "OpenAI"
 description: "Use GPT-4o, GPT-5, GPT-5-mini, and other OpenAI models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, openai
 weight: 200
+canonical: https://docs.docker.com/ai/docker-agent/providers/openai/
 ---
 
 _Use GPT-4o, GPT-5, GPT-5-mini, and other OpenAI models with docker-agent._

--- a/docs/providers/opencode-go/index.md
+++ b/docs/providers/opencode-go/index.md
@@ -3,6 +3,7 @@ title: "OpenCode Go"
 description: "Use OpenCode Go models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, opencode go
 weight: 210
+canonical: https://docs.docker.com/ai/docker-agent/providers/opencode-go/
 ---
 
 _Use OpenCode Go models with docker-agent._

--- a/docs/providers/opencode-zen/index.md
+++ b/docs/providers/opencode-zen/index.md
@@ -3,6 +3,7 @@ title: "OpenCode Zen"
 description: "Use OpenCode Zen models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, opencode zen
 weight: 220
+canonical: https://docs.docker.com/ai/docker-agent/providers/opencode-zen/
 ---
 
 _Use OpenCode Zen models with docker-agent._

--- a/docs/providers/openrouter/index.md
+++ b/docs/providers/openrouter/index.md
@@ -3,6 +3,7 @@ title: "OpenRouter"
 description: "Use OpenRouter models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, openrouter
 weight: 230
+canonical: https://docs.docker.com/ai/docker-agent/providers/openrouter/
 ---
 
 _Use OpenRouter models with docker-agent._

--- a/docs/providers/overview/index.md
+++ b/docs/providers/overview/index.md
@@ -4,6 +4,7 @@ description: "docker-agent supports multiple AI model providers. Choose the righ
 keywords: docker agent, ai agents, model providers, llm
 linkTitle: "Overview"
 weight: 10
+canonical: https://docs.docker.com/ai/docker-agent/providers/overview/
 aliases:
   - /ai/docker-agent/model-providers/
 ---

--- a/docs/providers/ovhcloud/index.md
+++ b/docs/providers/ovhcloud/index.md
@@ -3,6 +3,7 @@ title: "OVHcloud"
 description: "Use OVHcloud AI Endpoints models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, ovhcloud
 weight: 240
+canonical: https://docs.docker.com/ai/docker-agent/providers/ovhcloud/
 ---
 
 _Use OVHcloud AI Endpoints models with docker-agent._

--- a/docs/providers/together/index.md
+++ b/docs/providers/together/index.md
@@ -3,6 +3,7 @@ title: "Together AI"
 description: "Use Together AI models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, together ai
 weight: 250
+canonical: https://docs.docker.com/ai/docker-agent/providers/together/
 ---
 
 _Use Together AI models with docker-agent._

--- a/docs/providers/vercel/index.md
+++ b/docs/providers/vercel/index.md
@@ -3,6 +3,7 @@ title: "Vercel AI Gateway"
 description: "Use Vercel AI Gateway models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, vercel ai gateway
 weight: 260
+canonical: https://docs.docker.com/ai/docker-agent/providers/vercel/
 ---
 
 _Use Vercel AI Gateway models with docker-agent._

--- a/docs/providers/xai/index.md
+++ b/docs/providers/xai/index.md
@@ -3,6 +3,7 @@ title: "xAI (Grok)"
 description: "Use xAI's Grok models with docker-agent."
 keywords: docker agent, ai agents, model providers, llm, xai (grok)
 weight: 270
+canonical: https://docs.docker.com/ai/docker-agent/providers/xai/
 ---
 
 _Use xAI's Grok models with docker-agent._

--- a/docs/tools/a2a/index.md
+++ b/docs/tools/a2a/index.md
@@ -4,6 +4,7 @@ description: "Connect to remote agents via the Agent-to-Agent protocol."
 keywords: docker agent, ai agents, tools, toolsets, a2a tool
 linkTitle: "A2A"
 weight: 60
+canonical: https://docs.docker.com/ai/docker-agent/tools/a2a/
 ---
 
 _Connect to remote agents via the Agent-to-Agent protocol._

--- a/docs/tools/api/index.md
+++ b/docs/tools/api/index.md
@@ -4,6 +4,7 @@ description: "Create custom tools that call HTTP APIs."
 keywords: docker agent, ai agents, tools, toolsets, api tool
 linkTitle: "API"
 weight: 240
+canonical: https://docs.docker.com/ai/docker-agent/tools/api/
 ---
 
 _Create custom tools that call HTTP APIs._

--- a/docs/tools/background-agents/index.md
+++ b/docs/tools/background-agents/index.md
@@ -4,6 +4,7 @@ description: "Dispatch work to sub-agents concurrently and collect results async
 keywords: docker agent, ai agents, tools, toolsets, background agents tool
 linkTitle: "Background Agents"
 weight: 90
+canonical: https://docs.docker.com/ai/docker-agent/tools/background-agents/
 ---
 
 _Dispatch work to sub-agents concurrently and collect results asynchronously._

--- a/docs/tools/fetch/index.md
+++ b/docs/tools/fetch/index.md
@@ -4,6 +4,7 @@ description: "Read content from HTTP/HTTPS URLs."
 keywords: docker agent, ai agents, tools, toolsets, fetch tool
 linkTitle: "Fetch"
 weight: 50
+canonical: https://docs.docker.com/ai/docker-agent/tools/fetch/
 ---
 
 _Read content from HTTP/HTTPS URLs._

--- a/docs/tools/filesystem/index.md
+++ b/docs/tools/filesystem/index.md
@@ -4,6 +4,7 @@ description: "Read, write, list, search, and navigate files and directories."
 keywords: docker agent, ai agents, tools, toolsets, filesystem tool
 linkTitle: "Filesystem"
 weight: 10
+canonical: https://docs.docker.com/ai/docker-agent/tools/filesystem/
 ---
 
 _Read, write, list, search, and navigate files and directories._

--- a/docs/tools/handoff/index.md
+++ b/docs/tools/handoff/index.md
@@ -4,6 +4,7 @@ description: "Hand off the active conversation to another local agent defined in
 keywords: docker agent, ai agents, tools, toolsets, handoff tool
 linkTitle: "Handoff"
 weight: 70
+canonical: https://docs.docker.com/ai/docker-agent/tools/handoff/
 ---
 
 _Hand off the active conversation to another local agent defined in the same config._

--- a/docs/tools/lsp/index.md
+++ b/docs/tools/lsp/index.md
@@ -4,6 +4,7 @@ description: "Connect to Language Server Protocol servers for code intelligence.
 keywords: docker agent, ai agents, tools, toolsets, lsp tool
 linkTitle: "LSP"
 weight: 220
+canonical: https://docs.docker.com/ai/docker-agent/tools/lsp/
 ---
 
 _Connect to Language Server Protocol servers for code intelligence._

--- a/docs/tools/mcp-catalog/index.md
+++ b/docs/tools/mcp-catalog/index.md
@@ -4,6 +4,7 @@ description: "Let the agent discover and activate remote MCP servers from the Do
 keywords: docker agent, ai agents, tools, toolsets, mcp catalog tool
 linkTitle: "MCP Catalog"
 weight: 120
+canonical: https://docs.docker.com/ai/docker-agent/tools/mcp-catalog/
 ---
 
 _Let the agent discover and activate remote MCP servers from the Docker MCP Catalog on demand._

--- a/docs/tools/mcp/index.md
+++ b/docs/tools/mcp/index.md
@@ -4,6 +4,7 @@ description: "Extend agents with external tools via the Model Context Protocol."
 keywords: docker agent, ai agents, tools, toolsets, mcp tool
 linkTitle: "MCP"
 weight: 130
+canonical: https://docs.docker.com/ai/docker-agent/tools/mcp/
 aliases:
   - /ai/docker-agent/integrations/mcp/
 ---

--- a/docs/tools/memory/index.md
+++ b/docs/tools/memory/index.md
@@ -4,6 +4,7 @@ description: "Persistent key-value storage backed by SQLite for cross-session re
 keywords: docker agent, ai agents, tools, toolsets, memory tool
 linkTitle: "Memory"
 weight: 100
+canonical: https://docs.docker.com/ai/docker-agent/tools/memory/
 ---
 
 _Persistent key-value storage backed by SQLite for cross-session recall._

--- a/docs/tools/model-picker/index.md
+++ b/docs/tools/model-picker/index.md
@@ -4,6 +4,7 @@ description: "Let the agent pick between several models per turn."
 keywords: docker agent, ai agents, tools, toolsets, model picker tool
 linkTitle: "Model Picker"
 weight: 200
+canonical: https://docs.docker.com/ai/docker-agent/tools/model-picker/
 ---
 
 _Let the agent pick between several models per turn._

--- a/docs/tools/open-url/index.md
+++ b/docs/tools/open-url/index.md
@@ -4,6 +4,7 @@ description: "Open a fixed URL in the user's default browser."
 keywords: docker agent, ai agents, tools, toolsets, open url tool
 linkTitle: "Open URL"
 weight: 40
+canonical: https://docs.docker.com/ai/docker-agent/tools/open-url/
 ---
 
 _Open a fixed URL in the user's default browser._

--- a/docs/tools/openapi/index.md
+++ b/docs/tools/openapi/index.md
@@ -4,6 +4,7 @@ description: "Automatically generate tools from an OpenAPI specification."
 keywords: docker agent, ai agents, tools, toolsets, openapi tool
 linkTitle: "OpenAPI"
 weight: 230
+canonical: https://docs.docker.com/ai/docker-agent/tools/openapi/
 ---
 
 _Automatically generate tools from an OpenAPI specification._

--- a/docs/tools/plan/index.md
+++ b/docs/tools/plan/index.md
@@ -4,6 +4,7 @@ description: "Shared persistent scratchpad for multi-agent collaboration."
 keywords: docker agent, ai agents, tools, toolsets, plan tool
 linkTitle: "Plan"
 weight: 150
+canonical: https://docs.docker.com/ai/docker-agent/tools/plan/
 ---
 
 _Shared persistent scratchpad for multi-agent collaboration._

--- a/docs/tools/rag/index.md
+++ b/docs/tools/rag/index.md
@@ -4,6 +4,7 @@ description: "Give your agents access to document knowledge bases with backgroun
 keywords: docker agent, ai agents, tools, toolsets, rag tool
 linkTitle: "RAG"
 weight: 110
+canonical: https://docs.docker.com/ai/docker-agent/tools/rag/
 aliases:
   - /ai/docker-agent/rag/
 ---

--- a/docs/tools/script/index.md
+++ b/docs/tools/script/index.md
@@ -4,6 +4,7 @@ description: "Define custom shell scripts as named tools with typed parameters."
 keywords: docker agent, ai agents, tools, toolsets, script tool
 linkTitle: "Script"
 weight: 30
+canonical: https://docs.docker.com/ai/docker-agent/tools/script/
 ---
 
 _Define custom shell scripts as named tools with typed parameters._

--- a/docs/tools/session_context/index.md
+++ b/docs/tools/session_context/index.md
@@ -4,6 +4,7 @@ description: "Reference a previous session as context in the current one."
 keywords: docker agent, ai agents, tools, toolsets, session context tool
 linkTitle: "Session Context"
 weight: 210
+canonical: https://docs.docker.com/ai/docker-agent/tools/session_context/
 ---
 
 _Reference a previous session as context, without manual export/import._

--- a/docs/tools/session_plan/index.md
+++ b/docs/tools/session_plan/index.md
@@ -4,6 +4,7 @@ description: "Per-session plan tracker for the draft, review, execute workflow."
 keywords: docker agent, ai agents, tools, toolsets, session plan tool
 linkTitle: "Session Plan"
 weight: 160
+canonical: https://docs.docker.com/ai/docker-agent/tools/session_plan/
 ---
 
 _Per-session plan tracker for the "draft, review, execute" workflow._

--- a/docs/tools/shell/index.md
+++ b/docs/tools/shell/index.md
@@ -4,6 +4,7 @@ description: "Execute arbitrary shell commands in the user's environment."
 keywords: docker agent, ai agents, tools, toolsets, shell tool
 linkTitle: "Shell"
 weight: 20
+canonical: https://docs.docker.com/ai/docker-agent/tools/shell/
 ---
 
 _Execute arbitrary shell commands in the user's environment._

--- a/docs/tools/tasks/index.md
+++ b/docs/tools/tasks/index.md
@@ -4,6 +4,7 @@ description: "Persistent task database with priorities and dependencies, shared 
 keywords: docker agent, ai agents, tools, toolsets, tasks tool
 linkTitle: "Tasks"
 weight: 180
+canonical: https://docs.docker.com/ai/docker-agent/tools/tasks/
 ---
 
 _Persistent task database with priorities and dependencies, shared across sessions._

--- a/docs/tools/think/index.md
+++ b/docs/tools/think/index.md
@@ -4,6 +4,7 @@ description: "Step-by-step reasoning scratchpad for planning and decision-making
 keywords: docker agent, ai agents, tools, toolsets, think tool
 linkTitle: "Think"
 weight: 140
+canonical: https://docs.docker.com/ai/docker-agent/tools/think/
 ---
 
 _Step-by-step reasoning scratchpad for planning and decision-making._

--- a/docs/tools/todo/index.md
+++ b/docs/tools/todo/index.md
@@ -4,6 +4,7 @@ description: "Task list management for complex multi-step workflows."
 keywords: docker agent, ai agents, tools, toolsets, todo tool
 linkTitle: "Todo"
 weight: 170
+canonical: https://docs.docker.com/ai/docker-agent/tools/todo/
 ---
 
 _Task list management for complex multi-step workflows._

--- a/docs/tools/transfer-task/index.md
+++ b/docs/tools/transfer-task/index.md
@@ -4,6 +4,7 @@ description: "Delegate tasks to sub-agents in multi-agent setups."
 keywords: docker agent, ai agents, tools, toolsets, transfer task tool
 linkTitle: "Transfer Task"
 weight: 80
+canonical: https://docs.docker.com/ai/docker-agent/tools/transfer-task/
 ---
 
 _Delegate tasks to sub-agents in multi-agent setups._

--- a/docs/tools/user-prompt/index.md
+++ b/docs/tools/user-prompt/index.md
@@ -4,6 +4,7 @@ description: "Ask the user questions and collect interactive input during agent 
 keywords: docker agent, ai agents, tools, toolsets, user prompt tool
 linkTitle: "User Prompt"
 weight: 190
+canonical: https://docs.docker.com/ai/docker-agent/tools/user-prompt/
 ---
 
 _Ask the user questions and collect interactive input during agent execution._

--- a/scripts/docs-check-canonical.sh
+++ b/scripts/docs-check-canonical.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# scripts/docs-check-canonical.sh — every content page mounted on
+# docs.docker.com must declare the canonical: front matter value
+# derived from its path, so the github.io page defers to the stable
+# docs (issue #3371, phase 3.2). Missing or stale values (e.g. a page
+# scaffolded by copying another one) fail here and in docs-lint CI.
+#
+# Scope: docs/<section>/<page>/index.md and deeper. The homepage,
+# 404.md and section _index.md files are not github.io content pages
+# and are intentionally not checked (see docs/STYLE.md).
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+status=0
+checked=0
+while IFS= read -r file; do
+  rel=${file#docs/}
+  rel=${rel%/index.md}
+  want="canonical: https://docs.docker.com/ai/docker-agent/${rel}/"
+  if ! awk '/^---$/ { fm++; next } fm == 1' "$file" | grep -Fxq "$want"; then
+    echo "${file}: missing or stale canonical, expected exactly: ${want}"
+    status=1
+  fi
+  checked=$((checked + 1))
+done < <(find docs -mindepth 3 -name index.md -not -path 'docs/_site/*' -not -path 'docs/node_modules/*' | sort)
+
+if [ "$checked" -eq 0 ]; then
+  echo "no content pages found under docs/ — wrong working directory?"
+  exit 1
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "canonical front matter OK on ${checked} mounted content pages"
+fi
+exit "$status"


### PR DESCRIPTION
Completes phase 3.2 of #3371. The layout support landed in #3413 (a canonical link renders when a page sets `canonical:` front matter), but no page carried a value yet.

## What changed

| Change | Detail |
|---|---|
| `canonical:` front matter | Added to all 90 content pages mounted on docs.docker.com, derived from the mount map (`docs/<section>/<page>/` maps to `https://docs.docker.com/ai/docker-agent/<section>/<page>/`) |
| `scripts/docs-check-canonical.sh` | Verifies every mounted page carries the exact canonical derived from its path; catches pages scaffolded from an existing one without updating the value |
| `docs-lint.yml` | New `canonical-check` job running the script on every docs change |
| `STYLE.md` | New "Canonical URLs" section documenting the convention next to the linking rules |

## Scope

- `index.md` (homepage) and `404.md` are github.io-only, never mounted, and set no canonical.
- Section `_index.md` files produce no github.io page (Jekyll ignores underscore-prefixed files) and set no canonical.
- docs.docker.com ignores the param: its head template always canonicalizes to the page permalink, so mounted pages self-canonicalize as before.

## Validation

| Check | Result |
|---|---|
| Live URLs | 90/90 return HTTP 200 on docs.docker.com |
| markdownlint-cli2 (101 files) | 0 errors |
| lychee `--offline` | 0 errors |
| Jekyll build + rendered HTML | canonical tag present on exactly the 90 mounted pages, absent from homepage and 404 |
| `docs-check-canonical.sh` | passes on the tree; mutation-tested against a missing and a stale value |
| actionlint + `workflow-lint.sh` | OK |

Part of #3371 (phase 4, renderer convergence, stays open).
