### PR TITLE
feat(config): make the auto-compaction threshold configurable (compaction_threshold)

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -648,6 +648,22 @@
           "description": "Number of history items to keep",
           "minimum": 0
         },
+        "session_compaction": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enabled by default. When true (the default), the runtime automatically compacts the session: proactively when the estimated context usage crosses the compaction threshold, and reactively to recover from a context-overflow error. Set to false to disable both automatic triggers for this agent; the manual /compact command remains available."
+        },
+        "compaction_threshold": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "maximum": 1,
+          "default": 0.9,
+          "description": "Fraction of the model's context window at which proactive auto-compaction triggers for this agent. Must be greater than 0 and at most 1. Defaults to 0.9 (90% of the context window). A compaction_threshold set on the agent's model takes precedence over this value.",
+          "examples": [
+            0.75,
+            0.9
+          ]
+        },
         "add_prompt_files": {
           "type": "array",
           "description": "List of prompt files to add",
@@ -1617,6 +1633,17 @@
           "examples": [
             "openai/gpt-4o-mini",
             "fast"
+          ]
+        },
+        "compaction_threshold": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "maximum": 1,
+          "default": 0.9,
+          "description": "Fraction of the context window at which proactive auto-compaction triggers for agents running this model. Must be greater than 0 and at most 1. Defaults to 0.9 (90% of the context window). Takes precedence over the agent-level compaction_threshold. Cannot be combined with first_available.",
+          "examples": [
+            0.75,
+            0.9
           ]
         },
         "capabilities": {

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -34,6 +34,8 @@ agents:
     max_consecutive_tool_calls: int # Optional: max identical consecutive tool calls
     max_old_tool_call_tokens: int # Optional: token budget for old tool call content (disabled unless positive)
     num_history_items: int # Optional: limit conversation history
+    session_compaction: boolean # Optional: disable automatic session compaction (default: true)
+    compaction_threshold: float # Optional: context-window fraction that triggers auto-compaction (0–1, default: 0.9)
     use_toolsets: [list] # Optional: names of top-level toolsets to merge into this agent
     readonly: boolean # Optional: restrict all toolsets to read-only tools only
     skills: boolean | [list] # Optional: enable skill discovery (true/false or list of names and/or sources)
@@ -95,6 +97,8 @@ agents:
 | `max_consecutive_tool_calls` | int     | ✗        | Maximum consecutive identical tool calls before the agent is terminated, preventing degenerate loops. Default: `5`.                                                          |
 | `max_old_tool_call_tokens`  | int     | ✗        | Maximum number of tokens to keep from old tool call arguments and results. Older tool calls beyond this budget have their content replaced with a placeholder, saving context space. Tokens are approximated as `len/4`. Truncation is disabled by default; set a positive value to enable it. Set to `-1` to disable truncation (unlimited). |
 | `num_history_items`         | int     | ✗        | Limit the number of conversation history messages sent to the model. Useful for managing context window size with long conversations. Default: unlimited (all messages sent). |
+| `session_compaction`        | boolean | ✗        | When `false`, disables automatic session compaction for this agent: neither the proactive threshold trigger nor the post-overflow auto-recovery runs. The manual `/compact` command remains available. Default: `true`. |
+| `compaction_threshold`      | float   | ✗        | Fraction of the model's context window at which proactive auto-compaction triggers. Must be greater than `0` and at most `1`. A `compaction_threshold` set on the agent's model takes precedence. Default: `0.9`. See [Compaction Threshold](../models/index.md#delegating-session-compaction). |
 | `skills`                    | bool/array | ✗     | Enable automatic skill discovery. `true` loads all discovered local skills, `false` disables them. A list can mix skill sources (`local` or `https://…` URLs) and skill names to include — see [Skills](../../features/skills/index.md).                                                     |
 | `commands`                  | object  | ✗        | Named prompts that can be run with `docker agent run config.yaml /command_name`. Can be simple strings or objects with `instruction` and/or `agent` fields for agent switching, or a `url` field to open a link in the browser (TUI only). See [Named Commands](#named-commands) below. |
 | `use_commands`              | list of string | ✗   | Names of top-level `commands` groups to merge into this agent. Inline `commands` entries take precedence on name conflicts. Default: `[]`. |

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -40,6 +40,7 @@ models:
       key: value
     title_model: string # Optional: model used for session-title generation
     compaction_model: string # Optional: model used for session-compaction (summary generation)
+    compaction_threshold: float # Optional: context-window fraction that triggers auto-compaction (0–1, default: 0.9)
     bypass_models_gateway: boolean # Optional: skip the models gateway for this model
 ```
 
@@ -66,6 +67,7 @@ models:
 | `provider_opts`       | object     | ✗        | Provider-specific options (see provider pages)                                        |
 | `title_model`         | string     | ✗        | Model used for session-title generation. Can be a named model from the `models:` section or an inline `provider/model` string. When omitted, the agent's primary model generates titles. Cannot be combined with `first_available`. |
 | `compaction_model`    | string     | ✗        | Model used for session compaction (summary generation). Can be a named model or an inline `provider/model` string. When omitted, the primary model compacts. Cannot be combined with `first_available`. See [Delegating Session Compaction](#delegating-session-compaction). |
+| `compaction_threshold` | float     | ✗        | Fraction of the context window at which proactive auto-compaction triggers for agents running this model. Must be greater than `0` and at most `1`. Takes precedence over the agent-level `compaction_threshold`. Cannot be combined with `first_available`. Default: `0.9`. |
 | `bypass_models_gateway` | boolean  | ✗        | When `true`, this model connects directly to its provider even when a models gateway (`--models-gateway` / `CAGENT_MODELS_GATEWAY`) is configured. See [Gateway Bypass](#gateway-bypass). |
 
 ## Attachment Capability Overrides
@@ -152,12 +154,32 @@ call can always ingest the full conversation. Pair the primary with a
 compaction model whose window is at least as large to keep the proactive
 trigger aligned with the primary's window.
 
+By default the proactive trigger fires when the estimated token usage crosses
+**90%** of the context window. The `compaction_threshold` field tunes that
+fraction (greater than `0`, at most `1`): lower values compact earlier and
+keep requests smaller, higher values compact later and keep more verbatim
+history. It can be set on the model (as above, taking precedence) or on the
+agent, and automatic compaction can be disabled entirely per agent with
+`session_compaction: false` — see [Agent Config](../agents/index.md#properties-reference).
+
+```yaml
+models:
+  primary:
+    provider: anthropic
+    model: claude-sonnet-4-5
+    compaction_model: fast
+    # Compact at 80% of the window instead of the default 90%.
+    compaction_threshold: 0.8
+```
+
 > [!WARNING]
 > **Constraint**
 >
 > `compaction_model` cannot be combined with `first_available` model selection — the combination is rejected at validation time.
 
-See [`examples/compaction_model.yaml`](https://github.com/docker/docker-agent/blob/main/examples/compaction_model.yaml) for a complete example.
+See [`examples/compaction_model.yaml`](https://github.com/docker/docker-agent/blob/main/examples/compaction_model.yaml)
+and [`examples/compaction_threshold.yaml`](https://github.com/docker/docker-agent/blob/main/examples/compaction_threshold.yaml)
+for complete examples.
 
 ## Gateway Bypass
 

--- a/examples/compaction_threshold.yaml
+++ b/examples/compaction_threshold.yaml
@@ -1,0 +1,48 @@
+# Compaction Threshold Example
+#
+# This example demonstrates how to tune (or disable) automatic session
+# compaction via the `compaction_threshold` and `session_compaction` fields.
+#
+# By default, docker-agent proactively compacts a session when the estimated
+# token usage crosses 90% of the model's context window. Lowering the
+# threshold compacts earlier (keeping requests smaller and cheaper), raising
+# it compacts later (keeping more verbatim history in context).
+#
+# `compaction_threshold` accepts a fraction greater than 0 and at most 1 and
+# can be set in two places:
+#   - on an agent: applies to that agent's sessions
+#   - on a model (next to `compaction_model`): applies to agents running
+#     that model and takes precedence over the agent-level value
+#
+# `session_compaction: false` disables automatic compaction entirely for an
+# agent: no proactive threshold trigger and no post-overflow auto-compaction.
+# The manual `/compact` command remains available.
+
+models:
+  primary:
+    provider: anthropic
+    model: claude-sonnet-4-5
+    # Summarize with a cheaper model, and start compacting at 80% of the
+    # window instead of the default 90%. The model-level threshold overrides
+    # any agent-level `compaction_threshold`.
+    compaction_model: fast
+    compaction_threshold: 0.8
+  fast:
+    provider: anthropic
+    model: claude-haiku-4-5
+
+agents:
+  root:
+    model: primary
+    description: An assistant that compacts earlier than the default.
+    instruction: You are a helpful assistant.
+    sub_agents: [archivist]
+
+  archivist:
+    model: primary
+    description: An assistant that never auto-compacts its sessions.
+    instruction: You keep full conversation history and never lose context.
+    # Disable both automatic compaction triggers for this agent. Only use
+    # this when full history matters more than the risk of hitting the
+    # model's context limit.
+    session_compaction: false

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -31,6 +31,8 @@ type Agent struct {
 	fallbackCooldown        time.Duration                       // Duration to stick with fallback after non-retryable error
 	titleModel              provider.Provider                   // Optional dedicated model for session-title generation
 	compactionModel         provider.Provider                   // Optional dedicated model for session compaction (summary generation)
+	compactionThreshold     float64                             // Custom proactive-compaction trigger fraction; 0 means "use the default"
+	sessionCompactionOff    bool                                // True when the agent opted out of automatic session compaction
 	modelOverrides          atomic.Pointer[[]provider.Provider] // Optional model override(s) set at runtime (supports alloy)
 	subAgents               []*Agent
 	handoffs                []*Agent
@@ -334,6 +336,25 @@ func (a *Agent) TitleModels(ctx context.Context) []provider.Provider {
 // configured compaction model after the conversation model has been changed.
 func (a *Agent) CompactionModel() provider.Provider {
 	return a.compactionModel
+}
+
+// CompactionThreshold returns the configured fraction of the context window
+// at which proactive auto-compaction triggers, or 0 when the agent uses the
+// default. Callers pass the value verbatim to [compaction.ShouldCompact],
+// which maps 0 (and any out-of-range value) to the package default. Like
+// CompactionModel, it is resolved at load time and not affected by runtime
+// model switching.
+func (a *Agent) CompactionThreshold() float64 {
+	return a.compactionThreshold
+}
+
+// SessionCompaction reports whether automatic session compaction (the
+// proactive threshold trigger and post-overflow auto-recovery) is enabled
+// for this agent. Defaults to true; disabled only by an explicit
+// `session_compaction: false` in the agent's config. Manual /compact is
+// not affected by this flag.
+func (a *Agent) SessionCompaction() bool {
+	return !a.sessionCompactionOff
 }
 
 // Commands returns the named commands configured for this agent.

--- a/pkg/agent/opts.go
+++ b/pkg/agent/opts.go
@@ -100,6 +100,28 @@ func WithCompactionModel(model provider.Provider) Opt {
 	}
 }
 
+// WithCompactionThreshold sets the fraction of the context window at which
+// proactive auto-compaction triggers. Values outside (0, 1] are ignored and
+// the default (0.9) applies; config validation rejects them before this
+// point, so the guard only protects programmatic callers.
+func WithCompactionThreshold(threshold float64) Opt {
+	return func(a *Agent) {
+		if threshold > 0 && threshold <= 1 {
+			a.compactionThreshold = threshold
+		}
+	}
+}
+
+// WithSessionCompaction toggles automatic session compaction (proactive
+// threshold trigger and post-overflow auto-recovery) for this agent.
+// Enabled by default; the runtime only auto-compacts a session when both
+// this flag and the runtime-level session-compaction option are on.
+func WithSessionCompaction(enabled bool) Opt {
+	return func(a *Agent) {
+		a.sessionCompactionOff = !enabled
+	}
+}
+
 func WithSubAgents(subAgents ...*Agent) Opt {
 	return func(a *Agent) {
 		a.subAgents = subAgents

--- a/pkg/compaction/compaction.go
+++ b/pkg/compaction/compaction.go
@@ -15,20 +15,28 @@ var (
 	UserPrompt string
 )
 
-// contextThreshold is the fraction of the context window at which compaction
-// is triggered. When the estimated token usage exceeds this fraction of the
-// context limit, compaction is recommended.
-const contextThreshold = 0.9
+// DefaultThreshold is the fraction of the context window at which compaction
+// is triggered when no custom threshold is configured. When the estimated
+// token usage exceeds this fraction of the context limit, compaction is
+// recommended. Overridable per agent (and per model) via the
+// `compaction_threshold` config key.
+const DefaultThreshold = 0.9
 
 // ShouldCompact reports whether a session's context usage has crossed the
 // compaction threshold. It returns true when the total token count
-// (input + output + addedTokens) exceeds [contextThreshold] (90%) of
-// contextLimit.
-func ShouldCompact(inputTokens, outputTokens, addedTokens, contextLimit int64) bool {
+// (input + output + addedTokens) exceeds threshold*contextLimit.
+//
+// threshold is the fraction of the context window that triggers compaction;
+// values outside (0, 1] (including 0 for "not configured") fall back to
+// [DefaultThreshold], so callers can pass an unset value verbatim.
+func ShouldCompact(inputTokens, outputTokens, addedTokens, contextLimit int64, threshold float64) bool {
 	if contextLimit <= 0 {
 		return false
 	}
-	return (inputTokens + outputTokens + addedTokens) > int64(float64(contextLimit)*contextThreshold)
+	if threshold <= 0 || threshold > 1 {
+		threshold = DefaultThreshold
+	}
+	return (inputTokens + outputTokens + addedTokens) > int64(float64(contextLimit)*threshold)
 }
 
 // EstimateMessageTokens returns a rough token-count estimate for a single

--- a/pkg/compaction/compaction_test.go
+++ b/pkg/compaction/compaction_test.go
@@ -96,6 +96,7 @@ func TestShouldCompact(t *testing.T) {
 		output       int64
 		added        int64
 		contextLimit int64
+		threshold    float64
 		want         bool
 	}{
 		{
@@ -154,12 +155,66 @@ func TestShouldCompact(t *testing.T) {
 			contextLimit: 100000,
 			want:         false,
 		},
+		{
+			name:         "custom threshold triggers earlier than default",
+			input:        60000,
+			output:       0,
+			added:        0,
+			contextLimit: 100000,
+			threshold:    0.5,
+			want:         true, // 60000 > 50000, would not trigger at the 0.9 default
+		},
+		{
+			name:         "custom threshold not reached",
+			input:        40000,
+			output:       0,
+			added:        0,
+			contextLimit: 100000,
+			threshold:    0.5,
+			want:         false,
+		},
+		{
+			name:         "threshold of 1 only triggers past the full window",
+			input:        99999,
+			output:       0,
+			added:        0,
+			contextLimit: 100000,
+			threshold:    1,
+			want:         false,
+		},
+		{
+			name:         "zero threshold falls back to the 90% default",
+			input:        90001,
+			output:       0,
+			added:        0,
+			contextLimit: 100000,
+			threshold:    0,
+			want:         true,
+		},
+		{
+			name:         "negative threshold falls back to the 90% default",
+			input:        89000,
+			output:       0,
+			added:        0,
+			contextLimit: 100000,
+			threshold:    -0.5,
+			want:         false,
+		},
+		{
+			name:         "threshold above 1 falls back to the 90% default",
+			input:        90001,
+			output:       0,
+			added:        0,
+			contextLimit: 100000,
+			threshold:    1.5,
+			want:         true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := ShouldCompact(tt.input, tt.output, tt.added, tt.contextLimit)
+			got := ShouldCompact(tt.input, tt.output, tt.added, tt.contextLimit, tt.threshold)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/config/first_available_test.go
+++ b/pkg/config/first_available_test.go
@@ -268,6 +268,11 @@ func TestValidateFirstAvailable(t *testing.T) {
 			wantErr: "cannot be combined with compaction_model",
 		},
 		{
+			name:    "combined with compaction_threshold",
+			model:   latest.ModelConfig{FirstAvailable: []string{"openai/gpt-5"}, CompactionThreshold: new(0.8)},
+			wantErr: "cannot be combined with compaction_threshold",
+		},
+		{
 			name:    "combined with token key",
 			model:   latest.ModelConfig{FirstAvailable: []string{"openai/gpt-5"}, TokenKey: "CUSTOM_API_KEY"},
 			wantErr: "cannot be combined with token_key",

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -546,17 +546,29 @@ type AgentConfig struct {
 	// Pointer (tri-state) so we can distinguish "unset" (nil → default
 	// on) from "explicitly disabled" (false). Use
 	// [AgentConfig.RedactSecretsEnabled] to read the effective value.
-	RedactSecrets           *bool             `json:"redact_secrets,omitempty"`
-	CodeModeTools           bool              `json:"code_mode_tools,omitempty"`
-	AddDescriptionParameter bool              `json:"add_description_parameter,omitempty"`
-	MaxIterations           int               `json:"max_iterations,omitempty"`
-	MaxConsecutiveToolCalls int               `json:"max_consecutive_tool_calls,omitempty"`
-	MaxOldToolCallTokens    int               `json:"max_old_tool_call_tokens,omitempty"`
-	NumHistoryItems         int               `json:"num_history_items,omitempty"`
-	AddPromptFiles          []string          `json:"add_prompt_files,omitempty" yaml:"add_prompt_files,omitempty"`
-	Commands                types.Commands    `json:"commands,omitempty"`
-	StructuredOutput        *StructuredOutput `json:"structured_output,omitempty"`
-	Skills                  SkillsConfig      `json:"skills,omitzero"`
+	RedactSecrets           *bool `json:"redact_secrets,omitempty"`
+	CodeModeTools           bool  `json:"code_mode_tools,omitempty"`
+	AddDescriptionParameter bool  `json:"add_description_parameter,omitempty"`
+	MaxIterations           int   `json:"max_iterations,omitempty"`
+	MaxConsecutiveToolCalls int   `json:"max_consecutive_tool_calls,omitempty"`
+	MaxOldToolCallTokens    int   `json:"max_old_tool_call_tokens,omitempty"`
+	NumHistoryItems         int   `json:"num_history_items,omitempty"`
+	// SessionCompaction toggles automatic session compaction for this agent:
+	// the proactive threshold trigger and the post-overflow auto-recovery.
+	// Manual /compact stays available regardless. Pointer (tri-state) so
+	// "unset" (nil → default on) is distinguishable from an explicit
+	// `session_compaction: false`. Use [AgentConfig.SessionCompactionEnabled]
+	// to read the effective value.
+	SessionCompaction *bool `json:"session_compaction,omitempty"`
+	// CompactionThreshold is the fraction of the context window at which
+	// proactive auto-compaction triggers for this agent. Must be greater than
+	// 0 and at most 1; defaults to 0.9 when unset. A `compaction_threshold`
+	// set on the agent's model takes precedence.
+	CompactionThreshold *float64          `json:"compaction_threshold,omitempty"`
+	AddPromptFiles      []string          `json:"add_prompt_files,omitempty" yaml:"add_prompt_files,omitempty"`
+	Commands            types.Commands    `json:"commands,omitempty"`
+	StructuredOutput    *StructuredOutput `json:"structured_output,omitempty"`
+	Skills              SkillsConfig      `json:"skills,omitzero"`
 	// UseCommands and UseSkills reference reusable groups defined in the
 	// top-level Config.Commands / Config.Skills sections. The referenced
 	// groups are merged into Commands / Skills during config resolution;
@@ -866,6 +878,17 @@ func (a *AgentConfig) RedactSecretsEnabled() bool {
 	return *a.RedactSecrets
 }
 
+// SessionCompactionEnabled reports the effective value of the agent's
+// session_compaction flag. Automatic compaction is on by default: a nil
+// pointer (the field omitted from YAML) means enabled, an explicit
+// `session_compaction: false` is the only way to disable it.
+func (a *AgentConfig) SessionCompactionEnabled() bool {
+	if a == nil || a.SessionCompaction == nil {
+		return true
+	}
+	return *a.SessionCompaction
+}
+
 // SaferShellEnabled reports whether any of the agent's shell toolsets
 // has opted into destructive-command detection. The flag lives on the
 // toolset (not the agent), so this aggregates across all of an agent's
@@ -991,6 +1014,13 @@ type ModelConfig struct {
 	// primary, compaction is triggered against the smaller window so the
 	// summary call can always ingest the conversation it must compact.
 	CompactionModel string `json:"compaction_model,omitempty"`
+	// CompactionThreshold overrides, for agents running this model, the
+	// fraction of the context window at which proactive auto-compaction
+	// triggers. Must be greater than 0 and at most 1. It takes precedence over
+	// the agent-level `compaction_threshold`; when both are unset the default
+	// of 0.9 applies. Useful next to CompactionModel: a model that compacts
+	// with a slower/smaller summarizer may want to trigger earlier.
+	CompactionThreshold *float64 `json:"compaction_threshold,omitempty"`
 	// Capabilities optionally declares the model's attachment capabilities,
 	// overriding the automatic models.dev-based detection. See [CapabilitiesConfig].
 	Capabilities *CapabilitiesConfig `json:"capabilities,omitempty"`
@@ -1188,6 +1218,7 @@ func (f *FlexibleModelConfig) isShorthandOnly() bool {
 		f.FirstAvailable == nil &&
 		f.TitleModel == "" &&
 		f.CompactionModel == "" &&
+		f.CompactionThreshold == nil &&
 		f.Capabilities == nil
 }
 

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -28,6 +28,9 @@ func (t *Config) Validate() error {
 		if err := m.validateFirstAvailable(); err != nil {
 			return fmt.Errorf("models.%s: %w", name, err)
 		}
+		if err := validateCompactionThreshold(m.CompactionThreshold); err != nil {
+			return fmt.Errorf("models.%s: %w", name, err)
+		}
 		if err := m.Auth.Validate(EffectiveProviderType(m, t.Providers)); err != nil {
 			return fmt.Errorf("models.%s: %w", name, err)
 		}
@@ -54,6 +57,9 @@ func (t *Config) Validate() error {
 		}
 		if err := agent.validateHarness(); err != nil {
 			return err
+		}
+		if err := validateCompactionThreshold(agent.CompactionThreshold); err != nil {
+			return fmt.Errorf("agents.%s: %w", agent.Name, err)
 		}
 
 		for j := range agent.Toolsets {
@@ -132,10 +138,25 @@ func (m *ModelConfig) validateFirstAvailable() error {
 	if m.CompactionModel != "" {
 		return errors.New("first_available cannot be combined with compaction_model")
 	}
+	if m.CompactionThreshold != nil {
+		return errors.New("first_available cannot be combined with compaction_threshold")
+	}
 	for i, ref := range m.FirstAvailable {
 		if strings.TrimSpace(ref) == "" {
 			return fmt.Errorf("first_available[%d] must not be empty", i)
 		}
+	}
+	return nil
+}
+
+// validateCompactionThreshold rejects a compaction_threshold outside (0, 1].
+// nil (unset) is valid and means "use the default".
+func validateCompactionThreshold(v *float64) error {
+	if v == nil {
+		return nil
+	}
+	if *v <= 0 || *v > 1 {
+		return fmt.Errorf("compaction_threshold must be greater than 0 and at most 1, got %v", *v)
 	}
 	return nil
 }

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -67,6 +67,55 @@ func TestValidationErrors(t *testing.T) {
 	}
 }
 
+func TestCompactionThresholdValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		threshold float64
+		wantErr   bool
+	}{
+		{name: "valid low", threshold: 0.1},
+		{name: "valid default", threshold: 0.9},
+		{name: "valid max", threshold: 1},
+		{name: "zero rejected", threshold: 0, wantErr: true},
+		{name: "negative rejected", threshold: -0.5, wantErr: true},
+		{name: "above one rejected", threshold: 1.5, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run("model "+tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := latest.Config{Models: map[string]latest.ModelConfig{
+				"primary": {Provider: "openai", Model: "gpt-4o", CompactionThreshold: new(tt.threshold)},
+			}}
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "models.primary: compaction_threshold must be greater than 0 and at most 1")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+
+		t.Run("agent "+tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := latest.Config{Agents: []latest.AgentConfig{
+				{Name: "root", Model: "openai/gpt-4o", CompactionThreshold: new(tt.threshold)},
+			}}
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "agents.root: compaction_threshold must be greater than 0 and at most 1")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestLoadConfig_UnsupportedVersion(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runtime/compaction_trigger_test.go
+++ b/pkg/runtime/compaction_trigger_test.go
@@ -108,3 +108,128 @@ func TestCompactIfNeeded_TriggersOnOwnMessages(t *testing.T) {
 	}
 	assert.True(t, sawCompaction, "large own tool results must still trigger compaction")
 }
+
+// TestCompactIfNeeded_CustomThreshold verifies that the agent's configured
+// compaction_threshold replaces the 0.9 default in the proactive trigger:
+// the same session content that stays under the default threshold triggers
+// compaction once a lower threshold is configured.
+func TestCompactIfNeeded_CustomThreshold(t *testing.T) {
+	t.Parallel()
+
+	// ~150k chars ≈ ~37.5k estimated tokens: 37.5% of the 100k window —
+	// under the 0.9 default, over a 0.25 threshold.
+	buildSession := func() (*session.Session, int) {
+		sess := session.New(session.WithUserMessage("build the app"))
+		before := len(sess.OwnMessages())
+		sess.AddMessage(session.NewAgentMessage("root", &chat.Message{
+			Role:      chat.MessageRoleAssistant,
+			ToolCalls: []tools.ToolCall{{ID: "t1", Function: tools.FunctionCall{Name: "shell"}}},
+		}))
+		sess.AddMessage(session.NewAgentMessage("root", &chat.Message{
+			Role:       chat.MessageRoleTool,
+			ToolCallID: "t1",
+			Content:    strings.Repeat("z", 150_000),
+		}))
+		return sess, before
+	}
+
+	run := func(t *testing.T, agentOpts ...agent.Opt) bool {
+		t.Helper()
+		prov := &mockProvider{id: "test/model", stream: &mockStream{}}
+		root := agent.New("root", "agent", append([]agent.Opt{agent.WithModel(prov)}, agentOpts...)...)
+		tm := team.New(team.WithAgents(root))
+
+		rt, err := NewLocalRuntime(t.Context(), tm,
+			WithSessionCompaction(true),
+			WithModelStore(mockModelStoreWithLimit{limit: 100_000}))
+		require.NoError(t, err)
+
+		sess, before := buildSession()
+		events := make(chan Event, 16)
+		rt.compactIfNeeded(t.Context(), sess, root, 100_000, before, NewChannelSink(events))
+		close(events)
+
+		for ev := range events {
+			if _, ok := ev.(*SessionCompactionEvent); ok {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("default threshold does not trigger at 37% usage", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, run(t), "37%% usage must not trigger compaction at the 0.9 default")
+	})
+
+	t.Run("lower threshold triggers on the same session", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, run(t, agent.WithCompactionThreshold(0.25)),
+			"37%% usage must trigger compaction with compaction_threshold: 0.25")
+	})
+
+	t.Run("threshold of 1 suppresses the trigger even at high usage", func(t *testing.T) {
+		t.Parallel()
+		prov := &mockProvider{id: "test/model", stream: &mockStream{}}
+		root := agent.New("root", "agent", agent.WithModel(prov), agent.WithCompactionThreshold(1))
+		tm := team.New(team.WithAgents(root))
+
+		rt, err := NewLocalRuntime(t.Context(), tm,
+			WithSessionCompaction(true),
+			WithModelStore(mockModelStoreWithLimit{limit: 100_000}))
+		require.NoError(t, err)
+
+		sess := session.New(session.WithUserMessage("build the app"))
+		before := len(sess.OwnMessages())
+		sess.InputTokens = 95_000 // over the 0.9 default, under 1.0
+
+		events := make(chan Event, 16)
+		rt.compactIfNeeded(t.Context(), sess, root, 100_000, before, NewChannelSink(events))
+		close(events)
+
+		for ev := range events {
+			_, isCompaction := ev.(*SessionCompactionEvent)
+			assert.False(t, isCompaction, "95%% usage must not trigger compaction with compaction_threshold: 1")
+		}
+	})
+}
+
+// TestCompactIfNeeded_AgentSessionCompactionDisabled verifies that an agent
+// with `session_compaction: false` never auto-compacts, even when the
+// runtime-level session-compaction option is on and the context usage is
+// far past the threshold.
+func TestCompactIfNeeded_AgentSessionCompactionDisabled(t *testing.T) {
+	t.Parallel()
+
+	prov := &mockProvider{id: "test/model", stream: &mockStream{}}
+	root := agent.New("root", "agent", agent.WithModel(prov), agent.WithSessionCompaction(false))
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(t.Context(), tm,
+		WithSessionCompaction(true),
+		WithModelStore(mockModelStoreWithLimit{limit: 100_000}))
+	require.NoError(t, err)
+
+	sess := session.New(session.WithUserMessage("build the app"))
+	messageCountBefore := len(sess.OwnMessages())
+
+	sess.AddMessage(session.NewAgentMessage("root", &chat.Message{
+		Role:      chat.MessageRoleAssistant,
+		ToolCalls: []tools.ToolCall{{ID: "t1", Function: tools.FunctionCall{Name: "shell"}}},
+	}))
+	sess.AddMessage(session.NewAgentMessage("root", &chat.Message{
+		Role:       chat.MessageRoleTool,
+		ToolCallID: "t1",
+		Content:    strings.Repeat("z", 600_000), // ~150k estimated tokens
+	}))
+
+	events := make(chan Event, 16)
+	rt.compactIfNeeded(t.Context(), sess, root, 100_000, messageCountBefore, NewChannelSink(events))
+	close(events)
+
+	for ev := range events {
+		_, isCompaction := ev.(*SessionCompactionEvent)
+		assert.False(t, isCompaction,
+			"session_compaction: false must suppress the proactive compaction trigger")
+	}
+}

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -498,7 +498,7 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 		// trigger and the UI context gauge (issue #3241); it equals the primary
 		// window unless a smaller compaction model is configured.
 		contextLimit := r.effectiveContextLimit(ctx, a, r.resolveContextLimit(ctx, model, modelID))
-		if contextLimit > 0 && r.sessionCompaction && compaction.ShouldCompact(sess.InputTokens, sess.OutputTokens, 0, contextLimit) {
+		if contextLimit > 0 && r.sessionCompactionEnabled(a) && compaction.ShouldCompact(sess.InputTokens, sess.OutputTokens, 0, contextLimit, a.CompactionThreshold()) {
 			r.compactWithReason(ctx, sess, "", compactionReasonThreshold, sink)
 		}
 
@@ -1091,8 +1091,9 @@ func usageHasTokens(usage *chat.Usage) bool {
 
 // compactIfNeeded estimates the token impact of tool results added since
 // messageCountBefore and triggers proactive compaction when the estimated
-// total exceeds 90% of the context window. This prevents sending an
-// oversized request on the next iteration.
+// total crosses the agent's compaction threshold (90% of the context window
+// by default). This prevents sending an oversized request on the next
+// iteration.
 func (r *LocalRuntime) compactIfNeeded(
 	ctx context.Context,
 	sess *session.Session,
@@ -1104,7 +1105,7 @@ func (r *LocalRuntime) compactIfNeeded(
 	// contextLimit is the effective budget (primary window, capped to a smaller
 	// dedicated compaction model's window when configured) computed by
 	// runStreamLoop, so this site fires consistently with the pre-turn trigger.
-	if !r.sessionCompaction || contextLimit <= 0 {
+	if !r.sessionCompactionEnabled(a) || contextLimit <= 0 {
 		return
 	}
 
@@ -1119,11 +1120,11 @@ func (r *LocalRuntime) compactIfNeeded(
 		addedTokens += compaction.EstimateMessageTokens(&msg.Message)
 	}
 
-	if !compaction.ShouldCompact(sess.InputTokens, sess.OutputTokens, addedTokens, contextLimit) {
+	if !compaction.ShouldCompact(sess.InputTokens, sess.OutputTokens, addedTokens, contextLimit, a.CompactionThreshold()) {
 		return
 	}
 
-	slog.InfoContext(ctx, "Proactive compaction: tool results pushed estimated context past 90%% threshold",
+	slog.InfoContext(ctx, "Proactive compaction: tool results pushed estimated context past the compaction threshold",
 		"agent", a.Name(),
 		"input_tokens", sess.InputTokens,
 		"output_tokens", sess.OutputTokens,

--- a/pkg/runtime/loop_steps.go
+++ b/pkg/runtime/loop_steps.go
@@ -161,7 +161,7 @@ func (r *LocalRuntime) handleStreamError(
 	// request instead of surfacing raw errors. We allow at most
 	// r.maxOverflowCompactions consecutive attempts to avoid an infinite
 	// loop when compaction cannot reduce the context enough.
-	if _, ok := errors.AsType[*modelerrors.ContextOverflowError](err); ok && r.sessionCompaction && *overflowCompactions < r.maxOverflowCompactions {
+	if _, ok := errors.AsType[*modelerrors.ContextOverflowError](err); ok && r.sessionCompactionEnabled(a) && *overflowCompactions < r.maxOverflowCompactions {
 		*overflowCompactions++
 		slog.WarnContext(ctx, "Context window overflow detected, attempting auto-compaction",
 			"agent", a.Name(),

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1836,9 +1836,9 @@ func (r *LocalRuntime) Summarize(ctx context.Context, sess *session.Session, add
 //
 // reason is reported to BeforeCompaction / AfterCompaction hooks as
 // CompactionReason. Use [compactionReasonThreshold] for proactive
-// 90%-of-context triggers, [compactionReasonOverflow] for post-overflow
-// auto-recovery, [compactionReasonToolOverflow] for tool-result-driven
-// 90% triggers, or [compactionReasonManual] for user-invoked compactions.
+// threshold-of-context triggers (90% by default, tunable via
+// compaction_threshold), [compactionReasonOverflow] for post-overflow
+// auto-recovery, or [compactionReasonManual] for user-invoked compactions.
 //
 // PreCompact hooks fire first via the legacy [hooks.Input.Source] field
 // ("auto" / "tool_overflow" / "overflow" / "manual"); they may cancel the

--- a/pkg/runtime/session_compaction.go
+++ b/pkg/runtime/session_compaction.go
@@ -24,13 +24,21 @@ const (
 	compactionReasonManual    = "manual"
 )
 
+// sessionCompactionEnabled reports whether automatic compaction (proactive
+// threshold trigger, post-overflow recovery) is active for the given agent:
+// the runtime-wide option ANDed with the agent's own `session_compaction`
+// config. Manual /compact is intentionally not gated by either flag.
+func (r *LocalRuntime) sessionCompactionEnabled(a *agent.Agent) bool {
+	return r.sessionCompaction && a.SessionCompaction()
+}
+
 // doCompact orchestrates a session compaction. It is intentionally thin:
 // the heavy lifting (extracting the conversation, running the LLM, computing
 // the kept-tail boundary) lives in [pkg/runtime/compactor]; this function
 // owns only what's runtime-private: hook dispatch, session mutation, event
 // emission, and persistence.
 //
-// reason is one of [compactionReasonThreshold] (proactive 90% trigger),
+// reason is one of [compactionReasonThreshold] (proactive threshold trigger),
 // [compactionReasonOverflow] (post-overflow recovery) or
 // [compactionReasonManual] (user-invoked /compact). It is forwarded to
 // BeforeCompaction / AfterCompaction hooks.
@@ -192,8 +200,9 @@ func (r *LocalRuntime) compactionContextLimit(ctx context.Context, a *agent.Agen
 // operates within: the primary model's window, capped by the dedicated
 // compaction model's (smaller) window when one is configured. It drives both
 // the proactive compaction trigger and the UI context gauge, so the gauge
-// fills to ~90% right as compaction fires and the summary call can always
-// ingest the conversation it must compact. This is the maintainers' resolution
+// fills to the compaction threshold (~90% by default) right as compaction
+// fires and the summary call can always ingest the conversation it must
+// compact. This is the maintainers' resolution
 // for issue #3241 for the case where the dedicated compaction model has the
 // smaller context window.
 //

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -244,6 +244,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 			agent.WithMaxConsecutiveToolCalls(agentConfig.MaxConsecutiveToolCalls),
 			agent.WithMaxOldToolCallTokens(agentConfig.MaxOldToolCallTokens),
 			agent.WithNumHistoryItems(agentConfig.NumHistoryItems),
+			agent.WithSessionCompaction(agentConfig.SessionCompactionEnabled()),
 			agent.WithCommands(expander.ExpandCommands(ctx, agentConfig.Commands)),
 			agent.WithHooks(config.MergeHooks(config.MergeHooks(agentConfig.Hooks, globalHooks), cliHooks)),
 		}
@@ -311,6 +312,10 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 			}
 			if compactionModel != nil {
 				opts = append(opts, agent.WithCompactionModel(compactionModel))
+			}
+
+			if threshold := compactionThresholdForAgent(cfg, &agentConfig); threshold != nil {
+				opts = append(opts, agent.WithCompactionThreshold(*threshold))
 			}
 		}
 
@@ -661,6 +666,20 @@ func getCompactionModelForAgent(ctx context.Context, cfg *latest.Config, a *late
 		return nil, fmt.Errorf("failed to create compaction model '%s': %w", compactionRef, err)
 	}
 	return model, nil
+}
+
+// compactionThresholdForAgent resolves the proactive-compaction threshold for
+// an agent, or nil when neither the agent nor its models set one (the
+// compaction package default then applies). The `compaction_threshold` of the
+// first of the agent's configured models that sets it wins (mirroring
+// getCompactionModelForAgent); the agent-level value is the fallback.
+func compactionThresholdForAgent(cfg *latest.Config, a *latest.AgentConfig) *float64 {
+	for name := range strings.SplitSeq(a.Model, ",") {
+		if modelCfg, ok := cfg.Models[name]; ok && modelCfg.CompactionThreshold != nil {
+			return modelCfg.CompactionThreshold
+		}
+	}
+	return a.CompactionThreshold
 }
 
 // getToolsForAgent returns the tool definitions for an agent based on its

--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -369,6 +369,141 @@ agents:
 	})
 }
 
+func TestCompactionThresholdResolution(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+	t.Setenv("ANTHROPIC_API_KEY", "dummy")
+
+	t.Run("agent-level threshold", func(t *testing.T) {
+		data := []byte(`agents:
+  root:
+    model: openai/gpt-4o
+    compaction_threshold: 0.75
+    instruction: test
+`)
+
+		team, err := Load(t.Context(), config.NewBytesSource("threshold.yaml", data), &config.RuntimeConfig{}, withTestProviderRegistry()...)
+		require.NoError(t, err)
+
+		root, err := team.Agent("root")
+		require.NoError(t, err)
+
+		assert.InEpsilon(t, 0.75, root.CompactionThreshold(), 1e-9)
+	})
+
+	t.Run("model-level threshold", func(t *testing.T) {
+		data := []byte(`models:
+  primary:
+    provider: anthropic
+    model: claude-sonnet-4-5
+    compaction_threshold: 0.6
+agents:
+  root:
+    model: primary
+    instruction: test
+`)
+
+		team, err := Load(t.Context(), config.NewBytesSource("threshold.yaml", data), &config.RuntimeConfig{}, withTestProviderRegistry()...)
+		require.NoError(t, err)
+
+		root, err := team.Agent("root")
+		require.NoError(t, err)
+
+		assert.InEpsilon(t, 0.6, root.CompactionThreshold(), 1e-9)
+	})
+
+	t.Run("model-level threshold overrides agent-level", func(t *testing.T) {
+		data := []byte(`models:
+  primary:
+    provider: anthropic
+    model: claude-sonnet-4-5
+    compaction_threshold: 0.6
+agents:
+  root:
+    model: primary
+    compaction_threshold: 0.75
+    instruction: test
+`)
+
+		team, err := Load(t.Context(), config.NewBytesSource("threshold.yaml", data), &config.RuntimeConfig{}, withTestProviderRegistry()...)
+		require.NoError(t, err)
+
+		root, err := team.Agent("root")
+		require.NoError(t, err)
+
+		assert.InEpsilon(t, 0.6, root.CompactionThreshold(), 1e-9)
+	})
+
+	t.Run("unset threshold reports zero so the default applies", func(t *testing.T) {
+		data := []byte(`agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+`)
+
+		team, err := Load(t.Context(), config.NewBytesSource("threshold.yaml", data), &config.RuntimeConfig{}, withTestProviderRegistry()...)
+		require.NoError(t, err)
+
+		root, err := team.Agent("root")
+		require.NoError(t, err)
+
+		assert.Zero(t, root.CompactionThreshold())
+	})
+}
+
+func TestSessionCompactionKnob(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+
+	t.Run("enabled by default", func(t *testing.T) {
+		data := []byte(`agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+`)
+
+		team, err := Load(t.Context(), config.NewBytesSource("session_compaction.yaml", data), &config.RuntimeConfig{}, withTestProviderRegistry()...)
+		require.NoError(t, err)
+
+		root, err := team.Agent("root")
+		require.NoError(t, err)
+
+		assert.True(t, root.SessionCompaction())
+	})
+
+	t.Run("explicitly disabled", func(t *testing.T) {
+		data := []byte(`agents:
+  root:
+    model: openai/gpt-4o
+    session_compaction: false
+    instruction: test
+`)
+
+		team, err := Load(t.Context(), config.NewBytesSource("session_compaction.yaml", data), &config.RuntimeConfig{}, withTestProviderRegistry()...)
+		require.NoError(t, err)
+
+		root, err := team.Agent("root")
+		require.NoError(t, err)
+
+		assert.False(t, root.SessionCompaction())
+	})
+
+	t.Run("explicitly enabled", func(t *testing.T) {
+		data := []byte(`agents:
+  root:
+    model: openai/gpt-4o
+    session_compaction: true
+    instruction: test
+`)
+
+		team, err := Load(t.Context(), config.NewBytesSource("session_compaction.yaml", data), &config.RuntimeConfig{}, withTestProviderRegistry()...)
+		require.NoError(t, err)
+
+		root, err := team.Agent("root")
+		require.NoError(t, err)
+
+		assert.True(t, root.SessionCompaction())
+	})
+}
+
 func TestLoadHarnessAgentWithoutModel(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "dummy")
 


### PR DESCRIPTION
Closes #3433

## Summary

The proactive auto-compaction trigger was a hardcoded `contextThreshold = 0.9` constant in `pkg/compaction`. It is now configurable through a new `compaction_threshold` config key (per agent, with a per-model override), and an explicit `session_compaction` on/off knob is surfaced in YAML. Behavior is unchanged unless the new keys are set.

## Issue expectations vs implementation

| Issue expectation | Implementation |
| --- | --- |
| `compaction_threshold` key, range `0 < x <= 1`, default `0.9` | `AgentConfig.CompactionThreshold *float64`, validated at config load (`validateCompactionThreshold`); default lives in `compaction.DefaultThreshold` |
| Per-agent placement with per-model override next to `compaction_model` | `ModelConfig.CompactionThreshold`; `compactionThresholdForAgent` in teamloader mirrors `getCompactionModelForAgent` (first of the agent's models that sets it wins, agent value is the fallback) |
| `session_compaction: false` knob mapping to `WithSessionCompaction` semantics | `AgentConfig.SessionCompaction *bool` (tri-state, default on) wired to a new `agent.WithSessionCompaction`; runtime gates automatic triggers on `r.sessionCompaction && a.SessionCompaction()` |
| Replace the package const, thread the value through `ShouldCompact` | `ShouldCompact(..., threshold float64)`; values outside `(0, 1]` (including 0 for "not configured") fall back to `DefaultThreshold` |
| Runtime trigger sites | All three automatic sites covered: pre-turn trigger (`loop.go`), `compactIfNeeded` (`loop.go`), post-overflow recovery (`loop_steps.go`) |
| Config additions only in `pkg/config/latest` + schema + example | `latest/types.go` + `latest/validate.go` only (v0 to v11 untouched), `agent-schema.json`, new `examples/compaction_threshold.yaml` |
| Extend `compaction_trigger_test.go` | `TestCompactIfNeeded_CustomThreshold` (3 subcases) and `TestCompactIfNeeded_AgentSessionCompactionDisabled` |

## Value flow

```
YAML: models.<m>.compaction_threshold | agents.<a>.compaction_threshold
        -> teamloader.compactionThresholdForAgent   (model wins, else agent, else nil)
        -> agent.WithCompactionThreshold            (stores only (0, 1])
        -> runtime trigger sites
        -> compaction.ShouldCompact(..., threshold) (<= 0 or > 1 falls back to 0.9)

YAML: agents.<a>.session_compaction (default true)
        -> agent.WithSessionCompaction
        -> runtime.sessionCompactionEnabled = runtime opt AND agent flag
        -> gates proactive trigger + overflow recovery (manual /compact never gated)
```

## Behavior notes

| Case | Behavior |
| --- | --- |
| Keys unset | Identical to before (0.9, compaction on) |
| Threshold out of range in YAML | Rejected at validation with `agents.<name>` / `models.<name>` context |
| `first_available` combined with `compaction_threshold` | Rejected, same rule as `compaction_model` / `title_model` |
| `session_compaction: false` | Disables proactive trigger and post-overflow auto-compaction for that agent; manual `/compact` still works |
| Runtime model switching | Threshold resolved at load time, unaffected, consistent with `compaction_model` |
| Integer YAML value `compaction_threshold: 1` | Decodes correctly into `*float64` (strict goccy decoding verified) |

## Validation

| Check | Result |
| --- | --- |
| `go build ./...`, `go vet` | pass |
| `golangci-lint run` + `go run ./lint .` | 0 issues |
| Tests: compaction, agent, runtime, teamloader, config, schema, docs snippets, examples | pass |
| New tests | threshold table cases, 4 runtime trigger tests, 7 teamloader subtests, 12 validation subtests, first_available exclusion |
| Pre-existing environmental failures (SSRF tests, DMR example pull) | unrelated, also fail on a clean main checkout |

Docs updated: `docs/configuration/agents/index.md`, `docs/configuration/models/index.md`, new example `examples/compaction_threshold.yaml`.
