### PR TITLE
fix: box lean TUI tool calls

### DIFF
--- a/pkg/leantui/style.go
+++ b/pkg/leantui/style.go
@@ -22,6 +22,21 @@ func stReasoning() lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(styles.TextMutedGray).Italic(true)
 }
 
+func stToolBox(width int) lipgloss.Style {
+	if width < 1 {
+		width = 1
+	}
+	horizontalPadding := 1
+	if width < 4 {
+		horizontalPadding = 0
+	}
+	return lipgloss.NewStyle().
+		Foreground(styles.TextMutedGray).
+		Background(styles.BackgroundAlt).
+		Padding(1, horizontalPadding).
+		Width(width)
+}
+
 const (
 	promptText   = "❯ "
 	promptWidth  = 2

--- a/pkg/leantui/tool.go
+++ b/pkg/leantui/tool.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/animation"
 	toolcomponent "github.com/docker/docker-agent/pkg/tui/components/tool"
 	"github.com/docker/docker-agent/pkg/tui/service"
+	"github.com/docker/docker-agent/pkg/tui/styles"
 	tuitypes "github.com/docker/docker-agent/pkg/tui/types"
 )
 
@@ -56,14 +57,17 @@ func renderToolWithState(t *toolView, width, frame int, sessionState service.Ses
 		sessionState = service.StaticSessionState{}
 	}
 
+	boxStyle := stToolBox(width)
+	innerWidth := max(width-boxStyle.GetHorizontalFrameSize(), 1)
+
 	view := toolcomponent.New(t.message, sessionState)
-	view.SetSize(width, 0)
+	view.SetSize(innerWidth, 0)
 	if t.message.ToolStatus == tuitypes.ToolStatusPending || t.message.ToolStatus == tuitypes.ToolStatusRunning {
 		view, _ = view.Update(animation.TickMsg{Frame: frame})
 		defer animation.StopView(view)
 	}
 
-	lines := splitRenderedTool(view.View(), width)
+	lines := splitRenderedTool(renderToolBox(view.View(), width), width)
 	for _, img := range t.images {
 		lines = append(lines, renderInlineImage(img, width)...)
 	}
@@ -79,6 +83,14 @@ func renderToolWithState(t *toolView, width, frame int, sessionState service.Ses
 		t.lastWidth = 0
 	}
 	return lines
+}
+
+func renderToolBox(content string, width int) string {
+	content = strings.TrimRight(content, "\n")
+	if content == "" {
+		return ""
+	}
+	return styles.RenderComposite(stToolBox(width), content)
 }
 
 func (t *toolView) shouldKeepLastPendingLines(width int, lines []string) bool {

--- a/pkg/leantui/tool_test.go
+++ b/pkg/leantui/tool_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -33,6 +34,21 @@ func TestRenderToolUsesFullTUIRenderer(t *testing.T) {
 	assert.Contains(t, joined, "echo hi")
 	assert.Contains(t, joined, "hi")
 	assert.NotContains(t, joined, "Took")
+}
+
+func TestRenderToolWrapsCallInBox(t *testing.T) {
+	t.Parallel()
+	width := 40
+	lines := renderTool(*shellToolView(tuitypes.ToolStatusCompleted), width)
+	require.GreaterOrEqual(t, len(lines), 3)
+
+	for _, line := range lines {
+		assert.LessOrEqual(t, displayWidth(line), width)
+	}
+	assert.Empty(t, strings.TrimSpace(ansi.Strip(lines[0])))
+	assert.Equal(t, width, displayWidth(lines[0]))
+	assert.True(t, strings.HasPrefix(ansi.Strip(lines[1]), " "))
+	assert.Contains(t, ansi.Strip(strings.Join(lines, "\n")), builtinshell.ToolNameShell)
 }
 
 func TestRenderToolDoesNotLeakAnimationSubscription(t *testing.T) {


### PR DESCRIPTION
## Summary
- wrap lean TUI tool call rendering in a padded themed box
- shrink delegated tool renderer width so boxed content stays within the terminal width
- add lean TUI coverage for boxed tool rendering

## Tests
- go test ./pkg/leantui
- task lint
- task --force build
- env -u DEEPSEEK_API_KEY -u CEREBRAS_API_KEY -u FIREWORKS_API_KEY -u TOGETHER_API_KEY -u HF_TOKEN -u MOONSHOT_API_KEY -u AI_GATEWAY_API_KEY -u CLOUDFLARE_API_TOKEN task test