### PR TITLE
refactor: share git-branch detection between the lean and full TUIs

### DIFF
--- a/pkg/gitbranch/gitbranch.go
+++ b/pkg/gitbranch/gitbranch.go
@@ -1,4 +1,6 @@
-package leantui
+// Package gitbranch resolves the current branch of a git working directory by
+// reading .git metadata directly, without shelling out to the git binary.
+package gitbranch
 
 import (
 	"os"
@@ -6,10 +8,14 @@ import (
 	"strings"
 )
 
-// gitBranch returns the current branch name (or short commit for a detached
+// Current returns the current branch name (or the short commit for a detached
 // HEAD) for the repository containing dir, walking up parent directories until
-// a .git entry is found. It returns "" when dir is not inside a repository.
-func gitBranch(dir string) string {
+// a .git entry is found. It returns "" when dir is empty or not inside a
+// repository.
+func Current(dir string) string {
+	if dir == "" {
+		return ""
+	}
 	d := dir
 	for {
 		gitPath := filepath.Join(d, ".git")
@@ -60,19 +66,4 @@ func readHead(headPath string) string {
 		return line[:7] // detached HEAD
 	}
 	return ""
-}
-
-// shortenPath replaces the user's home directory prefix with "~".
-func shortenPath(dir string) string {
-	home, err := os.UserHomeDir()
-	if err != nil || home == "" {
-		return dir
-	}
-	if dir == home {
-		return "~"
-	}
-	if rest, ok := strings.CutPrefix(dir, home+string(filepath.Separator)); ok {
-		return "~" + string(filepath.Separator) + rest
-	}
-	return dir
 }

--- a/pkg/gitbranch/gitbranch_test.go
+++ b/pkg/gitbranch/gitbranch_test.go
@@ -1,4 +1,4 @@
-package leantui
+package gitbranch
 
 import (
 	"os"
@@ -33,7 +33,7 @@ func TestReadHeadDetached(t *testing.T) {
 	assert.Equal(t, "0123456", readHead(head))
 }
 
-func TestGitBranchWalksUp(t *testing.T) {
+func TestCurrentWalksUp(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(root, ".git"), 0o755))
@@ -42,19 +42,26 @@ func TestGitBranchWalksUp(t *testing.T) {
 	nested := filepath.Join(root, "a", "b")
 	require.NoError(t, os.MkdirAll(nested, 0o755))
 
-	assert.Equal(t, "dev", gitBranch(nested))
+	assert.Equal(t, "dev", Current(nested))
 }
 
-func TestGitBranchNoRepo(t *testing.T) {
+func TestCurrentWorktreePointer(t *testing.T) {
 	t.Parallel()
-	assert.Empty(t, gitBranch(t.TempDir()))
+	realGitDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(realGitDir, "HEAD"), []byte("ref: refs/heads/wt\n"), 0o644))
+
+	work := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(work, ".git"), []byte("gitdir: "+realGitDir+"\n"), 0o644))
+
+	assert.Equal(t, "wt", Current(work))
 }
 
-func TestShortenPath(t *testing.T) {
+func TestCurrentNoRepo(t *testing.T) {
 	t.Parallel()
-	home, err := os.UserHomeDir()
-	require.NoError(t, err)
-	assert.Equal(t, "~", shortenPath(home))
-	assert.Equal(t, filepath.Join("~", "x"), shortenPath(filepath.Join(home, "x")))
-	assert.Equal(t, "/etc", shortenPath("/etc"))
+	assert.Empty(t, Current(t.TempDir()))
+}
+
+func TestCurrentEmptyDir(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, Current(""))
 }

--- a/pkg/leantui/leantui.go
+++ b/pkg/leantui/leantui.go
@@ -10,6 +10,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/docker/docker-agent/pkg/app"
+	"github.com/docker/docker-agent/pkg/gitbranch"
 	"github.com/docker/docker-agent/pkg/tui/service"
 )
 
@@ -185,7 +186,7 @@ func newModel(term *terminal, cfg Config) *model {
 		editor:           newEditor("Type a message, / for commands"),
 		ac:               newAutocomplete(),
 		transcript:       newTranscript(),
-		status:           statusData{workingDir: cfg.WorkingDir, branch: gitBranch(cfg.WorkingDir)},
+		status:           statusData{workingDir: cfg.WorkingDir, branch: gitbranch.Current(cfg.WorkingDir)},
 		sessionState:     sessionState,
 		usage:            newUsageTracker(),
 		appName:          appName,

--- a/pkg/leantui/status.go
+++ b/pkg/leantui/status.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	pathx "github.com/docker/docker-agent/pkg/path"
 	"github.com/docker/docker-agent/pkg/tui/components/toolcommon"
 )
 
@@ -29,7 +30,7 @@ type statusData struct {
 //	<working dir>  ⎇ <branch>                          <agent>
 //	<context bar> <pct> · <tokens> · <cost>  <model> · <effort>
 func renderStatus(d statusData, width int) []string {
-	dir := stSecondary().Render(truncate(shortenPath(d.workingDir), max(10, width/2)))
+	dir := stSecondary().Render(truncate(pathx.ShortenHome(d.workingDir), max(10, width/2)))
 	left1 := dir
 	if d.branch != "" {
 		left1 += stMuted().Render("  ⎇ " + d.branch)

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"maps"
 	"os"
-	"os/exec"
 	"slices"
 	"strconv"
 	"strings"
@@ -17,6 +16,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/docker/docker-agent/pkg/effort"
+	"github.com/docker/docker-agent/pkg/gitbranch"
 	"github.com/docker/docker-agent/pkg/paths"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
@@ -175,7 +175,7 @@ func New(ctx context.Context, sessionState *service.SessionState) Model {
 	ti.CharLimit = 50
 	ti.Prompt = "" // No prompt to maximize usable width in collapsed sidebar
 
-	wd, branch := getCurrentWorkingDirectory(ctx)
+	wd, branch := getCurrentWorkingDirectory()
 
 	m := &model{
 		ctx:          func() context.Context { return context.WithoutCancel(ctx) },
@@ -496,7 +496,7 @@ func (m *model) LoadFromSession(sess *session.Session) {
 
 	// Load working directory from session
 	if sess.WorkingDir != "" {
-		m.workingDirectory, m.gitBranchName = formatWorkingDirectory(m.ctx(), sess.WorkingDir)
+		m.workingDirectory, m.gitBranchName = formatWorkingDirectory(sess.WorkingDir)
 	}
 
 	// Session has content if it has messages or token usage
@@ -566,30 +566,15 @@ func (m *model) contextPercent() string {
 	return ""
 }
 
-// gitBranch returns the current git branch name for the given directory,
-// or an empty string if the directory is not inside a git repository.
-func gitBranch(ctx context.Context, dir string) string {
-	if dir == "" {
-		return ""
-	}
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-	out, err := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--abbrev-ref", "HEAD").Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(out))
-}
-
 // formatWorkingDirectory formats a raw directory path for display,
 // replacing the home prefix with ~/. Returns the display path and the
 // current git branch (empty if not in a repo).
-func formatWorkingDirectory(ctx context.Context, rawDir string) (display, branch string) {
+func formatWorkingDirectory(rawDir string) (display, branch string) {
 	if rawDir == "" {
 		return "", ""
 	}
 
-	branch = gitBranch(ctx, rawDir)
+	branch = gitbranch.Current(rawDir)
 
 	display = rawDir
 	if homeDir := paths.GetHomeDir(); homeDir != "" && strings.HasPrefix(display, homeDir) {
@@ -601,13 +586,13 @@ func formatWorkingDirectory(ctx context.Context, rawDir string) (display, branch
 
 // getCurrentWorkingDirectory returns the current working directory with home directory
 // replaced by ~/, along with the current git branch name.
-func getCurrentWorkingDirectory(ctx context.Context) (string, string) {
+func getCurrentWorkingDirectory() (string, string) {
 	pwd, err := os.Getwd()
 	if err != nil {
 		return "", ""
 	}
 
-	return formatWorkingDirectory(ctx, pwd)
+	return formatWorkingDirectory(pwd)
 }
 
 // workingDirWithBranch returns the working directory path with the git branch

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/effort"
 	"github.com/docker/docker-agent/pkg/gitbranch"
-	"github.com/docker/docker-agent/pkg/paths"
+	pathx "github.com/docker/docker-agent/pkg/path"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tools"
@@ -573,15 +573,7 @@ func formatWorkingDirectory(rawDir string) (display, branch string) {
 	if rawDir == "" {
 		return "", ""
 	}
-
-	branch = gitbranch.Current(rawDir)
-
-	display = rawDir
-	if homeDir := paths.GetHomeDir(); homeDir != "" && strings.HasPrefix(display, homeDir) {
-		display = "~" + display[len(homeDir):]
-	}
-
-	return display, branch
+	return pathx.ShortenHome(rawDir), gitbranch.Current(rawDir)
 }
 
 // getCurrentWorkingDirectory returns the current working directory with home directory

--- a/pkg/tui/dialog/session_browser.go
+++ b/pkg/tui/dialog/session_browser.go
@@ -2,7 +2,6 @@ package dialog
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	goruntime "runtime"
 	"slices"
@@ -16,7 +15,7 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/atotto/clipboard"
 
-	"github.com/docker/docker-agent/pkg/paths"
+	pathx "github.com/docker/docker-agent/pkg/path"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tui/components/notification"
 	"github.com/docker/docker-agent/pkg/tui/components/scrollview"
@@ -112,20 +111,6 @@ func workspacePathsEqual(a, b string) bool {
 		return strings.EqualFold(a, b)
 	}
 	return a == b
-}
-
-// abbreviateHome replaces a $HOME prefix with "~" for compact display.
-func abbreviateHome(dir string) string {
-	home := paths.GetHomeDir()
-	if home == "" || !strings.HasPrefix(dir, home) {
-		return dir
-	}
-	rest := dir[len(home):]
-	// Reject prefix matches that fall inside a path component (/home/bob2).
-	if rest != "" && rest[0] != os.PathSeparator {
-		return dir
-	}
-	return "~" + rest
 }
 
 type sessionBrowserDialog struct {
@@ -619,7 +604,7 @@ func (d *sessionBrowserDialog) sessionDirLabel(sess session.Summary) string {
 	if dir == "" || d.workspace.matches(dir) {
 		return ""
 	}
-	return truncatePath(abbreviateHome(dir), sessionBrowserDirMaxLen)
+	return truncatePath(pathx.ShortenHome(dir), sessionBrowserDirMaxLen)
 }
 
 // renderSectionHeader renders a workspace group header. The current-workspace
@@ -635,7 +620,7 @@ func (d *sessionBrowserDialog) renderSectionHeader(header string, maxWidth int) 
 	if header == sessionBrowserHeaderWorkspace && d.workspaceDir != "" {
 		available := maxWidth - lipgloss.Width(label) - 3 // " · " separator
 		if available >= 8 {
-			dir = " · " + truncatePath(abbreviateHome(d.workspaceDir), available)
+			dir = " · " + truncatePath(pathx.ShortenHome(d.workspaceDir), available)
 		}
 	}
 

--- a/pkg/tui/dialog/session_browser_test.go
+++ b/pkg/tui/dialog/session_browser_test.go
@@ -13,7 +13,6 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/require"
 
-	"github.com/docker/docker-agent/pkg/paths"
 	"github.com/docker/docker-agent/pkg/session"
 )
 
@@ -555,16 +554,4 @@ func TestSessionBrowserNavigationSkipsHeaders(t *testing.T) {
 		d.Update(upKey)
 	}
 	require.Equal(t, 0, d.selected)
-}
-
-func TestAbbreviateHome(t *testing.T) {
-	home := paths.GetHomeDir()
-	if home == "" {
-		t.Skip("home directory unknown")
-	}
-
-	require.Equal(t, "~", abbreviateHome(home))
-	require.Equal(t, filepath.Join("~", "code"), abbreviateHome(filepath.Join(home, "code")))
-	require.Equal(t, home+"2", abbreviateHome(home+"2"), "sibling dirs sharing the prefix must not be abbreviated")
-	require.Equal(t, "/somewhere/else", abbreviateHome("/somewhere/else"))
 }


### PR DESCRIPTION
## What

Two related dedup steps for the two TUIs, each a behavior-preserving commit.

### 1. Share git-branch detection (`pkg/gitbranch`)

Both TUIs detected the current git branch independently — the lean TUI read `.git` metadata directly, the full-TUI sidebar shelled out to `git rev-parse --abbrev-ref HEAD`. Consolidated onto a new `pkg/gitbranch.Current(dir)` using the subprocess-free implementation.

- No dependency on a `git` binary; no subprocess spawn; preserves detached-HEAD info (short commit).
- Sidebar drops `os/exec` and the 2s-timeout/`context.Context` plumbing (`formatWorkingDirectory`/`getCurrentWorkingDirectory` no longer take a context).
- **Behavior note:** in the sidebar a detached HEAD now shows a short commit instead of the literal `HEAD`, matching the lean TUI.

### 2. Reuse `pathx.ShortenHome` for home-path display

The sidebar and the session browser each open-coded the "replace `$HOME` prefix with `~`" logic. Both now call the shared `pkg/path.ShortenHome`:

- Sidebar `formatWorkingDirectory`: drops the inline prefix replacement (and its partial-component-match bug, e.g. `/home/bob2`) and the `pkg/paths` dependency.
- Session browser: removes the local `abbreviateHome` helper; its sibling-directory edge case is already covered by `pkg/path`'s `TestIsWithin` / `TestShortenHomeDir`.
- The lean TUI's own `shortenPath` (introduced earlier in this branch) was likewise dropped in favour of `pathx.ShortenHome`.

### Validation

- `go build ./...`, `go vet`, `go test` — pass
- `golangci-lint run` (v2.12.2, repo config) on `pkg/leantui`, `pkg/gitbranch`, `pkg/tui/components/sidebar`, `pkg/tui/dialog` — 0 issues

Rebased onto `main` after #3455 merged.