### PR TITLE
refactor(leantui): decompose the model into cohesive subsystems

### DIFF
--- a/pkg/leantui/banner_test.go
+++ b/pkg/leantui/banner_test.go
@@ -11,11 +11,11 @@ import (
 
 func TestCommitWelcomePadsBanner(t *testing.T) {
 	t.Parallel()
-	m := &model{}
+	m := &model{transcript: newTranscript()}
 	m.commitWelcome()
 
-	require.Len(t, m.blocks, 1)
-	lines := m.blocks[0].lines(80)
+	require.Len(t, m.transcript.blocks, 1)
+	lines := m.transcript.blocks[0].lines(80)
 	require.GreaterOrEqual(t, len(lines), bannerTopPadding+len(bannerLines))
 
 	for i := range bannerTopPadding {

--- a/pkg/leantui/events.go
+++ b/pkg/leantui/events.go
@@ -1,0 +1,182 @@
+package leantui
+
+import (
+	"context"
+	"time"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/tools"
+	tuitypes "github.com/docker/docker-agent/pkg/tui/types"
+)
+
+// handleEvent applies a single runtime event emitted by the App to the model,
+// updating the conversation, tool state, status footer, or busy state.
+func (m *model) handleEvent(ctx context.Context, ev any) {
+	switch e := ev.(type) {
+	case *runtime.StreamStartedEvent:
+		m.busy = true
+		m.trackStreamStarted(e.SessionID)
+	case *runtime.StreamStoppedEvent:
+		m.trackStreamStopped()
+		m.handleStreamStopped(ctx)
+	case *runtime.AgentChoiceReasoningEvent:
+		m.appendPending(blockReasoning, e.Content)
+	case *runtime.AgentChoiceEvent:
+		m.appendPending(blockAssistant, e.Content)
+	case *runtime.PartialToolCallEvent:
+		m.flushPending()
+		toolDef := tools.Tool{Name: e.ToolCall.Function.Name}
+		if e.ToolDefinition != nil {
+			toolDef = *e.ToolDefinition
+		}
+		m.toolz.upsert(e.GetAgentName(), e.ToolCall, toolDef, tuitypes.ToolStatusPending)
+	case *runtime.ToolCallEvent:
+		m.flushPending()
+		m.toolz.upsert(e.GetAgentName(), e.ToolCall, e.ToolDefinition, tuitypes.ToolStatusRunning)
+	case *runtime.ToolCallOutputEvent:
+		if tv := m.toolz.get(e.ToolCallID); tv != nil && tv.message != nil {
+			tv.message.AppendToolOutput(e.Output)
+			if tv.message.ToolStatus == tuitypes.ToolStatusPending {
+				tv.message.ToolStatus = tuitypes.ToolStatusRunning
+				if tv.message.StartedAt == nil {
+					now := time.Now()
+					tv.message.StartedAt = &now
+				}
+			}
+		}
+	case *runtime.ToolCallResponseEvent:
+		m.finishTool(e)
+	case *runtime.ToolCallConfirmationEvent:
+		m.toolz.remove(toolViewID(e.ToolCall))
+		toolDef := ensureToolDefinition(e.ToolCall, e.ToolDefinition)
+		m.confirm = &confirmState{
+			tool:     toolDef.Name,
+			toolView: *newToolView(e.GetAgentName(), e.ToolCall, toolDef, tuitypes.ToolStatusConfirmation),
+		}
+	case *runtime.TokenUsageEvent:
+		m.setTokenUsage(e.SessionID, e.Usage)
+	case *runtime.AgentInfoEvent:
+		m.status.agent = e.AgentName
+		if m.sessionState != nil {
+			m.sessionState.SetCurrentAgentName(e.AgentName)
+		}
+		if e.Model != "" {
+			m.status.model = e.Model
+		}
+		if e.ContextLimit > 0 {
+			m.status.contextLimit = e.ContextLimit
+		}
+	case *runtime.TeamInfoEvent:
+		m.applyTeamInfo(ctx, e)
+	case *runtime.SessionCompactionEvent:
+		m.handleSessionCompaction(ctx, e)
+	case *runtime.ErrorEvent:
+		m.flushPending()
+		m.addNotice("✗ ", e.Error, stError())
+	case *runtime.WarningEvent:
+		m.addNotice("⚠ ", e.Message, stWarning())
+	case *runtime.ShellOutputEvent:
+		output := e.Output
+		m.addBlock(func(w int) []string { return renderToolOutput(output, w) })
+	case *runtime.AgentSwitchingEvent:
+		if e.Switching && e.ToAgent != "" {
+			m.addNotice("→ ", "Switching to "+e.ToAgent, stMuted())
+		}
+	case *runtime.MaxIterationsReachedEvent:
+		m.addNotice("⚠ ", "Maximum iterations reached.", stWarning())
+	case *runtime.ModelFallbackEvent:
+		m.addNotice("⚠ ", "Model "+e.FailedModel+" failed, falling back to "+e.FallbackModel+".", stWarning())
+	}
+}
+
+func (m *model) handleStreamStopped(ctx context.Context) {
+	if m.finishBusy(ctx) {
+		return
+	}
+
+	if m.app != nil && m.app.ShouldExitAfterFirstResponse() {
+		m.quit()
+	}
+}
+
+func (m *model) handleSessionCompaction(ctx context.Context, e *runtime.SessionCompactionEvent) {
+	switch e.Status {
+	case "started":
+		m.busy = true
+	case "completed":
+		m.finishBusy(ctx)
+	}
+}
+
+// finishBusy clears the busy state at the end of a run and starts the next
+// queued message, if any. It reports whether a queued run was started.
+func (m *model) finishBusy(ctx context.Context) bool {
+	m.flushPending()
+	m.busy = false
+	m.runCancel = nil
+
+	if len(m.queue) > 0 {
+		next := m.queue[0]
+		m.queue = m.queue[1:]
+		m.startRun(ctx, next, nil)
+		return true
+	}
+	return false
+}
+
+func (m *model) appendPending(kind blockKind, content string) {
+	if content == "" {
+		return
+	}
+	if m.pending == nil || m.pending.kind != kind {
+		m.flushPending()
+		m.pending = &pendingBlock{kind: kind}
+	}
+	m.pending.text.WriteString(content)
+}
+
+// flushPending finalizes the in-progress streamed block into the conversation.
+func (m *model) flushPending() {
+	if m.pending == nil {
+		return
+	}
+	text := m.pending.text.String()
+	kind := m.pending.kind
+	m.pending = nil
+
+	switch kind {
+	case blockReasoning:
+		m.addBlock(func(w int) []string { return renderReasoningLines(text, w) })
+	case blockAssistant:
+		m.addBlock(func(w int) []string { return renderAssistantLines(text, w) })
+	}
+}
+
+func (m *model) finishTool(e *runtime.ToolCallResponseEvent) {
+	view := m.toolz.finish(e)
+	if view == nil {
+		return
+	}
+	m.addBlock(func(w int) []string { return renderToolWithState(view, w, 0, m.sessionState) })
+}
+
+func (m *model) applyTeamInfo(ctx context.Context, e *runtime.TeamInfoEvent) {
+	if m.sessionState != nil {
+		m.sessionState.SetAvailableAgents(e.AvailableAgents)
+		m.sessionState.SetCurrentAgentName(e.CurrentAgent)
+	}
+	for _, a := range e.AvailableAgents {
+		if a.Name != e.CurrentAgent {
+			continue
+		}
+		m.status.agent = a.Name
+		switch {
+		case a.Provider != "" && a.Model != "":
+			m.status.model = a.Provider + "/" + a.Model
+		case a.Model != "":
+			m.status.model = a.Model
+		}
+		m.status.thinking = a.Thinking
+	}
+	m.refreshCommands(ctx)
+}

--- a/pkg/leantui/events.go
+++ b/pkg/leantui/events.go
@@ -20,21 +20,21 @@ func (m *model) handleEvent(ctx context.Context, ev any) {
 		m.trackStreamStopped()
 		m.handleStreamStopped(ctx)
 	case *runtime.AgentChoiceReasoningEvent:
-		m.appendPending(blockReasoning, e.Content)
+		m.transcript.appendPending(blockReasoning, e.Content)
 	case *runtime.AgentChoiceEvent:
-		m.appendPending(blockAssistant, e.Content)
+		m.transcript.appendPending(blockAssistant, e.Content)
 	case *runtime.PartialToolCallEvent:
-		m.flushPending()
+		m.transcript.flushPending()
 		toolDef := tools.Tool{Name: e.ToolCall.Function.Name}
 		if e.ToolDefinition != nil {
 			toolDef = *e.ToolDefinition
 		}
-		m.toolz.upsert(e.GetAgentName(), e.ToolCall, toolDef, tuitypes.ToolStatusPending)
+		m.transcript.upsertTool(e.GetAgentName(), e.ToolCall, toolDef, tuitypes.ToolStatusPending)
 	case *runtime.ToolCallEvent:
-		m.flushPending()
-		m.toolz.upsert(e.GetAgentName(), e.ToolCall, e.ToolDefinition, tuitypes.ToolStatusRunning)
+		m.transcript.flushPending()
+		m.transcript.upsertTool(e.GetAgentName(), e.ToolCall, e.ToolDefinition, tuitypes.ToolStatusRunning)
 	case *runtime.ToolCallOutputEvent:
-		if tv := m.toolz.get(e.ToolCallID); tv != nil && tv.message != nil {
+		if tv := m.transcript.tool(e.ToolCallID); tv != nil && tv.message != nil {
 			tv.message.AppendToolOutput(e.Output)
 			if tv.message.ToolStatus == tuitypes.ToolStatusPending {
 				tv.message.ToolStatus = tuitypes.ToolStatusRunning
@@ -45,9 +45,9 @@ func (m *model) handleEvent(ctx context.Context, ev any) {
 			}
 		}
 	case *runtime.ToolCallResponseEvent:
-		m.finishTool(e)
+		m.transcript.finishTool(e, m.sessionState)
 	case *runtime.ToolCallConfirmationEvent:
-		m.toolz.remove(toolViewID(e.ToolCall))
+		m.transcript.removeTool(toolViewID(e.ToolCall))
 		toolDef := ensureToolDefinition(e.ToolCall, e.ToolDefinition)
 		m.confirm = &confirmState{
 			tool:     toolDef.Name,
@@ -71,13 +71,13 @@ func (m *model) handleEvent(ctx context.Context, ev any) {
 	case *runtime.SessionCompactionEvent:
 		m.handleSessionCompaction(ctx, e)
 	case *runtime.ErrorEvent:
-		m.flushPending()
+		m.transcript.flushPending()
 		m.addNotice("✗ ", e.Error, stError())
 	case *runtime.WarningEvent:
 		m.addNotice("⚠ ", e.Message, stWarning())
 	case *runtime.ShellOutputEvent:
 		output := e.Output
-		m.addBlock(func(w int) []string { return renderToolOutput(output, w) })
+		m.transcript.addBlock(func(w int) []string { return renderToolOutput(output, w) })
 	case *runtime.AgentSwitchingEvent:
 		if e.Switching && e.ToAgent != "" {
 			m.addNotice("→ ", "Switching to "+e.ToAgent, stMuted())
@@ -111,7 +111,7 @@ func (m *model) handleSessionCompaction(ctx context.Context, e *runtime.SessionC
 // finishBusy clears the busy state at the end of a run and starts the next
 // queued message, if any. It reports whether a queued run was started.
 func (m *model) finishBusy(ctx context.Context) bool {
-	m.flushPending()
+	m.transcript.flushPending()
 	m.busy = false
 	m.runCancel = nil
 
@@ -122,42 +122,6 @@ func (m *model) finishBusy(ctx context.Context) bool {
 		return true
 	}
 	return false
-}
-
-func (m *model) appendPending(kind blockKind, content string) {
-	if content == "" {
-		return
-	}
-	if m.pending == nil || m.pending.kind != kind {
-		m.flushPending()
-		m.pending = &pendingBlock{kind: kind}
-	}
-	m.pending.text.WriteString(content)
-}
-
-// flushPending finalizes the in-progress streamed block into the conversation.
-func (m *model) flushPending() {
-	if m.pending == nil {
-		return
-	}
-	text := m.pending.text.String()
-	kind := m.pending.kind
-	m.pending = nil
-
-	switch kind {
-	case blockReasoning:
-		m.addBlock(func(w int) []string { return renderReasoningLines(text, w) })
-	case blockAssistant:
-		m.addBlock(func(w int) []string { return renderAssistantLines(text, w) })
-	}
-}
-
-func (m *model) finishTool(e *runtime.ToolCallResponseEvent) {
-	view := m.toolz.finish(e)
-	if view == nil {
-		return
-	}
-	m.addBlock(func(w int) []string { return renderToolWithState(view, w, 0, m.sessionState) })
 }
 
 func (m *model) applyTeamInfo(ctx context.Context, e *runtime.TeamInfoEvent) {

--- a/pkg/leantui/leantui.go
+++ b/pkg/leantui/leantui.go
@@ -132,18 +132,6 @@ func readKeys(r io.Reader, keys chan<- key, done <-chan struct{}) {
 	}
 }
 
-type blockKind int
-
-const (
-	blockReasoning blockKind = iota
-	blockAssistant
-)
-
-type pendingBlock struct {
-	kind blockKind
-	text strings.Builder
-}
-
 type model struct {
 	app  *app.App
 	term *terminal
@@ -157,17 +145,13 @@ type model struct {
 
 	status       statusData
 	sessionState *service.SessionState
+	usage        *usageTracker
 
-	usage *usageTracker
-
-	blocks       []*block
+	transcript   *transcript
 	busy         bool
 	spinnerFrame int
-	pending      *pendingBlock
-	toolz        *toolTracker
-
-	runCancel context.CancelFunc
-	queue     []string
+	runCancel    context.CancelFunc
+	queue        []string
 
 	confirm *confirmState
 
@@ -200,7 +184,7 @@ func newModel(term *terminal, cfg Config) *model {
 		height:           h,
 		editor:           newEditor("Type a message, / for commands"),
 		ac:               newAutocomplete(),
-		toolz:            newToolTracker(),
+		transcript:       newTranscript(),
 		status:           statusData{workingDir: cfg.WorkingDir, branch: gitBranch(cfg.WorkingDir)},
 		sessionState:     sessionState,
 		usage:            newUsageTracker(),
@@ -218,18 +202,13 @@ func (m *model) render() {
 // renderFinal repaints the current state, then erases the input box and footer
 // so only the conversation remains once the program exits.
 func (m *model) renderFinal() {
-	m.flushPending()
+	m.transcript.flushPending()
 	m.render()
-	m.r.eraseBelow(len(m.conversationLines(m.width)))
-}
-
-// addBlock appends a finalized, lazily-rendered block to the conversation.
-func (m *model) addBlock(render func(width int) []string) {
-	m.blocks = append(m.blocks, &block{render: render})
+	m.r.eraseBelow(len(m.transcript.lines(m.width, m.spinnerFrame, m.busy, m.sessionState)))
 }
 
 func (m *model) commitWelcome() {
-	m.addBlock(func(int) []string {
+	m.transcript.addBlock(func(int) []string {
 		lines := make([]string, 0, bannerTopPadding+len(bannerLines)+2)
 		for range bannerTopPadding {
 			lines = append(lines, "")

--- a/pkg/leantui/leantui.go
+++ b/pkg/leantui/leantui.go
@@ -158,17 +158,13 @@ type model struct {
 	status       statusData
 	sessionState *service.SessionState
 
-	usageBySession       map[string]usageSnapshot
-	rootSessionID        string
-	latestUsageSessionID string
-	sessionStack         []string
+	usage *usageTracker
 
 	blocks       []*block
 	busy         bool
 	spinnerFrame int
 	pending      *pendingBlock
-	tools        map[string]*toolView
-	toolOrder    []string
+	toolz        *toolTracker
 
 	runCancel context.CancelFunc
 	queue     []string
@@ -204,10 +200,10 @@ func newModel(term *terminal, cfg Config) *model {
 		height:           h,
 		editor:           newEditor("Type a message, / for commands"),
 		ac:               newAutocomplete(),
-		tools:            make(map[string]*toolView),
+		toolz:            newToolTracker(),
 		status:           statusData{workingDir: cfg.WorkingDir, branch: gitBranch(cfg.WorkingDir)},
 		sessionState:     sessionState,
-		usageBySession:   make(map[string]usageSnapshot),
+		usage:            newUsageTracker(),
 		appName:          appName,
 		disabledCommands: disabled,
 	}

--- a/pkg/leantui/status.go
+++ b/pkg/leantui/status.go
@@ -24,13 +24,6 @@ type statusData struct {
 	costKnown     bool
 }
 
-type usageSnapshot struct {
-	contextLength int64
-	contextLimit  int64
-	tokens        int64
-	cost          float64
-}
-
 // renderStatus builds the two-line footer:
 //
 //	<working dir>  ⎇ <branch>                          <agent>

--- a/pkg/leantui/status_test.go
+++ b/pkg/leantui/status_test.go
@@ -133,7 +133,7 @@ func TestTokenUsageBeforeStreamUsesFirstSessionAsRoot(t *testing.T) {
 		Cost:          0.05,
 	}))
 
-	assert.Equal(t, "root-session", m.rootSessionID)
+	assert.Equal(t, "root-session", m.usage.rootSessionID)
 	assert.Equal(t, int64(3_000), m.status.tokens)
 	assert.InDelta(t, 0.15, m.status.cost, 0.0001)
 }

--- a/pkg/leantui/stream_test.go
+++ b/pkg/leantui/stream_test.go
@@ -28,7 +28,7 @@ func bareModel(height int) *model {
 		r:            newRenderer(w, width, height),
 		editor:       newEditor("type here"),
 		ac:           newAutocomplete(),
-		toolz:        newToolTracker(),
+		transcript:   newTranscript(),
 		status:       statusData{workingDir: "/tmp/project"},
 		sessionState: service.NewSessionState(nil),
 		usage:        newUsageTracker(),
@@ -41,9 +41,9 @@ func TestStreamingGrowthScrollsAndRendersMarkdown(t *testing.T) {
 	m.busy = true
 	m.render() // initial frame
 
-	m.pending = &pendingBlock{kind: blockAssistant}
+	m.transcript.pending = &pendingBlock{kind: blockAssistant}
 	for i := range 40 {
-		m.pending.text.WriteString("Paragraph " + strconv.Itoa(i) + " with some streamed text.\n\n")
+		m.transcript.pending.text.WriteString("Paragraph " + strconv.Itoa(i) + " with some streamed text.\n\n")
 		lines, cl, cc := m.buildLines()
 		require.NotPanics(t, func() { m.r.frame(lines, cl, cc) })
 	}
@@ -53,8 +53,8 @@ func TestStreamingGrowthScrollsAndRendersMarkdown(t *testing.T) {
 
 	// Finalizing the stream turns it into a cached block; the visible output is
 	// unchanged because it was already rendered as markdown live.
-	m.flushPending()
-	assert.Len(t, m.blocks, 1)
+	m.transcript.flushPending()
+	assert.Len(t, m.transcript.blocks, 1)
 	require.NotPanics(t, func() {
 		lines, cl, cc := m.buildLines()
 		m.r.frame(lines, cl, cc)
@@ -77,7 +77,7 @@ func TestConversationLinesShowsSpinnerWhenBusy(t *testing.T) {
 	t.Parallel()
 	m := bareModel(24)
 	m.busy = true
-	lines := m.conversationLines(80)
+	lines := m.transcript.lines(80, m.spinnerFrame, m.busy, m.sessionState)
 	assert.Contains(t, strings.Join(lines, ""), "Working")
 }
 
@@ -85,14 +85,14 @@ func TestToolConfirmationReplacesRunningTool(t *testing.T) {
 	t.Parallel()
 	m := bareModel(24)
 	tv := shellToolView(tuitypes.ToolStatusRunning)
-	m.toolz.upsert("root", tv.message.ToolCall, tv.message.ToolDefinition, tuitypes.ToolStatusRunning)
-	require.Len(t, m.toolz.order, 1)
+	m.transcript.upsertTool("root", tv.message.ToolCall, tv.message.ToolDefinition, tuitypes.ToolStatusRunning)
+	require.Len(t, m.transcript.toolz.order, 1)
 
 	event := runtime.ToolCallConfirmation(tv.message.ToolCall, tv.message.ToolDefinition, "root", nil)
 	m.handleEvent(t.Context(), event)
 
-	assert.Empty(t, m.toolz.order)
-	assert.Empty(t, m.toolz.byID)
+	assert.Empty(t, m.transcript.toolz.order)
+	assert.Empty(t, m.transcript.toolz.byID)
 	require.NotNil(t, m.confirm)
 }
 

--- a/pkg/leantui/stream_test.go
+++ b/pkg/leantui/stream_test.go
@@ -23,15 +23,15 @@ func bareModel(height int) *model {
 	var buf bytes.Buffer
 	w := bufio.NewWriter(&buf)
 	return &model{
-		width:          width,
-		height:         height,
-		r:              newRenderer(w, width, height),
-		editor:         newEditor("type here"),
-		ac:             newAutocomplete(),
-		tools:          map[string]*toolView{},
-		status:         statusData{workingDir: "/tmp/project"},
-		sessionState:   service.NewSessionState(nil),
-		usageBySession: map[string]usageSnapshot{},
+		width:        width,
+		height:       height,
+		r:            newRenderer(w, width, height),
+		editor:       newEditor("type here"),
+		ac:           newAutocomplete(),
+		toolz:        newToolTracker(),
+		status:       statusData{workingDir: "/tmp/project"},
+		sessionState: service.NewSessionState(nil),
+		usage:        newUsageTracker(),
 	}
 }
 
@@ -85,14 +85,14 @@ func TestToolConfirmationReplacesRunningTool(t *testing.T) {
 	t.Parallel()
 	m := bareModel(24)
 	tv := shellToolView(tuitypes.ToolStatusRunning)
-	m.upsertTool("root", tv.message.ToolCall, tv.message.ToolDefinition, tuitypes.ToolStatusRunning)
-	require.Len(t, m.toolOrder, 1)
+	m.toolz.upsert("root", tv.message.ToolCall, tv.message.ToolDefinition, tuitypes.ToolStatusRunning)
+	require.Len(t, m.toolz.order, 1)
 
 	event := runtime.ToolCallConfirmation(tv.message.ToolCall, tv.message.ToolDefinition, "root", nil)
 	m.handleEvent(t.Context(), event)
 
-	assert.Empty(t, m.toolOrder)
-	assert.Empty(t, m.tools)
+	assert.Empty(t, m.toolz.order)
+	assert.Empty(t, m.toolz.byID)
 	require.NotNil(t, m.confirm)
 }
 

--- a/pkg/leantui/toolstate.go
+++ b/pkg/leantui/toolstate.go
@@ -1,0 +1,133 @@
+package leantui
+
+import (
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/tools"
+	tuitypes "github.com/docker/docker-agent/pkg/tui/types"
+)
+
+// toolTracker holds the render state of in-flight tool calls, keyed by id and
+// kept in call order so the conversation shows them as they arrive.
+type toolTracker struct {
+	byID  map[string]*toolView
+	order []string
+}
+
+func newToolTracker() *toolTracker {
+	return &toolTracker{byID: map[string]*toolView{}}
+}
+
+func (t *toolTracker) reset() {
+	t.byID = map[string]*toolView{}
+	t.order = nil
+}
+
+func (t *toolTracker) empty() bool { return len(t.order) == 0 }
+
+func (t *toolTracker) get(id string) *toolView { return t.byID[id] }
+
+// forEach visits the tracked tools in call order, skipping nil entries.
+func (t *toolTracker) forEach(fn func(*toolView)) {
+	for _, id := range t.order {
+		if tv := t.byID[id]; tv != nil {
+			fn(tv)
+		}
+	}
+}
+
+func (t *toolTracker) remove(id string) {
+	if id == "" {
+		return
+	}
+	delete(t.byID, id)
+	t.order = slices.DeleteFunc(t.order, func(s string) bool { return s == id })
+}
+
+// upsert creates or updates the tracked view for a tool call. Argument
+// fragments streamed while the call is still pending are concatenated.
+func (t *toolTracker) upsert(agentName string, toolCall tools.ToolCall, toolDef tools.Tool, status tuitypes.ToolStatus) {
+	id := toolViewID(toolCall)
+	tv := t.byID[id]
+	if tv == nil {
+		tv = newToolView(agentName, toolCall, toolDef, status)
+		t.byID[id] = tv
+		t.order = append(t.order, id)
+		return
+	}
+
+	msg := tv.message
+	if msg == nil {
+		msg = newToolView(agentName, toolCall, toolDef, status).message
+		tv.message = msg
+		return
+	}
+
+	if agentName != "" {
+		msg.Sender = agentName
+	}
+	if toolDef.Name != "" || toolCall.Function.Name != "" {
+		msg.ToolDefinition = ensureToolDefinition(toolCall, toolDef)
+	}
+	msg.ToolStatus = status
+	if status == tuitypes.ToolStatusRunning && msg.StartedAt == nil {
+		now := time.Now()
+		msg.StartedAt = &now
+	}
+	if toolCall.ID != "" {
+		msg.ToolCall.ID = toolCall.ID
+	}
+	if toolCall.Type != "" {
+		msg.ToolCall.Type = toolCall.Type
+	}
+	if toolCall.Function.Name != "" {
+		msg.ToolCall.Function.Name = toolCall.Function.Name
+	}
+	if toolCall.Function.Arguments != "" {
+		if status == tuitypes.ToolStatusPending {
+			msg.ToolCall.Function.Arguments += toolCall.Function.Arguments
+		} else {
+			msg.ToolCall.Function.Arguments = toolCall.Function.Arguments
+		}
+	}
+}
+
+// finish marks a tool call complete, drops it from the tracker, and returns an
+// immutable snapshot to commit into the conversation. It returns nil when there
+// is nothing to render.
+func (t *toolTracker) finish(e *runtime.ToolCallResponseEvent) *toolView {
+	id := e.ToolCallID
+	tv := t.byID[id]
+	if tv == nil {
+		toolCall := tools.ToolCall{ID: id, Function: tools.FunctionCall{Name: e.ToolDefinition.Name}}
+		tv = newToolView(e.GetAgentName(), toolCall, e.ToolDefinition, tuitypes.ToolStatusCompleted)
+	}
+	if tv.message == nil {
+		return nil
+	}
+
+	status := tuitypes.ToolStatusCompleted
+	if e.Result != nil && e.Result.IsError {
+		status = tuitypes.ToolStatusError
+	}
+	tv.message.ToolStatus = status
+	tv.message.ToolDefinition = ensureToolDefinition(tv.message.ToolCall, e.ToolDefinition)
+	tv.message.Content = strings.ReplaceAll(e.Response, "\t", "    ")
+	tv.message.ToolResult = e.Result.WithoutPayload()
+	tv.images = inlineImagesFromToolResult(e.Result)
+
+	msg := *tv.message
+	snapshot := &toolView{message: &msg, images: tv.images}
+	t.remove(id)
+	return snapshot
+}
+
+func toolViewID(toolCall tools.ToolCall) string {
+	if toolCall.ID != "" {
+		return toolCall.ID
+	}
+	return toolCall.Function.Name
+}

--- a/pkg/leantui/transcript.go
+++ b/pkg/leantui/transcript.go
@@ -1,0 +1,159 @@
+package leantui
+
+import (
+	"strings"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tui/service"
+	tuitypes "github.com/docker/docker-agent/pkg/tui/types"
+)
+
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+type blockKind int
+
+const (
+	blockReasoning blockKind = iota
+	blockAssistant
+)
+
+// pendingBlock accumulates the text of the block currently being streamed.
+type pendingBlock struct {
+	kind blockKind
+	text strings.Builder
+}
+
+// block is a finalized piece of the conversation. Its lines are rendered lazily
+// and cached per width, so finalized content is not re-rendered every frame and
+// only reflows when the terminal is resized.
+type block struct {
+	render func(width int) []string
+	cacheW int
+	cache  []string
+	cached bool
+}
+
+func (b *block) lines(width int) []string {
+	if !b.cached || b.cacheW != width {
+		b.cache = b.render(width)
+		b.cacheW = width
+		b.cached = true
+	}
+	return b.cache
+}
+
+// transcript owns everything that scrolls: the finalized conversation blocks,
+// the in-progress streamed block, and the in-flight tool calls. Committed
+// blocks are immutable scrollback; the pending block and tool calls are the
+// live region that changes each frame until they finalize into blocks.
+type transcript struct {
+	blocks  []*block
+	pending *pendingBlock
+	toolz   *toolTracker
+}
+
+func newTranscript() *transcript {
+	return &transcript{toolz: newToolTracker()}
+}
+
+// clearActive drops the live region (the streamed block and any in-flight tool
+// calls) while keeping the committed scrollback intact. Used when starting a
+// new session.
+func (t *transcript) clearActive() {
+	t.pending = nil
+	t.toolz.reset()
+}
+
+// addBlock appends a finalized, lazily-rendered block to the conversation.
+func (t *transcript) addBlock(render func(width int) []string) {
+	t.blocks = append(t.blocks, &block{render: render})
+}
+
+func (t *transcript) appendPending(kind blockKind, content string) {
+	if content == "" {
+		return
+	}
+	if t.pending == nil || t.pending.kind != kind {
+		t.flushPending()
+		t.pending = &pendingBlock{kind: kind}
+	}
+	t.pending.text.WriteString(content)
+}
+
+// flushPending finalizes the in-progress streamed block into the conversation.
+func (t *transcript) flushPending() {
+	if t.pending == nil {
+		return
+	}
+	text := t.pending.text.String()
+	kind := t.pending.kind
+	t.pending = nil
+
+	switch kind {
+	case blockReasoning:
+		t.addBlock(func(w int) []string { return renderReasoningLines(text, w) })
+	case blockAssistant:
+		t.addBlock(func(w int) []string { return renderAssistantLines(text, w) })
+	}
+}
+
+func (t *transcript) upsertTool(agentName string, toolCall tools.ToolCall, toolDef tools.Tool, status tuitypes.ToolStatus) {
+	t.toolz.upsert(agentName, toolCall, toolDef, status)
+}
+
+func (t *transcript) tool(id string) *toolView { return t.toolz.get(id) }
+
+func (t *transcript) removeTool(id string) { t.toolz.remove(id) }
+
+// finishTool commits a completed tool call as an immutable block.
+func (t *transcript) finishTool(e *runtime.ToolCallResponseEvent, sessionState service.SessionStateReader) {
+	view := t.toolz.finish(e)
+	if view == nil {
+		return
+	}
+	t.addBlock(func(w int) []string { return renderToolWithState(view, w, 0, sessionState) })
+}
+
+// lines renders everything that scrolls: finalized blocks, the in-progress
+// streamed block, and any running tool calls. A blank line separates each
+// entry. The spinner is shown only while busy with nothing yet streaming.
+func (t *transcript) lines(width, spinnerFrame int, busy bool, sessionState service.SessionStateReader) []string {
+	var lines []string
+	for _, b := range t.blocks {
+		lines = append(lines, b.lines(width)...)
+		lines = append(lines, "")
+	}
+	if t.pending != nil {
+		lines = append(lines, t.pendingLines(width)...)
+		lines = append(lines, "")
+	}
+	t.toolz.forEach(func(tv *toolView) {
+		lines = append(lines, renderToolWithState(tv, width, spinnerFrame, sessionState)...)
+		lines = append(lines, "")
+	})
+	if busy && t.pending == nil && t.toolz.empty() {
+		lines = append(lines, spinnerLine(spinnerFrame), "")
+	}
+	return lines
+}
+
+// pendingLines renders the message currently being streamed. Assistant text is
+// rendered as markdown live (the same renderer used once it is finalized), so
+// formatting appears as it streams.
+func (t *transcript) pendingLines(width int) []string {
+	text := t.pending.text.String()
+	switch t.pending.kind {
+	case blockReasoning:
+		return renderReasoningLines(text, width)
+	case blockAssistant:
+		return renderAssistantLines(text, width)
+	default:
+		return nil
+	}
+}
+
+func spinnerLine(frame int) string {
+	f := spinnerFrames[frame%len(spinnerFrames)]
+	return stAccent().Render(f) + " " + stMuted().Render("Working…")
+}

--- a/pkg/leantui/update.go
+++ b/pkg/leantui/update.go
@@ -89,7 +89,7 @@ func (m *model) handleInterrupt() {
 			m.runCancel()
 		}
 		m.queue = nil
-		m.addBlock(func(int) []string { return []string{stWarning().Render("⏹ Cancelled")} })
+		m.transcript.addBlock(func(int) []string { return []string{stWarning().Render("⏹ Cancelled")} })
 	case !m.editor.isEmpty():
 		m.editor.reset()
 		m.ac.dismiss()
@@ -359,8 +359,7 @@ func (m *model) resetConversation() {
 		m.runCancel()
 		m.runCancel = nil
 	}
-	m.pending = nil
-	m.toolz.reset()
+	m.transcript.clearActive()
 	m.queue = nil
 	m.busy = false
 	m.confirm = nil
@@ -384,15 +383,15 @@ func (m *model) quit() {
 }
 
 func (m *model) addUserEcho(text string) {
-	m.addBlock(func(w int) []string { return renderUserLines(text, w) })
+	m.transcript.addBlock(func(w int) []string { return renderUserLines(text, w) })
 }
 
 func (m *model) addNotice(prefix, text string, style lipgloss.Style) {
-	m.addBlock(func(w int) []string { return renderNoticeLines(prefix, text, w, style) })
+	m.transcript.addBlock(func(w int) []string { return renderNoticeLines(prefix, text, w, style) })
 }
 
 func (m *model) commitHelp() {
-	m.addBlock(func(int) []string {
+	m.transcript.addBlock(func(int) []string {
 		return []string{
 			stBold().Render("Commands"),
 			stMuted().Render("  /new       start a new session"),

--- a/pkg/leantui/update.go
+++ b/pkg/leantui/update.go
@@ -5,17 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"slices"
 	"strings"
-	"time"
 
 	"charm.land/lipgloss/v2"
 
 	"github.com/docker/docker-agent/pkg/effort"
 	"github.com/docker/docker-agent/pkg/runtime"
-	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/tui/messages"
-	tuitypes "github.com/docker/docker-agent/pkg/tui/types"
 )
 
 func (m *model) handleKey(ctx context.Context, k key) {
@@ -124,20 +120,12 @@ func (m *model) handleTab() {
 }
 
 func (m *model) handleCycleThinkingLevel(ctx context.Context) {
-	if m.app == nil {
-		return
-	}
-	if !m.app.SupportsModelSwitching() {
-		m.addNotice("", "Thinking levels can't be changed with remote runtimes", stMuted())
+	if !m.thinkingLevelChangeable() {
 		return
 	}
 	level, err := m.app.CycleAgentThinkingLevel(ctx)
 	if err != nil {
-		if errors.Is(err, runtime.ErrUnsupported) {
-			m.addNotice("", "Current model does not support thinking levels", stMuted())
-			return
-		}
-		m.addNotice("✗ ", fmt.Sprintf("Failed to change thinking level: %v", err), stError())
+		m.reportThinkingLevelError("change", err)
 		return
 	}
 	m.status.thinking = level.String()
@@ -146,11 +134,7 @@ func (m *model) handleCycleThinkingLevel(ctx context.Context) {
 // handleSetThinkingLevel applies the /effort command: it sets the current
 // model's reasoning-effort level to the requested value.
 func (m *model) handleSetThinkingLevel(ctx context.Context, level string) {
-	if m.app == nil {
-		return
-	}
-	if !m.app.SupportsModelSwitching() {
-		m.addNotice("", "Thinking levels can't be changed with remote runtimes", stMuted())
+	if !m.thinkingLevelChangeable() {
 		return
 	}
 	if level == "" {
@@ -164,15 +148,34 @@ func (m *model) handleSetThinkingLevel(ctx context.Context, level string) {
 	}
 	applied, err := m.app.SetAgentThinkingLevel(ctx, parsed)
 	if err != nil {
-		if errors.Is(err, runtime.ErrUnsupported) {
-			m.addNotice("", "Current model does not support thinking levels", stMuted())
-			return
-		}
-		m.addNotice("✗ ", fmt.Sprintf("Failed to set thinking level: %v", err), stError())
+		m.reportThinkingLevelError("set", err)
 		return
 	}
 	m.status.thinking = applied.String()
 	m.addNotice("", "Reasoning effort set to "+applied.String(), stMuted())
+}
+
+// thinkingLevelChangeable reports whether the reasoning-effort level can be
+// changed, emitting an explanatory notice when it cannot.
+func (m *model) thinkingLevelChangeable() bool {
+	if m.app == nil {
+		return false
+	}
+	if !m.app.SupportsModelSwitching() {
+		m.addNotice("", "Thinking levels can't be changed with remote runtimes", stMuted())
+		return false
+	}
+	return true
+}
+
+// reportThinkingLevelError emits a notice for a failed thinking-level change,
+// distinguishing the unsupported-model case from other failures.
+func (m *model) reportThinkingLevelError(action string, err error) {
+	if errors.Is(err, runtime.ErrUnsupported) {
+		m.addNotice("", "Current model does not support thinking levels", stMuted())
+		return
+	}
+	m.addNotice("✗ ", fmt.Sprintf("Failed to %s thinking level: %v", action, err), stError())
 }
 
 func (m *model) submit(ctx context.Context, text string) {
@@ -288,370 +291,28 @@ func (m *model) sendFirstMessage(ctx context.Context, msg, attachPath string) {
 	m.startRun(ctx, content, atts)
 }
 
-func (m *model) startRun(ctx context.Context, message string, attachments []messages.Attachment) {
+// beginRun marks the model busy and returns a cancelable context for a new
+// run, storing its cancel func so it can be interrupted.
+func (m *model) beginRun(ctx context.Context) (context.Context, context.CancelFunc) {
 	runCtx, cancel := context.WithCancel(ctx)
 	m.runCancel = cancel
 	m.busy = true
+	return runCtx, cancel
+}
+
+func (m *model) startRun(ctx context.Context, message string, attachments []messages.Attachment) {
+	runCtx, cancel := m.beginRun(ctx)
 	m.app.Run(runCtx, cancel, message, attachments)
 }
 
 func (m *model) startCompact(ctx context.Context, prompt string) {
-	runCtx, cancel := context.WithCancel(ctx)
-	m.runCancel = cancel
-	m.busy = true
+	runCtx, cancel := m.beginRun(ctx)
 	m.app.CompactSession(runCtx, cancel, prompt)
 }
 
 func (m *model) startSkillFork(ctx context.Context, name, task string) {
-	runCtx, cancel := context.WithCancel(ctx)
-	m.runCancel = cancel
-	m.busy = true
+	runCtx, cancel := m.beginRun(ctx)
 	m.app.RunSkillFork(runCtx, cancel, name, task, nil)
-}
-
-func (m *model) handleEvent(ctx context.Context, ev any) {
-	switch e := ev.(type) {
-	case *runtime.StreamStartedEvent:
-		m.busy = true
-		m.trackStreamStarted(e.SessionID)
-	case *runtime.StreamStoppedEvent:
-		m.trackStreamStopped()
-		m.handleStreamStopped(ctx)
-	case *runtime.AgentChoiceReasoningEvent:
-		m.appendPending(blockReasoning, e.Content)
-	case *runtime.AgentChoiceEvent:
-		m.appendPending(blockAssistant, e.Content)
-	case *runtime.PartialToolCallEvent:
-		m.flushPending()
-		toolDef := tools.Tool{Name: e.ToolCall.Function.Name}
-		if e.ToolDefinition != nil {
-			toolDef = *e.ToolDefinition
-		}
-		m.upsertTool(e.GetAgentName(), e.ToolCall, toolDef, tuitypes.ToolStatusPending)
-	case *runtime.ToolCallEvent:
-		m.flushPending()
-		m.upsertTool(e.GetAgentName(), e.ToolCall, e.ToolDefinition, tuitypes.ToolStatusRunning)
-	case *runtime.ToolCallOutputEvent:
-		if tv := m.tools[e.ToolCallID]; tv != nil && tv.message != nil {
-			tv.message.AppendToolOutput(e.Output)
-			if tv.message.ToolStatus == tuitypes.ToolStatusPending {
-				tv.message.ToolStatus = tuitypes.ToolStatusRunning
-				if tv.message.StartedAt == nil {
-					now := time.Now()
-					tv.message.StartedAt = &now
-				}
-			}
-		}
-	case *runtime.ToolCallResponseEvent:
-		m.finishTool(e)
-	case *runtime.ToolCallConfirmationEvent:
-		m.removeTool(toolViewID(e.ToolCall))
-		toolDef := ensureToolDefinition(e.ToolCall, e.ToolDefinition)
-		m.confirm = &confirmState{
-			tool:     toolDef.Name,
-			toolView: *newToolView(e.GetAgentName(), e.ToolCall, toolDef, tuitypes.ToolStatusConfirmation),
-		}
-	case *runtime.TokenUsageEvent:
-		m.setTokenUsage(e.SessionID, e.Usage)
-	case *runtime.AgentInfoEvent:
-		m.status.agent = e.AgentName
-		if m.sessionState != nil {
-			m.sessionState.SetCurrentAgentName(e.AgentName)
-		}
-		if e.Model != "" {
-			m.status.model = e.Model
-		}
-		if e.ContextLimit > 0 {
-			m.status.contextLimit = e.ContextLimit
-		}
-	case *runtime.TeamInfoEvent:
-		m.applyTeamInfo(ctx, e)
-	case *runtime.SessionCompactionEvent:
-		m.handleSessionCompaction(ctx, e)
-	case *runtime.ErrorEvent:
-		m.flushPending()
-		m.addNotice("✗ ", e.Error, stError())
-	case *runtime.WarningEvent:
-		m.addNotice("⚠ ", e.Message, stWarning())
-	case *runtime.ShellOutputEvent:
-		output := e.Output
-		m.addBlock(func(w int) []string { return renderToolOutput(output, w) })
-	case *runtime.AgentSwitchingEvent:
-		if e.Switching && e.ToAgent != "" {
-			m.addNotice("→ ", "Switching to "+e.ToAgent, stMuted())
-		}
-	case *runtime.MaxIterationsReachedEvent:
-		m.addNotice("⚠ ", "Maximum iterations reached.", stWarning())
-	case *runtime.ModelFallbackEvent:
-		m.addNotice("⚠ ", "Model "+e.FailedModel+" failed, falling back to "+e.FallbackModel+".", stWarning())
-	}
-}
-
-func (m *model) handleStreamStopped(ctx context.Context) {
-	if m.finishBusy(ctx) {
-		return
-	}
-
-	if m.app != nil && m.app.ShouldExitAfterFirstResponse() {
-		m.quit()
-	}
-}
-
-func (m *model) trackStreamStarted(sessionID string) {
-	if sessionID == "" {
-		return
-	}
-	if len(m.sessionStack) == 0 {
-		m.rootSessionID = sessionID
-	}
-	m.sessionStack = append(m.sessionStack, sessionID)
-	m.applyUsageSnapshot()
-}
-
-func (m *model) trackStreamStopped() {
-	if n := len(m.sessionStack); n > 0 {
-		m.sessionStack = m.sessionStack[:n-1]
-	}
-	m.applyUsageSnapshot()
-}
-
-func (m *model) setTokenUsage(sessionID string, usage *runtime.Usage) {
-	if usage == nil {
-		return
-	}
-
-	snapshot := usageSnapshot{
-		contextLength: usage.ContextLength,
-		contextLimit:  usage.ContextLimit,
-		tokens:        usage.InputTokens + usage.OutputTokens,
-		cost:          usage.Cost,
-	}
-	if sessionID == "" {
-		// Once session-scoped usage exists, it is authoritative for the chat
-		// footer. Empty-session usage comes from side work such as RAG indexing.
-		if len(m.usageBySession) == 0 {
-			m.applyStatusUsage(snapshot, usage.Cost, true)
-		}
-		return
-	}
-	if m.usageBySession == nil {
-		m.usageBySession = make(map[string]usageSnapshot)
-	}
-	if m.rootSessionID == "" && len(m.usageBySession) == 0 {
-		m.rootSessionID = sessionID
-	}
-	m.usageBySession[sessionID] = snapshot
-	m.latestUsageSessionID = sessionID
-	m.applyUsageSnapshot()
-}
-
-func (m *model) applyUsageSnapshot() {
-	if len(m.usageBySession) == 0 {
-		return
-	}
-
-	var totalCost float64
-	for _, usage := range m.usageBySession {
-		totalCost += usage.cost
-	}
-
-	if usage, ok := m.activeUsage(); ok {
-		m.applyStatusUsage(usage, totalCost, true)
-		return
-	}
-
-	m.status.cost = totalCost
-	m.status.costKnown = true
-}
-
-func (m *model) activeUsage() (usageSnapshot, bool) {
-	if n := len(m.sessionStack); n > 0 {
-		usage, ok := m.usageBySession[m.sessionStack[n-1]]
-		return usage, ok
-	}
-	if m.rootSessionID != "" {
-		usage, ok := m.usageBySession[m.rootSessionID]
-		return usage, ok
-	}
-	if m.latestUsageSessionID != "" {
-		usage, ok := m.usageBySession[m.latestUsageSessionID]
-		return usage, ok
-	}
-	if len(m.usageBySession) == 1 {
-		for _, usage := range m.usageBySession {
-			return usage, true
-		}
-	}
-	return usageSnapshot{}, false
-}
-
-func (m *model) applyStatusUsage(usage usageSnapshot, cost float64, costKnown bool) {
-	m.status.contextLength = usage.contextLength
-	m.status.contextLimit = usage.contextLimit
-	m.status.tokens = usage.tokens
-	m.status.cost = cost
-	m.status.costKnown = costKnown
-}
-
-func (m *model) handleSessionCompaction(ctx context.Context, e *runtime.SessionCompactionEvent) {
-	switch e.Status {
-	case "started":
-		m.busy = true
-	case "completed":
-		m.finishBusy(ctx)
-	}
-}
-
-func (m *model) finishBusy(ctx context.Context) bool {
-	m.flushPending()
-	m.busy = false
-	m.runCancel = nil
-
-	if len(m.queue) > 0 {
-		next := m.queue[0]
-		m.queue = m.queue[1:]
-		m.startRun(ctx, next, nil)
-		return true
-	}
-	return false
-}
-
-func (m *model) appendPending(kind blockKind, content string) {
-	if content == "" {
-		return
-	}
-	if m.pending == nil || m.pending.kind != kind {
-		m.flushPending()
-		m.pending = &pendingBlock{kind: kind}
-	}
-	m.pending.text.WriteString(content)
-}
-
-// flushPending finalizes the in-progress streamed block into the conversation.
-func (m *model) flushPending() {
-	if m.pending == nil {
-		return
-	}
-	text := m.pending.text.String()
-	kind := m.pending.kind
-	m.pending = nil
-
-	switch kind {
-	case blockReasoning:
-		m.addBlock(func(w int) []string { return renderReasoningLines(text, w) })
-	case blockAssistant:
-		m.addBlock(func(w int) []string { return renderAssistantLines(text, w) })
-	}
-}
-
-func (m *model) upsertTool(agentName string, toolCall tools.ToolCall, toolDef tools.Tool, status tuitypes.ToolStatus) {
-	id := toolViewID(toolCall)
-	tv := m.tools[id]
-	if tv == nil {
-		tv = newToolView(agentName, toolCall, toolDef, status)
-		m.tools[id] = tv
-		m.toolOrder = append(m.toolOrder, id)
-		return
-	}
-
-	msg := tv.message
-	if msg == nil {
-		msg = newToolView(agentName, toolCall, toolDef, status).message
-		tv.message = msg
-		return
-	}
-
-	if agentName != "" {
-		msg.Sender = agentName
-	}
-	if toolDef.Name != "" || toolCall.Function.Name != "" {
-		msg.ToolDefinition = ensureToolDefinition(toolCall, toolDef)
-	}
-	msg.ToolStatus = status
-	if status == tuitypes.ToolStatusRunning && msg.StartedAt == nil {
-		now := time.Now()
-		msg.StartedAt = &now
-	}
-	if toolCall.ID != "" {
-		msg.ToolCall.ID = toolCall.ID
-	}
-	if toolCall.Type != "" {
-		msg.ToolCall.Type = toolCall.Type
-	}
-	if toolCall.Function.Name != "" {
-		msg.ToolCall.Function.Name = toolCall.Function.Name
-	}
-	if toolCall.Function.Arguments != "" {
-		if status == tuitypes.ToolStatusPending {
-			msg.ToolCall.Function.Arguments += toolCall.Function.Arguments
-		} else {
-			msg.ToolCall.Function.Arguments = toolCall.Function.Arguments
-		}
-	}
-}
-
-func (m *model) finishTool(e *runtime.ToolCallResponseEvent) {
-	id := e.ToolCallID
-	tv := m.tools[id]
-	if tv == nil {
-		toolCall := tools.ToolCall{ID: id, Function: tools.FunctionCall{Name: e.ToolDefinition.Name}}
-		tv = newToolView(e.GetAgentName(), toolCall, e.ToolDefinition, tuitypes.ToolStatusCompleted)
-	}
-	if tv.message == nil {
-		return
-	}
-
-	status := tuitypes.ToolStatusCompleted
-	if e.Result != nil && e.Result.IsError {
-		status = tuitypes.ToolStatusError
-	}
-	tv.message.ToolStatus = status
-	tv.message.ToolDefinition = ensureToolDefinition(tv.message.ToolCall, e.ToolDefinition)
-	tv.message.Content = strings.ReplaceAll(e.Response, "\t", "    ")
-	tv.message.ToolResult = e.Result.WithoutPayload()
-	tv.images = inlineImagesFromToolResult(e.Result)
-
-	msg := *tv.message
-	view := toolView{message: &msg, images: tv.images}
-	m.addBlock(func(w int) []string { return renderToolWithState(&view, w, 0, m.sessionState) })
-
-	m.removeTool(id)
-}
-
-func (m *model) removeTool(id string) {
-	if id == "" {
-		return
-	}
-	delete(m.tools, id)
-	m.toolOrder = slices.DeleteFunc(m.toolOrder, func(s string) bool { return s == id })
-}
-
-func toolViewID(toolCall tools.ToolCall) string {
-	if toolCall.ID != "" {
-		return toolCall.ID
-	}
-	return toolCall.Function.Name
-}
-
-func (m *model) applyTeamInfo(ctx context.Context, e *runtime.TeamInfoEvent) {
-	if m.sessionState != nil {
-		m.sessionState.SetAvailableAgents(e.AvailableAgents)
-		m.sessionState.SetCurrentAgentName(e.CurrentAgent)
-	}
-	for _, a := range e.AvailableAgents {
-		if a.Name != e.CurrentAgent {
-			continue
-		}
-		m.status.agent = a.Name
-		switch {
-		case a.Provider != "" && a.Model != "":
-			m.status.model = a.Provider + "/" + a.Model
-		case a.Model != "":
-			m.status.model = a.Model
-		}
-		m.status.thinking = a.Thinking
-	}
-	m.refreshCommands(ctx)
 }
 
 func (m *model) refreshCommands(ctx context.Context) {
@@ -699,15 +360,11 @@ func (m *model) resetConversation() {
 		m.runCancel = nil
 	}
 	m.pending = nil
-	m.tools = make(map[string]*toolView)
-	m.toolOrder = nil
+	m.toolz.reset()
 	m.queue = nil
 	m.busy = false
 	m.confirm = nil
-	m.usageBySession = make(map[string]usageSnapshot)
-	m.rootSessionID = ""
-	m.latestUsageSessionID = ""
-	m.sessionStack = nil
+	m.usage.reset()
 	m.status.contextLength = 0
 	m.status.contextLimit = 0
 	m.status.tokens = 0

--- a/pkg/leantui/update_test.go
+++ b/pkg/leantui/update_test.go
@@ -122,7 +122,7 @@ func TestShiftTabCyclesThinkingLevel(t *testing.T) {
 
 	assert.Equal(t, 1, rt.cycleCalls)
 	assert.Equal(t, "high", m.status.thinking)
-	assert.Empty(t, m.blocks)
+	assert.Empty(t, m.transcript.blocks)
 }
 
 func TestShiftTabReportsUnsupportedThinkingLevel(t *testing.T) {
@@ -135,7 +135,7 @@ func TestShiftTabReportsUnsupportedThinkingLevel(t *testing.T) {
 
 	assert.Equal(t, 1, rt.cycleCalls)
 	assert.Empty(t, m.status.thinking)
-	assert.Len(t, m.blocks, 1)
+	assert.Len(t, m.transcript.blocks, 1)
 }
 
 func TestEffortCommandSetsThinkingLevel(t *testing.T) {
@@ -161,5 +161,5 @@ func TestEffortCommandRejectsUnknownLevel(t *testing.T) {
 
 	assert.Zero(t, rt.setCalls)
 	assert.Empty(t, m.status.thinking)
-	assert.Len(t, m.blocks, 1)
+	assert.Len(t, m.transcript.blocks, 1)
 }

--- a/pkg/leantui/usage.go
+++ b/pkg/leantui/usage.go
@@ -1,0 +1,157 @@
+package leantui
+
+import "github.com/docker/docker-agent/pkg/runtime"
+
+// usageSnapshot is the per-session token and cost usage summarized in the
+// status footer.
+type usageSnapshot struct {
+	contextLength int64
+	contextLimit  int64
+	tokens        int64
+	cost          float64
+}
+
+// usageTracker aggregates per-session token usage so the footer can show the
+// active session's context window alongside the total cost of the whole run
+// (the root session plus any nested agent sessions). It keeps a stack of
+// in-flight sessions so the "active" session is whichever stream is on top.
+type usageTracker struct {
+	bySession       map[string]usageSnapshot
+	rootSessionID   string
+	latestSessionID string
+	stack           []string
+}
+
+func newUsageTracker() *usageTracker {
+	return &usageTracker{bySession: map[string]usageSnapshot{}}
+}
+
+func (u *usageTracker) reset() {
+	u.bySession = map[string]usageSnapshot{}
+	u.rootSessionID = ""
+	u.latestSessionID = ""
+	u.stack = nil
+}
+
+// streamStarted pushes a newly-started session onto the active stack, adopting
+// the first one as the root session.
+func (u *usageTracker) streamStarted(sessionID string) {
+	if sessionID == "" {
+		return
+	}
+	if len(u.stack) == 0 {
+		u.rootSessionID = sessionID
+	}
+	u.stack = append(u.stack, sessionID)
+}
+
+// streamStopped pops the most recently-started session off the active stack.
+func (u *usageTracker) streamStopped() {
+	if n := len(u.stack); n > 0 {
+		u.stack = u.stack[:n-1]
+	}
+}
+
+// record stores usage for a session, adopting the first session seen as the
+// root when no stream has started yet.
+func (u *usageTracker) record(sessionID string, snapshot usageSnapshot) {
+	if u.rootSessionID == "" && len(u.bySession) == 0 {
+		u.rootSessionID = sessionID
+	}
+	u.bySession[sessionID] = snapshot
+	u.latestSessionID = sessionID
+}
+
+func (u *usageTracker) empty() bool { return len(u.bySession) == 0 }
+
+func (u *usageTracker) totalCost() float64 {
+	var total float64
+	for _, usage := range u.bySession {
+		total += usage.cost
+	}
+	return total
+}
+
+// active returns the usage of the session whose context the footer should show:
+// the top of the active stack, else the root, else the most recent, else the
+// sole recorded session.
+func (u *usageTracker) active() (usageSnapshot, bool) {
+	if n := len(u.stack); n > 0 {
+		usage, ok := u.bySession[u.stack[n-1]]
+		return usage, ok
+	}
+	if u.rootSessionID != "" {
+		usage, ok := u.bySession[u.rootSessionID]
+		return usage, ok
+	}
+	if u.latestSessionID != "" {
+		usage, ok := u.bySession[u.latestSessionID]
+		return usage, ok
+	}
+	if len(u.bySession) == 1 {
+		for _, usage := range u.bySession {
+			return usage, true
+		}
+	}
+	return usageSnapshot{}, false
+}
+
+// trackStreamStarted records a newly-started stream and refreshes the footer.
+func (m *model) trackStreamStarted(sessionID string) {
+	m.usage.streamStarted(sessionID)
+	m.applyUsageSnapshot()
+}
+
+// trackStreamStopped records a finished stream and refreshes the footer.
+func (m *model) trackStreamStopped() {
+	m.usage.streamStopped()
+	m.applyUsageSnapshot()
+}
+
+func (m *model) setTokenUsage(sessionID string, usage *runtime.Usage) {
+	if usage == nil {
+		return
+	}
+
+	snapshot := usageSnapshot{
+		contextLength: usage.ContextLength,
+		contextLimit:  usage.ContextLimit,
+		tokens:        usage.InputTokens + usage.OutputTokens,
+		cost:          usage.Cost,
+	}
+	if sessionID == "" {
+		// Once session-scoped usage exists, it is authoritative for the chat
+		// footer. Empty-session usage comes from side work such as RAG indexing.
+		if m.usage.empty() {
+			m.applyStatusUsage(snapshot, usage.Cost, true)
+		}
+		return
+	}
+	m.usage.record(sessionID, snapshot)
+	m.applyUsageSnapshot()
+}
+
+// applyUsageSnapshot pushes the tracker's derived footer usage onto the status
+// line: the active session's context window plus the run's total cost.
+func (m *model) applyUsageSnapshot() {
+	if m.usage.empty() {
+		return
+	}
+
+	totalCost := m.usage.totalCost()
+	if usage, ok := m.usage.active(); ok {
+		m.applyStatusUsage(usage, totalCost, true)
+		return
+	}
+
+	m.status.cost = totalCost
+	m.status.costKnown = true
+}
+
+func (m *model) applyStatusUsage(usage usageSnapshot, cost float64, costKnown bool) {
+	m.status.contextLength = usage.contextLength
+	m.status.contextLimit = usage.contextLimit
+	m.status.tokens = usage.tokens
+	m.status.cost = cost
+	m.status.costKnown = costKnown
+}

--- a/pkg/leantui/view.go
+++ b/pkg/leantui/view.go
@@ -65,13 +65,11 @@ func (m *model) conversationLines(width int) []string {
 		lines = append(lines, m.pendingLines(width)...)
 		lines = append(lines, "")
 	}
-	for _, id := range m.toolOrder {
-		if tv := m.tools[id]; tv != nil {
-			lines = append(lines, renderToolWithState(tv, width, m.spinnerFrame, m.sessionState)...)
-			lines = append(lines, "")
-		}
-	}
-	if m.busy && m.pending == nil && len(m.toolOrder) == 0 {
+	m.toolz.forEach(func(tv *toolView) {
+		lines = append(lines, renderToolWithState(tv, width, m.spinnerFrame, m.sessionState)...)
+		lines = append(lines, "")
+	})
+	if m.busy && m.pending == nil && m.toolz.empty() {
 		lines = append(lines, m.spinnerLine(), "")
 	}
 	return lines

--- a/pkg/leantui/view.go
+++ b/pkg/leantui/view.go
@@ -1,33 +1,12 @@
 package leantui
 
-var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
-
-// block is a finalized piece of the conversation. Its lines are rendered lazily
-// and cached per width, so finalized content is not re-rendered every frame and
-// only reflows when the terminal is resized.
-type block struct {
-	render func(width int) []string
-	cacheW int
-	cache  []string
-	cached bool
-}
-
-func (b *block) lines(width int) []string {
-	if !b.cached || b.cacheW != width {
-		b.cache = b.render(width)
-		b.cacheW = width
-		b.cached = true
-	}
-	return b.cache
-}
-
 // buildLines produces the entire frame: the conversation, the slash-command
 // popup, the input box (or a confirmation prompt) and the status footer. It
 // returns the lines plus the hardware cursor position (a line index and column).
 func (m *model) buildLines() (lines []string, cursorLine, cursorCol int) {
 	width := m.width
 
-	lines = m.conversationLines(width)
+	lines = m.transcript.lines(width, m.spinnerFrame, m.busy, m.sessionState)
 
 	lines = append(lines, m.ac.render(width)...)
 
@@ -50,49 +29,6 @@ func (m *model) buildLines() (lines []string, cursorLine, cursorCol int) {
 	lines = append(lines, renderStatus(m.status, width)...)
 
 	return lines, cursorLine, cursorCol
-}
-
-// conversationLines renders everything that scrolls: finalized blocks, the
-// in-progress streamed block, and any running tool calls. A blank line
-// separates each entry.
-func (m *model) conversationLines(width int) []string {
-	var lines []string
-	for _, b := range m.blocks {
-		lines = append(lines, b.lines(width)...)
-		lines = append(lines, "")
-	}
-	if m.pending != nil {
-		lines = append(lines, m.pendingLines(width)...)
-		lines = append(lines, "")
-	}
-	m.toolz.forEach(func(tv *toolView) {
-		lines = append(lines, renderToolWithState(tv, width, m.spinnerFrame, m.sessionState)...)
-		lines = append(lines, "")
-	})
-	if m.busy && m.pending == nil && m.toolz.empty() {
-		lines = append(lines, m.spinnerLine(), "")
-	}
-	return lines
-}
-
-// pendingLines renders the message currently being streamed. Assistant text is
-// rendered as markdown live (the same renderer used once it is finalized), so
-// formatting appears as it streams.
-func (m *model) pendingLines(width int) []string {
-	text := m.pending.text.String()
-	switch m.pending.kind {
-	case blockReasoning:
-		return renderReasoningLines(text, width)
-	case blockAssistant:
-		return renderAssistantLines(text, width)
-	default:
-		return nil
-	}
-}
-
-func (m *model) spinnerLine() string {
-	frame := spinnerFrames[m.spinnerFrame%len(spinnerFrames)]
-	return stAccent().Render(frame) + " " + stMuted().Render("Working…")
 }
 
 // confirmState holds a pending tool-approval prompt.


### PR DESCRIPTION
## What

Progressively decomposes `pkg/leantui`'s large `model` struct and `update.go` into cohesive, independently-testable subsystems. **No functional change** — purely structural. Done as a series of behavior-preserving commits.

### Commits

**1. Extract usage/tool trackers and split `update.go`**
- `usageTracker` (`usage.go`): per-session token/cost aggregation — the session stack, root/latest bookkeeping, and "active session" resolution. Replaces four model fields (`usageBySession`, `rootSessionID`, `latestUsageSessionID`, `sessionStack`) with one.
- `toolTracker` (`toolstate.go`): in-flight tool-call state (`tools` map + `toolOrder`); `finish()` returns an immutable snapshot for the model to commit.
- Runtime event handling moves to `events.go`, leaving `update.go` focused on input and command dispatch.
- Deduplicated run-lifecycle boilerplate (`beginRun`) and thinking-level guard/error handling.

**2. Extract the `transcript` type**
- Groups everything that scrolls — finalized blocks, the in-progress streamed block, and in-flight tool calls — into one `transcript` type that owns its rendering (the former `conversationLines`, now `transcript.lines`).
- `resetConversation`'s manual pending/tool reset becomes `transcript.clearActive()`, which keeps committed scrollback intact.

### Net effect

The `model` struct drops from **~30 fields to 18**, and `update.go` from **761 to ~417 lines**. The three most self-contained concerns (usage, conversation content, tool state) are now typed components with their behavior exercisable in isolation.

### Validation

- `go build ./...` — passes
- `go test ./pkg/leantui/...` — passes (tests touched only for renamed field paths; no assertions changed)
- `golangci-lint run ./pkg/leantui/...` (v2.12.2, repo config) — 0 issues

### Deliberately left alone

The differential `renderer`, the `editor`, and the `keys` parser are already cohesive single-responsibility units. A `runState` extraction (busy/runCancel/queue) was considered but held back — it is borderline because the actual `app.Run` calls must stay on the model; the run-lifecycle fields are grouped together to make that a clean follow-up if desired.