### PR TITLE
feat(cli): actionable errors for missing models and credentials (phase 1 of #3442)

### DIFF
--- a/cmd/root/flags.go
+++ b/cmd/root/flags.go
@@ -103,6 +103,13 @@ func addGatewayFlags(cmd *cobra.Command, runConfig *config.RuntimeConfig, loadUs
 
 		env := runConfig.EnvProvider()
 
+		// A missing or malformed --env-from-file must abort the run: the flag
+		// is the documented way to supply credentials, so silently continuing
+		// without it leads to confusing "env var must be set" errors later.
+		if err := runConfig.EnvFilesError(); err != nil {
+			return fmt.Errorf("--env-from-file: %w", err)
+		}
+
 		// Precedence: CLI flag > environment variable > user config
 		if runConfig.ModelsGateway == "" {
 			if gateway, _ := env.Get(ctx, envModelsGateway); gateway != "" {

--- a/cmd/root/flags_test.go
+++ b/cmd/root/flags_test.go
@@ -2,6 +2,8 @@ package root
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -326,4 +328,60 @@ func TestDefaultModelLogic(t *testing.T) {
 			}
 		})
 	}
+}
+
+// A missing or malformed --env-from-file must abort the run instead of being
+// logged and skipped: the flag is the documented way to supply credentials
+// (issue #3442).
+func TestEnvFromFileErrorsAbortPreRun(t *testing.T) {
+	t.Parallel()
+
+	loadUserConfig := func() (*userconfig.Config, error) {
+		return &userconfig.Config{}, nil
+	}
+
+	t.Run("missing file", func(t *testing.T) {
+		t.Parallel()
+
+		cmd := &cobra.Command{
+			SilenceErrors: true,
+			SilenceUsage:  true,
+			RunE:          func(*cobra.Command, []string) error { return nil },
+		}
+		runConfig := config.RuntimeConfig{
+			Config: config.Config{EnvFiles: []string{filepath.Join(t.TempDir(), "missing.env")}},
+		}
+		addGatewayFlags(cmd, &runConfig, loadUserConfig)
+
+		cmd.SetArgs(nil)
+		err := cmd.Execute()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--env-from-file")
+		assert.Contains(t, err.Error(), "missing.env")
+	})
+
+	t.Run("malformed file", func(t *testing.T) {
+		t.Parallel()
+
+		bad := filepath.Join(t.TempDir(), "bad.env")
+		require.NoError(t, os.WriteFile(bad, []byte("NOT_A_PAIR\n"), 0o600))
+
+		cmd := &cobra.Command{
+			SilenceErrors: true,
+			SilenceUsage:  true,
+			RunE:          func(*cobra.Command, []string) error { return nil },
+		}
+		runConfig := config.RuntimeConfig{
+			Config: config.Config{EnvFiles: []string{bad}},
+		}
+		addGatewayFlags(cmd, &runConfig, loadUserConfig)
+
+		cmd.SetArgs(nil)
+		err := cmd.Execute()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--env-from-file")
+		assert.Contains(t, err.Error(), "bad.env")
+	})
 }

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -213,8 +213,10 @@ func Run(ctx context.Context, out *Printer, cfg Config, rt runtime.Runtime, sess
 				if strings.Contains(lowerErr, "context cancel") && ctx.Err() != nil { // treat Ctrl+C cancellations as non-errors
 					lastErr = nil
 				} else {
+					// Not printed here: the error is returned to the command layer,
+					// which prints it exactly once. Printing here too showed every
+					// failure twice in --exec runs.
 					lastErr = fmt.Errorf("%s", e.Error)
-					out.PrintError(lastErr)
 				}
 			case *runtime.MaxIterationsReachedEvent:
 				switch handleMaxIterationsAutoApprove(cfg.AutoApprove, &autoExtensions, e.MaxIterations) {
@@ -274,6 +276,9 @@ func Run(ctx context.Context, out *Printer, cfg Config, rt runtime.Runtime, sess
 		if err != nil {
 			return fmt.Errorf("failed to read from stdin: %w", err)
 		}
+		if strings.TrimSpace(string(buf)) == "" {
+			return errors.New(`no message received on stdin: with "-" the prompt is read from stdin, e.g. echo "Hello" | docker agent run <agent> -`)
+		}
 
 		if err := oneLoop(string(buf), os.Stdin); err != nil {
 			return err
@@ -290,6 +295,11 @@ func Run(ctx context.Context, out *Printer, cfg Config, rt runtime.Runtime, sess
 		buf, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return fmt.Errorf("failed to read from stdin: %w", err)
+		}
+		// Exiting 0 with no output on empty input (e.g. bare `docker agent`
+		// in CI) would be a silent no-op; fail with the next steps instead.
+		if strings.TrimSpace(string(buf)) == "" {
+			return errors.New("no message provided and stdin is not a terminal: pass a message (docker agent run <agent> \"<message>\"), pipe one on stdin, or run from an interactive terminal to use the chat UI")
 		}
 
 		if err := oneLoop(string(buf), os.Stdin); err != nil {

--- a/pkg/cli/runner_test.go
+++ b/pkg/cli/runner_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -480,4 +482,89 @@ func TestPrepareUserMessage_CommandResolution(t *testing.T) {
 	assert.NilError(t, err)
 
 	assert.Equal(t, "Fix the file main.go", msg.Message.Content, "Command should be resolved with args")
+}
+
+// swapStdin replaces os.Stdin with a pipe carrying the given content for the
+// duration of the test. A pipe is never a terminal, so it also exercises the
+// non-TTY stdin paths. Tests using it must not run in parallel: os.Stdin is
+// process-global state.
+func swapStdin(t *testing.T, content string) {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("creating stdin pipe: %v", err)
+	}
+	if _, err := w.WriteString(content); err != nil {
+		t.Fatalf("writing stdin pipe: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing stdin pipe: %v", err)
+	}
+
+	old := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = old
+		_ = r.Close()
+	})
+}
+
+// A run that would silently do nothing (no message, empty non-TTY stdin, e.g.
+// bare `docker agent` in CI) must fail with an actionable error instead of
+// exiting 0 with no output (issue #3442).
+func TestRunEmptyStdinNonTTYFails(t *testing.T) {
+	swapStdin(t, "")
+
+	rt := &mockRuntime{}
+	var buf bytes.Buffer
+	sess := session.New()
+
+	err := Run(t.Context(), NewPrinter(&buf), Config{}, rt, sess, nil)
+	assert.ErrorContains(t, err, "no message provided and stdin is not a terminal")
+	assert.ErrorContains(t, err, "interactive terminal")
+}
+
+func TestRunEmptyStdinWithDashFails(t *testing.T) {
+	swapStdin(t, "")
+
+	rt := &mockRuntime{}
+	var buf bytes.Buffer
+	sess := session.New()
+
+	err := Run(t.Context(), NewPrinter(&buf), Config{}, rt, sess, []string{"-"})
+	assert.ErrorContains(t, err, "no message received on stdin")
+}
+
+func TestRunPipedStdinStillWorks(t *testing.T) {
+	swapStdin(t, "hello agent\n")
+
+	rt := &mockRuntime{
+		events: []runtime.Event{&runtime.AgentChoiceEvent{Content: "4"}},
+	}
+	var buf bytes.Buffer
+	sess := session.New()
+
+	err := Run(t.Context(), NewPrinter(&buf), Config{}, rt, sess, nil)
+	assert.NilError(t, err)
+	assert.Equal(t, len(sess.GetAllMessages()) > 0, true)
+}
+
+// An ErrorEvent must surface exactly once: returned to the command layer
+// (which prints it), never also printed by the runner (issue #3442).
+func TestErrorEventReturnedNotPrinted(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{
+		events: []runtime.Event{runtime.Error("model failed: HTTP 404")},
+	}
+	var buf bytes.Buffer
+	sess := session.New()
+
+	err := Run(t.Context(), NewPrinter(&buf), Config{}, rt, sess, []string{"hello"})
+	assert.ErrorContains(t, err, "model failed: HTTP 404")
+
+	var runtimeErr RuntimeError
+	assert.Equal(t, errors.As(err, &runtimeErr), true)
+	assert.Equal(t, strings.Contains(buf.String(), "model failed"), false)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -146,7 +146,7 @@ func CheckRequiredEnvVars(ctx context.Context, cfg *latest.Config, modelsGateway
 		}
 	}
 
-	missing, err := gatherMissingEnvVars(ctx, cfg, modelsGateway, env)
+	missing, missingModelCreds, err := gatherMissingEnvVars(ctx, cfg, modelsGateway, env)
 	if err != nil {
 		// If there's a tool preflight error, log it but continue
 		slog.WarnContext(ctx, "Failed to preflight toolset environment variables; continuing", "error", err)
@@ -155,7 +155,8 @@ func CheckRequiredEnvVars(ctx context.Context, cfg *latest.Config, modelsGateway
 	// Return error if there are missing environment variables
 	if len(missing) > 0 {
 		return &environment.RequiredEnvError{
-			Missing: missing,
+			Missing:                 missing,
+			MissingModelCredentials: missingModelCreds,
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -283,6 +283,7 @@ func TestCheckRequiredEnvVars(t *testing.T) {
 				var reqErr *environment.RequiredEnvError
 				require.ErrorAs(t, err, &reqErr)
 				assert.Equal(t, test.expectedMissing, reqErr.Missing)
+				assert.True(t, reqErr.MissingModelCredentials, "missing vars are model credentials, so the local-model hint must be offered")
 			}
 		})
 	}

--- a/pkg/config/first_available.go
+++ b/pkg/config/first_available.go
@@ -174,10 +174,15 @@ func (e *firstAvailableMissingEnvError) Error() string {
 
 	fmt.Fprintln(&msg, "No 'first_available' candidate has credentials configured.")
 	fmt.Fprintln(&msg, "Set the environment variables for at least one candidate:")
-	for _, candidate := range e.Candidates {
+	example := "OPENAI_API_KEY"
+	for i, candidate := range e.Candidates {
 		fmt.Fprintf(&msg, " - %s: %s\n", candidate.Ref, strings.Join(candidate.Missing, ", "))
+		if i == 0 && len(candidate.Missing) > 0 {
+			example = candidate.Missing[0]
+		}
 	}
-	fmt.Fprintln(&msg, "\nEither:\n - Set one of those groups of environment variables before running docker agent\n - Run docker agent with --env-from-file\n - Store those secrets using one of the built-in environment variable providers.")
+	msg.WriteString("\n")
+	msg.WriteString(environment.SecretSourcesHelp(example))
 
 	return msg.String()
 }

--- a/pkg/config/first_available_test.go
+++ b/pkg/config/first_available_test.go
@@ -180,8 +180,9 @@ func TestResolveFirstAvailableModels_NoCandidateAvailable(t *testing.T) {
 	assert.Contains(t, err.Error(), "Set the environment variables for at least one candidate:")
 	assert.Contains(t, err.Error(), " - anthropic/claude-sonnet-4-6: ANTHROPIC_API_KEY")
 	assert.Contains(t, err.Error(), " - openai/gpt-5: OPENAI_API_KEY")
-	assert.Contains(t, err.Error(), "Set one of those groups of environment variables")
-	assert.Contains(t, err.Error(), "Run docker agent with --env-from-file")
+	assert.Contains(t, err.Error(), "export ANTHROPIC_API_KEY=<value>")
+	assert.Contains(t, err.Error(), "--env-from-file")
+	assert.Contains(t, err.Error(), environment.SecretsDocsURL)
 }
 
 func TestResolveFirstAvailableModels_InvalidCandidate(t *testing.T) {

--- a/pkg/config/gather.go
+++ b/pkg/config/gather.go
@@ -16,24 +16,26 @@ import (
 )
 
 // gatherMissingEnvVars finds out which environment variables are required by the models and tools.
-// It returns the missing variables and any non-fatal error encountered during tool discovery.
-func gatherMissingEnvVars(ctx context.Context, cfg *latest.Config, modelsGateway string, env environment.Provider) (missing []string, toolErr error) {
+// It returns the missing variables, whether any of them is a model-provider
+// credential (as opposed to a tool secret), and any non-fatal error
+// encountered during tool discovery.
+func gatherMissingEnvVars(ctx context.Context, cfg *latest.Config, modelsGateway string, env environment.Provider) (missing []string, missingModelCreds bool, toolErr error) {
 	requiredEnv := map[string]bool{}
+	modelEnv := map[string]bool{}
 
 	// Models
+	var modelNames []string
 	if modelsGateway == "" {
-		names := GatherEnvVarsForModels(ctx, cfg, env)
-		for _, e := range names {
-			requiredEnv[e] = true
-		}
+		modelNames = GatherEnvVarsForModels(ctx, cfg, env)
 	} else {
 		// A gateway supplies credentials for routed models, but models that
 		// bypass it dial their provider directly and still need their own
 		// credentials present.
-		names := gatherEnvVarsForModels(ctx, cfg, env, true)
-		for _, e := range names {
-			requiredEnv[e] = true
-		}
+		modelNames = gatherEnvVarsForModels(ctx, cfg, env, true)
+	}
+	for _, e := range modelNames {
+		requiredEnv[e] = true
+		modelEnv[e] = true
 	}
 
 	// Tools
@@ -52,10 +54,11 @@ func gatherMissingEnvVars(ctx context.Context, cfg *latest.Config, modelsGateway
 	for _, e := range sortedKeys(requiredEnv) {
 		if v, _ := env.Get(ctx, e); v == "" {
 			missing = append(missing, e)
+			missingModelCreds = missingModelCreds || modelEnv[e]
 		}
 	}
 
-	return missing, toolErr
+	return missing, missingModelCreds, toolErr
 }
 
 func GatherEnvVarsForModels(ctx context.Context, cfg *latest.Config, env environment.Provider) []string {

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -19,6 +19,7 @@ type RuntimeConfig struct {
 	EnvProviderForTests environment.Provider
 	envProviderCached   environment.Provider
 	envProviderOnce     sync.Once
+	envFilesErr         error
 
 	ModelsDevStoreOverride *modelsdev.Store
 	modelsDevStore         *modelsdev.Store
@@ -82,6 +83,7 @@ func (runConfig *RuntimeConfig) Clone() *RuntimeConfig {
 		Config:                 runConfig.Config,
 		EnvProviderForTests:    runConfig.EnvProviderForTests,
 		envProviderCached:      env,
+		envFilesErr:            runConfig.envFilesErr,
 		ModelsDevStoreOverride: runConfig.ModelsDevStoreOverride,
 		modelsDevStore:         store,
 		modelsDevStoreErr:      storeErr,
@@ -140,6 +142,15 @@ func (runConfig *RuntimeConfig) EnvProvider() environment.Provider {
 	return runConfig.envProviderCached
 }
 
+// EnvFilesError reports a failure to resolve, read, or parse the configured
+// env files (--env-from-file). The provider chain silently falls back to the
+// default sources in that case, so callers that must not run without the
+// file's variables (e.g. the CLI) should surface this error and abort.
+func (runConfig *RuntimeConfig) EnvFilesError() error {
+	runConfig.EnvProvider() // materialize the provider chain
+	return runConfig.envFilesErr
+}
+
 func (runConfig *RuntimeConfig) computedEnvProvider() environment.Provider {
 	defaultEnv := environment.NewDefaultProvider()
 
@@ -148,12 +159,14 @@ func (runConfig *RuntimeConfig) computedEnvProvider() environment.Provider {
 	runConfig.EnvFiles, err = environment.AbsolutePaths(runConfig.WorkingDir, runConfig.EnvFiles)
 	if err != nil {
 		slog.Error("Failed to make env file paths absolute", "error", err)
+		runConfig.envFilesErr = err
 		return defaultEnv
 	}
 
 	envFilesProviders, err := environment.NewEnvFilesProvider(runConfig.EnvFiles)
 	if err != nil {
 		slog.Error("Failed to read env files", "error", err)
+		runConfig.envFilesErr = err
 		return defaultEnv
 	}
 

--- a/pkg/config/runtime_test.go
+++ b/pkg/config/runtime_test.go
@@ -1,9 +1,12 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClone_ChangeWorkingDir(t *testing.T) {
@@ -23,4 +26,48 @@ func TestClone_ChangeWorkingDir(t *testing.T) {
 
 	assert.Equal(t, "/newapp", original.WorkingDir)
 	assert.Equal(t, "/cloneapp", clone.WorkingDir)
+}
+
+func TestEnvFilesError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing file", func(t *testing.T) {
+		t.Parallel()
+		missing := filepath.Join(t.TempDir(), "missing.env")
+		rc := &RuntimeConfig{Config: Config{EnvFiles: []string{missing}}}
+
+		err := rc.EnvFilesError()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing.env")
+	})
+
+	t.Run("malformed file", func(t *testing.T) {
+		t.Parallel()
+		bad := filepath.Join(t.TempDir(), "bad.env")
+		require.NoError(t, os.WriteFile(bad, []byte("NOT_A_PAIR\n"), 0o600))
+		rc := &RuntimeConfig{Config: Config{EnvFiles: []string{bad}}}
+
+		err := rc.EnvFilesError()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bad.env")
+	})
+
+	t.Run("valid file", func(t *testing.T) {
+		t.Parallel()
+		ok := filepath.Join(t.TempDir(), "ok.env")
+		require.NoError(t, os.WriteFile(ok, []byte("SOME_TEST_ONLY_VAR=some-value\n"), 0o600))
+		rc := &RuntimeConfig{Config: Config{EnvFiles: []string{ok}}}
+
+		require.NoError(t, rc.EnvFilesError())
+		v, _ := rc.EnvProvider().Get(t.Context(), "SOME_TEST_ONLY_VAR")
+		assert.Equal(t, "some-value", v)
+	})
+
+	t.Run("clone preserves error", func(t *testing.T) {
+		t.Parallel()
+		missing := filepath.Join(t.TempDir(), "missing.env")
+		rc := &RuntimeConfig{Config: Config{EnvFiles: []string{missing}}}
+
+		require.Error(t, rc.Clone().EnvFilesError())
+	})
 }

--- a/pkg/environment/env_files.go
+++ b/pkg/environment/env_files.go
@@ -92,7 +92,7 @@ func ReadEnvFile(absolutePath string) ([]KeyValuePair, error) {
 
 		k, v, ok := strings.Cut(line, "=")
 		if !ok {
-			return nil, fmt.Errorf("invalid env file line: %s", line)
+			return nil, fmt.Errorf("invalid line in env file %s: %q (expected KEY=VALUE)", absolutePath, line)
 		}
 
 		k = strings.TrimSpace(k)

--- a/pkg/environment/env_files_test.go
+++ b/pkg/environment/env_files_test.go
@@ -157,6 +157,9 @@ func TestReadEnvFileInvalid(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Empty(t, lines)
+	// The error names the offending file so multi-file runs stay debuggable.
+	assert.Contains(t, err.Error(), filepath.Join(temp, ".invalid"))
+	assert.Contains(t, err.Error(), "KEY=VALUE")
 }
 
 func write(t *testing.T, path, content string) {

--- a/pkg/environment/errors.go
+++ b/pkg/environment/errors.go
@@ -5,8 +5,17 @@ import (
 	"strings"
 )
 
+// SecretsDocsURL is the documentation page describing every built-in secret
+// source and how to configure it.
+const SecretsDocsURL = "https://docs.docker.com/ai/docker-agent/guides/secrets/"
+
 type RequiredEnvError struct {
 	Missing []string
+
+	// MissingModelCredentials reports whether at least one missing variable is
+	// a model-provider credential, in which case the error also suggests
+	// running a local model instead of configuring an API key.
+	MissingModelCredentials bool
 }
 
 var _ error = &RequiredEnvError{}
@@ -18,7 +27,35 @@ func (e *RequiredEnvError) Error() string {
 	for _, v := range e.Missing {
 		fmt.Fprintf(&msg, " - %s\n", v)
 	}
-	fmt.Fprintln(&msg, "\nEither:\n - Set those environment variables before running docker agent\n - Run docker agent with --env-from-file\n - Store those secrets using one of the built-in environment variable providers.")
+
+	example := "OPENAI_API_KEY"
+	if len(e.Missing) > 0 {
+		example = e.Missing[0]
+	}
+	msg.WriteString("\n")
+	msg.WriteString(SecretSourcesHelp(example))
+
+	if e.MissingModelCredentials {
+		msg.WriteString("\nNo API key? Run a local model instead: docker agent run --model dmr/ai/qwen3 ...\n(the model is pulled on first use; `docker model ls` shows models already pulled)\n")
+	}
 
 	return msg.String()
+}
+
+// SecretSourcesHelp returns guidance naming the built-in secret sources able
+// to supply arbitrary variables, with a one-line example for the given
+// variable and a link to the docs. Docker Desktop and the credential helper
+// are deliberately absent: they only resolve fixed Docker variables
+// (DOCKER_TOKEN, ...) and can never satisfy the keys reported missing here.
+// Shared by the errors that report missing credentials so the advice never
+// drifts between them.
+func SecretSourcesHelp(exampleVar string) string {
+	var b strings.Builder
+	b.WriteString("Provide them using any of these sources:\n")
+	fmt.Fprintf(&b, " - Shell environment:  export %s=<value>\n", exampleVar)
+	b.WriteString(" - Env file:           docker agent run --env-from-file <file> ...\n")
+	fmt.Fprintf(&b, " - pass:               pass insert %s\n", exampleVar)
+	fmt.Fprintf(&b, " - macOS Keychain:     security add-generic-password -a \"$USER\" -s %s -w\n", exampleVar)
+	fmt.Fprintf(&b, "\nSee %s for details.\n", SecretsDocsURL)
+	return b.String()
 }

--- a/pkg/environment/errors_test.go
+++ b/pkg/environment/errors_test.go
@@ -1,0 +1,49 @@
+package environment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequiredEnvError_NamesSecretSources(t *testing.T) {
+	t.Parallel()
+
+	err := &RequiredEnvError{Missing: []string{"ANTHROPIC_API_KEY", "GITHUB_PERSONAL_ACCESS_TOKEN"}}
+	msg := err.Error()
+
+	assert.Contains(t, msg, "environment variables must be set")
+	assert.Contains(t, msg, " - ANTHROPIC_API_KEY")
+	assert.Contains(t, msg, " - GITHUB_PERSONAL_ACCESS_TOKEN")
+
+	// Each listed secret source comes with a concrete example using the
+	// first missing variable.
+	assert.Contains(t, msg, "export ANTHROPIC_API_KEY=<value>")
+	assert.Contains(t, msg, "--env-from-file")
+	assert.Contains(t, msg, `security add-generic-password -a "$USER" -s ANTHROPIC_API_KEY -w`)
+	assert.Contains(t, msg, "pass insert ANTHROPIC_API_KEY")
+	assert.Contains(t, msg, SecretsDocsURL)
+
+	// Docker Desktop and the credential helper only ever resolve fixed
+	// Docker variables (DOCKER_TOKEN, ...), so they must not be suggested
+	// as places to store the missing keys.
+	assert.NotContains(t, msg, "Docker Desktop")
+	assert.NotContains(t, msg, "credential_helper")
+
+	// The local-model alternative only applies to model credentials.
+	assert.NotContains(t, msg, "dmr/ai/qwen3")
+}
+
+func TestRequiredEnvError_SuggestsLocalModelForModelCredentials(t *testing.T) {
+	t.Parallel()
+
+	err := &RequiredEnvError{
+		Missing:                 []string{"OPENAI_API_KEY"},
+		MissingModelCredentials: true,
+	}
+	msg := err.Error()
+
+	assert.Contains(t, msg, "--model dmr/ai/qwen3")
+	assert.Contains(t, msg, "pulled on first use")
+	assert.Contains(t, msg, "docker model ls")
+}

--- a/pkg/model/provider/dmr/available.go
+++ b/pkg/model/provider/dmr/available.go
@@ -1,0 +1,81 @@
+package dmr
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+)
+
+// errIndicatesNotInstalled reports whether a `docker model` invocation failed
+// because the Docker installation predates Model Runner (the CLI rejects the
+// --json flag). Matching on content rather than the exact message keeps the
+// detection stable across docker CLI usage-text changes.
+func errIndicatesNotInstalled(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "unknown flag: --json")
+}
+
+// ModelNotAvailableError is returned at client-creation time when the
+// requested model is not pulled in Docker Model Runner and the `docker model`
+// CLI could not be used to offer a pull. Failing here replaces the raw HTTP
+// 404 the chat endpoint would otherwise return at message time.
+type ModelNotAvailableError struct {
+	Model string
+}
+
+func (e *ModelNotAvailableError) Error() string {
+	return fmt.Sprintf("model %s is not pulled in Docker Model Runner\n\nTo resolve this, you can:\n  - Pull it first: docker model pull %s\n  - Or choose a model that is already available (see `docker model ls`).", e.Model, e.Model)
+}
+
+// ModelPullErrorSummary is the concise one-liner used when this error is
+// nested as the cause of another error (e.g. config.AutoModelFallbackError),
+// so the full multi-line guidance is not duplicated.
+func (e *ModelNotAvailableError) ModelPullErrorSummary() string {
+	return fmt.Sprintf("model %s is not pulled in Docker Model Runner", e.Model)
+}
+
+// checkModelAvailable verifies through the DMR HTTP API that a model is
+// pulled locally. It is the fallback used when `docker model status` fails
+// (missing or broken CLI plugin) and the CLI-based inspect/pull flow is
+// therefore unusable.
+func checkModelAvailable(ctx context.Context, httpClient *http.Client, baseURL, model string) error {
+	available, err := listModelsAt(ctx, httpClient, baseURL)
+	if err != nil {
+		return fmt.Errorf("cannot query Docker Model Runner at %s (is it installed and running? https://docs.docker.com/ai/model-runner/get-started/): %w", baseURL, err)
+	}
+	if !modelAvailable(available, model) {
+		return &ModelNotAvailableError{Model: model}
+	}
+	return nil
+}
+
+// modelAvailable reports whether model matches one of the locally-available
+// IDs. An untagged model (e.g. "ai/qwen3") matches any tag of the same
+// repository, mirroring how `docker model` resolves references; a model with
+// an explicit tag requires an exact match.
+func modelAvailable(available []string, model string) bool {
+	if slices.Contains(available, model) {
+		return true
+	}
+	if modelRepo(model) != model {
+		return false
+	}
+	for _, id := range available {
+		if modelRepo(id) == model {
+			return true
+		}
+	}
+	return false
+}
+
+// modelRepo returns the repository portion of a DMR model ID, dropping a
+// trailing ":<tag>" suffix. A trailing colon is only treated as a tag
+// separator when the suffix has no slash, so a registry host:port like
+// "registry:5000/ai/x" is preserved.
+func modelRepo(id string) string {
+	if i := strings.LastIndex(id, ":"); i >= 0 && !strings.Contains(id[i+1:], "/") {
+		return id[:i]
+	}
+	return id
+}

--- a/pkg/model/provider/dmr/available_test.go
+++ b/pkg/model/provider/dmr/available_test.go
@@ -1,0 +1,98 @@
+package dmr
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrIndicatesNotInstalled(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, errIndicatesNotInstalled(nil))
+	assert.False(t, errIndicatesNotInstalled(errors.New("dial tcp: connection refused")))
+
+	// The exact message the docker CLI printed when the test suite was
+	// written, and a variant with different usage text around it: detection
+	// must not depend on the full message staying byte-identical.
+	assert.True(t, errIndicatesNotInstalled(errors.New("unknown flag: --json\n\nUsage:  docker [OPTIONS] COMMAND [ARG...]\n\nRun 'docker --help' for more information")))
+	assert.True(t, errIndicatesNotInstalled(errors.New("some prefix\nunknown flag: --json\nsome other usage text")))
+}
+
+func TestModelAvailable(t *testing.T) {
+	t.Parallel()
+
+	available := []string{"ai/embeddinggemma:latest", "ai/qwen3:latest", "registry:5000/ai/foo:latest"}
+
+	tests := []struct {
+		model string
+		want  bool
+	}{
+		{"ai/qwen3:latest", true},
+		{"ai/qwen3", true}, // untagged matches any tag of the repository
+		{"ai/qwen3:Q4_K_M", false},
+		{"ai/other", false},
+		{"registry:5000/ai/foo", true}, // host:port colon is not a tag separator
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, modelAvailable(available, tt.model))
+		})
+	}
+
+	assert.False(t, modelAvailable(nil, "ai/qwen3"))
+}
+
+func TestCheckModelAvailable(t *testing.T) {
+	t.Parallel()
+
+	newServer := func(body string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/models", r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(body))
+		}))
+	}
+
+	t.Run("model pulled", func(t *testing.T) {
+		t.Parallel()
+		server := newServer(`{"data":[{"id":"ai/qwen3:latest"}]}`)
+		defer server.Close()
+
+		err := checkModelAvailable(t.Context(), server.Client(), server.URL+"/", "ai/qwen3")
+		require.NoError(t, err)
+	})
+
+	t.Run("model not pulled", func(t *testing.T) {
+		t.Parallel()
+		server := newServer(`{"data":[{"id":"ai/gemma3:latest"}]}`)
+		defer server.Close()
+
+		err := checkModelAvailable(t.Context(), server.Client(), server.URL+"/", "ai/qwen3")
+		require.Error(t, err)
+
+		var notAvailable *ModelNotAvailableError
+		require.ErrorAs(t, err, &notAvailable)
+		assert.Equal(t, "ai/qwen3", notAvailable.Model)
+		assert.Contains(t, err.Error(), "not pulled in Docker Model Runner")
+		assert.Contains(t, err.Error(), "docker model pull ai/qwen3")
+	})
+
+	t.Run("endpoint unreachable", func(t *testing.T) {
+		t.Parallel()
+		server := newServer(`{"data":[]}`)
+		server.Close() // unreachable from the start
+
+		err := checkModelAvailable(t.Context(), &http.Client{}, server.URL+"/", "ai/qwen3")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot query Docker Model Runner")
+		assert.Contains(t, err.Error(), "https://docs.docker.com/ai/model-runner/get-started/")
+	})
+}

--- a/pkg/model/provider/dmr/client.go
+++ b/pkg/model/provider/dmr/client.go
@@ -82,21 +82,27 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, opts ...options.Opt
 	// Skip docker model status query when BaseURL is explicitly provided.
 	// This avoids unnecessary exec calls and speeds up tests/CI scenarios.
 	var endpoint, engine string
+	verifyViaAPI := false
 	if cfg.BaseURL == "" && os.Getenv("MODEL_RUNNER_HOST") == "" {
 		var err error
 		endpoint, engine, err = getDockerModelEndpointAndEngine(ctx)
-		if err != nil {
-			if err.Error() == "unknown flag: --json\n\nUsage:  docker [OPTIONS] COMMAND [ARG...]\n\nRun 'docker --help' for more information" {
-				slog.DebugContext(ctx, "docker model status query failed", "error", err)
-				return nil, ErrNotInstalled
-			}
-			slog.ErrorContext(ctx, "docker model status query failed", "error", err)
-		} else {
+		switch {
+		case err == nil:
 			// Auto-pull the model if needed
 			if err := pullDockerModelIfNeeded(ctx, cfg.Model); err != nil {
 				slog.DebugContext(ctx, "docker model pull failed", "error", err)
 				return nil, err
 			}
+		case errIndicatesNotInstalled(err):
+			slog.DebugContext(ctx, "docker model status query failed", "error", err)
+			return nil, ErrNotInstalled
+		default:
+			// The `docker model` CLI is unusable (broken plugin, docker not on
+			// PATH, ...) but the DMR endpoint may still be up: check model
+			// availability through the HTTP API below so a missing model fails
+			// here instead of as a raw HTTP 404 at message time.
+			slog.ErrorContext(ctx, "docker model status query failed", "error", err)
+			verifyViaAPI = true
 		}
 	}
 
@@ -105,6 +111,12 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, opts ...options.Opt
 	// Ensure we always have a non-nil HTTP client for both OpenAI adapter and direct HTTP calls (rerank).
 	if httpClient == nil {
 		httpClient = &http.Client{}
+	}
+
+	if verifyViaAPI {
+		if err := checkModelAvailable(ctx, httpClient, baseURL, cfg.Model); err != nil {
+			return nil, err
+		}
 	}
 
 	clientOptions = append(clientOptions, option.WithBaseURL(baseURL), option.WithAPIKey("")) // DMR doesn't need auth

--- a/pkg/model/provider/dmr/client_test.go
+++ b/pkg/model/provider/dmr/client_test.go
@@ -58,6 +58,34 @@ func TestNewClientReturnsErrNotInstalledWhenDockerModelUnsupported(t *testing.T)
 	require.ErrorIs(t, err, ErrNotInstalled)
 }
 
+// The "not installed" detection must not depend on the docker CLI usage text
+// staying byte-identical: any failure mentioning the unknown --json flag means
+// the installation predates Model Runner (issue #3442).
+func TestNewClientReturnsErrNotInstalledWithVariantUsageText(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping docker CLI shim test on Windows")
+	}
+
+	tempDir := t.TempDir()
+	dockerPath := filepath.Join(tempDir, "docker")
+	script := "#!/bin/sh\n" +
+		"printf 'unknown flag: --json\\n\\nUsage:  docker model COMMAND\\n\\nSee docker model --help\\n' >&2\n" +
+		"exit 1\n"
+	require.NoError(t, os.WriteFile(dockerPath, []byte(script), 0o755))
+
+	t.Setenv("PATH", tempDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("MODEL_RUNNER_HOST", "")
+
+	cfg := &latest.ModelConfig{
+		Provider: "dmr",
+		Model:    "ai/qwen3",
+	}
+
+	_, err := NewClient(t.Context(), cfg)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrNotInstalled)
+}
+
 func TestGetDMRFallbackURLs(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/model/provider/dmr/list.go
+++ b/pkg/model/provider/dmr/list.go
@@ -36,7 +36,7 @@ func ListModels(ctx context.Context) ([]string, error) {
 			// Mirror NewClient: the unknown "--json" flag is the signal that
 			// the Docker installation predates Model Runner, i.e. DMR is not
 			// installed at all.
-			if strings.Contains(err.Error(), "unknown flag: --json") {
+			if errIndicatesNotInstalled(err) {
 				return nil, ErrNotInstalled
 			}
 			// Otherwise the docker CLI plugin may simply be unavailable while

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -266,11 +266,12 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 		} else {
 			models, err := getModelsForAgent(ctx, cfg, &agentConfig, autoModel, dmrFallbackSelectors, runConfig, loadOpts.providerRegistry)
 			if err != nil {
-				// Return auto model fallback errors, DMR not installed errors, and
-				// DMR pull failures directly without wrapping to provide cleaner,
-				// actionable messages.
+				// Return auto model fallback errors, DMR not installed errors,
+				// DMR pull failures, and DMR model-not-available errors directly
+				// without wrapping to provide cleaner, actionable messages.
 				_, isPull := errors.AsType[*dmr.PullFailedError](err)
-				if _, ok := errors.AsType[*config.AutoModelFallbackError](err); ok || errors.Is(err, dmr.ErrNotInstalled) || isPull {
+				_, isNotAvailable := errors.AsType[*dmr.ModelNotAvailableError](err)
+				if _, ok := errors.AsType[*config.AutoModelFallbackError](err); ok || errors.Is(err, dmr.ErrNotInstalled) || isPull || isNotAvailable {
 					return nil, err
 				}
 				return nil, fmt.Errorf("failed to get models: %w", err)


### PR DESCRIPTION
Part of #3442 (Phase 1: actionable errors). Phases 2-4 (`doctor`, guided `setup`, docs tutorial) are independently shippable and left to follow-up PRs, as laid out in the issue.

## Changes mapped to the issue scenarios

| # | Scenario | Before | After |
|---|---|---|---|
| 3 | Bare `docker agent`, non-TTY, empty stdin (CI) | exit 0, zero output | error naming the next steps (pass a message, pipe one, or use a terminal), exit 1; piped prompts keep working |
| 2 | DMR endpoint reachable, `docker model` CLI broken, model not pulled | TUI starts, first message fails with raw `HTTP 404: POST .../chat/completions` | fails at client creation: "model X is not pulled in Docker Model Runner" + `docker model pull X` |
| 1/2 | "Not installed" detection | exact string match on the full docker usage text | content match on `unknown flag: --json`, shared between `NewClient` and `ListModels` |
| 4 | Missing model credentials (`RequiredEnvError`, `first_available` variant) | "use one of the built-in environment variable providers" (never named) | the secret sources able to hold arbitrary keys are named with a one-line example each (export, `--env-from-file`, `pass`, macOS Keychain), plus the docs URL and the local-model alternative (only when the missing vars are model credentials) |
| 6 | `run --env-from-file typo.env` | missing/malformed file logged via `slog` (invisible without `--debug`), run continues | run aborts: `--env-from-file: open typo.env: no such file or directory`; parse errors name the file and expected format |
| 5 | Exec-mode failure | printed twice (CLI error printer + cobra `Error: ...`) | printed once by cobra, on stderr |

## Sample output (missing model credentials)

```
Error: The following environment variables must be set:
 - ANTHROPIC_API_KEY

Provide them using any of these sources:
 - Shell environment:  export ANTHROPIC_API_KEY=<value>
 - Env file:           docker agent run --env-from-file <file> ...
 - pass:               pass insert ANTHROPIC_API_KEY
 - macOS Keychain:     security add-generic-password -a "$USER" -s ANTHROPIC_API_KEY -w

See https://docs.docker.com/ai/docker-agent/guides/secrets/ for details.

No API key? Run a local model instead: docker agent run --model dmr/ai/qwen3 ...
(the model is pulled on first use; `docker model ls` shows models already pulled)
```

## Message coherence pass

Follow-up to the review comment about message consistency. Every claim made by the new messages is now backed by the code path it describes:

| Message | Problem | Fix |
|---|---|---|
| `ModelNotAvailableError` | "is not available" in the full message but "is not pulled" in the summary shown under `AutoModelFallbackError`; final bullet diverged from `PullFailedError`'s | both say "is not pulled in Docker Model Runner"; final bullet identical to `PullFailedError`'s |
| Secret sources help | suggested Docker Desktop and the credential helper, but `DockerDesktopProvider` and `CredentialHelperProvider` only resolve `DOCKER_EMAIL`/`DOCKER_USERNAME`/`DOCKER_TOKEN` and can never satisfy the reported missing keys | both lines removed; a `NotContains` test locks the exclusion |
| Local-model hint | claimed pulled models are "detected automatically by the default `auto` model" (the built-in agent uses `first_available`, and pinned agentfile models are never re-selected) and pointed at `docker agent models` for local models (that command deliberately skips DMR discovery and lists the catalog) | now: "the model is pulled on first use; `docker model ls` shows models already pulled" |
| Empty-stdin errors | the two sibling messages introduced their next steps with different separators | aligned on ": " |

Pre-existing divergences left out of this PR, candidates for follow-ups:

- `docs/guides/secrets/` presents Docker Desktop and the credential helper as generic secret sources (same conflation as above, docs side)
- "To fix this, you can:" (`auto.go`) vs "To resolve this, you can:" (`pull.go`, `available.go`)
- `ErrNotInstalled` lowercase "docker model runner" branding
- lowercase fallback branch "no first_available candidate has credentials configured (tried: ...)" vs the capitalized main branch

## Implementation notes

```
docker agent run (dmr model, no BaseURL / MODEL_RUNNER_HOST)
  |- docker model status ok        -> inspect + pull prompt (unchanged)
  |- status fails, "unknown flag"  -> ErrNotInstalled (content match, was exact match)
  `- status fails otherwise        -> GET <dmr>/models at client creation
       |- model listed             -> proceed
       |- model absent             -> ModelNotAvailableError ("docker model pull X")
       `- endpoint unqueryable     -> "cannot query Docker Model Runner at <url>" + install link
```

- `ModelNotAvailableError` passes through the teamloader unwrapped (same treatment as `PullFailedError`) and exposes a one-line summary when nested under `AutoModelFallbackError`, so guidance blocks do not stack.
- The non-TTY check lives at input time in `cli.Run` rather than at bare-command dispatch: a dispatch-level `isatty(stdout)` check would break the working `echo "prompt" | docker agent > out.txt` flow. The acceptance criterion (actionable error, exit != 0, never a silent no-op) is met either way; if the dispatch-level check seems preferable, it can be changed.
- `--env-from-file` validation reuses the provider chain built by `RuntimeConfig.EnvProvider()` (new `EnvFilesError()` accessor) and aborts in the shared command pre-run, so every command taking the flag is covered.
- `RequiredEnvError.MissingModelCredentials` is computed in `gatherMissingEnvVars` so the local-model hint is not shown for missing tool secrets (e.g. `GITHUB_PERSONAL_ACCESS_TOKEN`).

## Testing

| Area | Coverage |
|---|---|
| `pkg/environment` | message content for both flag states, sources that cannot hold arbitrary keys are excluded, parse error names the file |
| `pkg/model/provider/dmr` | `errIndicatesNotInstalled`, `modelAvailable` (tag/repo matching), `checkModelAvailable` via httptest (pulled / not pulled / unqueryable), `NewClient` shim test with variant docker usage text |
| `pkg/cli` | empty stdin (bare and `-`) fails, piped stdin still works, `ErrorEvent` returned once and not printed |
| `pkg/config` | `EnvFilesError` (missing, malformed, valid, clone), `MissingModelCredentials` wiring, updated `first_available` assertions |
| `cmd/root` | pre-run aborts on missing and malformed `--env-from-file` |

All scenarios also verified end to end against a built binary (including a live reproduction of scenario 2: reachable DMR, broken `docker model` CLI, not-pulled model). The message coherence pass only changes user-facing strings; the updated unit tests assert the new content. Existing e2e expectations (`environment variables must be set`, `OPENAI_API_KEY` on stderr) are preserved. Remaining suite failures (`TestURLSource_Read_RejectsLocalAddresses`, SSRF tests, `TestLoadExamples` DMR pull) reproduce on `main` and are environment-related.
