### PR TITLE
feat(compaction): reconcile token estimator with provider-reported usage

### DIFF
--- a/pkg/compaction/compaction.go
+++ b/pkg/compaction/compaction.go
@@ -2,6 +2,7 @@ package compaction
 
 import (
 	_ "embed"
+	"iter"
 	"slices"
 
 	"github.com/docker/docker-agent/pkg/chat"
@@ -22,6 +23,42 @@ var (
 // `compaction_threshold` config key.
 const DefaultThreshold = 0.9
 
+const (
+	// charsPerToken converts text length to a token estimate. Agentic
+	// conversations are dominated by code, JSON and diffs (~3–3.5 chars
+	// per token), so 3.5 tracks those closely and mildly overestimates
+	// English prose (~4.2 chars per token) — the safe direction: compact
+	// slightly early rather than overflow.
+	charsPerToken = 3.5
+
+	// perMessageOverhead: role, ToolCallID, delimiters, etc.
+	perMessageOverhead = 5
+
+	// binaryAttachmentTokens is the flat estimate for a binary message
+	// part (image or document attachment). Providers bill a full-size
+	// image around 1.1k–1.6k tokens (OpenAI high-detail tiles, Anthropic
+	// width×height/750 capped near 1.15MP), so 1500 is a conservative
+	// per-attachment figure; previously these parts counted as zero.
+	binaryAttachmentTokens = 1_500
+)
+
+// Calibration guard rails for [NewEstimator].
+const (
+	// calibrationMinTokens is the minimum heuristic token mass that must
+	// back a calibration ratio before it is trusted; smaller samples (a
+	// couple of short messages) are noise.
+	calibrationMinTokens = 512
+
+	// calibrationMin and calibrationMax clamp the calibration ratio.
+	// The floor limits how far provider reports can lower estimates,
+	// preserving the compact-early bias; the cap bounds the damage of a
+	// polluted window (provider usage glitches, mid-session model
+	// switches) which could otherwise inflate estimates into
+	// compact-everything territory.
+	calibrationMin = 0.75
+	calibrationMax = 2.0
+)
+
 // ShouldCompact reports whether a session's context usage has crossed the
 // compaction threshold. It returns true when the total token count
 // (input + output + addedTokens) exceeds threshold*contextLimit.
@@ -39,36 +76,204 @@ func ShouldCompact(inputTokens, outputTokens, addedTokens, contextLimit int64, t
 	return (inputTokens + outputTokens + addedTokens) > int64(float64(contextLimit)*threshold)
 }
 
-// EstimateMessageTokens returns a rough token-count estimate for a single
-// chat message based on its text length. This is intentionally conservative
-// (overestimates) so that proactive compaction fires before we hit the limit.
+// EstimateMessageTokens returns a token estimate for a single chat
+// message: the provider-reported count when the message carries usage
+// data (assistant turns), otherwise a chars-per-token heuristic that is
+// intentionally conservative (overestimates) so proactive compaction
+// fires before we hit the limit.
 //
-// The estimate accounts for message content, multi-content text parts,
-// reasoning content, tool call arguments, and a small per-message overhead
-// for role/metadata tokens.
+// This is the uncalibrated entry point; use [NewEstimator] when a
+// conversation with provider-reported usage is available to reconcile
+// the heuristic against.
 func EstimateMessageTokens(msg *chat.Message) int64 {
-	// charsPerToken: average characters per token. 4 is a widely-used
-	// heuristic for English; slightly overestimates for code/JSON (~3.5).
-	const charsPerToken = 4
+	return Estimator{}.EstimateMessageTokens(msg)
+}
 
-	// perMessageOverhead: role, ToolCallID, delimiters, etc.
-	const perMessageOverhead = 5
+// Estimator estimates message token counts, reconciling the
+// chars-per-token heuristic with provider-reported usage observed in a
+// conversation. The zero value is a neutral estimator (no calibration).
+type Estimator struct {
+	scale float64
+}
 
+// NewEstimator derives an [Estimator] calibrated against the
+// provider-reported usage found in a conversation.
+//
+// Every assistant message that carries usage is an anchor whose prompt
+// tokens are the provider's exact count of everything before it. For
+// two consecutive anchors i < j:
+//
+//	prompt(j) − (prompt(i) + output(i))
+//
+// is the provider-tokenized size of the messages between them (tool
+// results and user turns — precisely the content the heuristic has to
+// guess at). System-prompt and tool-definition overhead cancels out of
+// the delta. The ratio of summed deltas to the summed heuristic
+// estimates of those in-between messages becomes a multiplicative
+// correction applied to heuristic estimates.
+//
+// Guard rails, biased toward compacting slightly early rather than
+// overflowing:
+//   - windows with a non-positive delta are discarded — a compaction
+//     between the two anchors rebuilt the prompt from a summary, so the
+//     delta no longer measures the in-between messages;
+//   - windows whose anchors were produced by different models are
+//     discarded — the delta would mix two tokenizers;
+//   - the anchor's reasoning tokens are excluded from its total, since
+//     providers strip reasoning from subsequent prompts (when they do
+//     resend it, the delta only grows, erring conservative);
+//   - in-between messages with their own reported counts contribute to
+//     neither sum: their exact size is subtracted from the delta so the
+//     ratio stays a pure heuristic-vs-provider comparison;
+//   - transient context injected per turn (hook output) inflates deltas
+//     slightly, erring on the conservative side;
+//   - the ratio is trusted only when backed by [calibrationMinTokens]
+//     of heuristic mass and is clamped to [calibrationMin, calibrationMax].
+func NewEstimator(messages iter.Seq[*chat.Message]) Estimator {
+	var reportedSum, estimatedSum int64
+	var windowHeuristic, windowReported int64
+	prevTotal := int64(-1)
+	prevModel := ""
+	for msg := range messages {
+		prompt, total := promptAndTotalTokens(msg)
+		if prompt <= 0 {
+			// Not a usable anchor (no usage, or usage without prompt
+			// counts): it is in-between content, sized exactly when it
+			// carries a reported count and heuristically otherwise.
+			if reported := reportedMessageTokens(msg); reported > 0 {
+				windowReported += reported + perMessageOverhead
+			} else {
+				windowHeuristic += heuristicMessageTokens(msg)
+			}
+			continue
+		}
+		if prevTotal >= 0 && windowHeuristic > 0 && sameTokenizer(prevModel, msg.Model) {
+			if actual := prompt - prevTotal - windowReported; actual > 0 {
+				reportedSum += actual
+				estimatedSum += windowHeuristic
+			}
+		}
+		prevTotal = total
+		prevModel = msg.Model
+		windowHeuristic, windowReported = 0, 0
+	}
+	if estimatedSum < calibrationMinTokens {
+		return Estimator{}
+	}
+	ratio := float64(reportedSum) / float64(estimatedSum)
+	return Estimator{scale: min(max(ratio, calibrationMin), calibrationMax)}
+}
+
+// sameTokenizer reports whether two anchor messages can be assumed to
+// share a tokenizer. Unknown models get the benefit of the doubt; only
+// a proven model switch invalidates the pair.
+func sameTokenizer(a, b string) bool {
+	return a == "" || b == "" || a == b
+}
+
+// NewSliceEstimator is a convenience wrapper around [NewEstimator] for
+// a slice of messages.
+func NewSliceEstimator(messages []chat.Message) Estimator {
+	return NewEstimator(func(yield func(*chat.Message) bool) {
+		for i := range messages {
+			if !yield(&messages[i]) {
+				return
+			}
+		}
+	})
+}
+
+// Scale returns the multiplier applied to heuristic estimates: 1 for a
+// neutral estimator, >1 when provider reports showed the heuristic
+// underestimating this conversation's content, <1 when it overestimated.
+func (e Estimator) Scale() float64 {
+	if e.scale <= 0 {
+		return 1
+	}
+	return e.scale
+}
+
+// EstimateMessageTokens returns the token estimate for one message: the
+// provider-reported count when available (exact, never scaled),
+// otherwise the calibrated heuristic.
+func (e Estimator) EstimateMessageTokens(msg *chat.Message) int64 {
+	if reported := reportedMessageTokens(msg); reported > 0 {
+		return reported + perMessageOverhead
+	}
+	return int64(float64(heuristicMessageTokens(msg)) * e.Scale())
+}
+
+// reportedMessageTokens returns the provider-counted size of a message,
+// or 0 when no usable usage data is attached (non-assistant messages,
+// providers with usage tracking disabled).
+//
+// OutputTokens is the provider's exact count of everything this message
+// contains (text, reasoning, tool-call arguments). Reasoning tokens are
+// subtracted only when no reasoning content was stored: reasoning that
+// providers never expose (e.g. OpenAI o-series) is not resent as input,
+// while stored reasoning (Anthropic thinking blocks) is — and keeping
+// it counted errs on the conservative side for providers that drop it.
+func reportedMessageTokens(msg *chat.Message) int64 {
+	u := msg.Usage
+	if u == nil {
+		return 0
+	}
+	reported := u.OutputTokens
+	if msg.ReasoningContent == "" {
+		reported -= u.ReasoningTokens
+	}
+	return reported
+}
+
+// promptAndTotalTokens returns the provider-reported token counts of
+// the request that produced msg: prompt is the full input size (fresh +
+// cached + cache-written — the provider splits them for billing, but
+// all of them were in the prompt); total additionally includes the
+// generated tokens that subsequent prompts will contain, i.e. output
+// minus reasoning (see [NewEstimator] for why reasoning is excluded).
+// Both are 0 when the message carries no usage.
+func promptAndTotalTokens(msg *chat.Message) (prompt, total int64) {
+	u := msg.Usage
+	if u == nil {
+		return 0, 0
+	}
+	prompt = u.InputTokens + u.CachedInputTokens + u.CacheWriteTokens
+	return prompt, prompt + max(u.OutputTokens-u.ReasoningTokens, 0)
+}
+
+// heuristicMessageTokens is the chars-per-token estimate for a message:
+// text content, multi-content text parts (including inline document
+// text), reasoning content and tool-call payloads, plus a flat charge
+// per binary attachment and a small per-message overhead for
+// role/metadata tokens.
+func heuristicMessageTokens(msg *chat.Message) int64 {
 	var chars int
 	chars += len(msg.Content)
+	chars += len(msg.ReasoningContent)
+
+	var attachments int64
 	for _, part := range msg.MultiContent {
 		chars += len(part.Text)
+		if part.Document != nil {
+			chars += len(part.Document.Source.InlineText)
+			if len(part.Document.Source.InlineData) > 0 {
+				attachments++
+			}
+		}
+		if part.ImageURL != nil || part.File != nil {
+			attachments++
+		}
 	}
-	chars += len(msg.ReasoningContent)
 	for _, tc := range msg.ToolCalls {
 		chars += len(tc.Function.Arguments)
 		chars += len(tc.Function.Name)
 	}
-
-	if chars == 0 {
-		return perMessageOverhead
+	if msg.FunctionCall != nil {
+		chars += len(msg.FunctionCall.Arguments)
+		chars += len(msg.FunctionCall.Name)
 	}
-	return int64(chars/charsPerToken) + perMessageOverhead
+
+	return int64(float64(chars)/charsPerToken) + attachments*binaryAttachmentTokens + perMessageOverhead
 }
 
 // SplitIndexForKeep walks messages from the end and returns the earliest
@@ -77,6 +282,10 @@ func EstimateMessageTokens(msg *chat.Message) int64 {
 // to be preserved verbatim across a compaction; messages before it are
 // the candidates to summarize. Returns len(messages) when everything
 // fits in the keep budget — i.e. compact everything.
+//
+// Token sizes come from an [Estimator] calibrated on the same slice, so
+// assistant turns weigh their provider-reported counts and the rest is
+// heuristic corrected by observed usage.
 //
 // The boundary snap matters for providers (notably Anthropic) that
 // reject conversations starting on a tool-result message: by stopping
@@ -87,10 +296,11 @@ func SplitIndexForKeep(messages []chat.Message, maxTokens int64) int {
 		return 0
 	}
 
+	estimator := NewSliceEstimator(messages)
 	var tokens int64
 	lastValidBoundary := len(messages)
 	for i := range slices.Backward(messages) {
-		tokens += EstimateMessageTokens(&messages[i])
+		tokens += estimator.EstimateMessageTokens(&messages[i])
 		if tokens > maxTokens {
 			return lastValidBoundary
 		}
@@ -106,7 +316,8 @@ func SplitIndexForKeep(messages []chat.Message, maxTokens int64) int {
 // messages[N:] fits within contextLimit, snapping to a user/assistant
 // turn boundary. Used to truncate the conversation handed to the
 // summarization model so the request itself doesn't blow the context
-// window.
+// window. Like [SplitIndexForKeep] it sizes messages with an
+// [Estimator] calibrated on the slice.
 //
 // When the entire slice fits within contextLimit, the function returns
 // the index of the earliest user/assistant message in the suffix —
@@ -115,10 +326,11 @@ func SplitIndexForKeep(messages []chat.Message, maxTokens int64) int {
 // no user/asst turns, it returns len(messages); callers should treat
 // that as "nothing to send" and skip the truncation.
 func FirstIndexInBudget(messages []chat.Message, contextLimit int64) int {
+	estimator := NewSliceEstimator(messages)
 	var tokens int64
 	lastValidMessageSeen := len(messages)
 	for i := range slices.Backward(messages) {
-		tokens += EstimateMessageTokens(&messages[i])
+		tokens += estimator.EstimateMessageTokens(&messages[i])
 		if tokens > contextLimit {
 			return lastValidMessageSeen
 		}

--- a/pkg/compaction/compaction_test.go
+++ b/pkg/compaction/compaction_test.go
@@ -25,7 +25,7 @@ func TestEstimateMessageTokens(t *testing.T) {
 		},
 		{
 			name:     "text-only message",
-			msg:      chat.Message{Content: "Hello, world!"}, // 13 chars → 13/4 = 3 + 5 = 8
+			msg:      chat.Message{Content: "Hello, world!"}, // 13 chars → 13/3.5 = 3 + 5 = 8
 			expected: 8,
 		},
 		{
@@ -36,8 +36,8 @@ func TestEstimateMessageTokens(t *testing.T) {
 					{Type: chat.MessagePartTypeText, Text: "second part"}, // 11 chars
 				},
 			},
-			// 21 total chars → 21/4 = 5 + 5 overhead = 10
-			expected: 10,
+			// 21 total chars → 21/3.5 = 6 + 5 overhead = 11
+			expected: 11,
 		},
 		{
 			name: "message with tool calls",
@@ -51,17 +51,17 @@ func TestEstimateMessageTokens(t *testing.T) {
 					},
 				},
 			},
-			// 33 chars → 33/4 = 8 + 5 overhead = 13
-			expected: 13,
+			// 33 chars → 33/3.5 = 9 + 5 overhead = 14
+			expected: 14,
 		},
 		{
 			name: "message with reasoning content",
 			msg: chat.Message{
 				Content:          "answer",                                         // 6 chars
-				ReasoningContent: "Let me think about this carefully step by step", // 47 chars
+				ReasoningContent: "Let me think about this carefully step by step", // 46 chars
 			},
-			// 53 chars → 53/4 = 13 + 5 overhead = 18
-			expected: 18,
+			// 52 total chars → 52/3.5 = 14 + 5 overhead = 19
+			expected: 19,
 		},
 		{
 			name: "combined content types",
@@ -73,8 +73,87 @@ func TestEstimateMessageTokens(t *testing.T) {
 					{Function: tools.FunctionCall{Name: "cmd", Arguments: `{"x":"y"}`}}, // 3 + 9 = 12 chars
 				},
 			},
-			// 38 total chars → 38/4 = 9 + 5 overhead = 14
-			expected: 14,
+			// 38 total chars → 38/3.5 = 10 + 5 overhead = 15
+			expected: 15,
+		},
+		{
+			name: "inline document text is counted",
+			msg: chat.Message{
+				MultiContent: []chat.MessagePart{
+					{
+						Type: chat.MessagePartTypeDocument,
+						Document: &chat.Document{
+							Name:     "notes.txt",
+							MimeType: "text/plain",
+							Source:   chat.DocumentSource{InlineText: strings.Repeat("x", 35)},
+						},
+					},
+				},
+			},
+			// 35 chars → 35/3.5 = 10 + 5 overhead = 15
+			expected: 15,
+		},
+		{
+			name: "binary attachments get a flat charge",
+			msg: chat.Message{
+				MultiContent: []chat.MessagePart{
+					{
+						Type: chat.MessagePartTypeDocument,
+						Document: &chat.Document{
+							Name:     "screenshot.png",
+							MimeType: "image/png",
+							Source:   chat.DocumentSource{InlineData: []byte{0x89, 0x50}},
+						},
+					},
+					{Type: chat.MessagePartTypeImageURL, ImageURL: &chat.MessageImageURL{URL: "data:image/png;base64,xyz"}},
+				},
+			},
+			// 2 binary parts × 1500 + 5 overhead; base64 payloads are
+			// billed as image tokens by providers, never as text.
+			expected: 3_005,
+		},
+		{
+			name: "provider-reported usage wins over the heuristic",
+			msg: chat.Message{
+				Role:    chat.MessageRoleAssistant,
+				Content: strings.Repeat("a", 4_000), // heuristic would say ~1147
+				Usage:   &chat.Usage{InputTokens: 50_000, OutputTokens: 900},
+			},
+			// 900 reported + 5 overhead; InputTokens describe the prompt,
+			// not this message, and must not leak into the estimate.
+			expected: 905,
+		},
+		{
+			name: "reasoning tokens are excluded when reasoning is not stored",
+			msg: chat.Message{
+				Role:    chat.MessageRoleAssistant,
+				Content: "short answer",
+				Usage:   &chat.Usage{OutputTokens: 5_000, ReasoningTokens: 4_990},
+			},
+			// o-series style: 4990 hidden reasoning tokens never come back
+			// as input → only 10 visible tokens + 5 overhead.
+			expected: 15,
+		},
+		{
+			name: "reasoning tokens stay counted when reasoning is stored",
+			msg: chat.Message{
+				Role:             chat.MessageRoleAssistant,
+				Content:          "answer",
+				ReasoningContent: "stored thinking block",
+				Usage:            &chat.Usage{OutputTokens: 1_000, ReasoningTokens: 800},
+			},
+			// Anthropic style: the thinking block is resent as input, so
+			// the full output count applies.
+			expected: 1_005,
+		},
+		{
+			name: "usage without output tokens falls back to the heuristic",
+			msg: chat.Message{
+				Role:    chat.MessageRoleAssistant,
+				Content: "Hello, world!", // 13 chars → 3 + 5 = 8
+				Usage:   &chat.Usage{InputTokens: 1_000},
+			},
+			expected: 8,
 		},
 	}
 
@@ -85,6 +164,153 @@ func TestEstimateMessageTokens(t *testing.T) {
 			assert.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+// usageMsg builds an assistant anchor message: a turn whose usage
+// carries the provider-reported prompt and output token counts.
+func usageMsg(model string, promptTokens, outputTokens int64) chat.Message {
+	return chat.Message{
+		Role:    chat.MessageRoleAssistant,
+		Content: "ok",
+		Model:   model,
+		Usage:   &chat.Usage{InputTokens: promptTokens, OutputTokens: outputTokens},
+	}
+}
+
+func TestNewEstimator(t *testing.T) {
+	t.Parallel()
+
+	// 7000-char tool result → heuristic 7000/3.5 + 5 = 2005 tokens.
+	toolResult := chat.Message{Role: chat.MessageRoleTool, Content: strings.Repeat("x", 7_000)}
+
+	t.Run("no usage data yields a neutral estimator", func(t *testing.T) {
+		t.Parallel()
+		e := NewSliceEstimator([]chat.Message{
+			{Role: chat.MessageRoleUser, Content: strings.Repeat("a", 10_000)},
+			{Role: chat.MessageRoleAssistant, Content: "reply"},
+		})
+		assert.InEpsilon(t, 1.0, e.Scale(), 1e-9)
+	})
+
+	t.Run("underestimated content scales the heuristic up", func(t *testing.T) {
+		t.Parallel()
+		// Anchor 1 ends at total 1100; anchor 2 reports a prompt of
+		// 4108, so the tool result in between cost 3008 real tokens
+		// against a 2005 heuristic → ratio ≈ 1.5.
+		e := NewSliceEstimator([]chat.Message{
+			{Role: chat.MessageRoleUser, Content: "question"},
+			usageMsg("test/m", 1_000, 100),
+			toolResult,
+			usageMsg("test/m", 4_108, 50),
+		})
+		assert.InDelta(t, 1.5, e.Scale(), 0.01)
+
+		// The scale applies to heuristic estimates only.
+		fresh := chat.Message{Role: chat.MessageRoleTool, Content: strings.Repeat("y", 3_500)}
+		assert.InDelta(t, 1005*1.5, float64(e.EstimateMessageTokens(&fresh)), 2)
+
+		reported := usageMsg("test/m", 9_999, 200)
+		assert.Equal(t, int64(205), e.EstimateMessageTokens(&reported),
+			"provider-reported counts must never be scaled")
+	})
+
+	t.Run("overestimated content scales down but never below the floor", func(t *testing.T) {
+		t.Parallel()
+		// Real cost 600 vs 2005 heuristic → raw ratio ≈0.3, clamped to 0.75.
+		e := NewSliceEstimator([]chat.Message{
+			usageMsg("test/m", 1_000, 100),
+			toolResult,
+			usageMsg("test/m", 1_700, 50),
+		})
+		assert.InEpsilon(t, 0.75, e.Scale(), 1e-9)
+	})
+
+	t.Run("inflated deltas are capped", func(t *testing.T) {
+		t.Parallel()
+		// Real cost 10000 vs 2005 heuristic → raw ratio ≈5, clamped to 2.
+		e := NewSliceEstimator([]chat.Message{
+			usageMsg("test/m", 1_000, 100),
+			toolResult,
+			usageMsg("test/m", 11_100, 50),
+		})
+		assert.InEpsilon(t, 2.0, e.Scale(), 1e-9)
+	})
+
+	t.Run("small samples are not trusted", func(t *testing.T) {
+		t.Parallel()
+		// 100 chars → ~33 heuristic tokens, below calibrationMinTokens.
+		e := NewSliceEstimator([]chat.Message{
+			usageMsg("test/m", 1_000, 100),
+			{Role: chat.MessageRoleTool, Content: strings.Repeat("x", 100)},
+			usageMsg("test/m", 11_100, 50),
+		})
+		assert.InEpsilon(t, 1.0, e.Scale(), 1e-9)
+	})
+
+	t.Run("negative deltas from a mid-window compaction are discarded", func(t *testing.T) {
+		t.Parallel()
+		// The second window's prompt shrank (compaction rebuilt it), so
+		// only the first window's clean 1.5 ratio survives.
+		e := NewSliceEstimator([]chat.Message{
+			usageMsg("test/m", 1_000, 100),
+			toolResult,
+			usageMsg("test/m", 4_108, 50),
+			toolResult,
+			usageMsg("test/m", 500, 50),
+		})
+		assert.InDelta(t, 1.5, e.Scale(), 0.01)
+	})
+
+	t.Run("windows spanning a model switch are discarded", func(t *testing.T) {
+		t.Parallel()
+		e := NewSliceEstimator([]chat.Message{
+			usageMsg("openai/gpt-5", 1_000, 100),
+			toolResult,
+			usageMsg("anthropic/claude", 11_100, 50),
+		})
+		assert.InEpsilon(t, 1.0, e.Scale(), 1e-9)
+	})
+
+	t.Run("exactly sized in-between messages are subtracted from the delta", func(t *testing.T) {
+		t.Parallel()
+		// The in-between assistant turn has an output-only usage report
+		// (5000 tokens, no prompt data → not an anchor). Its exact size
+		// must not dilute the tool result's 2005-vs-3008 ratio.
+		interAssistant := chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: "large reply",
+			Model:   "test/m",
+			Usage:   &chat.Usage{OutputTokens: 5_000},
+		}
+		e := NewSliceEstimator([]chat.Message{
+			usageMsg("test/m", 1_000, 100),
+			interAssistant,
+			toolResult,
+			usageMsg("test/m", 9_113, 50), // delta 8013 − (5000+5) reported = 3008
+		})
+		assert.InDelta(t, 1.5, e.Scale(), 0.01)
+	})
+}
+
+// TestSplitIndexForKeep_UsageCalibration verifies that provider-reported
+// usage recorded on assistant turns shifts the keep boundary: content
+// the heuristic undercounts 2× fills the keep budget twice as fast.
+func TestSplitIndexForKeep_UsageCalibration(t *testing.T) {
+	t.Parallel()
+
+	// Each user message: 40000 chars → heuristic 11433 tokens, but the
+	// anchor deltas report 22866 real tokens (ratio exactly 2.0).
+	messages := []chat.Message{
+		{Role: chat.MessageRoleUser, Content: strings.Repeat("u", 40_000)},
+		usageMsg("test/m", 15_000, 100),
+		{Role: chat.MessageRoleUser, Content: strings.Repeat("v", 40_000)},
+		usageMsg("test/m", 37_966, 100), // 15100 + 22866
+	}
+
+	// Uncalibrated walk would fit messages[1:] in 23k (105 + 11433 +
+	// 105); with the observed 2× correction the kept tail shrinks to
+	// messages[2:] (105 + 22866).
+	assert.Equal(t, 2, SplitIndexForKeep(messages, 23_000))
 }
 
 func TestShouldCompact(t *testing.T) {
@@ -251,14 +477,14 @@ func TestSplitIndexForKeep(t *testing.T) {
 		{
 			name: "recent messages kept, older ones compacted",
 			messages: []chat.Message{
-				msg(chat.MessageRoleUser, strings.Repeat("a", 40000)),      // ~10005 tokens
-				msg(chat.MessageRoleAssistant, strings.Repeat("b", 40000)), // ~10005 tokens
-				msg(chat.MessageRoleUser, strings.Repeat("c", 40000)),      // ~10005 tokens
-				msg(chat.MessageRoleAssistant, strings.Repeat("d", 40000)), // ~10005 tokens
-				msg(chat.MessageRoleUser, strings.Repeat("e", 40000)),      // ~10005 tokens
-				msg(chat.MessageRoleAssistant, strings.Repeat("f", 40000)), // ~10005 tokens
+				msg(chat.MessageRoleUser, strings.Repeat("a", 40000)),      // ~11433 tokens
+				msg(chat.MessageRoleAssistant, strings.Repeat("b", 40000)), // ~11433 tokens
+				msg(chat.MessageRoleUser, strings.Repeat("c", 40000)),      // ~11433 tokens
+				msg(chat.MessageRoleAssistant, strings.Repeat("d", 40000)), // ~11433 tokens
+				msg(chat.MessageRoleUser, strings.Repeat("e", 40000)),      // ~11433 tokens
+				msg(chat.MessageRoleAssistant, strings.Repeat("f", 40000)), // ~11433 tokens
 			},
-			maxTokens: 20_100, // enough for exactly 2 messages
+			maxTokens: 23_000, // enough for exactly 2 messages
 			wantSplit: 4,      // last 2 messages are kept
 		},
 		{
@@ -402,7 +628,7 @@ func TestFirstIndexInBudget(t *testing.T) {
 				msg(chat.MessageRoleUser, strings.Repeat("c", 4000)),
 				msg(chat.MessageRoleAssistant, strings.Repeat("d", 4000)),
 			},
-			budget:    2100, // ~2 messages worth
+			budget:    2400, // ~2 messages worth (~1147 tokens each)
 			wantFirst: 2,
 		},
 	}

--- a/pkg/runtime/compaction_trigger_test.go
+++ b/pkg/runtime/compaction_trigger_test.go
@@ -233,3 +233,101 @@ func TestCompactIfNeeded_AgentSessionCompactionDisabled(t *testing.T) {
 			"session_compaction: false must suppress the proactive compaction trigger")
 	}
 }
+
+// TestCompactIfNeeded_UsageCalibratedTrigger pins the estimator
+// reconciliation from issue #3437: identical fresh tool results either
+// trigger or don't trigger proactive compaction depending on what the
+// session's provider-reported usage said about earlier, similar
+// content.
+//
+// Both sessions carry ~43k provider-counted tokens and add a 120k-char
+// tool result (heuristic ≈ 34k tokens, uncalibrated total ≈ 77k of the
+// 100k window — under the 90% threshold). The calibrated session's
+// anchors additionally prove the heuristic undercounts this content 2×
+// (prompt deltas of 40k tokens for 70k-char results), pushing the
+// estimate past the threshold.
+func TestCompactIfNeeded_UsageCalibratedTrigger(t *testing.T) {
+	t.Parallel()
+
+	const contextLimit = 100_000
+
+	newRuntime := func(t *testing.T) (*LocalRuntime, *agent.Agent) {
+		t.Helper()
+		prov := &mockProvider{id: "test/model", stream: &mockStream{}}
+		root := agent.New("root", "agent", agent.WithModel(prov))
+		rt, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root)),
+			WithSessionCompaction(true),
+			WithModelStore(mockModelStoreWithLimit{limit: contextLimit}))
+		require.NoError(t, err)
+		return rt, root
+	}
+
+	assistantMsg := func(usage *chat.Usage) *session.Message {
+		return session.NewAgentMessage("root", &chat.Message{
+			Role:      chat.MessageRoleAssistant,
+			Content:   "running tools",
+			Model:     "test/model",
+			Usage:     usage,
+			ToolCalls: []tools.ToolCall{{ID: "t1", Function: tools.FunctionCall{Name: "shell"}}},
+		})
+	}
+	toolMsg := func(size int) *session.Message {
+		return session.NewAgentMessage("root", &chat.Message{
+			Role:       chat.MessageRoleTool,
+			ToolCallID: "t1",
+			Content:    strings.Repeat("z", size),
+		})
+	}
+
+	runScenario := func(t *testing.T, calibrated bool) bool {
+		t.Helper()
+		rt, root := newRuntime(t)
+
+		sess := session.New(session.WithUserMessage("build the app"))
+		var anchors []*chat.Usage
+		if calibrated {
+			// 70k-char tool result between the anchors: heuristic says
+			// ~20_005 tokens, the prompt delta says 40_010 → scale 2.0.
+			anchors = []*chat.Usage{
+				{InputTokens: 3_000, OutputTokens: 100},
+				{InputTokens: 43_110, OutputTokens: 100},
+			}
+		}
+		usageAt := func(i int) *chat.Usage {
+			if anchors == nil {
+				return nil
+			}
+			return anchors[i]
+		}
+		sess.AddMessage(assistantMsg(usageAt(0)))
+		sess.AddMessage(toolMsg(70_000))
+		sess.AddMessage(assistantMsg(usageAt(1)))
+		sess.SetUsage(43_110, 100)
+
+		messageCountBefore := len(sess.OwnMessages())
+		sess.AddMessage(toolMsg(120_000))
+
+		events := make(chan Event, 16)
+		rt.compactIfNeeded(t.Context(), sess, root, contextLimit, messageCountBefore, NewChannelSink(events))
+		close(events)
+
+		for ev := range events {
+			if _, ok := ev.(*SessionCompactionEvent); ok {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("provider-calibrated estimate crosses the threshold", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, runScenario(t, true),
+			"usage anchors proving 2× undercount must push the estimate past 90%")
+	})
+
+	t.Run("without usage anchors the heuristic stays below the threshold", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, runScenario(t, false),
+			"same content without usage history must not trigger compaction")
+	})
+}

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -1114,10 +1114,23 @@ func (r *LocalRuntime) compactIfNeeded(
 	// never enters this session's prompt, so counting it here would
 	// attribute phantom tokens to a small parent conversation and
 	// trigger a compaction that wipes it (see issue #2871).
-	newMessages := sess.OwnMessages()[messageCountBefore:]
+	//
+	// The estimator is calibrated against the provider-reported usage
+	// already recorded on this session's assistant messages, so the
+	// heuristic guess for the fresh tool results tracks the provider's
+	// actual tokenizer instead of a fixed chars-per-token ratio.
+	ownMessages := sess.OwnMessages()
+	estimator := compaction.NewEstimator(func(yield func(*chat.Message) bool) {
+		for i := range ownMessages {
+			if !yield(&ownMessages[i].Message) {
+				return
+			}
+		}
+	})
+	newMessages := ownMessages[messageCountBefore:]
 	var addedTokens int64
-	for _, msg := range newMessages {
-		addedTokens += compaction.EstimateMessageTokens(&msg.Message)
+	for i := range newMessages {
+		addedTokens += estimator.EstimateMessageTokens(&newMessages[i].Message)
 	}
 
 	if !compaction.ShouldCompact(sess.InputTokens, sess.OutputTokens, addedTokens, contextLimit, a.CompactionThreshold()) {
@@ -1129,6 +1142,7 @@ func (r *LocalRuntime) compactIfNeeded(
 		"input_tokens", sess.InputTokens,
 		"output_tokens", sess.OutputTokens,
 		"added_estimated_tokens", addedTokens,
+		"estimator_scale", estimator.Scale(),
 		"estimated_total", sess.InputTokens+sess.OutputTokens+addedTokens,
 		"context_limit", contextLimit,
 	)


### PR DESCRIPTION
## Summary

Closes #3437. `compaction.EstimateMessageTokens` was a fixed `len/4 + 5` heuristic. It now reconciles with provider-reported usage: exact counts for messages that carry usage, plus a session-calibrated correction for unreported content, with a conservative bias so compaction fires slightly early rather than overflowing.

## Issue expectations vs implementation

| Issue expectation | Implementation |
| --- | --- |
| Reconcile the heuristic against provider-reported usage per message | Messages carrying `chat.Message.Usage` weigh their provider-counted size (`OutputTokens`, minus reasoning tokens that are never resent as input) |
| Usage available via `MessageUsage` | The underlying per-message data (`msg.Usage`) is read directly; a new `compaction.Estimator` additionally calibrates on prompt-token deltas between consecutive usage-bearing assistant turns |
| Conservative bias (compact slightly early rather than overflow) | Base heuristic at 3.5 chars/token (tracks code/JSON, mildly overestimates prose), calibration ratio clamped to [0.75, 2.0], invalid delta windows discarded |
| Starting points `pkg/compaction`, `pkg/runtime/compactor` | `SplitIndexForKeep` / `FirstIndexInBudget` self-calibrate on the slice they receive (signatures unchanged, the compactor benefits transitively); `compactIfNeeded` calibrates the fresh tool-result estimate against session history |
| Extend estimator tests | 11 `EstimateMessageTokens` cases, 8 `NewEstimator` sub-tests, calibration test for `SplitIndexForKeep`, runtime test proving calibration flips the `compactIfNeeded` decision |

## Calibration mechanism

```
prompt(j) - (prompt(i) + output(i)) = provider-exact size of the messages between assistant turns i and j
ratio = sum(deltas) / sum(heuristic estimates of those messages)
      = multiplicative correction applied to heuristic estimates only
```

Guard rails:

- non-positive deltas discarded (a compaction between the anchors rebuilt the prompt)
- anchor pairs spanning a model switch discarded (mixed tokenizers)
- exactly sized in-between content subtracted from the delta, keeping the ratio a pure heuristic-vs-provider comparison
- ratio trusted only past 512 heuristic tokens of sample mass, then clamped to [0.75, 2.0]
- provider-reported counts are never scaled

## Estimator accuracy fixes

| Content | Before | After |
| --- | --- | --- |
| Assistant turns with usage | `len/4` guess | exact provider count |
| Code/JSON tool results | `len/4` (undercounts 15-25%) | `len/3.5`, then usage-calibrated |
| Inline document text | not counted | counted as text |
| Binary attachments (images, documents) | not counted | flat 1500 tokens per part |
| Hidden reasoning (OpenAI o-series) | counted as if resent | excluded when no reasoning content is stored |

## Interaction with #3448 (configurable threshold)

Built on top of the merged threshold work: `ShouldCompact(..., threshold)`, `sessionCompactionEnabled(a)` and `a.CompactionThreshold()` are untouched; this PR only changes how `addedTokens` and split boundaries are estimated.

## Validation

| Check | Result |
| --- | --- |
| `go build`, `go vet`, `golangci-lint` | clean, 0 issues |
| `pkg/compaction`, `pkg/runtime` (+ compactor, toolexec, wire), `pkg/agent`, `pkg/session`, `pkg/tui` | green |
| Full `go test ./...` | green except pre-existing network-dependent failures (`pkg/config`, `pkg/httpclient`, `pkg/teamloader`), reproduced identically on a clean `main` checkout |

## Residual design note

The 0.75 calibration floor limits downward correction: if provider reports prove the heuristic overestimates by more than 25%, compaction still fires early. That is the conservative trade-off the issue asks for; the floor can be lowered if accuracy is preferred over the early-compaction bias.
