### PR TITLE
feat(mcp/remote): support unix:// URLs in remote MCP client

### DIFF
--- a/pkg/tools/mcp/remote.go
+++ b/pkg/tools/mcp/remote.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/cookiejar"
 	neturl "net/url"
+	"strings"
 
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -77,6 +79,12 @@ func sanitizeRemoteAddress(rawURL string) string {
 	return u.Host
 }
 
+// unixSocketPath mirrors pkg/server.Listen: it strips the "unix://" prefix so
+// `unix:///tmp/x.sock` maps to `/tmp/x.sock`.
+func unixSocketPath(rawURL string) (string, bool) {
+	return strings.CutPrefix(rawURL, "unix://")
+}
+
 func (c *remoteMCPClient) Initialize(ctx context.Context, _ *gomcp.InitializeRequest) (*gomcp.InitializeResult, error) {
 	// Create HTTP client with OAuth support. We keep a reference to the
 	// oauthTransport so we can enrich Connect errors with the server's own
@@ -89,15 +97,22 @@ func (c *remoteMCPClient) Initialize(ctx context.Context, _ *gomcp.InitializeReq
 
 	var transport gomcp.Transport
 
+	endpoint := c.url
+	if _, ok := unixSocketPath(c.url); ok {
+		// http.Client can't dial the "unix" scheme; the socket is dialed by
+		// the transport, the host here is a placeholder.
+		endpoint = "http://localhost/"
+	}
+
 	switch c.transportType {
 	case "sse":
 		transport = &gomcp.SSEClientTransport{
-			Endpoint:   c.url,
+			Endpoint:   endpoint,
 			HTTPClient: httpClient,
 		}
 	case "streamable", "streamable-http":
 		transport = &gomcp.StreamableClientTransport{
-			Endpoint:             c.url,
+			Endpoint:             endpoint,
 			HTTPClient:           httpClient,
 			DisableStandaloneSSE: true,
 		}
@@ -224,8 +239,16 @@ func (c *remoteMCPClient) createHTTPClient() (*http.Client, *oauthTransport, err
 }
 
 func (c *remoteMCPClient) headerTransport() http.RoundTripper {
-	if len(c.headers) > 0 {
-		return upstream.NewHeaderTransport(http.DefaultTransport, c.headers)
+	base := http.DefaultTransport
+	if path, ok := unixSocketPath(c.url); ok {
+		t := http.DefaultTransport.(*http.Transport).Clone()
+		t.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", path)
+		}
+		base = t
 	}
-	return http.DefaultTransport
+	if len(c.headers) > 0 {
+		return upstream.NewHeaderTransport(base, c.headers)
+	}
+	return base
 }

--- a/pkg/tools/mcp/remote_test.go
+++ b/pkg/tools/mcp/remote_test.go
@@ -3,13 +3,17 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -490,4 +494,45 @@ func TestNewRemoteToolsetWithAllowPrivateIPsPropagatesToClient(t *testing.T) {
 	client, ok := ts.mcpClient.(*remoteMCPClient)
 	require.True(t, ok, "remote toolset should use remoteMCPClient")
 	require.True(t, client.allowPrivateIPs, "allow_private_ips should be stored on remote client")
+}
+
+// shortTempDir returns a temp dir with a short path so unix socket paths
+// created under it stay within the platform limit (macOS caps sun_path at
+// ~104 bytes, which t.TempDir()'s long, test-name-derived paths can exceed).
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "rc") //nolint:forbidigo,usetesting // need a short path for the unix sun_path limit (~104 bytes); t.TempDir() embeds the long test name and overflows it
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// TestRemoteClientUnixSocket verifies the remote client can connect to an MCP
+// server listening on a unix socket via a unix:// URL.
+func TestRemoteClientUnixSocket(t *testing.T) {
+	t.Parallel()
+
+	server := gomcp.NewServer(&gomcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+	gomcp.AddTool(server, &gomcp.Tool{Name: "ping", Description: "ping"}, func(context.Context, *gomcp.CallToolRequest, struct{}) (*gomcp.CallToolResult, struct{}, error) {
+		return &gomcp.CallToolResult{Content: []gomcp.Content{&gomcp.TextContent{Text: "pong"}}}, struct{}{}, nil
+	})
+
+	sockPath := filepath.Join(shortTempDir(t), "mcp.sock")
+	ln, err := (&net.ListenConfig{}).Listen(t.Context(), "unix", sockPath)
+	require.NoError(t, err)
+	httpServer := &http.Server{Handler: gomcp.NewStreamableHTTPHandler(func(*http.Request) *gomcp.Server { return server }, nil)}
+	go func() { _ = httpServer.Serve(ln) }()
+	t.Cleanup(func() { _ = httpServer.Close() })
+
+	client := newRemoteClient("unix://"+sockPath, "streamable", nil, NewInMemoryTokenStore(), nil, false)
+	_, err = client.Initialize(t.Context(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close(context.WithoutCancel(t.Context())) })
+
+	var names []string
+	for tool, err := range client.ListTools(t.Context(), nil) {
+		require.NoError(t, err)
+		names = append(names, tool.Name)
+	}
+	assert.Equal(t, []string{"ping"}, names)
 }


### PR DESCRIPTION
I wanted to expose MCP server running on my host to `docker-agent` running inside a container and realized it was forced to use http port for this.

This PR add support for unix socket so one can run:

```
      - type: mcp
        remote:
          url: unix:///tmp/mcp-notify.sock
          transport_type: streamable
```

If that's reasonable I'd like to delegate the documentation to someone else :)  