### PR TITLE
feat(tui): add /context command with a categorized context-window breakdown

### DIFF
--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -81,6 +81,7 @@ Type `/` during a session to see available commands, or press <kbd>Ctrl</kbd>+<k
 | `/attach`          | Attach a file to your message                                                        |
 | `/shell`           | Open a shell                                                                         |
 | `/star`            | Star/unstar the current session                                                      |
+| `/context`         | Show a context-window breakdown: estimated tokens per category (system prompt, tool definitions, prompt files, messages, tool results, compaction summary) |
 | `/cost`            | Show cost breakdown for this session                                                 |
 | `/eval`            | Create an evaluation report                                                          |
 | `/pause`           | Pause/resume the runtime loop. While the agent is mid-request, the resize handle shows "Pausing…" until the in-flight request completes; once the loop is blocked the indicator changes to "⏸ Paused". Run `/pause` again to resume. |

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -896,6 +896,25 @@ func (a *App) Session() *session.Session {
 	return a.session
 }
 
+// contextBreakdownProvider is an optional runtime capability: computing the
+// estimated context-window composition for a session. Only the local runtime
+// (which holds the agent and its tools) implements it; remote runtimes
+// don't, so the /context dialog reports the feature as unavailable.
+type contextBreakdownProvider interface {
+	ContextBreakdown(ctx context.Context, sess *session.Session) (*runtime.ContextBreakdown, error)
+}
+
+// ContextBreakdown returns the estimated context-window composition for the
+// current session. Returns an error wrapping [runtime.ErrUnsupported] when
+// the runtime cannot compute it (e.g. remote runtimes).
+func (a *App) ContextBreakdown(ctx context.Context) (*runtime.ContextBreakdown, error) {
+	cp, ok := a.runtime.(contextBreakdownProvider)
+	if !ok {
+		return nil, fmt.Errorf("context breakdown: %w", runtime.ErrUnsupported)
+	}
+	return cp.ContextBreakdown(ctx, a.Session())
+}
+
 // PermissionsInfo returns combined permissions info from team and session.
 // Returns nil if no permissions are configured at either level.
 func (a *App) PermissionsInfo() *runtime.PermissionsInfo {

--- a/pkg/runtime/context_breakdown.go
+++ b/pkg/runtime/context_breakdown.go
@@ -1,0 +1,185 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/compaction"
+	"github.com/docker/docker-agent/pkg/promptfiles"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// ContextCategory aggregates the estimated token footprint of one slice of
+// the context window along with the number of items composing it (messages,
+// tool definitions, or prompt files depending on the category).
+type ContextCategory struct {
+	Tokens int64 `json:"tokens"`
+	Items  int   `json:"items"`
+}
+
+func (c *ContextCategory) add(tokens int64) {
+	c.Tokens += tokens
+	c.Items++
+}
+
+// ContextBreakdown describes the estimated composition of the prompt the
+// runtime would send on the next model call, broken down by category. All
+// token counts are estimates produced by [compaction.EstimateMessageTokens]
+// (provider-reported counts where available, a chars-per-token heuristic
+// otherwise); the actual provider tokenizer may count differently.
+type ContextBreakdown struct {
+	// SystemPrompt covers the invariant system messages: the agent
+	// instruction, multi-agent/handoff prompts, and toolset instructions.
+	SystemPrompt ContextCategory `json:"system_prompt"`
+	// ToolDefinitions covers the JSON schemas (name, description,
+	// parameters) of every tool exposed to the agent.
+	ToolDefinitions ContextCategory `json:"tool_definitions"`
+	// PromptFiles covers the add_prompt_files content (AGENTS.md, ...)
+	// injected as transient context at every turn.
+	PromptFiles ContextCategory `json:"prompt_files"`
+	// Messages covers the user and assistant conversation turns.
+	Messages ContextCategory `json:"messages"`
+	// ToolResults covers the tool-role result messages.
+	ToolResults ContextCategory `json:"tool_results"`
+	// CompactionSummary covers the synthetic message that carries the
+	// latest compaction summary, when the session has been compacted.
+	CompactionSummary ContextCategory `json:"compaction_summary"`
+
+	// ContextLimit is the resolved context window of the effective model,
+	// or 0 when it cannot be determined (harness-backed agents, models
+	// absent from the catalogue).
+	ContextLimit int64 `json:"context_limit"`
+	// Model is the effective model label ("provider/model", or the
+	// harness label for harness-backed agents).
+	Model string `json:"model"`
+}
+
+// TotalTokens returns the estimated size of the whole prompt.
+func (b *ContextBreakdown) TotalTokens() int64 {
+	return b.SystemPrompt.Tokens +
+		b.ToolDefinitions.Tokens +
+		b.PromptFiles.Tokens +
+		b.Messages.Tokens +
+		b.ToolResults.Tokens +
+		b.CompactionSummary.Tokens
+}
+
+// ContextBreakdown computes the estimated context-window composition for
+// sess, categorizing the output of [session.Session.GetMessages] and adding
+// the tool definitions and prompt files that accompany every model call.
+//
+// Tool listing failures and unreadable prompt files degrade gracefully: the
+// corresponding category is computed from whatever could be gathered and the
+// failure is logged, so a broken toolset never hides the rest of the data.
+func (r *LocalRuntime) ContextBreakdown(ctx context.Context, sess *session.Session) (*ContextBreakdown, error) {
+	if sess == nil {
+		return nil, errors.New("no active session")
+	}
+	a := r.resolveSessionAgent(sess)
+	if a == nil {
+		return nil, errors.New("no active agent")
+	}
+
+	b := &ContextBreakdown{Model: agentModelLabel(ctx, a)}
+	if !a.HasHarness() {
+		b.ContextLimit = r.contextLimitForAgentModel(ctx, a, r.getEffectiveModelID(ctx, a))
+	}
+
+	messages := sess.GetMessages(a)
+	// Calibrate the heuristic against the provider-reported usage already
+	// recorded on this conversation, mirroring what the proactive
+	// compaction trigger does (see compactIfNeeded).
+	estimator := compaction.NewSliceEstimator(messages)
+
+	summaryContent := ""
+	if summary := sess.LastSummary(); summary != "" {
+		summaryContent = session.SummaryMessageContent(summary)
+	}
+
+	for i := range messages {
+		msg := &messages[i]
+		tokens := estimator.EstimateMessageTokens(msg)
+		switch {
+		case msg.Role == chat.MessageRoleSystem:
+			b.SystemPrompt.add(tokens)
+		case msg.Role == chat.MessageRoleTool:
+			b.ToolResults.add(tokens)
+		case summaryContent != "" && msg.Role == chat.MessageRoleUser && msg.Content == summaryContent:
+			b.CompactionSummary.add(tokens)
+		default:
+			b.Messages.add(tokens)
+		}
+	}
+
+	agentTools, err := a.Tools(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "Context breakdown: failed to list tools; tool definitions omitted",
+			"agent", a.Name(), "session_id", sess.ID, "error", err)
+	}
+	for i := range agentTools {
+		b.ToolDefinitions.add(estimateToolDefinitionTokens(&agentTools[i]))
+	}
+
+	b.PromptFiles = r.promptFilesCategory(ctx, a.AddPromptFiles())
+
+	return b, nil
+}
+
+// estimateToolDefinitionTokens estimates the prompt cost of one tool
+// definition from the parts every provider serializes into the request:
+// name, description, and the parameters JSON schema. The estimate runs
+// through the same chars-per-token heuristic as messages; the synthetic
+// message's per-message overhead stands in for the provider's per-tool
+// wrapper tokens.
+func estimateToolDefinitionTokens(tool *tools.Tool) int64 {
+	content := tool.Name + tool.Description
+	if tool.Parameters != nil {
+		if params, err := json.Marshal(tool.Parameters); err == nil {
+			content += string(params)
+		}
+	}
+	return compaction.EstimateMessageTokens(&chat.Message{
+		Role:    chat.MessageRoleSystem,
+		Content: content,
+	})
+}
+
+// promptFilesCategory estimates the transient context injected by the
+// add_prompt_files builtin at every turn. It resolves each configured name
+// through the same lookup the hook uses (workdir hierarchy plus home or
+// staged kit, keyed off the runtime working directory the hooks executor is
+// built with) and sizes the joined contents as the single system message the
+// hook would produce. Items counts the files found, not the names configured.
+func (r *LocalRuntime) promptFilesCategory(ctx context.Context, names []string) ContextCategory {
+	var category ContextCategory
+	if len(names) == 0 {
+		return category
+	}
+	home, _ := os.UserHomeDir() // empty string disables the home-dir lookup
+	var parts []string
+	for _, name := range names {
+		for _, path := range promptfiles.PathsFromEnv(r.workingDir, home, name) {
+			content, err := os.ReadFile(path)
+			if err != nil {
+				slog.WarnContext(ctx, "Context breakdown: failed to read prompt file", "path", path, "error", err)
+				continue
+			}
+			parts = append(parts, string(content))
+			category.Items++
+		}
+	}
+	if len(parts) == 0 {
+		return category
+	}
+	category.Tokens = compaction.EstimateMessageTokens(&chat.Message{
+		Role:    chat.MessageRoleSystem,
+		Content: strings.Join(parts, "\n\n"),
+	})
+	return category
+}

--- a/pkg/runtime/context_breakdown_test.go
+++ b/pkg/runtime/context_breakdown_test.go
@@ -1,0 +1,220 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/compaction"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/team"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// newBreakdownRuntime builds a LocalRuntime around a single agent with a
+// mock model whose context window is 1000 tokens.
+func newBreakdownRuntime(t *testing.T, agentOpts ...agent.Opt) *LocalRuntime {
+	t.Helper()
+
+	opts := append([]agent.Opt{
+		agent.WithModel(&mockProvider{id: "test/mock-model"}),
+	}, agentOpts...)
+	root := agent.New("root", "You are a test agent", opts...)
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(t.Context(), tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStoreWithLimit{limit: 1000}),
+	)
+	require.NoError(t, err)
+	return rt
+}
+
+func TestContextBreakdown_CategorizesMessages(t *testing.T) {
+	t.Parallel()
+
+	promptDir := t.TempDir()
+	promptFile := "CONTEXT_BREAKDOWN_TEST_PROMPT.md"
+	promptContent := "Always be excellent to each other."
+	require.NoError(t, os.WriteFile(filepath.Join(promptDir, promptFile), []byte(promptContent), 0o600))
+
+	rt := newBreakdownRuntime(t,
+		agent.WithTools(
+			tools.Tool{Name: "echo", Description: "Echoes input", Parameters: map[string]any{"type": "object"}},
+			tools.Tool{Name: "list", Description: "Lists files"},
+		),
+		agent.WithAddPromptFiles([]string{promptFile}),
+	)
+	rt.workingDir = promptDir
+
+	sess := session.New(session.WithUserMessage("hello"))
+	sess.AddMessage(&session.Message{Message: chat.Message{
+		Role:      chat.MessageRoleAssistant,
+		Content:   "let me check",
+		ToolCalls: []tools.ToolCall{{ID: "call_1", Function: tools.FunctionCall{Name: "echo", Arguments: `{"text":"hi"}`}}},
+	}})
+	sess.AddMessage(&session.Message{Message: chat.Message{
+		Role:       chat.MessageRoleTool,
+		ToolCallID: "call_1",
+		Content:    "hi",
+	}})
+
+	b, err := rt.ContextBreakdown(t.Context(), sess)
+	require.NoError(t, err)
+
+	assert.Equal(t, "test/mock-model", b.Model)
+	assert.Equal(t, int64(1000), b.ContextLimit)
+
+	// One invariant system message: the agent instruction.
+	assert.Equal(t, 1, b.SystemPrompt.Items)
+	assert.Positive(t, b.SystemPrompt.Tokens)
+
+	// Two static tools.
+	assert.Equal(t, 2, b.ToolDefinitions.Items)
+	assert.Positive(t, b.ToolDefinitions.Tokens)
+
+	// One prompt file found in the working directory.
+	assert.Equal(t, 1, b.PromptFiles.Items)
+	expectedPromptTokens := compaction.EstimateMessageTokens(&chat.Message{
+		Role:    chat.MessageRoleSystem,
+		Content: promptContent,
+	})
+	assert.Equal(t, expectedPromptTokens, b.PromptFiles.Tokens)
+
+	// user + assistant turns; the tool result is its own category.
+	assert.Equal(t, 2, b.Messages.Items)
+	assert.Positive(t, b.Messages.Tokens)
+	assert.Equal(t, 1, b.ToolResults.Items)
+	assert.Positive(t, b.ToolResults.Tokens)
+
+	// No compaction happened.
+	assert.Zero(t, b.CompactionSummary.Items)
+	assert.Zero(t, b.CompactionSummary.Tokens)
+
+	total := b.SystemPrompt.Tokens + b.ToolDefinitions.Tokens + b.PromptFiles.Tokens +
+		b.Messages.Tokens + b.ToolResults.Tokens + b.CompactionSummary.Tokens
+	assert.Equal(t, total, b.TotalTokens())
+}
+
+func TestContextBreakdown_CompactionSummary(t *testing.T) {
+	t.Parallel()
+
+	rt := newBreakdownRuntime(t)
+
+	items := []session.Item{
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "old question"}}),
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "old answer"}}),
+		{Summary: "We discussed old things."},
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "new question"}}),
+	}
+	sess := session.New(session.WithMessages(items))
+
+	b, err := rt.ContextBreakdown(t.Context(), sess)
+	require.NoError(t, err)
+
+	// The synthetic summary message lands in its own category; the
+	// pre-compaction turns are gone and only the new question remains.
+	assert.Equal(t, 1, b.CompactionSummary.Items)
+	assert.Positive(t, b.CompactionSummary.Tokens)
+	assert.Equal(t, 1, b.Messages.Items)
+}
+
+// TestContextBreakdown_UserMessageLooksLikeSummary pins the exact-match
+// classification: a user message that merely starts with the summary prefix
+// must stay in the conversation bucket.
+func TestContextBreakdown_UserMessageLooksLikeSummary(t *testing.T) {
+	t.Parallel()
+
+	rt := newBreakdownRuntime(t)
+	sess := session.New(session.WithUserMessage("Session Summary: not actually one"))
+
+	b, err := rt.ContextBreakdown(t.Context(), sess)
+	require.NoError(t, err)
+
+	assert.Zero(t, b.CompactionSummary.Items)
+	assert.Equal(t, 1, b.Messages.Items)
+}
+
+func TestContextBreakdown_ReportedUsageWins(t *testing.T) {
+	t.Parallel()
+
+	rt := newBreakdownRuntime(t)
+
+	sess := session.New(session.WithUserMessage("hi"))
+	sess.AddMessage(&session.Message{Message: chat.Message{
+		Role:    chat.MessageRoleAssistant,
+		Content: "hello there",
+		Usage:   &chat.Usage{InputTokens: 10, OutputTokens: 42},
+	}})
+
+	b, err := rt.ContextBreakdown(t.Context(), sess)
+	require.NoError(t, err)
+
+	// The assistant turn carries provider-reported usage, so its estimate is
+	// the reported output count (plus the per-message overhead), not the
+	// chars-per-token heuristic. The user turn stays heuristic.
+	userTokens := compaction.EstimateMessageTokens(&chat.Message{Role: chat.MessageRoleUser, Content: "hi"})
+	assistantTokens := compaction.EstimateMessageTokens(&chat.Message{
+		Role: chat.MessageRoleAssistant, Content: "hello there",
+		Usage: &chat.Usage{InputTokens: 10, OutputTokens: 42},
+	})
+	assert.Equal(t, userTokens+assistantTokens, b.Messages.Tokens)
+	assert.Equal(t, 2, b.Messages.Items)
+}
+
+func TestContextBreakdown_UnknownContextLimit(t *testing.T) {
+	t.Parallel()
+
+	root := agent.New("root", "You are a test agent",
+		agent.WithModel(&mockProvider{id: "test/mock-model"}))
+	tm := team.New(team.WithAgents(root))
+	rt, err := NewLocalRuntime(t.Context(), tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStore{}), // no catalogue entry
+	)
+	require.NoError(t, err)
+
+	b, err := rt.ContextBreakdown(t.Context(), session.New(session.WithUserMessage("hi")))
+	require.NoError(t, err)
+	assert.Zero(t, b.ContextLimit)
+	assert.Positive(t, b.TotalTokens())
+}
+
+func TestContextBreakdown_NilSession(t *testing.T) {
+	t.Parallel()
+
+	rt := newBreakdownRuntime(t)
+	_, err := rt.ContextBreakdown(t.Context(), nil)
+	require.Error(t, err)
+}
+
+func TestContextBreakdown_NoPromptFiles(t *testing.T) {
+	t.Parallel()
+
+	rt := newBreakdownRuntime(t)
+	rt.workingDir = t.TempDir()
+
+	b, err := rt.ContextBreakdown(t.Context(), session.New(session.WithUserMessage("hi")))
+	require.NoError(t, err)
+	assert.Zero(t, b.PromptFiles.Items)
+	assert.Zero(t, b.PromptFiles.Tokens)
+}
+
+func TestEstimateToolDefinitionTokens(t *testing.T) {
+	t.Parallel()
+
+	withSchema := estimateToolDefinitionTokens(&tools.Tool{
+		Name:        "shell",
+		Description: "Run a shell command",
+		Parameters:  map[string]any{"type": "object", "properties": map[string]any{"cmd": map[string]any{"type": "string"}}},
+	})
+	withoutSchema := estimateToolDefinitionTokens(&tools.Tool{Name: "noop"})
+
+	assert.Positive(t, withoutSchema)
+	assert.Greater(t, withSchema, withoutSchema, "the parameters schema must contribute to the estimate")
+}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1123,6 +1123,32 @@ func buildInvariantSystemMessages(a *agent.Agent) []chat.Message {
 	return messages
 }
 
+// summaryMessagePrefix prefixes the synthetic user message that carries a
+// compaction summary into the prompt. Shared by buildSessionSummaryMessages
+// and CompactionInput; exposed to callers via SummaryMessageContent.
+const summaryMessagePrefix = "Session Summary: "
+
+// SummaryMessageContent returns the content of the synthetic user message
+// that GetMessages emits to carry a compaction summary into the prompt.
+// Callers that need to recognize that message in GetMessages output (e.g.
+// the runtime's context-window breakdown) match against this exact string
+// instead of duplicating the prefix.
+func SummaryMessageContent(summary string) string {
+	return summaryMessagePrefix + summary
+}
+
+// LastSummary returns the most recent compaction summary stored in the
+// session history, or "" when the session has never been compacted.
+func (s *Session) LastSummary() string {
+	items := s.snapshotItems()
+	for i := range slices.Backward(items) {
+		if items[i].Summary != "" {
+			return items[i].Summary
+		}
+	}
+	return ""
+}
+
 // buildSessionSummaryMessages builds system messages containing the session summary
 // if one exists. Session summaries are context-specific per session and thus should not have a checkpoint (they will be cached alongside the first user message anyway)
 //
@@ -1146,7 +1172,7 @@ func (s *Session) buildSessionSummaryMessages(items []Item) ([]chat.Message, int
 	if lastSummaryIndex >= 0 && lastSummaryIndex < len(items) {
 		messages = append(messages, chat.Message{
 			Role:      chat.MessageRoleUser,
-			Content:   "Session Summary: " + items[lastSummaryIndex].Summary,
+			Content:   SummaryMessageContent(items[lastSummaryIndex].Summary),
 			CreatedAt: s.now().Format(time.RFC3339),
 		})
 	}
@@ -1211,7 +1237,7 @@ func (s *Session) CompactionInput() ([]chat.Message, []int) {
 	if lastSummaryIndex >= 0 {
 		messages = append(messages, chat.Message{
 			Role:      chat.MessageRoleUser,
-			Content:   "Session Summary: " + items[lastSummaryIndex].Summary,
+			Content:   SummaryMessageContent(items[lastSummaryIndex].Summary),
 			CreatedAt: s.now().Format(time.RFC3339),
 		})
 		// The synthetic message stands in for the prior summary item;

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -175,6 +175,42 @@ func TestGetMessagesWithSummary(t *testing.T) {
 	assert.Equal(t, 3, userAssistantMessages, "should only include messages after summary")
 }
 
+func TestLastSummary(t *testing.T) {
+	t.Parallel()
+
+	s := New()
+	assert.Empty(t, s.LastSummary(), "fresh session has no summary")
+
+	s.AddMessage(NewAgentMessage("", &chat.Message{Role: chat.MessageRoleUser, Content: "hi"}))
+	s.Messages = append(s.Messages, Item{Summary: "first summary"})
+	s.AddMessage(NewAgentMessage("", &chat.Message{Role: chat.MessageRoleUser, Content: "more"}))
+	s.Messages = append(s.Messages, Item{Summary: "second summary"})
+
+	assert.Equal(t, "second summary", s.LastSummary(), "most recent summary wins")
+}
+
+// TestSummaryMessageContentMatchesGetMessages pins the contract consumers
+// (e.g. the runtime context breakdown) rely on: the synthetic summary
+// message in GetMessages output equals SummaryMessageContent(LastSummary()).
+func TestSummaryMessageContentMatchesGetMessages(t *testing.T) {
+	t.Parallel()
+
+	s := New()
+	s.Messages = append(s.Messages, Item{Summary: "what happened before"})
+
+	messages := s.GetMessages(&agent.Agent{})
+	require.NotEmpty(t, messages)
+
+	want := SummaryMessageContent(s.LastSummary())
+	found := false
+	for _, msg := range messages {
+		if msg.Role == chat.MessageRoleUser && msg.Content == want {
+			found = true
+		}
+	}
+	assert.True(t, found, "GetMessages output must contain the exact SummaryMessageContent string")
+}
+
 func TestGetMessages_Instructions(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -118,6 +118,17 @@ func builtInSessionCommands() []Item {
 			},
 		},
 		{
+			ID:           "session.context",
+			Label:        "Context",
+			SlashCommand: "/context",
+			Description:  "Show what is consuming the context window, by category",
+			Category:     "Session",
+			Immediate:    true,
+			Execute: func(string) tea.Cmd {
+				return core.CmdHandler(messages.ShowContextDialogMsg{})
+			},
+		},
+		{
 			ID:           "session.cost",
 			Label:        "Cost",
 			SlashCommand: "/cost",

--- a/pkg/tui/commands/commands_test.go
+++ b/pkg/tui/commands/commands_test.go
@@ -125,6 +125,15 @@ func TestParseSlashCommand_OtherCommands(t *testing.T) {
 		assert.True(t, ok)
 	})
 
+	t.Run("context command", func(t *testing.T) {
+		t.Parallel()
+		cmd := parser.Parse("/context")
+		require.NotNil(t, cmd)
+		msg := cmd()
+		_, ok := msg.(messages.ShowContextDialogMsg)
+		assert.True(t, ok)
+	})
+
 	t.Run("effort command with level", func(t *testing.T) {
 		t.Parallel()
 		cmd := parser.Parse("/effort high")

--- a/pkg/tui/dialog/context.go
+++ b/pkg/tui/dialog/context.go
@@ -1,0 +1,377 @@
+package dialog
+
+import (
+	"fmt"
+	"image/color"
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/atotto/clipboard"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/tui/components/notification"
+	"github.com/docker/docker-agent/pkg/tui/components/scrollview"
+	"github.com/docker/docker-agent/pkg/tui/core"
+	"github.com/docker/docker-agent/pkg/tui/core/layout"
+	"github.com/docker/docker-agent/pkg/tui/styles"
+)
+
+// ---------------------------------------------------------------------------
+// contextDialog – TUI dialog displaying the context-window composition
+// ---------------------------------------------------------------------------
+
+type contextDialog struct {
+	BaseDialog
+
+	breakdown  *runtime.ContextBreakdown
+	keyMap     contextDialogKeyMap
+	scrollview *scrollview.Model
+}
+
+type contextDialogKeyMap struct {
+	Close, Copy key.Binding
+}
+
+// NewContextDialog creates the /context dialog showing the estimated
+// context-window composition by category.
+func NewContextDialog(breakdown *runtime.ContextBreakdown) Dialog {
+	if breakdown == nil {
+		breakdown = &runtime.ContextBreakdown{}
+	}
+	return &contextDialog{
+		breakdown: breakdown,
+		scrollview: scrollview.New(
+			scrollview.WithKeyMap(scrollview.ReadOnlyScrollKeyMap()),
+			scrollview.WithReserveScrollbarSpace(true),
+		),
+		keyMap: contextDialogKeyMap{
+			Close: key.NewBinding(key.WithKeys("esc", "enter", "q"), key.WithHelp("Esc", "close")),
+			Copy:  key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "copy")),
+		},
+	}
+}
+
+func (d *contextDialog) Init() tea.Cmd { return nil }
+
+func (d *contextDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
+	if handled, cmd := d.scrollview.Update(msg); handled {
+		return d, cmd
+	}
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		cmd := d.SetSize(msg.Width, msg.Height)
+		return d, cmd
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, d.keyMap.Close):
+			return d, core.CmdHandler(CloseDialogMsg{})
+		case key.Matches(msg, d.keyMap.Copy):
+			_ = clipboard.WriteAll(d.renderPlainText())
+			return d, notification.SuccessCmd("Context breakdown copied to clipboard.")
+		}
+	}
+	return d, nil
+}
+
+func (d *contextDialog) dialogSize() (dialogWidth, maxHeight, contentWidth int) {
+	dialogWidth = d.ComputeDialogWidth(70, 50, 100)
+	maxHeight = min(d.Height()*70/100, 30)
+	contentWidth = d.ContentWidth(dialogWidth, 2) - d.scrollview.ReservedCols()
+	return dialogWidth, maxHeight, contentWidth
+}
+
+func (d *contextDialog) Position() (row, col int) {
+	dialogWidth, maxHeight, _ := d.dialogSize()
+	return CenterPosition(d.Width(), d.Height(), dialogWidth, maxHeight)
+}
+
+func (d *contextDialog) View() string {
+	dialogWidth, maxHeight, contentWidth := d.dialogSize()
+	content := d.renderContent(contentWidth, maxHeight)
+	return styles.DialogStyle.Padding(1, 2).Width(dialogWidth).Render(content)
+}
+
+// ---------------------------------------------------------------------------
+// Row model – one renderable category
+// ---------------------------------------------------------------------------
+
+// contextRow is one line of the breakdown: a category (or the free-space
+// remainder) with its estimated token count and item count.
+type contextRow struct {
+	label  string
+	tokens int64
+	items  int
+	noun   string // singular item noun ("message", "tool", "file", "result")
+	free   bool   // true for the free-space remainder row
+}
+
+// contextRows flattens the breakdown into display order. Categories are
+// always listed (zero values included) so users see every bucket the
+// runtime accounts for; the free-space row is appended only when the
+// context limit is known and not already exceeded by the estimate.
+func contextRows(b *runtime.ContextBreakdown) []contextRow {
+	rows := []contextRow{
+		{label: "System prompt", tokens: b.SystemPrompt.Tokens, items: b.SystemPrompt.Items, noun: "message"},
+		{label: "Tool definitions", tokens: b.ToolDefinitions.Tokens, items: b.ToolDefinitions.Items, noun: "tool"},
+		{label: "Prompt files", tokens: b.PromptFiles.Tokens, items: b.PromptFiles.Items, noun: "file"},
+		{label: "Messages", tokens: b.Messages.Tokens, items: b.Messages.Items, noun: "message"},
+		{label: "Tool results", tokens: b.ToolResults.Tokens, items: b.ToolResults.Items, noun: "result"},
+		{label: "Compaction summary", tokens: b.CompactionSummary.Tokens, items: b.CompactionSummary.Items, noun: "summary"},
+	}
+	if free := b.ContextLimit - b.TotalTokens(); b.ContextLimit > 0 && free > 0 {
+		rows = append(rows, contextRow{label: "Free space", tokens: free, free: true})
+	}
+	return rows
+}
+
+// itemsSuffix returns the parenthesized item count, e.g. "(12 messages)".
+func (r *contextRow) itemsSuffix() string {
+	if r.free || r.items == 0 {
+		return ""
+	}
+	noun := r.noun
+	if r.items > 1 {
+		noun += "s"
+	}
+	return fmt.Sprintf("(%d %s)", r.items, noun)
+}
+
+// scaleTokens returns the denominator percentages and the usage bar are
+// computed against: the context limit when known, otherwise the estimated
+// total (the bar then shows relative composition instead of fill level).
+func scaleTokens(b *runtime.ContextBreakdown) int64 {
+	if b.ContextLimit > 0 {
+		return max(b.ContextLimit, b.TotalTokens())
+	}
+	return b.TotalTokens()
+}
+
+// percentLabel formats tokens as a percentage of scale: "<1%" for tiny
+// non-zero slices, "-" for empty ones.
+func percentLabel(tokens, scale int64) string {
+	if tokens <= 0 || scale <= 0 {
+		return "-"
+	}
+	pct := float64(tokens) / float64(scale) * 100
+	if pct < 1 {
+		return "<1%"
+	}
+	return fmt.Sprintf("%.0f%%", pct)
+}
+
+// ---------------------------------------------------------------------------
+// Styled rendering (TUI view)
+// ---------------------------------------------------------------------------
+
+// contextBarGlyphs are the block glyphs of the stacked usage bar.
+const (
+	contextBarFilled = "█"
+	contextBarFree   = "░"
+	contextRowMarker = "■"
+)
+
+// contextEstimateNote labels every figure in the dialog as an estimate, as
+// the counts come from a heuristic rather than the provider's tokenizer.
+const contextEstimateNote = "Token counts are estimates; the provider's tokenizer may count differently."
+
+// categoryColors returns the per-category accent colors, aligned with the
+// order of contextRows. Hues are used categorically (Error's rose tint
+// carries no alarm semantics here); each maps to a distinct color in the
+// bundled themes. A function (not a var) so it picks up theme changes.
+func categoryColors() []color.Color {
+	return []color.Color{
+		styles.MobyBlue,    // system prompt
+		styles.Info,        // tool definitions
+		styles.BadgePurple, // prompt files
+		styles.Success,     // messages
+		styles.Warning,     // tool results
+		styles.Error,       // compaction summary
+	}
+}
+
+func (d *contextDialog) renderContent(contentWidth, maxHeight int) string {
+	b := d.breakdown
+	rows := contextRows(b)
+	scale := scaleTokens(b)
+
+	header := RenderTitle("Context Window", contentWidth, styles.DialogTitleStyle)
+	if meta := contextHeaderMeta(b); meta != "" {
+		header += "\n" + styles.DialogOptionsStyle.Width(contentWidth).Render(meta)
+	}
+
+	lines := []string{
+		header,
+		RenderSeparator(contentWidth),
+		"",
+		renderContextBar(rows, scale, contentWidth),
+		styles.MutedStyle.Render(usageSummary(b)),
+		"",
+	}
+
+	labelWidth := contextLabelWidth(rows)
+	colors := categoryColors()
+	for i, row := range rows {
+		lines = append(lines, renderContextRow(&row, scale, labelWidth, markerColor(i, row, colors)))
+	}
+
+	lines = append(lines, "")
+	lines = append(lines, wrapMutedLines(contextEstimateNote, contentWidth)...)
+
+	return d.applyScrolling(lines, contentWidth, maxHeight)
+}
+
+// wrapMutedLines wraps text to width in the muted style and returns the
+// individual lines, so the scrollview's line accounting stays exact.
+func wrapMutedLines(text string, width int) []string {
+	return strings.Split(styles.MutedStyle.Width(width).Render(text), "\n")
+}
+
+// markerColor picks the row's accent color: its category color, or muted
+// for the free-space remainder.
+func markerColor(i int, row contextRow, colors []color.Color) color.Color {
+	if row.free || i >= len(colors) {
+		return styles.TextMutedGray
+	}
+	return colors[i]
+}
+
+// contextHeaderMeta returns the "model • limit" line under the title.
+func contextHeaderMeta(b *runtime.ContextBreakdown) string {
+	var parts []string
+	if b.Model != "" {
+		parts = append(parts, b.Model)
+	}
+	if b.ContextLimit > 0 {
+		parts = append(parts, "limit: "+formatTokenCount(b.ContextLimit)+" tokens")
+	} else {
+		parts = append(parts, "context limit unknown")
+	}
+	return strings.Join(parts, "  •  ")
+}
+
+// usageSummary is the line under the bar: "~24.5K of 128.0K tokens (19%)",
+// or just the estimated total when the limit is unknown.
+func usageSummary(b *runtime.ContextBreakdown) string {
+	total := b.TotalTokens()
+	if b.ContextLimit <= 0 {
+		return "~" + formatTokenCount(total) + " tokens estimated"
+	}
+	return fmt.Sprintf("~%s of %s tokens (%s)",
+		formatTokenCount(total),
+		formatTokenCount(b.ContextLimit),
+		percentLabel(total, scaleTokens(b)))
+}
+
+// renderContextBar renders the stacked usage bar: one colored segment per
+// category, proportional to its share of scale, with the remainder drawn
+// as muted free-space cells. Cumulative rounding keeps the bar exactly
+// barWidth cells wide with no drift.
+func renderContextBar(rows []contextRow, scale int64, barWidth int) string {
+	if barWidth < 1 || scale <= 0 {
+		return ""
+	}
+	colors := categoryColors()
+	var bar strings.Builder
+	cells := 0
+	var cum int64
+	for i, row := range rows {
+		if row.free {
+			continue
+		}
+		cum += row.tokens
+		end := int(float64(cum) / float64(scale) * float64(barWidth))
+		if n := min(end, barWidth) - cells; n > 0 {
+			bar.WriteString(lipgloss.NewStyle().
+				Foreground(markerColor(i, row, colors)).
+				Render(strings.Repeat(contextBarFilled, n)))
+			cells += n
+		}
+	}
+	if n := barWidth - cells; n > 0 {
+		bar.WriteString(styles.MutedStyle.Render(strings.Repeat(contextBarFree, n)))
+	}
+	return bar.String()
+}
+
+// contextLabelWidth returns the widest row label, so token columns align.
+func contextLabelWidth(rows []contextRow) int {
+	width := 0
+	for _, row := range rows {
+		width = max(width, len(row.label))
+	}
+	return width
+}
+
+// renderContextRow renders one category line:
+// "■ Tool definitions   8.4K   7%  (23 tools)".
+func renderContextRow(row *contextRow, scale int64, labelWidth int, markerCol color.Color) string {
+	marker := lipgloss.NewStyle().Foreground(markerCol).Render(contextRowMarker)
+	label := row.label + strings.Repeat(" ", labelWidth-len(row.label))
+	if row.free {
+		label = styles.MutedStyle.Render(label)
+	} else {
+		label = labelStyle().Render(label)
+	}
+	line := fmt.Sprintf("%s %s  %s  %s",
+		marker,
+		label,
+		valueStyle().Render(padRight(formatTokenCount(row.tokens))),
+		valueStyle().Render(fmt.Sprintf("%4s", percentLabel(row.tokens, scale))))
+	if suffix := row.itemsSuffix(); suffix != "" {
+		line += "  " + styles.MutedStyle.Render(suffix)
+	}
+	return line
+}
+
+func (d *contextDialog) applyScrolling(allLines []string, contentWidth, maxHeight int) string {
+	const headerLines = 3 // title + separator + space
+	const footerLines = 2 // space + help
+
+	visibleLines := max(1, maxHeight-headerLines-footerLines-4)
+	contentLines := allLines[headerLines:]
+
+	regionWidth := contentWidth + d.scrollview.ReservedCols()
+	d.scrollview.SetSize(regionWidth, visibleLines)
+
+	dialogRow, dialogCol := d.Position()
+	d.scrollview.SetPosition(dialogCol+3, dialogRow+2+headerLines)
+	d.scrollview.SetContent(contentLines, len(contentLines))
+
+	parts := make([]string, 0, headerLines+3)
+	parts = append(parts, allLines[:headerLines]...)
+	parts = append(parts, d.scrollview.View(), "", RenderHelpKeys(regionWidth, "↑↓", "scroll", "c", "copy", "Esc", "close"))
+	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+}
+
+// ---------------------------------------------------------------------------
+// Plain-text rendering (clipboard copy)
+// ---------------------------------------------------------------------------
+
+func (d *contextDialog) renderPlainText() string {
+	b := d.breakdown
+	rows := contextRows(b)
+	scale := scaleTokens(b)
+	labelWidth := contextLabelWidth(rows)
+
+	lines := []string{"Context Window"}
+	if meta := contextHeaderMeta(b); meta != "" {
+		lines = append(lines, meta)
+	}
+	lines = append(lines, "", usageSummary(b), "")
+
+	for _, row := range rows {
+		line := fmt.Sprintf("%s  %-8s %4s",
+			row.label+strings.Repeat(" ", labelWidth-len(row.label)),
+			formatTokenCount(row.tokens),
+			percentLabel(row.tokens, scale))
+		if suffix := row.itemsSuffix(); suffix != "" {
+			line += "  " + suffix
+		}
+		lines = append(lines, line)
+	}
+
+	lines = append(lines, "", contextEstimateNote)
+	return strings.Join(lines, "\n")
+}

--- a/pkg/tui/dialog/context_test.go
+++ b/pkg/tui/dialog/context_test.go
@@ -1,0 +1,166 @@
+package dialog
+
+import (
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+)
+
+func testBreakdown() *runtime.ContextBreakdown {
+	return &runtime.ContextBreakdown{
+		SystemPrompt:      runtime.ContextCategory{Tokens: 1200, Items: 3},
+		ToolDefinitions:   runtime.ContextCategory{Tokens: 8400, Items: 23},
+		PromptFiles:       runtime.ContextCategory{Tokens: 600, Items: 1},
+		Messages:          runtime.ContextCategory{Tokens: 6100, Items: 12},
+		ToolResults:       runtime.ContextCategory{Tokens: 8200, Items: 18},
+		CompactionSummary: runtime.ContextCategory{Tokens: 900, Items: 1},
+		ContextLimit:      128_000,
+		Model:             "openai/gpt-4o",
+	}
+}
+
+func TestNewContextDialog(t *testing.T) {
+	t.Parallel()
+
+	dialog := NewContextDialog(testBreakdown())
+	require.NotNil(t, dialog)
+}
+
+func TestContextDialogView(t *testing.T) {
+	t.Parallel()
+
+	dialog := NewContextDialog(testBreakdown())
+	dialog.SetSize(100, 50)
+	view := dialog.View()
+
+	assert.Contains(t, view, "Context Window")
+	assert.Contains(t, view, "openai/gpt-4o")
+	assert.Contains(t, view, "limit: 128.0K tokens")
+
+	// Every category is listed, even implicitly small ones.
+	assert.Contains(t, view, "System prompt")
+	assert.Contains(t, view, "Tool definitions")
+	assert.Contains(t, view, "Prompt files")
+	assert.Contains(t, view, "Messages")
+	assert.Contains(t, view, "Tool results")
+	assert.Contains(t, view, "Compaction summary")
+	assert.Contains(t, view, "Free space")
+
+	// Item counts and the estimate disclaimer.
+	assert.Contains(t, view, "(23 tools)")
+	assert.Contains(t, view, "(12 messages)")
+	assert.Contains(t, view, "(1 file)")
+	assert.Contains(t, view, "estimates")
+
+	// Usage summary: 25.4K used of 128K.
+	assert.Contains(t, view, "~25.4K of 128.0K tokens")
+}
+
+func TestContextDialogViewUnknownLimit(t *testing.T) {
+	t.Parallel()
+
+	b := testBreakdown()
+	b.ContextLimit = 0
+	b.Model = "external-harness"
+
+	dialog := NewContextDialog(b)
+	dialog.SetSize(100, 50)
+	view := dialog.View()
+
+	assert.Contains(t, view, "context limit unknown")
+	assert.Contains(t, view, "tokens estimated")
+	assert.NotContains(t, view, "Free space")
+}
+
+func TestContextDialogEmptyBreakdown(t *testing.T) {
+	t.Parallel()
+
+	dialog := NewContextDialog(&runtime.ContextBreakdown{Model: "openai/gpt-4o"})
+	dialog.SetSize(100, 50)
+	view := dialog.View()
+
+	assert.Contains(t, view, "Context Window")
+	assert.Contains(t, view, "System prompt")
+}
+
+func TestContextRowsFreeSpace(t *testing.T) {
+	t.Parallel()
+
+	rows := contextRows(testBreakdown())
+	require.Len(t, rows, 7)
+	last := rows[len(rows)-1]
+	assert.True(t, last.free)
+	// 128000 - 25400 estimated tokens used.
+	assert.Equal(t, int64(102_600), last.tokens)
+
+	// An over-budget estimate must not produce a negative free-space row.
+	over := testBreakdown()
+	over.Messages.Tokens = 500_000
+	rows = contextRows(over)
+	require.Len(t, rows, 6)
+	for _, row := range rows {
+		assert.False(t, row.free)
+	}
+}
+
+func TestContextPercentLabel(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "-", percentLabel(0, 1000))
+	assert.Equal(t, "-", percentLabel(10, 0))
+	assert.Equal(t, "<1%", percentLabel(1, 1000))
+	assert.Equal(t, "5%", percentLabel(50, 1000))
+	assert.Equal(t, "100%", percentLabel(1000, 1000))
+}
+
+func TestContextScaleTokens(t *testing.T) {
+	t.Parallel()
+
+	b := testBreakdown()
+	assert.Equal(t, int64(128_000), scaleTokens(b))
+
+	// Estimate exceeding the limit scales against the estimate so the bar
+	// and percentages stay consistent (never above 100%).
+	b.Messages.Tokens = 500_000
+	assert.Equal(t, b.TotalTokens(), scaleTokens(b))
+
+	// Unknown limit scales against the estimated total.
+	b = testBreakdown()
+	b.ContextLimit = 0
+	assert.Equal(t, b.TotalTokens(), scaleTokens(b))
+}
+
+func TestRenderContextBarWidth(t *testing.T) {
+	t.Parallel()
+
+	b := testBreakdown()
+	rows := contextRows(b)
+
+	for _, width := range []int{1, 10, 40, 80, 200} {
+		bar := renderContextBar(rows, scaleTokens(b), width)
+		assert.Equal(t, width, lipgloss.Width(bar), "bar must span exactly %d cells", width)
+	}
+
+	assert.Empty(t, renderContextBar(rows, 0, 40), "zero scale renders no bar")
+	assert.Empty(t, renderContextBar(rows, scaleTokens(b), 0), "zero width renders no bar")
+}
+
+func TestContextDialogPlainText(t *testing.T) {
+	t.Parallel()
+
+	d := &contextDialog{breakdown: testBreakdown()}
+	text := d.renderPlainText()
+
+	assert.Contains(t, text, "Context Window")
+	assert.Contains(t, text, "openai/gpt-4o")
+	assert.Contains(t, text, "Tool definitions")
+	assert.Contains(t, text, "8.4K")
+	assert.Contains(t, text, "(23 tools)")
+	assert.Contains(t, text, "Free space")
+	assert.Contains(t, text, "estimates")
+	assert.NotContains(t, text, "\x1b[", "plain text must carry no ANSI escapes")
+}

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -447,6 +447,32 @@ func (m *appModel) handleShowCostDialog() (tea.Model, tea.Cmd) {
 	})
 }
 
+// handleShowContextDialog computes the context breakdown in a tea.Cmd
+// goroutine: the computation lists the agent's tools, which may start
+// not-yet-started toolsets (e.g. MCP servers) and block for a while, so it
+// must not run inside the Update loop. The dialog opens when the data is
+// ready.
+func (m *appModel) handleShowContextDialog() (tea.Model, tea.Cmd) {
+	appRef := m.application
+	ctx := m.ctx()
+	return m, func() tea.Msg {
+		breakdown, err := appRef.ContextBreakdown(ctx)
+		switch {
+		case errors.Is(err, runtime.ErrUnsupported):
+			return notification.ShowMsg{
+				Text: "Context breakdown is not supported with remote runtimes",
+				Type: notification.TypeInfo,
+			}
+		case err != nil:
+			return notification.ShowMsg{
+				Text: fmt.Sprintf("Failed to compute context breakdown: %v", err),
+				Type: notification.TypeError,
+			}
+		}
+		return dialog.OpenDialogMsg{Model: dialog.NewContextDialog(breakdown)}
+	}
+}
+
 func (m *appModel) handleShowPermissionsDialog() (tea.Model, tea.Cmd) {
 	perms := m.application.PermissionsInfo()
 	sess := m.application.Session()

--- a/pkg/tui/messages/toggle.go
+++ b/pkg/tui/messages/toggle.go
@@ -24,6 +24,11 @@ type (
 	// ShowCostDialogMsg shows the cost/usage dialog.
 	ShowCostDialogMsg struct{}
 
+	// ShowContextDialogMsg shows the context-window breakdown dialog:
+	// estimated tokens per category (system prompt, tool definitions,
+	// prompt files, messages, tool results, compaction summary).
+	ShowContextDialogMsg struct{}
+
 	// ShowPermissionsDialogMsg shows the permissions dialog.
 	ShowPermissionsDialogMsg struct{}
 

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1083,6 +1083,9 @@ func (m *appModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case messages.ShowCostDialogMsg:
 		return m.handleShowCostDialog()
 
+	case messages.ShowContextDialogMsg:
+		return m.handleShowContextDialog()
+
 	case messages.ShowPermissionsDialogMsg:
 		return m.handleShowPermissionsDialog()
 


### PR DESCRIPTION
Closes #3432

## Summary

Adds a `/context` slash command that opens a dialog (consistent with the existing `/cost` dialog) showing the estimated context-window composition, broken down by category, with a stacked usage bar, per-category rows, free space, and a copy-to-clipboard action.

```
╭─────────────────────────────────────────────────────────────╮
│                      Context Window                         │
│          openai/gpt-4o  •  limit: 128.0K tokens             │
│  ───────────────────────────────────────────────────────    │
│                                                             │
│  ███████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░    │
│  ~45.4K of 128.0K tokens (35%)                              │
│                                                             │
│  ■ System prompt       1.2K       <1%  (3 messages)         │
│  ■ Tool definitions    8.4K        7%  (23 tools)           │
│  ■ Prompt files        600        <1%  (1 file)             │
│  ■ Messages            6.1K        5%  (12 messages)        │
│  ■ Tool results        28.2K      22%  (18 results)         │
│  ■ Compaction summary  900        <1%  (1 summary)          │
│  ■ Free space          82.6K      65%                       │
│                                                             │
│  Token counts are estimates; the provider's tokenizer       │
│  may count differently.                                     │
│                                                             │
│                ↑↓ scroll  c copy  Esc close                 │
╰─────────────────────────────────────────────────────────────╯
```

Bar segments and row markers use per-category theme colors; the free space remainder is muted.

## Issue expectations

| Expectation | Implementation |
| --- | --- |
| `/context` command | `pkg/tui/commands/commands.go` (`session.context`): palette, slash parser, completion; compatible with `--disable-commands` |
| New message type | `messages.ShowContextDialogMsg` in `pkg/tui/messages/toggle.go`, next to the sibling `Show*DialogMsg` types (the issue sketched `session.go`; `toggle.go` is where the existing dialog messages live) |
| New dialog | `pkg/tui/dialog/context.go`, modeled on `cost.go`: scrollview, `c` copies a plain-text version, `Esc`/`Enter`/`q` closes |
| Breakdown computed in `pkg/runtime` from `Session.GetMessages` | `pkg/runtime/context_breakdown.go`: `ContextBreakdown`/`ContextCategory` types, `(*LocalRuntime).ContextBreakdown(ctx, sess)` |
| Categories | system prompt, tool definitions, prompt files, conversation messages, tool results, compaction summary |
| Estimates via `compaction.EstimateMessageTokens`, labeled as such | usage-calibrated `compaction.NewSliceEstimator` (same estimator the proactive compaction trigger uses); explicit disclaimer line in the dialog |
| % of the resolved context limit | resolved via `contextLimitForAgentModel` (same source as the sidebar gauge, including compaction-model capping); "context limit unknown" fallback for harness agents and uncatalogued models |
| Bar/grid rendering | stacked color bar (cumulative rounding keeps it exactly content-width) plus aligned per-category rows with tokens, percent, and item counts |
| Reuse `toolcommon/tokencount.go` | via the shared `FormatTokenCount` helper |

## Flow

```
/context → ShowContextDialogMsg → handleShowContextDialog (tea.Cmd goroutine)
  → App.ContextBreakdown → LocalRuntime.ContextBreakdown
      ├─ sess.GetMessages(agent) → categorize by role / exact summary match
      ├─ agent.Tools(ctx)        → tool schema (name+description+parameters) estimates
      └─ promptfiles lookup      → add_prompt_files content estimate
  → OpenDialogMsg{NewContextDialog(breakdown)}
```

## Design decisions

- Pull, not push: the issue said to "consider a `ContextBreakdownEvent`". An on-demand method was implemented instead: the data is fresh at dialog-open time and there is a single consumer today. #3438 can call `LocalRuntime.ContextBreakdown` directly; an event can be layered on later if #3439 needs one.
- Optional capability interface in `pkg/app` (same pattern as `agentConfigProvider`): remote runtimes show an info toast ("Context breakdown is not supported with remote runtimes").
- Async computation in a `tea.Cmd` goroutine (unlike `/tools`, which blocks the Update loop) because tool listing may lazily start MCP toolsets.
- Exact summary matching: new `session.SummaryMessageContent()` and `Session.LastSummary()` helpers classify the summary message by exact content, so a user message that merely starts with "Session Summary: " stays in the conversation bucket (pinned by a test). The two former string literals in `session.go` now share the same helper.
- Degraded modes: tool-listing failures and unreadable prompt files are logged and skipped instead of failing the dialog; a nil breakdown is guarded in the dialog constructor.

## Testing

| Area | Coverage |
| --- | --- |
| `pkg/runtime` (8 tests) | categorization and item counts, compaction summary bucket, summary look-alike guard, reported-usage precedence, unknown context limit, nil session, no prompt files, tool definition estimator |
| `pkg/tui/dialog` (9 tests) | view rendering, unknown limit, empty breakdown, free-space clamping (never negative), percent labels, scale selection, bar width invariants across widths, ANSI-free plain-text copy |
| `pkg/session` | `LastSummary`, `SummaryMessageContent`/`GetMessages` exact-content contract |
| `pkg/tui/commands` | `/context` parse test |

`go build ./...`, `golangci-lint run ./...` (0 issues), `go run ./lint .` (no offenses), full test suite green except pre-existing environment-dependent SSRF/network tests that also fail on a clean checkout of `main`.
