### PR TITLE
feat: add shell background job recall

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -2182,6 +2182,10 @@
           "type": "boolean",
           "description": "Opt in to a sudo privilege escalation flow for the shell toolset (only valid for type 'shell'). When enabled, sudo commands prompt the user for their password through the host UI via SUDO_ASKPASS; in non-interactive runs the prompt is declined automatically. Only a bare 'sudo ...' invocation in a POSIX shell is handled. No effect on Windows. Default false."
         },
+        "recall": {
+          "type": "boolean",
+          "description": "Opt in to background-job recall for the shell toolset (only valid for type 'shell'). When enabled, run_background_job exposes a recall boolean parameter. If the agent sets recall=true for a background job, the runtime injects a steering message with a short completion sentence and the job output when the job finishes. Default false."
+        },
         "safer": {
           "type": "boolean",
           "description": "Opt in to destructive-command detection for the shell toolset (only valid for type 'shell'). When enabled, the agent auto-registers the safer_shell builtin under the pre_tool_use hook event with preempt_yolo:true. Destructive commands (rm -rf, docker volume rm, mkfs, ...) get an Ask verdict with a blast-radius classification; known-safe reads (ls, git status, docker ps, ...) flow through silently; everything else asks with blast_radius=unknown so the user sees the prompt before --yolo or permission allow-rules can auto-approve it. Default false."

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -454,7 +454,7 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 		return f.handleExecMode(ctx, out, rt, sess, args)
 	}
 
-	listenOpt, err := f.startAttachedServer(ctx, out, rt, sess)
+	coordinatorOpt, err := f.startSessionCoordinator(ctx, out, rt, sess)
 	if err != nil {
 		return err
 	}
@@ -464,8 +464,8 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 	if err != nil {
 		return err
 	}
-	if listenOpt != nil {
-		opts = append(opts, listenOpt)
+	if coordinatorOpt != nil {
+		opts = append(opts, coordinatorOpt)
 	}
 
 	eventHooks, err := parseOnEventFlags(f.onEventSpecs)
@@ -1088,6 +1088,9 @@ func (f *runExecFlags) createSessionSpawner(agentSource config.Source, sessStore
 		}
 		if ctrl != nil {
 			appOpts = append(appOpts, app.WithSnapshotController(ctrl))
+		}
+		if coordinatorOpt := f.recallCoordinatorOpt(spawnCtx, localRt, newSess); coordinatorOpt != nil {
+			appOpts = append(appOpts, coordinatorOpt)
 		}
 
 		a := app.New(spawnCtx, localRt, newSess, appOpts...)

--- a/cmd/root/run_listen.go
+++ b/cmd/root/run_listen.go
@@ -17,14 +17,25 @@ import (
 	"github.com/docker/docker-agent/pkg/session"
 )
 
-// startAttachedServer exposes the in-process runtime over HTTP so external
-// processes can drive the running TUI (steer, followup, resume, ...). It
-// returns an app.Opt that, once the App is constructed, registers the App's
-// event stream as the session's event source so /events SSE works. No-op
-// when --listen is empty.
-func (f *runExecFlags) startAttachedServer(ctx context.Context, out *cli.Printer, rt runtime.Runtime, sess *session.Session) (app.Opt, error) {
+// recallCoordinatorOpt wires the session manager's recall handler to this
+// in-process runtime even when the HTTP control plane is disabled. That lets a
+// background tool wake an idle local TUI by routing through the same injector
+// used by control-plane follow-ups.
+func (f *runExecFlags) recallCoordinatorOpt(ctx context.Context, rt runtime.Runtime, sess *session.Session) app.Opt {
+	sm := server.NewSessionManager(ctx, nil, rt.SessionStore(), 0, &f.runConfig)
+	sm.AttachRuntime(ctx, sess.ID, rt, sess)
+	return func(a *app.App) {
+		sm.RegisterFollowUpInjector(sess.ID, a.InjectUserMessage)
+	}
+}
+
+// startSessionCoordinator wires local recall delivery for the in-process
+// runtime and, when --listen is set, exposes that runtime over HTTP so
+// external processes can drive the running TUI (steer, followup, resume, ...).
+// It returns an app.Opt that registers the App as the attached session owner.
+func (f *runExecFlags) startSessionCoordinator(ctx context.Context, out *cli.Printer, rt runtime.Runtime, sess *session.Session) (app.Opt, error) {
 	if f.listenAddr == "" {
-		return nil, nil
+		return f.recallCoordinatorOpt(ctx, rt, sess), nil
 	}
 
 	sm := server.NewSessionManager(ctx, nil, rt.SessionStore(), 0, &f.runConfig)
@@ -67,9 +78,8 @@ func (f *runExecFlags) startAttachedServer(ctx context.Context, out *cli.Printer
 				}
 			})
 		})
-		// Route control-plane follow-ups into the TUI App so each starts a
-		// real turn (even when the agent is idle) and streams events to the
-		// TUI and SSE subscribers alike.
+		// Route control-plane follow-ups and idle recalls into the TUI App so
+		// each starts a real turn and streams events to every subscriber.
 		sm.RegisterFollowUpInjector(sess.ID, a.InjectUserMessage)
 	}, nil
 }

--- a/cmd/root/run_listen_test.go
+++ b/cmd/root/run_listen_test.go
@@ -1,0 +1,69 @@
+package root
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/app"
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+	msgtypes "github.com/docker/docker-agent/pkg/tui/messages"
+)
+
+type recallRuntime struct {
+	runtime.Runtime
+
+	store         session.Store
+	recallHandler runtime.RecallHandler
+}
+
+func (r *recallRuntime) SessionStore() session.Store { return r.store }
+
+func (r *recallRuntime) SetRecallHandler(handler runtime.RecallHandler) {
+	r.recallHandler = handler
+}
+
+func TestStartSessionCoordinatorWithoutListenRoutesIdleRecallToApp(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	rt := &recallRuntime{store: store}
+	flags := &runExecFlags{runConfig: config.RuntimeConfig{}}
+	opt, err := flags.startSessionCoordinator(ctx, nil, rt, sess)
+	require.NoError(t, err)
+	require.NotNil(t, opt)
+	require.NotNil(t, rt.recallHandler)
+
+	a := app.New(ctx, rt, sess, opt)
+	events := make(chan tea.Msg, 1)
+	subCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go a.SubscribeWith(subCtx, func(msg tea.Msg) {
+		select {
+		case events <- msg:
+		default:
+		}
+		cancel()
+	})
+
+	require.True(t, rt.recallHandler(ctx, runtime.QueuedMessage{Content: "background job finished"}))
+
+	select {
+	case msg := <-events:
+		sendMsg, ok := msg.(msgtypes.SendMsg)
+		require.True(t, ok, "expected SendMsg, got %T", msg)
+		assert.Equal(t, "background job finished", sendMsg.Content)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for injected recall message")
+	}
+}

--- a/docs/tools/shell/index.md
+++ b/docs/tools/shell/index.md
@@ -27,6 +27,7 @@ toolsets:
 | Property       | Type    | Description                                                                                          |
 | -------------- | ------- | --------------------------------------------------------------------------------------------------- |
 | `env`          | object  | Environment variables to set for all shell commands                                                 |
+| `recall`       | boolean | Let `run_background_job` expose a `recall` parameter so jobs can steer the agent when they finish (see [Background job recall](#background-job-recall)). Default `false`. |
 | `safer`        | boolean | Detect destructive shell commands and force confirmation regardless of `--yolo` or permission rules (see [Safer mode](#safer-mode)). Default `false`. |
 | `sudo_askpass` | boolean | Opt in to prompting for a `sudo` password (see [Sudo support](#sudo-support)). Default `false`.     |
 
@@ -39,6 +40,20 @@ toolsets:
       MY_VAR: "value"
       PATH: "${env.PATH}:/custom/bin"
 ```
+
+### Background job recall
+
+Set `recall: true` to let the `run_background_job` tool expose a `recall` boolean parameter:
+
+```yaml
+toolsets:
+  - type: shell
+    recall: true
+```
+
+When the agent starts a background job with `recall: true`, docker-agent sends a steering message back into the running agent loop after the job finishes. The message contains a short completion sentence and the job output, so the agent can react without polling `view_background_job`.
+
+Use recall for finite background work where completion matters (for example, a long build or test suite). Avoid it for servers and watchers that are expected to run until stopped. See [`examples/shell_recall.yaml`](https://github.com/docker/docker-agent/blob/main/examples/shell_recall.yaml) for a complete configuration.
 
 ### Safer mode
 
@@ -114,8 +129,9 @@ Background job output is captured up to 10 MB per job. All background jobs are a
 
 | Parameter | Type   | Required | Description                                                             |
 | --------- | ------ | -------- | ----------------------------------------------------------------------- |
-| `cmd`     | string | ✓        | The shell command to execute in the background.                         |
-| `cwd`     | string | ✗        | Working directory to run the command in (default: `.`).                 |
+| `cmd`     | string  | ✓        | The shell command to execute in the background.                         |
+| `cwd`     | string  | ✗        | Working directory to run the command in (default: `.`).                 |
+| `recall`  | boolean | ✗        | Only available when the shell toolset has `recall: true`. When true, send a steering message with the job output when the job finishes. |
 
 `view_background_job` and `stop_background_job` each take a single required `job_id` string returned by `run_background_job` or `list_background_jobs`.
 

--- a/examples/golibrary/tool/main.go
+++ b/examples/golibrary/tool/main.go
@@ -33,7 +33,7 @@ type AddNumbersArgs struct {
 	B int `json:"b"`
 }
 
-func addNumbers(_ context.Context, toolCall tools.ToolCall) (*tools.ToolCallResult, error) {
+func addNumbers(_ context.Context, toolCall tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 	var p AddNumbersArgs
 	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &p); err != nil {
 		return nil, err

--- a/examples/shell_recall.yaml
+++ b/examples/shell_recall.yaml
@@ -1,0 +1,10 @@
+agents:
+  root:
+    model: openai/gpt-4o
+    description: Run long shell jobs and resume automatically when they finish.
+    instruction: |
+      Use background-job recall for finite long-running commands, such as builds or tests.
+      Avoid recall for servers and watchers that are meant to keep running.
+    toolsets:
+      - type: shell
+        recall: true

--- a/pkg/acp/filesystem.go
+++ b/pkg/acp/filesystem.go
@@ -182,7 +182,7 @@ func evalSymlinksAllowMissing(path string) (string, error) {
 	return filepath.Join(realParent, filepath.Base(path)), nil
 }
 
-func (t *FilesystemToolset) handleReadFile(ctx context.Context, toolCall tools.ToolCall) (*tools.ToolCallResult, error) {
+func (t *FilesystemToolset) handleReadFile(ctx context.Context, toolCall tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 	var args filesystem.ReadFileArgs
 	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err != nil {
 		return nil, fmt.Errorf("failed to parse arguments: %w", err)
@@ -212,7 +212,7 @@ func (t *FilesystemToolset) handleReadFile(ctx context.Context, toolCall tools.T
 	return tools.ResultSuccess(resp.Content), nil
 }
 
-func (t *FilesystemToolset) handleWriteFile(ctx context.Context, toolCall tools.ToolCall) (*tools.ToolCallResult, error) {
+func (t *FilesystemToolset) handleWriteFile(ctx context.Context, toolCall tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 	var args filesystem.WriteFileArgs
 	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err != nil {
 		return nil, fmt.Errorf("failed to parse arguments: %w", err)
@@ -243,7 +243,7 @@ func (t *FilesystemToolset) handleWriteFile(ctx context.Context, toolCall tools.
 	return tools.ResultSuccess("File written successfully"), nil
 }
 
-func (t *FilesystemToolset) handleEditFile(ctx context.Context, toolCall tools.ToolCall) (*tools.ToolCallResult, error) {
+func (t *FilesystemToolset) handleEditFile(ctx context.Context, toolCall tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 	data := toolCall.Function.Arguments
 	if data == "" {
 		data = "{}"

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -1419,6 +1419,12 @@ type Toolset struct {
 	// nil/false keeps the default behaviour (sudo has no TTY and fails fast).
 	SudoAskpass *bool `json:"sudo_askpass,omitempty" yaml:"sudo_askpass,omitempty"`
 
+	// For the `shell` toolset — opt in to background-job recall. When enabled,
+	// run_background_job exposes a recall boolean parameter. If the agent sets
+	// recall:true on a background job, the runtime injects a steering message
+	// with a short completion sentence and the job output when the job finishes.
+	Recall *bool `json:"recall,omitempty" yaml:"recall,omitempty"`
+
 	// For the `shell` toolset — opt in to destructive-command detection.
 	// When enabled, the agent auto-registers the safer_shell builtin under
 	// pre_tool_use with preempt_yolo:true. Destructive commands (rm -rf, docker

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -268,6 +268,9 @@ func (t *Toolset) validate() error {
 	if t.SudoAskpass != nil && t.Type != "shell" {
 		return errors.New("sudo_askpass can only be used with type 'shell'")
 	}
+	if t.Recall != nil && t.Type != "shell" {
+		return errors.New("recall can only be used with type 'shell'")
+	}
 	if t.Safer != nil && t.Type != "shell" {
 		return errors.New("safer can only be used with type 'shell'")
 	}

--- a/pkg/config/toolset_validate_test.go
+++ b/pkg/config/toolset_validate_test.go
@@ -200,6 +200,69 @@ agents:
 	}
 }
 
+func TestToolset_Validate_Recall(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  string
+		wantErr string
+	}{
+		{
+			name: "recall on shell is allowed",
+			config: `
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: shell
+        recall: true
+`,
+			wantErr: "",
+		},
+		{
+			name: "recall false on shell is allowed",
+			config: `
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: shell
+        recall: false
+`,
+			wantErr: "",
+		},
+		{
+			name: "recall on non-shell toolset is rejected",
+			config: `
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: filesystem
+        recall: true
+`,
+			wantErr: "recall can only be used with type 'shell'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var cfg latest.Config
+			err := yaml.Unmarshal([]byte(tt.config), &cfg)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestToolset_Validate_MCP_WorkingDir(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/js/eval_test.go
+++ b/pkg/js/eval_test.go
@@ -15,13 +15,13 @@ func TestEvaluate(t *testing.T) {
 	mockTools := []tools.Tool{
 		{
 			Name: "echo",
-			Handler: func(_ context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+			Handler: func(_ context.Context, tc tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 				return tools.ResultSuccess("echoed: " + tc.Function.Arguments), nil
 			},
 		},
 		{
 			Name: "shell",
-			Handler: func(_ context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+			Handler: func(_ context.Context, tc tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 				return tools.ResultSuccess("output: " + tc.Function.Arguments), nil
 			},
 		},

--- a/pkg/js/expand.go
+++ b/pkg/js/expand.go
@@ -194,7 +194,7 @@ func createToolCaller(ctx context.Context, tool tools.Tool) func(args map[string
 			return "", fmt.Errorf("tool '%s' has no handler", tool.Name)
 		}
 
-		result, err := tool.Handler(ctx, toolCall)
+		result, err := tool.Handler(ctx, toolCall, tools.NopRuntime{})
 		if err != nil {
 			return "", err
 		}

--- a/pkg/js/expand_test.go
+++ b/pkg/js/expand_test.go
@@ -263,7 +263,7 @@ func TestExpandCommandsThenEvaluate(t *testing.T) {
 	mockTools := []tools.Tool{
 		{
 			Name: "shell",
-			Handler: func(_ context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+			Handler: func(_ context.Context, tc tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 				return tools.ResultSuccess("lint output"), nil
 			},
 		},

--- a/pkg/leantui/events.go
+++ b/pkg/leantui/events.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/tools"
+	msgtypes "github.com/docker/docker-agent/pkg/tui/messages"
 	tuitypes "github.com/docker/docker-agent/pkg/tui/types"
 )
 
@@ -13,6 +14,8 @@ import (
 // updating the conversation, tool state, status footer, or busy state.
 func (m *model) handleEvent(ctx context.Context, ev any) {
 	switch e := ev.(type) {
+	case msgtypes.SendMsg:
+		m.submit(ctx, e.Content)
 	case *runtime.StreamStartedEvent:
 		m.busy = true
 		m.trackStreamStarted(e.SessionID)

--- a/pkg/runtime/before_llm_call_test.go
+++ b/pkg/runtime/before_llm_call_test.go
@@ -107,7 +107,7 @@ func TestMaxIterationsBuiltin_TripsAfterConfiguredLimit(t *testing.T) {
 	loopTool := tools.Tool{
 		Name:       "do_thing",
 		Parameters: map[string]any{},
-		Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(_ context.Context, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			return tools.ResultSuccess("ok"), nil
 		},
 	}

--- a/pkg/runtime/commands.go
+++ b/pkg/runtime/commands.go
@@ -271,7 +271,7 @@ func executeSingleToolCommand(ctx context.Context, toolMap map[string]tools.Tool
 	toolCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	result, err := tool.Handler(toolCtx, toolCall)
+	result, err := tool.Handler(toolCtx, toolCall, tools.NopRuntime{})
 	if err != nil {
 		slog.WarnContext(ctx, "Tool execution failed", "tool", toolName, "error", err)
 		return "Error executing '" + toolName + "': " + err.Error()

--- a/pkg/runtime/commands_test.go
+++ b/pkg/runtime/commands_test.go
@@ -235,7 +235,7 @@ func TestResolveCommand_ToolCommand(t *testing.T) {
 		tools: []tools.Tool{
 			{
 				Name: "echo_tool",
-				Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+				Handler: func(_ context.Context, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 					return tools.ResultSuccess("hello from tool"), nil
 				},
 			},
@@ -256,7 +256,7 @@ func TestResolveCommand_ToolCommandWithArgs(t *testing.T) {
 		tools: []tools.Tool{
 			{
 				Name: "greet_tool",
-				Handler: func(_ context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+				Handler: func(_ context.Context, tc tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 					// Parse the args to verify they're passed correctly
 					return tools.ResultSuccess("Hello, " + tc.Function.Arguments), nil
 				},
@@ -279,7 +279,7 @@ func TestResolveCommand_ToolCommandWithQuotedArgs(t *testing.T) {
 		tools: []tools.Tool{
 			{
 				Name: "search_tool",
-				Handler: func(_ context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+				Handler: func(_ context.Context, tc tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 					return tools.ResultSuccess("searched: " + tc.Function.Arguments), nil
 				},
 			},
@@ -318,7 +318,7 @@ func TestResolveCommand_CombinedPositionalAndTool(t *testing.T) {
 		tools: []tools.Tool{
 			{
 				Name: "check_tool",
-				Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+				Handler: func(_ context.Context, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 					return tools.ResultSuccess("check_output"), nil
 				},
 			},
@@ -573,7 +573,7 @@ func TestResolveCommand_NestedParentheses(t *testing.T) {
 		tools: []tools.Tool{
 			{
 				Name: "shell",
-				Handler: func(_ context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+				Handler: func(_ context.Context, tc tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 					// Return the arguments to verify they're parsed correctly
 					return tools.ResultSuccess("args: " + tc.Function.Arguments), nil
 				},
@@ -595,7 +595,7 @@ func TestResolveCommand_MultipleNestedParens(t *testing.T) {
 		tools: []tools.Tool{
 			{
 				Name: "tool",
-				Handler: func(_ context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+				Handler: func(_ context.Context, tc tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 					return tools.ResultSuccess(tc.Function.Arguments), nil
 				},
 			},

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -226,7 +226,13 @@ func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-c
 	slog.DebugContext(ctx, "Starting runtime stream", "agent", r.currentAgentName(), "session_id", sess.ID)
 	events := make(chan Event, defaultEventChannelCapacity)
 
-	go r.runStreamLoop(ctx, sess, events)
+	go func() {
+		if !sess.IsSubSession() {
+			r.activeRootStreams.Add(1)
+			defer r.activeRootStreams.Add(-1)
+		}
+		r.runStreamLoop(ctx, sess, events)
+	}()
 	return r.observe(ctx, sess, events)
 }
 

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -225,10 +225,13 @@ func (r *LocalRuntime) finalizeEventChannel(ctx context.Context, sess *session.S
 func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-chan Event {
 	slog.DebugContext(ctx, "Starting runtime stream", "agent", r.currentAgentName(), "session_id", sess.ID)
 	events := make(chan Event, defaultEventChannelCapacity)
+	rootStream := !sess.IsSubSession()
+	if rootStream {
+		r.activeRootStreams.Add(1)
+	}
 
 	go func() {
-		if !sess.IsSubSession() {
-			r.activeRootStreams.Add(1)
+		if rootStream {
 			defer r.activeRootStreams.Add(-1)
 		}
 		r.runStreamLoop(ctx, sess, events)

--- a/pkg/runtime/message_queue.go
+++ b/pkg/runtime/message_queue.go
@@ -14,6 +14,11 @@ type QueuedMessage struct {
 	MultiContent []chat.MessagePart
 }
 
+// RecallHandler delivers a tool-produced message through an embedder-owned
+// wake-up path. Embedders use it to resume an idle UI/session when background
+// work completes after the active RunStream has stopped.
+type RecallHandler func(ctx context.Context, msg QueuedMessage) bool
+
 // MessageQueue is the interface for storing messages that are injected into
 // the agent loop. Implementations must be safe for concurrent use: Enqueue
 // is called from API handlers while Dequeue/Drain are called from the agent

--- a/pkg/runtime/pre_tool_use_approval_test.go
+++ b/pkg/runtime/pre_tool_use_approval_test.go
@@ -39,7 +39,7 @@ func recordingTool(name string, executed *bool) []tools.Tool {
 	return []tools.Tool{{
 		Name:       name,
 		Parameters: map[string]any{},
-		Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(_ context.Context, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			*executed = true
 			return tools.ResultSuccess("ok"), nil
 		},

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -276,6 +277,17 @@ type LocalRuntime struct {
 	// followUpQueue stores end-of-turn messages. The agent loop pops
 	// exactly ONE message after the model stops and stop-hooks have run.
 	followUpQueue MessageQueue
+
+	// activeRootStreams tracks top-level RunStream loops. Recalls use this to
+	// preserve mid-turn steering while still waking the embedder once the parent
+	// stream has gone idle.
+	activeRootStreams atomic.Int32
+
+	// recallHandler wakes embedders (TUI/App) when a tool recall arrives after
+	// the active RunStream has gone idle. Protected by recallMu because tool
+	// callbacks can fire from background goroutines.
+	recallMu      sync.RWMutex
+	recallHandler RecallHandler
 
 	// onToolsChanged is called when an MCP toolset reports a tool list change.
 	onToolsChanged func(Event)
@@ -1791,6 +1803,32 @@ func (r *LocalRuntime) Steer(ctx context.Context, msg QueuedMessage) error {
 func (r *LocalRuntime) FollowUp(ctx context.Context, msg QueuedMessage) error {
 	if !r.followUpQueue.Enqueue(ctx, msg) {
 		return errors.New("follow-up queue full")
+	}
+	return nil
+}
+
+// SetRecallHandler registers an embedder-owned wake-up path for tool recalls.
+// When unset, recalls fall back to the steer queue and are consumed by the next
+// active RunStream.
+func (r *LocalRuntime) SetRecallHandler(handler RecallHandler) {
+	r.recallMu.Lock()
+	defer r.recallMu.Unlock()
+	r.recallHandler = handler
+}
+
+func (r *LocalRuntime) recall(ctx context.Context, msg QueuedMessage) error {
+	if r.activeRootStreams.Load() > 0 {
+		return r.Steer(ctx, msg)
+	}
+
+	r.recallMu.RLock()
+	handler := r.recallHandler
+	r.recallMu.RUnlock()
+	if handler == nil {
+		return r.Steer(ctx, msg)
+	}
+	if !handler(ctx, msg) {
+		return errors.New("recall handler rejected message")
 	}
 	return nil
 }

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -499,6 +499,70 @@ func TestToolCallSequence(t *testing.T) {
 	require.True(t, hasEventType(t, events, &StreamStoppedEvent{}), "Expected StreamStoppedEvent")
 }
 
+func TestRecallUsesSteerWhileRootStreamActive(t *testing.T) {
+	t.Parallel()
+
+	rt := &LocalRuntime{steerQueue: NewInMemoryMessageQueue(1)}
+	rt.activeRootStreams.Store(1)
+	handlerCalled := false
+	rt.SetRecallHandler(func(context.Context, QueuedMessage) bool {
+		handlerCalled = true
+		return true
+	})
+
+	recall := QueuedMessage{Content: "job finished"}
+	require.NoError(t, rt.recall(t.Context(), recall))
+	assert.False(t, handlerCalled)
+
+	got, ok := rt.steerQueue.Dequeue(t.Context())
+	require.True(t, ok)
+	assert.Equal(t, recall, got)
+}
+
+func TestProcessToolCallsRecallEnqueuesSteeringMessage(t *testing.T) {
+	t.Parallel()
+
+	const recallMessage = "Background job job_1 finished with status completed.\n--- Output ---\nhello"
+	agentTools := []tools.Tool{{
+		Name:       "recall_tool",
+		Parameters: map[string]any{},
+		Handler: func(ctx context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+			require.True(t, tools.EmitRecall(ctx, recallMessage))
+			return tools.ResultSuccess("started"), nil
+		},
+	}}
+
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	root := agent.New("root", "You are a test agent",
+		agent.WithModel(prov),
+		agent.WithToolSets(newStubToolSet(nil, agentTools, nil)),
+	)
+	rt, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root)), WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	sess := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))
+	events := make(chan Event, 16)
+	stopRun, stopMsg := rt.processToolCalls(t.Context(), sess, []tools.ToolCall{{
+		ID:       "call_1",
+		Type:     "function",
+		Function: tools.FunctionCall{Name: "recall_tool", Arguments: "{}"},
+	}}, agentTools, NewChannelSink(events))
+	require.False(t, stopRun)
+	require.Empty(t, stopMsg)
+
+	sr := rt.drainAndEmitSteered(t.Context(), sess, root, NewChannelSink(events))
+	require.True(t, sr.drained)
+	close(events)
+
+	var sawRecall bool
+	for ev := range events {
+		if msg, ok := ev.(*UserMessageEvent); ok && msg.Message == recallMessage {
+			sawRecall = true
+		}
+	}
+	assert.True(t, sawRecall, "recall message should be emitted as a steered user message")
+}
+
 // TestXMLToolCallFallback verifies that <tool_call> blocks in text content
 // are extracted as tool calls and not leaked as AgentChoice events.
 func TestXMLToolCallFallback(t *testing.T) {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -206,6 +206,25 @@ func (m *mockProvider) BaseConfig() base.Config { return base.Config{} }
 
 func (m *mockProvider) MaxTokens() int { return 0 }
 
+type activeRootBlockingProvider struct {
+	id      string
+	release <-chan struct{}
+}
+
+func (p *activeRootBlockingProvider) ID() modelsdev.ID { return modelsdev.ParseIDOrZero(p.id) }
+
+func (p *activeRootBlockingProvider) CreateChatCompletionStream(ctx context.Context, _ []chat.Message, _ []tools.Tool) (chat.MessageStream, error) {
+	select {
+	case <-p.release:
+		return newStreamBuilder().AddStopWithUsage(1, 1).Build(), nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (p *activeRootBlockingProvider) BaseConfig() base.Config { return base.Config{} }
+func (p *activeRootBlockingProvider) MaxTokens() int          { return 0 }
+
 type mockProviderWithError struct {
 	id string
 }
@@ -497,6 +516,26 @@ func TestToolCallSequence(t *testing.T) {
 
 	require.True(t, hasEventType(t, events, &StreamStartedEvent{}), "Expected StreamStartedEvent")
 	require.True(t, hasEventType(t, events, &StreamStoppedEvent{}), "Expected StreamStoppedEvent")
+}
+
+func TestRunStreamIncrementsActiveRootStreamsBeforeReturning(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	prov := &activeRootBlockingProvider{id: "test/mock-model", release: release}
+	root := agent.New("root", "You are a test agent", agent.WithModel(prov))
+	rt, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root)), WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	events := rt.RunStream(ctx, session.New(session.WithUserMessage("block")))
+	assert.Equal(t, int32(1), rt.activeRootStreams.Load())
+
+	cancel()
+	for range events {
+	}
+	assert.Equal(t, int32(0), rt.activeRootStreams.Load())
+	close(release)
 }
 
 func TestRecallUsesSteerWhileRootStreamActive(t *testing.T) {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -565,8 +565,8 @@ func TestProcessToolCallsRecallEnqueuesSteeringMessage(t *testing.T) {
 	agentTools := []tools.Tool{{
 		Name:       "recall_tool",
 		Parameters: map[string]any{},
-		Handler: func(ctx context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
-			require.True(t, tools.EmitRecall(ctx, recallMessage))
+		Handler: func(ctx context.Context, _ tools.ToolCall, rt tools.Runtime) (*tools.ToolCallResult, error) {
+			require.NoError(t, rt.Recall(ctx, recallMessage))
 			return tools.ResultSuccess("started"), nil
 		},
 	}}
@@ -1967,7 +1967,7 @@ func TestPermissions_DenyBlocksToolExecution(t *testing.T) {
 	agentTools := []tools.Tool{{
 		Name:       "dangerous_tool",
 		Parameters: map[string]any{},
-		Handler: func(ctx context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(ctx context.Context, tc tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			return tools.ResultSuccess("executed"), nil
 		},
 	}}
@@ -2001,7 +2001,7 @@ func TestPermissions_AllowAutoApprovesTool(t *testing.T) {
 	agentTools := []tools.Tool{{
 		Name:       "safe_tool",
 		Parameters: map[string]any{},
-		Handler: func(ctx context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(ctx context.Context, tc tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			executed = true
 			return tools.ResultSuccess("executed"), nil
 		},
@@ -2068,7 +2068,7 @@ func TestPermissions_DenyTakesPriorityOverAllow(t *testing.T) {
 	agentTools := []tools.Tool{{
 		Name:       "forbidden_tool",
 		Parameters: map[string]any{},
-		Handler: func(ctx context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(ctx context.Context, tc tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			return tools.ResultSuccess("executed"), nil
 		},
 	}}
@@ -2118,7 +2118,7 @@ func TestSessionPermissions_DenyBlocksToolExecution(t *testing.T) {
 	agentTools := []tools.Tool{{
 		Name:       "blocked_tool",
 		Parameters: map[string]any{},
-		Handler: func(ctx context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(ctx context.Context, tc tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			return tools.ResultSuccess("executed"), nil
 		},
 	}}
@@ -2147,7 +2147,7 @@ func TestSessionPermissions_AllowAutoApprovesTool(t *testing.T) {
 	agentTools := []tools.Tool{{
 		Name:       "allowed_tool",
 		Parameters: map[string]any{},
-		Handler: func(ctx context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(ctx context.Context, tc tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			executed = true
 			return tools.ResultSuccess("executed"), nil
 		},
@@ -2221,7 +2221,7 @@ func TestSessionPermissions_TakePriorityOverTeamPermissions(t *testing.T) {
 	agentTools := []tools.Tool{{
 		Name:       "overridden_tool",
 		Parameters: map[string]any{},
-		Handler: func(ctx context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(ctx context.Context, tc tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			return tools.ResultSuccess("executed"), nil
 		},
 	}}
@@ -2250,7 +2250,7 @@ func TestToolRejectionWithReason(t *testing.T) {
 	agentTools := []tools.Tool{{
 		Name:       "shell",
 		Parameters: map[string]any{},
-		Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(_ context.Context, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			t.Fatal("tool should not be executed when rejected")
 			return nil, nil
 		},
@@ -2308,7 +2308,7 @@ func TestToolRejectionWithoutReason(t *testing.T) {
 	agentTools := []tools.Tool{{
 		Name:       "shell",
 		Parameters: map[string]any{},
-		Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(_ context.Context, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			t.Fatal("tool should not be executed when rejected")
 			return nil, nil
 		},
@@ -2529,7 +2529,7 @@ func TestYoloMode_OverridesPermissionsDeny(t *testing.T) {
 	agentTools := []tools.Tool{{
 		Name:       "dangerous_tool",
 		Parameters: map[string]any{},
-		Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(_ context.Context, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			executed = true
 			return tools.ResultSuccess("executed"), nil
 		},
@@ -2577,7 +2577,7 @@ func TestYoloMode_OverridesForceAsk(t *testing.T) {
 	agentTools := []tools.Tool{{
 		Name:       "careful_tool",
 		Parameters: map[string]any{},
-		Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(_ context.Context, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			executed = true
 			return tools.ResultSuccess("executed"), nil
 		},
@@ -2621,7 +2621,7 @@ func TestYoloMode_OverridesSessionDeny(t *testing.T) {
 	agentTools := []tools.Tool{{
 		Name:       "blocked_tool",
 		Parameters: map[string]any{},
-		Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(_ context.Context, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			executed = true
 			return tools.ResultSuccess("executed"), nil
 		},
@@ -2930,7 +2930,7 @@ func TestProcessToolCalls_UsesPinnedAgent(t *testing.T) {
 	workerTool := tools.Tool{
 		Name:       "worker_tool",
 		Parameters: map[string]any{},
-		Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(_ context.Context, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			executed = true
 			return tools.ResultSuccess("ok"), nil
 		},
@@ -3296,7 +3296,7 @@ func TestReprobe_NewToolsAvailableAfterToolCall(t *testing.T) {
 	installTool := tools.Tool{
 		Name:       "install_mcp",
 		Parameters: map[string]any{},
-		Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(_ context.Context, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			return tools.ResultSuccess("installed"), nil
 		},
 	}
@@ -3374,7 +3374,7 @@ func TestReprobe_NoChangeMeansNoExtraEvents(t *testing.T) {
 	staticTool := tools.Tool{
 		Name:       "do_thing",
 		Parameters: map[string]any{},
-		Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(_ context.Context, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			return tools.ResultSuccess("done"), nil
 		},
 	}
@@ -4014,7 +4014,7 @@ func TestPostToolHookReceivesToolResult(t *testing.T) {
 	agentTools := []tools.Tool{{
 		Name:       "echo_tool",
 		Parameters: map[string]any{},
-		Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(_ context.Context, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			return tools.ResultSuccess("actual tool output"), nil
 		},
 	}}
@@ -4068,7 +4068,7 @@ func TestPostToolHookEmitsLifecycleEvents(t *testing.T) {
 	agentTools := []tools.Tool{{
 		Name:       "echo_tool",
 		Parameters: map[string]any{},
-		Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(_ context.Context, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			return tools.ResultSuccess("ok"), nil
 		},
 	}}
@@ -4343,7 +4343,7 @@ func TestEmptyTrailingTurnAfterToolCallsIsSilent(t *testing.T) {
 	doneTool := tools.Tool{
 		Name:       "do_thing",
 		Parameters: map[string]any{},
-		Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(_ context.Context, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			return tools.ResultSuccess("done"), nil
 		},
 	}

--- a/pkg/runtime/tool_dispatch.go
+++ b/pkg/runtime/tool_dispatch.go
@@ -47,6 +47,9 @@ func (r *LocalRuntime) processToolCalls(ctx context.Context, sess *session.Sessi
 		AgentFor:    r.resolveSessionAgent,
 		Permissions: r.permissionCheckers,
 		Handlers:    handlers,
+		Recall: func(ctx context.Context, _ *session.Session, _ *agent.Agent, message string) error {
+			return r.recall(ctx, QueuedMessage{Content: message})
+		},
 	}
 	return d.Process(ctx, sess, calls, agentTools, &sinkEmitter{events: events})
 }

--- a/pkg/runtime/tool_dispatch.go
+++ b/pkg/runtime/tool_dispatch.go
@@ -35,7 +35,7 @@ func (r *LocalRuntime) processToolCalls(ctx context.Context, sess *session.Sessi
 	// toolexec.ToolHandler doesn't.
 	handlers := make(map[string]toolexec.ToolHandler, len(r.toolMap))
 	for name, h := range r.toolMap {
-		handlers[name] = func(ctx context.Context, sess *session.Session, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+		handlers[name] = func(ctx context.Context, sess *session.Session, tc tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			return h(ctx, sess, tc, events)
 		}
 	}

--- a/pkg/runtime/toolexec/dispatcher.go
+++ b/pkg/runtime/toolexec/dispatcher.go
@@ -168,6 +168,10 @@ type Dispatcher struct {
 	// their toolset Handler.
 	Handlers map[string]ToolHandler
 
+	// Recall enqueues a tool-produced steering message. Tool handlers get this
+	// through their context and may call it after the handler has returned.
+	Recall func(ctx context.Context, sess *session.Session, a *agent.Agent, message string) error
+
 	confirmationMu sync.Mutex
 	approvalMu     sync.Mutex
 }
@@ -877,6 +881,16 @@ func (c *call) invoke(ctx context.Context, spanName string, exec func(ctx contex
 		output = c.applyToolResponseTransform(ctx, output, false)
 		c.em.EmitToolCallOutput(c.tc.ID, c.tool, output, c.a.Name())
 	})
+	if c.d.Recall != nil {
+		recallCtx := context.WithoutCancel(ctx)
+		toolCtx = tools.WithToolRecallEmitter(toolCtx, func(message string) bool {
+			if err := c.d.Recall(recallCtx, c.sess, c.a, message); err != nil {
+				slog.WarnContext(recallCtx, "Failed to enqueue tool recall", "tool", c.tc.Function.Name, "session_id", c.sess.ID, "error", err)
+				return false
+			}
+			return true
+		})
+	}
 	res, duration, err := exec(toolCtx)
 	telemetry.RecordToolCall(ctx, c.tc.Function.Name, c.sess.ID, c.a.Name(), duration, err)
 

--- a/pkg/runtime/toolexec/dispatcher.go
+++ b/pkg/runtime/toolexec/dispatcher.go
@@ -119,7 +119,7 @@ type HookDispatcher interface {
 // ToolCall/ToolCallResponse themselves. Handlers that need to emit other
 // event types should be wired by the caller to capture the relevant
 // channel via closure when registering the handler.
-type ToolHandler func(ctx context.Context, sess *session.Session, tc tools.ToolCall) (*tools.ToolCallResult, error)
+type ToolHandler func(ctx context.Context, sess *session.Session, tc tools.ToolCall, rt tools.Runtime) (*tools.ToolCallResult, error)
 
 // ResumeRequest carries the user's response to a tool-confirmation prompt.
 // The runtime aliases this type publicly via runtime.ResumeRequest so the
@@ -168,8 +168,10 @@ type Dispatcher struct {
 	// their toolset Handler.
 	Handlers map[string]ToolHandler
 
-	// Recall enqueues a tool-produced steering message. Tool handlers get this
-	// through their context and may call it after the handler has returned.
+	// Recall enqueues a tool-produced steering message. Tool handlers reach it
+	// through their [tools.Runtime] handle and may call it after the handler
+	// has returned. When nil, [tools.Runtime.Recall] reports
+	// [tools.ErrRecallNotSupported].
 	Recall func(ctx context.Context, sess *session.Session, a *agent.Agent, message string) error
 
 	confirmationMu sync.Mutex
@@ -829,7 +831,7 @@ func (c *call) handleResume(ctx context.Context, req ResumeRequest, runTool func
 // returned [CallOutcome].
 func (c *call) runToolset(ctx context.Context) CallOutcome {
 	res := c.invoke(ctx, "runtime.tool.handler", func(ctx context.Context) (*tools.ToolCallResult, time.Duration, error) {
-		res, err := c.tool.Handler(ctx, c.tc)
+		res, err := c.tool.Handler(ctx, c.tc, callRuntime{c})
 		return res, 0, err
 	})
 
@@ -843,9 +845,38 @@ func (c *call) runToolset(ctx context.Context) CallOutcome {
 func (c *call) runHandler(ctx context.Context, handler ToolHandler) {
 	c.invoke(ctx, "runtime.tool.handler.runtime", func(ctx context.Context) (*tools.ToolCallResult, time.Duration, error) {
 		start := time.Now()
-		res, err := handler(ctx, c.sess, c.tc)
+		res, err := handler(ctx, c.sess, c.tc, callRuntime{c})
 		return res, time.Since(start), err
 	})
+}
+
+// callRuntime is the [tools.Runtime] handed to tool handlers. It carries only
+// per-call state (no context); every method takes ctx from the caller, so
+// handles held by background work stay valid after the tool call returns.
+type callRuntime struct {
+	c *call
+}
+
+func (r callRuntime) EmitOutput(ctx context.Context, output string) {
+	output = r.c.applyToolResponseTransform(ctx, output, false)
+	r.c.em.EmitToolCallOutput(r.c.tc.ID, r.c.tool, output, r.c.a.Name())
+}
+
+func (r callRuntime) Recall(ctx context.Context, message string) error {
+	if r.c.d.Recall == nil {
+		return tools.ErrRecallNotSupported
+	}
+	return r.c.d.Recall(ctx, r.c.sess, r.c.a, message)
+}
+
+func (r callRuntime) Supports(capability tools.Capability) bool {
+	switch capability {
+	case tools.CapabilityOutput:
+		return true
+	case tools.CapabilityRecall:
+		return r.c.d.Recall != nil
+	}
+	return false
 }
 
 // invoke is the common pipeline shared by toolset tools and runtime-
@@ -877,21 +908,7 @@ func (c *call) invoke(ctx context.Context, spanName string, exec func(ctx contex
 
 	c.em.EmitToolCall(c.tc, c.tool, c.a.Name())
 
-	toolCtx := tools.WithToolOutputEmitter(ctx, func(output string) {
-		output = c.applyToolResponseTransform(ctx, output, false)
-		c.em.EmitToolCallOutput(c.tc.ID, c.tool, output, c.a.Name())
-	})
-	if c.d.Recall != nil {
-		recallCtx := context.WithoutCancel(ctx)
-		toolCtx = tools.WithToolRecallEmitter(toolCtx, func(message string) bool {
-			if err := c.d.Recall(recallCtx, c.sess, c.a, message); err != nil {
-				slog.WarnContext(recallCtx, "Failed to enqueue tool recall", "tool", c.tc.Function.Name, "session_id", c.sess.ID, "error", err)
-				return false
-			}
-			return true
-		})
-	}
-	res, duration, err := exec(toolCtx)
+	res, duration, err := exec(ctx)
 	telemetry.RecordToolCall(ctx, c.tc.Function.Name, c.sess.ID, c.a.Name(), duration, err)
 
 	if err != nil {

--- a/pkg/runtime/toolexec/dispatcher_test.go
+++ b/pkg/runtime/toolexec/dispatcher_test.go
@@ -108,7 +108,7 @@ func TestDispatcher_RoutesToToolsetHandler(t *testing.T) {
 	var handlerCalls int
 	tool := tools.Tool{
 		Name: "echo",
-		Handler: func(_ context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(_ context.Context, tc tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			handlerCalls++
 			return tools.ResultSuccess("hello " + tc.Function.Arguments), nil
 		},
@@ -142,7 +142,7 @@ func TestDispatcher_RunsToolHandlersInParallel(t *testing.T) {
 	var maxRunning atomic.Int32
 	tool := tools.Tool{
 		Name: "slow",
-		Handler: func(ctx context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(ctx context.Context, tc tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			current := running.Add(1)
 			for {
 				observed := maxRunning.Load()
@@ -199,9 +199,9 @@ func TestDispatcher_EmitsToolOutputFromHandlerContext(t *testing.T) {
 
 	tool := tools.Tool{
 		Name: "streamer",
-		Handler: func(ctx context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
-			tools.EmitOutput(ctx, "first\n")
-			tools.EmitOutput(ctx, "second\n")
+		Handler: func(ctx context.Context, _ tools.ToolCall, rt tools.Runtime) (*tools.ToolCallResult, error) {
+			rt.EmitOutput(ctx, "first\n")
+			rt.EmitOutput(ctx, "second\n")
 			return tools.ResultSuccess("done"), nil
 		},
 	}
@@ -228,7 +228,7 @@ func TestDispatcher_RecordsDocumentToolResult(t *testing.T) {
 
 	tool := tools.Tool{
 		Name: "report",
-		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
 			return &tools.ToolCallResult{
 				Output: "created report",
 				Documents: []tools.DocumentContent{{
@@ -269,7 +269,7 @@ func TestDispatcher_RoutesToRuntimeHandler(t *testing.T) {
 	d := &toolexec.Dispatcher{
 		AgentFor: func(*session.Session) *agent.Agent { return a },
 		Handlers: map[string]toolexec.ToolHandler{
-			"transfer_task": func(_ context.Context, _ *session.Session, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+			"transfer_task": func(_ context.Context, _ *session.Session, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 				handlerCalls++
 				return tools.ResultSuccess("transferred"), nil
 			},
@@ -281,7 +281,7 @@ func TestDispatcher_RoutesToRuntimeHandler(t *testing.T) {
 	// for the same name.
 	tool := tools.Tool{
 		Name: "transfer_task",
-		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
 			t.Fatal("toolset handler must not be called when runtime handler exists")
 			return nil, nil
 		},
@@ -333,7 +333,9 @@ func TestDispatcher_UserCancellationStopsBatchAndErrorsAllCalls(t *testing.T) {
 	tool := tools.Tool{
 		Name:     "shell",
 		Category: "shell",
-		Handler:  func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) { panic("must not run") },
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
+			panic("must not run")
+		},
 	}
 
 	// Cancel as soon as the dispatcher asks for confirmation on the first
@@ -369,7 +371,7 @@ func TestDispatcher_ResumeApproveRunsTool(t *testing.T) {
 	var ran bool
 	tool := tools.Tool{
 		Name: "shell",
-		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
 			ran = true
 			return tools.ResultSuccess("done"), nil
 		},
@@ -402,8 +404,10 @@ func TestDispatcher_ResumeRejectEmitsErrorResponseWithReason(t *testing.T) {
 	sess := session.New()
 
 	tool := tools.Tool{
-		Name:    "shell",
-		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) { panic("must not run") },
+		Name: "shell",
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
+			panic("must not run")
+		},
 	}
 
 	resume := make(chan toolexec.ResumeRequest, 1)
@@ -434,7 +438,7 @@ func TestDispatcher_ResumeApproveToolPersistsToSessionPermissions(t *testing.T) 
 	var ran bool
 	tool := tools.Tool{
 		Name: "shell",
-		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
 			ran = true
 			return tools.ResultSuccess("ok"), nil
 		},
@@ -470,7 +474,7 @@ func TestDispatcher_ReadOnlyHintAutoApproves(t *testing.T) {
 		Annotations: tools.ToolAnnotations{
 			ReadOnlyHint: true,
 		},
-		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
 			ran = true
 			return tools.ResultSuccess("contents"), nil
 		},
@@ -498,8 +502,10 @@ func TestDispatcher_DenyByPermissionsEmitsErrorResponse(t *testing.T) {
 	sess := session.New()
 
 	tool := tools.Tool{
-		Name:    "shell",
-		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) { panic("must not run") },
+		Name: "shell",
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
+			panic("must not run")
+		},
 	}
 
 	d := &toolexec.Dispatcher{
@@ -542,7 +548,7 @@ func TestDispatcher_ToolResponseTransformRewritesOutput(t *testing.T) {
 	tool := tools.Tool{
 		Name:     "leaky",
 		Category: "filesystem",
-		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
 			return tools.ResultSuccess(original), nil
 		},
 	}
@@ -594,7 +600,7 @@ func TestDispatcher_ToolResponseTransformIsNoOpWithoutHooks(t *testing.T) {
 	tool := tools.Tool{
 		Name:     "leaky",
 		Category: "filesystem",
-		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
 			return tools.ResultSuccess(original), nil
 		},
 	}
@@ -629,8 +635,10 @@ func TestDispatcher_ToolResponseTransformAppliesToErrorResponse(t *testing.T) {
 	sess := session.New()
 
 	tool := tools.Tool{
-		Name:    "shell",
-		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) { panic("must not run") },
+		Name: "shell",
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
+			panic("must not run")
+		},
 	}
 
 	rewritten := "rejected with [REDACTED] secret"
@@ -673,7 +681,9 @@ func TestDispatcher_ConfirmationCarriesToolMetadata(t *testing.T) {
 	tool := tools.Tool{
 		Name:     "shell",
 		Metadata: map[string]string{"danger": "high", "category": "exec"},
-		Handler:  func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) { panic("must not run") },
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
+			panic("must not run")
+		},
 	}
 
 	resume := make(chan toolexec.ResumeRequest, 1)
@@ -706,7 +716,9 @@ func TestDispatcher_ConfirmationMergesHookMetadata(t *testing.T) {
 	tool := tools.Tool{
 		Name:     "shell",
 		Metadata: map[string]string{"danger": "high", "source": "toolset"},
-		Handler:  func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) { panic("must not run") },
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
+			panic("must not run")
+		},
 	}
 
 	// Hook allows the prompt to proceed (no short-circuit) but contributes
@@ -752,8 +764,10 @@ func TestDispatcher_ConfirmationMetadataNilWhenNoneSupplied(t *testing.T) {
 	sess := session.New()
 
 	tool := tools.Tool{
-		Name:    "shell",
-		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) { panic("must not run") },
+		Name: "shell",
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
+			panic("must not run")
+		},
 	}
 
 	resume := make(chan toolexec.ResumeRequest, 1)
@@ -788,7 +802,7 @@ func TestDispatcher_PreToolUsePreYoloAskPreemptsYolo(t *testing.T) {
 
 	tool := tools.Tool{
 		Name: "shell",
-		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
 			panic("must not run before approval")
 		},
 	}
@@ -847,7 +861,7 @@ func TestDispatcher_PreToolUsePreYoloDenyShortCircuits(t *testing.T) {
 
 	tool := tools.Tool{
 		Name: "shell",
-		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
 			panic("must not run when denied")
 		},
 	}
@@ -894,7 +908,7 @@ func TestDispatcher_PreToolUsePreYoloAllowIsAdvisory(t *testing.T) {
 	ran := false
 	tool := tools.Tool{
 		Name: "shell",
-		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
 			ran = true
 			return tools.ResultSuccess("ok"), nil
 		},
@@ -941,7 +955,7 @@ func TestDispatcher_PreToolUseDefaultLaneSkippedUnderYolo(t *testing.T) {
 	ran := false
 	tool := tools.Tool{
 		Name: "shell",
-		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
 			ran = true
 			return tools.ResultSuccess("ok"), nil
 		},
@@ -993,7 +1007,7 @@ func TestDispatcher_NonInteractiveAskAutoDenies(t *testing.T) {
 
 	tool := tools.Tool{
 		Name: "shell",
-		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
 			panic("must not run when denied")
 		},
 	}
@@ -1039,7 +1053,7 @@ func TestDispatcher_NonInteractiveDefaultAskAutoDenies(t *testing.T) {
 
 	tool := tools.Tool{
 		Name: "shell",
-		Handler: func(context.Context, tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
 			panic("must not run when denied")
 		},
 	}

--- a/pkg/runtime/turn_end_test.go
+++ b/pkg/runtime/turn_end_test.go
@@ -348,7 +348,7 @@ func TestTurnEndFiresEveryIteration(t *testing.T) {
 	noopTool := tools.Tool{
 		Name:       "noop",
 		Parameters: map[string]any{},
-		Handler: func(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+		Handler: func(_ context.Context, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 			return tools.ResultSuccess("ok"), nil
 		},
 	}

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -179,6 +179,24 @@ func (sm *SessionManager) RegisterFollowUpInjector(sessionID string, fn FollowUp
 	sm.followUpInjectors.Store(sessionID, fn)
 }
 
+type recallHandlerSetter interface {
+	SetRecallHandler(handler runtime.RecallHandler)
+}
+
+func (sm *SessionManager) registerRecallHandler(sessionID string, rt runtime.Runtime) {
+	setter, ok := rt.(recallHandlerSetter)
+	if !ok {
+		return
+	}
+	setter.SetRecallHandler(func(ctx context.Context, msg runtime.QueuedMessage) bool {
+		if err := sm.recallSession(ctx, sessionID, msg); err != nil {
+			slog.WarnContext(ctx, "Failed to handle tool recall", "session_id", sessionID, "error", err)
+			return false
+		}
+		return true
+	})
+}
+
 // StreamEvents replays and tails the events buffered for sessionID, calling
 // send for each one with its sequence number. When since is non-nil only
 // events newer than *since are replayed before tailing (see [eventLog.stream]
@@ -210,6 +228,7 @@ func (sm *SessionManager) AttachRuntime(ctx context.Context, sessionID string, r
 		cancel:  cancel,
 		session: sess,
 	})
+	sm.registerRecallHandler(sessionID, rt)
 	sm.markReady()
 }
 
@@ -613,6 +632,7 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 			titleGen: titleGen,
 		}
 		sm.runtimeSessions.Store(sessionID, runtimeSession)
+		sm.registerRecallHandler(sessionID, rt)
 		sm.markReady()
 	} else {
 		titleGen = runtimeSession.titleGen
@@ -809,6 +829,56 @@ func (sm *SessionManager) FollowUpSession(ctx context.Context, sessionID string,
 	}
 
 	return streaming, false, nil
+}
+
+func (sm *SessionManager) recallSession(ctx context.Context, sessionID string, msg runtime.QueuedMessage) error {
+	if inject, ok := sm.followUpInjectors.Load(sessionID); ok {
+		inject(ctx, msg.Content)
+		return nil
+	}
+
+	rt, exists := sm.runtimeSessions.Load(sessionID)
+	if !exists {
+		return ErrSessionNotRunning
+	}
+	if !rt.streaming.TryLock() {
+		return rt.runtime.Steer(ctx, msg)
+	}
+
+	sm.mux.Lock()
+	sess := rt.session
+	if sess == nil {
+		var err error
+		sess, err = sm.sessionStore.GetSession(ctx, sessionID)
+		if err != nil {
+			sm.mux.Unlock()
+			rt.streaming.Unlock()
+			return err
+		}
+	}
+	sess.AddMessage(session.UserMessage(msg.Content, msg.MultiContent...))
+	if err := sm.sessionStore.UpdateSession(ctx, sess); err != nil {
+		sm.mux.Unlock()
+		rt.streaming.Unlock()
+		return err
+	}
+	rt.session = sess
+	sm.mux.Unlock()
+
+	go func() {
+		defer rt.streaming.Unlock()
+		stream := rt.runtime.RunStream(context.WithoutCancel(ctx), sess)
+		for event := range stream {
+			if pe, ok := sm.eventLogs.Load(sessionID); ok {
+				pe.log.append(event)
+			}
+		}
+		if err := sm.sessionStore.UpdateSession(context.WithoutCancel(ctx), sess); err != nil {
+			slog.WarnContext(ctx, "Failed to persist recalled session", "session_id", sessionID, "error", err)
+		}
+	}()
+
+	return nil
 }
 
 // ResumeElicitation resumes an elicitation request.

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -63,12 +63,10 @@ type SessionManager struct {
 	sessionReady     chan struct{}
 	sessionReadyOnce sync.Once
 
-	// followUpInjectors routes a follow-up for an attached session to its
-	// owner (the TUI App) instead of the runtime follow-up queue. The queue
-	// is only drained mid-stream, so for an idle attached session it would
-	// never be consumed; the injector starts a real turn whose events reach
-	// the TUI and every SSE subscriber. Keyed by session ID; set via
-	// RegisterFollowUpInjector.
+	// followUpInjectors routes follow-ups and idle recalls for an attached
+	// session to its owner instead of queues that are only drained mid-stream.
+	// The injector starts a real turn whose events reach the owner and every
+	// SSE subscriber. Keyed by session ID; set via RegisterFollowUpInjector.
 	followUpInjectors *concurrent.Map[string, FollowUpInjector]
 
 	// followUpKeys deduplicates follow-up requests per session by their
@@ -82,9 +80,10 @@ type SessionManager struct {
 // must be safe to call concurrently across requests.
 type EventSource func(ctx context.Context, send func(any))
 
-// FollowUpInjector delivers a follow-up message to the session's owner (the
-// TUI App) as if a user had submitted it, starting a real turn. Registered by
-// the attached control plane via [SessionManager.RegisterFollowUpInjector].
+// FollowUpInjector delivers a follow-up or idle recall message to the
+// session's owner as if a user had submitted it, starting a real turn.
+// Registered by the attached control plane via
+// [SessionManager.RegisterFollowUpInjector].
 type FollowUpInjector func(ctx context.Context, content string)
 
 // NewSessionManager creates a new session manager.
@@ -524,7 +523,9 @@ func (sm *SessionManager) DeleteSession(ctx context.Context, sessionID string) e
 	}
 
 	if sessionRuntime, ok := sm.runtimeSessions.Load(sess.ID); ok {
-		sessionRuntime.cancel()
+		if sessionRuntime.cancel != nil {
+			sessionRuntime.cancel()
+		}
 		// Keep the entry in deletedSessions so WaitStopped can probe the
 		// streaming mutex after the runtime is deregistered.
 		sm.deletedSessions.Store(sess.ID, sessionRuntime)
@@ -646,6 +647,7 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 		cancel()
 		return nil, ErrSessionBusy
 	}
+	runtimeSession.cancel = cancel
 
 	// Apply the model override (if any) before persisting the user
 	// messages so that an invalid ref does not leave an orphaned user
@@ -845,7 +847,14 @@ func (sm *SessionManager) recallSession(ctx context.Context, sessionID string, m
 		return rt.runtime.Steer(ctx, msg)
 	}
 
+	runCtx, runCancel := context.WithCancel(context.WithoutCancel(ctx))
 	sm.mux.Lock()
+	if _, stillExists := sm.runtimeSessions.Load(sessionID); !stillExists {
+		sm.mux.Unlock()
+		rt.streaming.Unlock()
+		runCancel()
+		return ErrSessionNotRunning
+	}
 	sess := rt.session
 	if sess == nil {
 		var err error
@@ -853,6 +862,7 @@ func (sm *SessionManager) recallSession(ctx context.Context, sessionID string, m
 		if err != nil {
 			sm.mux.Unlock()
 			rt.streaming.Unlock()
+			runCancel()
 			return err
 		}
 	}
@@ -860,18 +870,26 @@ func (sm *SessionManager) recallSession(ctx context.Context, sessionID string, m
 	if err := sm.sessionStore.UpdateSession(ctx, sess); err != nil {
 		sm.mux.Unlock()
 		rt.streaming.Unlock()
+		runCancel()
 		return err
 	}
 	rt.session = sess
+	rt.cancel = runCancel
 	sm.mux.Unlock()
 
 	go func() {
 		defer rt.streaming.Unlock()
-		stream := rt.runtime.RunStream(context.WithoutCancel(ctx), sess)
+		defer runCancel()
+		stream := rt.runtime.RunStream(runCtx, sess)
 		for event := range stream {
 			if pe, ok := sm.eventLogs.Load(sessionID); ok {
 				pe.log.append(event)
 			}
+		}
+		sm.mux.Lock()
+		defer sm.mux.Unlock()
+		if _, stillExists := sm.runtimeSessions.Load(sessionID); !stillExists {
+			return
 		}
 		if err := sm.sessionStore.UpdateSession(context.WithoutCancel(ctx), sess); err != nil {
 			slog.WarnContext(ctx, "Failed to persist recalled session", "session_id", sessionID, "error", err)

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -79,6 +80,7 @@ func newTestSessionManager(t *testing.T, sess *session.Session, fake *fakeRuntim
 	sm := &SessionManager{
 		runtimeSessions:   concurrent.NewMap[string, *activeRuntimes](),
 		deletedSessions:   concurrent.NewMap[string, *activeRuntimes](),
+		eventLogs:         concurrent.NewMap[string, *pumpedEventLog](),
 		followUpInjectors: concurrent.NewMap[string, FollowUpInjector](),
 		followUpKeys:      concurrent.NewMap[string, *idempotencyCache](),
 		sessionStore:      store,
@@ -342,6 +344,27 @@ func TestFollowUpSession_UnknownSession(t *testing.T) {
 
 	_, _, err := sm.FollowUpSession(t.Context(), "does-not-exist", []api.Message{{Content: "x"}}, "")
 	assert.ErrorIs(t, err, ErrSessionNotRunning)
+}
+
+func TestRecallSession_DeleteCancelsRecalledRunAndDoesNotResurrect(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	sess := session.New()
+	fake := &fakeRuntime{release: make(chan struct{})}
+	sm := newTestSessionManager(t, sess, fake)
+
+	recall := runtime.QueuedMessage{Content: "background job finished"}
+	require.NoError(t, sm.recallSession(ctx, sess.ID, recall))
+	require.Eventually(t, func() bool {
+		return fake.concurrentStreams.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, sm.DeleteSession(ctx, sess.ID))
+	require.NoError(t, sm.WaitStopped(ctx, sess.ID, time.Second))
+
+	_, err := sm.sessionStore.GetSession(ctx, sess.ID)
+	assert.ErrorIs(t, err, session.ErrNotFound)
 }
 
 // TestFollowUpSession_IdempotencyKeyDedupes verifies that two follow-ups with

--- a/pkg/teamloader/toon.go
+++ b/pkg/teamloader/toon.go
@@ -33,8 +33,8 @@ func (f *toonTools) Tools(ctx context.Context) ([]tools.Tool, error) {
 			}
 
 			handler := tool.Handler
-			tool.Handler = func(ctx context.Context, toolCall tools.ToolCall) (*tools.ToolCallResult, error) {
-				res, err := handler(ctx, toolCall)
+			tool.Handler = func(ctx context.Context, toolCall tools.ToolCall, rt tools.Runtime) (*tools.ToolCallResult, error) {
+				res, err := handler(ctx, toolCall, rt)
 				if err != nil {
 					return res, err
 				}

--- a/pkg/teamloader/toon_test.go
+++ b/pkg/teamloader/toon_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func mockHandler(output string) tools.ToolHandler {
-	return func(ctx context.Context, toolCall tools.ToolCall) (*tools.ToolCallResult, error) {
+	return func(ctx context.Context, toolCall tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 		return tools.ResultSuccess(output), nil
 	}
 }
@@ -66,7 +66,7 @@ func TestToon(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, resultTools, 1)
 
-			result, err := resultTools[0].Handler(t.Context(), tools.ToolCall{})
+			result, err := resultTools[0].Handler(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, result.Output)
 		})

--- a/pkg/tools/a2a/a2a.go
+++ b/pkg/tools/a2a/a2a.go
@@ -213,7 +213,7 @@ func (t *Toolset) Stop(_ context.Context) error {
 }
 
 func (t *Toolset) createHandler() tools.ToolHandler {
-	return func(ctx context.Context, toolCall tools.ToolCall) (*tools.ToolCallResult, error) {
+	return func(ctx context.Context, toolCall tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 		var args struct {
 			Message string `json:"message"`
 		}

--- a/pkg/tools/a2a/a2a_test.go
+++ b/pkg/tools/a2a/a2a_test.go
@@ -66,7 +66,7 @@ func TestToolSetStreamingWithAllowPrivateIPs(t *testing.T) {
 		t.Fatalf("Tools() returned %d tools, want 1", len(toolList))
 	}
 
-	result, err := toolList[0].Handler(t.Context(), tools.ToolCall{Function: tools.FunctionCall{Arguments: `{"message":"hello"}`}})
+	result, err := toolList[0].Handler(t.Context(), tools.ToolCall{Function: tools.FunctionCall{Arguments: `{"message":"hello"}`}}, tools.NopRuntime{})
 	if err != nil {
 		t.Fatalf("Handler() error = %v", err)
 	}

--- a/pkg/tools/builtin/api/api.go
+++ b/pkg/tools/builtin/api/api.go
@@ -35,7 +35,7 @@ var (
 	_ tools.Instructable = (*ToolSet)(nil)
 )
 
-func (t *ToolSet) callTool(ctx context.Context, toolCall tools.ToolCall) (*tools.ToolCallResult, error) {
+func (t *ToolSet) callTool(ctx context.Context, toolCall tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 	endpoint := t.expander.Expand(ctx, t.config.Endpoint, nil)
 	headers := t.expander.ExpandMap(ctx, t.config.Headers)
 

--- a/pkg/tools/builtin/api/api_test.go
+++ b/pkg/tools/builtin/api/api_test.go
@@ -77,7 +77,7 @@ func TestAPITool_GET(t *testing.T) {
 		Function: tools.FunctionCall{
 			Arguments: `{"key": "mykey", "value": "myvalue"}`,
 		},
-	})
+	}, tools.NopRuntime{})
 
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"status":"ok"}`, result.Output)
@@ -98,7 +98,7 @@ func TestAPITool_POST(t *testing.T) {
 		Function: tools.FunctionCall{
 			Arguments: `{"name":"John Doe","age":30}`,
 		},
-	})
+	}, tools.NopRuntime{})
 
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"status":"ok"}`, result.Output)
@@ -126,7 +126,7 @@ func TestAPITool_Headers(t *testing.T) {
 		},
 	}, testExpander())
 
-	result, err := tool.callTool(t.Context(), tools.ToolCall{})
+	result, err := tool.callTool(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
 
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"status":"ok"}`, result.Output)
@@ -148,7 +148,7 @@ func TestAPITool_IdentityHeaders(t *testing.T) {
 		Endpoint: ts.serverURL,
 	}, testExpander())
 
-	_, err := tool.callTool(t.Context(), tools.ToolCall{})
+	_, err := tool.callTool(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
 	require.NoError(t, err)
 
 	assert.Equal(t, useragent.Header, ts.receivedHeaders.Get("User-Agent"))
@@ -228,7 +228,7 @@ func TestAPITool_RejectsLocalAddresses(t *testing.T) {
 				Endpoint: target,
 			}, testExpander())
 
-			_, err := tool.callTool(t.Context(), tools.ToolCall{})
+			_, err := tool.callTool(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "non-public address")
 		})
@@ -246,7 +246,7 @@ func TestAPITool_AllowPrivateIPsRestoresLegacyBehaviour(t *testing.T) {
 		Endpoint: ts.serverURL,
 	}, testExpander(), WithAllowPrivateIPs(true))
 
-	_, err := tool.callTool(t.Context(), tools.ToolCall{})
+	_, err := tool.callTool(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
 	require.NoError(t, err, "WithAllowPrivateIPs(true) must permit dialling 127.0.0.1")
 }
 
@@ -264,7 +264,7 @@ func TestAPITool_TimeoutHonoured(t *testing.T) {
 		Endpoint: slow.URL,
 	}, testExpander(), WithAllowPrivateIPs(true), WithTimeout(50*time.Millisecond))
 
-	_, err := tool.callTool(t.Context(), tools.ToolCall{})
+	_, err := tool.callTool(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
 	require.Error(t, err)
 }
 
@@ -298,7 +298,7 @@ func TestAPITool_LazyReplaceHeaders(t *testing.T) {
 		Function: tools.FunctionCall{
 			Arguments: `{"value": "myvalue"}`,
 		},
-	})
+	}, tools.NopRuntime{})
 
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"status":"ok"}`, result.Output)

--- a/pkg/tools/builtin/fetch/fetch_test.go
+++ b/pkg/tools/builtin/fetch/fetch_test.go
@@ -986,7 +986,7 @@ func TestFetch_LazyReplaceHeaders(t *testing.T) {
 		Function: tools.FunctionCall{
 			Arguments: fmt.Sprintf(`{"urls": [%q], "format": "text"}`, server.URL),
 		},
-	})
+	}, tools.NopRuntime{})
 
 	require.NoError(t, err)
 	assert.Contains(t, result.Output, `header value: "REFRESHED"`)

--- a/pkg/tools/builtin/filesystem/filesystem.go
+++ b/pkg/tools/builtin/filesystem/filesystem.go
@@ -881,7 +881,7 @@ func countTreeNodes(node *fsx.TreeNode) (files, dirs int) {
 // This bypasses tools.NewHandler because Go's json.Unmarshal scanner rejects
 // structurally invalid JSON before calling any custom UnmarshalJSON method.
 func (t *ToolSet) editFileHandler() tools.ToolHandler {
-	return func(ctx context.Context, toolCall tools.ToolCall) (*tools.ToolCallResult, error) {
+	return func(ctx context.Context, toolCall tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 		data := toolCall.Function.Arguments
 		if data == "" {
 			data = "{}"

--- a/pkg/tools/builtin/lsp/lsp.go
+++ b/pkg/tools/builtin/lsp/lsp.go
@@ -504,14 +504,14 @@ func lspTool(name, title, description string, readOnly bool, params any, handler
 	// kept under the cagent.* namespace for symmetry with the other
 	// builtin tool annotations and so dashboards have a uniform
 	// `cagent.tool.{kind}.*` query surface across builtins.
-	wrapped := func(ctx context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+	wrapped := func(ctx context.Context, tc tools.ToolCall, rt tools.Runtime) (*tools.ToolCallResult, error) {
 		if span := trace.SpanFromContext(ctx); span.IsRecording() {
 			span.SetAttributes(
 				attribute.String("cagent.tool.lsp.tool", name),
 				attribute.Bool("cagent.tool.lsp.read_only", readOnly),
 			)
 		}
-		return handler(ctx, tc)
+		return handler(ctx, tc, rt)
 	}
 	return tools.Tool{
 		Name:        name,

--- a/pkg/tools/builtin/lsp/lsp_multiplexer.go
+++ b/pkg/tools/builtin/lsp/lsp_multiplexer.go
@@ -141,7 +141,7 @@ func (m *Multiplexer) Tools(ctx context.Context) ([]tools.Tool, error) {
 // routeByFile returns a handler that extracts the "file" field from the JSON
 // arguments and dispatches to the backend whose file-type filter matches.
 func routeByFile(handlers []lspRouteTarget) tools.ToolHandler {
-	return func(ctx context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+	return func(ctx context.Context, tc tools.ToolCall, rt tools.Runtime) (*tools.ToolCallResult, error) {
 		var args struct {
 			File string `json:"file"`
 		}
@@ -153,7 +153,7 @@ func routeByFile(handlers []lspRouteTarget) tools.ToolHandler {
 		}
 		for _, h := range handlers {
 			if h.lsp.HandlesFile(args.File) {
-				return h.handler(ctx, tc)
+				return h.handler(ctx, tc, rt)
 			}
 		}
 		return tools.ResultError("no LSP server configured for file: " + args.File), nil
@@ -164,11 +164,11 @@ func routeByFile(handlers []lspRouteTarget) tools.ToolHandler {
 // merges the outputs. Individual backend failures are collected rather than
 // aborting the entire operation.
 func broadcastLSP(handlers []lspRouteTarget) tools.ToolHandler {
-	return func(ctx context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+	return func(ctx context.Context, tc tools.ToolCall, rt tools.Runtime) (*tools.ToolCallResult, error) {
 		var sections []string
 		var errs []error
 		for _, h := range handlers {
-			result, err := h.handler(ctx, tc)
+			result, err := h.handler(ctx, tc, rt)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("backend %s: %w", h.lsp.handler.command, err))
 				continue

--- a/pkg/tools/builtin/lsp/lsp_multiplexer_test.go
+++ b/pkg/tools/builtin/lsp/lsp_multiplexer_test.go
@@ -45,7 +45,7 @@ func callHover(t *testing.T, mux *Multiplexer, args string) *tools.ToolCallResul
 	require.NoError(t, err)
 	hover := findTool(t, allTools, ToolNameLSPHover)
 	tc := tools.ToolCall{Function: tools.FunctionCall{Name: ToolNameLSPHover, Arguments: args}}
-	result, err := hover.Handler(t.Context(), tc)
+	result, err := hover.Handler(t.Context(), tc, tools.NopRuntime{})
 	require.NoError(t, err)
 	return result
 }
@@ -136,7 +136,7 @@ func TestLSPMultiplexer_WorkspaceToolBroadcasts(t *testing.T) {
 
 	args, _ := json.Marshal(WorkspaceArgs{})
 	tc := tools.ToolCall{Function: tools.FunctionCall{Name: ToolNameLSPWorkspace, Arguments: string(args)}}
-	result, err := workspace.Handler(t.Context(), tc)
+	result, err := workspace.Handler(t.Context(), tc, tools.NopRuntime{})
 	require.NoError(t, err)
 	assert.NotEmpty(t, result.Output)
 }

--- a/pkg/tools/builtin/openapi/openapi_test.go
+++ b/pkg/tools/builtin/openapi/openapi_test.go
@@ -117,7 +117,7 @@ func callTool(t *testing.T, tool tools.Tool, args string) *tools.ToolCallResult 
 	t.Helper()
 	result, err := tool.Handler(t.Context(), tools.ToolCall{
 		Function: tools.FunctionCall{Arguments: args},
-	})
+	}, tools.NopRuntime{})
 	require.NoError(t, err)
 	return result
 }

--- a/pkg/tools/builtin/plan/plan.go
+++ b/pkg/tools/builtin/plan/plan.go
@@ -463,7 +463,7 @@ func (t *ToolSet) readPlan(ctx context.Context, params ReadPlanArgs) (*tools.Too
 	return tools.ResultJSON(plan), nil
 }
 
-func (t *ToolSet) listPlans(ctx context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+func (t *ToolSet) listPlans(ctx context.Context, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 	plans, warnings, err := t.storage.List(ctx)
 	if err != nil {
 		return tools.ResultError(err.Error()), nil

--- a/pkg/tools/builtin/plan/plan_test.go
+++ b/pkg/tools/builtin/plan/plan_test.go
@@ -225,7 +225,7 @@ func TestPlanTool_ListPlans(t *testing.T) {
 	_, err = tool.writePlan(t.Context(), WritePlanArgs{Name: "alpha", Content: "a", Author: "y"})
 	require.NoError(t, err)
 
-	result, err := tool.listPlans(t.Context(), tools.ToolCall{})
+	result, err := tool.listPlans(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
 	require.NoError(t, err)
 	assert.False(t, result.IsError)
 
@@ -242,7 +242,7 @@ func TestPlanTool_ListEmpty(t *testing.T) {
 	t.Parallel()
 	tool := newTestPlanTool(t)
 
-	result, err := tool.listPlans(t.Context(), tools.ToolCall{})
+	result, err := tool.listPlans(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
 	require.NoError(t, err)
 	assert.False(t, result.IsError)
 
@@ -262,7 +262,7 @@ func TestPlanTool_ListSkipsCorrupt(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.json"), []byte("{nope"), 0o600))
 
-	result, err := tool.listPlans(t.Context(), tools.ToolCall{})
+	result, err := tool.listPlans(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
 	require.NoError(t, err)
 	assert.False(t, result.IsError)
 
@@ -286,7 +286,7 @@ func TestPlanTool_ListNameFromFilename(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "real-name.json"), data, 0o600))
 
-	result, err := tool.listPlans(t.Context(), tools.ToolCall{})
+	result, err := tool.listPlans(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
 	require.NoError(t, err)
 	assert.False(t, result.IsError)
 
@@ -432,7 +432,7 @@ func TestPlanTool_ListNilNormalizedToEmptyArray(t *testing.T) {
 	t.Parallel()
 	tool := New(WithStorage(noBumpStorage{}))
 
-	result, err := tool.listPlans(t.Context(), tools.ToolCall{})
+	result, err := tool.listPlans(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
 	require.NoError(t, err)
 	assert.False(t, result.IsError)
 	assert.Contains(t, result.Output, `"plans":[]`)
@@ -457,7 +457,7 @@ func TestPlanTool_StorageErrorsSurfaceAsIsError(t *testing.T) {
 	assert.True(t, read.IsError)
 	assert.Contains(t, read.Output, "backend boom")
 
-	list, err := tool.listPlans(ctx, tools.ToolCall{})
+	list, err := tool.listPlans(ctx, tools.ToolCall{}, tools.NopRuntime{})
 	require.NoError(t, err)
 	assert.True(t, list.IsError)
 	assert.Contains(t, list.Output, "backend boom")
@@ -873,7 +873,7 @@ func TestPlanTool_ListIncludesStatus(t *testing.T) {
 	_, err := tool.writePlan(t.Context(), WritePlanArgs{Name: "p", Content: "x", Status: "review"})
 	require.NoError(t, err)
 
-	result, err := tool.listPlans(t.Context(), tools.ToolCall{})
+	result, err := tool.listPlans(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
 	require.NoError(t, err)
 	var list ListResult
 	require.NoError(t, json.Unmarshal([]byte(result.Output), &list))

--- a/pkg/tools/builtin/shell/script_shell.go
+++ b/pkg/tools/builtin/shell/script_shell.go
@@ -197,8 +197,8 @@ func (t *ScriptToolSet) Tools(context.Context) ([]tools.Tool, error) {
 			Description:  description,
 			Parameters:   inputSchema,
 			OutputSchema: tools.MustSchemaFor[string](),
-			Handler: func(ctx context.Context, toolCall tools.ToolCall) (*tools.ToolCallResult, error) {
-				return t.execute(ctx, &cfg, toolCall)
+			Handler: func(ctx context.Context, toolCall tools.ToolCall, rt tools.Runtime) (*tools.ToolCallResult, error) {
+				return t.execute(ctx, rt, &cfg, toolCall)
 			},
 		})
 	}
@@ -206,7 +206,7 @@ func (t *ScriptToolSet) Tools(context.Context) ([]tools.Tool, error) {
 	return toolsList, nil
 }
 
-func (t *ScriptToolSet) execute(ctx context.Context, toolConfig *latest.ScriptShellToolConfig, toolCall tools.ToolCall) (*tools.ToolCallResult, error) {
+func (t *ScriptToolSet) execute(ctx context.Context, rt tools.Runtime, toolConfig *latest.ScriptShellToolConfig, toolCall tools.ToolCall) (*tools.ToolCallResult, error) {
 	var params map[string]any
 	if toolCall.Function.Arguments != "" {
 		if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &params); err != nil {
@@ -272,7 +272,7 @@ func (t *ScriptToolSet) execute(ctx context.Context, toolConfig *latest.ScriptSh
 	}
 	cmd.Env = envCopy
 
-	output := newCommandOutput(ctx)
+	output := newCommandOutput(ctx, rt)
 	cmd.Stdout = output
 	cmd.Stderr = output
 

--- a/pkg/tools/builtin/shell/script_shell_test.go
+++ b/pkg/tools/builtin/shell/script_shell_test.go
@@ -191,7 +191,7 @@ func TestNewScript_NumberArg(t *testing.T) {
 		Function: tools.FunctionCall{
 			Arguments: `{"message": "hello", "count": 3}`,
 		},
-	})
+	}, tools.NopRuntime{})
 	require.NoError(t, err)
 	assert.False(t, result.IsError, "unexpected error: %s", result.Output)
 	assert.Equal(t, "hello\nhello\nhello\n", result.Output)
@@ -228,7 +228,7 @@ func TestScriptShellTool_DropsUndeclaredArgs(t *testing.T) {
 		Function: tools.FunctionCall{
 			Arguments: `{"name": "alice", "LD_PRELOAD": "/tmp/evil.so"}`,
 		},
-	})
+	}, tools.NopRuntime{})
 	require.NoError(t, err)
 	assert.False(t, result.IsError, "unexpected error: %s", result.Output)
 	assert.Contains(t, result.Output, "name=alice")
@@ -261,7 +261,7 @@ func TestScriptShellTool_PerToolEnvAndWorkingDir(t *testing.T) {
 
 	result, err := allTools[0].Handler(t.Context(), tools.ToolCall{
 		Function: tools.FunctionCall{Arguments: `{}`},
-	})
+	}, tools.NopRuntime{})
 	require.NoError(t, err)
 	require.False(t, result.IsError, "unexpected error: %s", result.Output)
 
@@ -316,7 +316,7 @@ func TestCreateScriptToolSet_EnvPrecedence(t *testing.T) {
 
 	result, err := allTools[0].Handler(t.Context(), tools.ToolCall{
 		Function: tools.FunctionCall{Arguments: `{"SCRIPT_PREC_ARG": "from-arg"}`},
-	})
+	}, tools.NopRuntime{})
 	require.NoError(t, err)
 	require.False(t, result.IsError, "unexpected error: %s", result.Output)
 	// `env` prints the spawned process's effective environment, i.e. what
@@ -345,7 +345,7 @@ func TestScriptShellTool_PerToolEnvOverridesToolsetEnv(t *testing.T) {
 
 	result, err := allTools[0].Handler(t.Context(), tools.ToolCall{
 		Function: tools.FunctionCall{Arguments: `{}`},
-	})
+	}, tools.NopRuntime{})
 	require.NoError(t, err)
 	require.False(t, result.IsError, "unexpected error: %s", result.Output)
 	assert.Equal(t, "per-tool", result.Output)
@@ -377,7 +377,7 @@ func TestScriptShellTool_RejectsNULInValue(t *testing.T) {
 		Function: tools.FunctionCall{
 			Arguments: "{\"name\": \"alice\\u0000extra\"}",
 		},
-	})
+	}, tools.NopRuntime{})
 	require.NoError(t, err)
 	assert.True(t, result.IsError)
 	assert.Contains(t, result.Output, "NUL byte")

--- a/pkg/tools/builtin/shell/shell.go
+++ b/pkg/tools/builtin/shell/shell.go
@@ -34,6 +34,8 @@ const (
 	ToolNameViewBackgroundJob  = "view_background_job"
 	ToolNameStopBackgroundJob  = "stop_background_job"
 	ToolNameWaitBackgroundJob  = "wait_background_job"
+
+	maxBackgroundJobOutputBytes = 10 * 1024 * 1024
 )
 
 // ToolSet provides shell command execution capabilities.
@@ -57,6 +59,7 @@ type shellHandler struct {
 	workingDir      string
 	jobs            *concurrent.Map[string, *backgroundJob]
 	jobCounter      atomic.Int64
+	recall          bool
 
 	// sudoAskpass opts this toolset into the one-time sudo privilege
 	// escalation flow (SUDO_ASKPASS bridged to the elicitation handler).
@@ -90,7 +93,8 @@ type backgroundJob struct {
 	exitCode     int
 	err          error
 	// done is closed by monitorJob when the job finishes (any terminal state).
-	done chan struct{}
+	done   chan struct{}
+	recall tools.ToolRecallEmitter
 }
 
 // limitedWriter wraps a buffer and stops writing after maxSize bytes.
@@ -180,6 +184,12 @@ type RunShellBackgroundArgs struct {
 	Cwd string `json:"cwd,omitempty" jsonschema:"Working directory (default \".\")"`
 }
 
+type RunShellBackgroundRecallArgs struct {
+	Cmd    string `json:"cmd" jsonschema:"Shell command to run in background"`
+	Cwd    string `json:"cwd,omitempty" jsonschema:"Working directory (default \".\")"`
+	Recall bool   `json:"recall,omitempty" jsonschema:"Ask to be recalled with a steering message when the background job finishes"`
+}
+
 // UnmarshalJSON accepts both "cmd" (canonical) and "command" (common alias),
 // mirroring RunShellArgs.UnmarshalJSON. See its comment for rationale.
 func (a *RunShellBackgroundArgs) UnmarshalJSON(data []byte) error {
@@ -193,6 +203,24 @@ func (a *RunShellBackgroundArgs) UnmarshalJSON(data []byte) error {
 	}
 	a.Cmd = preferNonBlank(raw.Cmd, raw.Command)
 	a.Cwd = raw.Cwd
+	return nil
+}
+
+// UnmarshalJSON accepts both "cmd" (canonical) and "command" (common alias),
+// mirroring RunShellArgs.UnmarshalJSON. See its comment for rationale.
+func (a *RunShellBackgroundRecallArgs) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Cmd     string `json:"cmd"`
+		Command string `json:"command"`
+		Cwd     string `json:"cwd"`
+		Recall  bool   `json:"recall"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	a.Cmd = preferNonBlank(raw.Cmd, raw.Command)
+	a.Cwd = raw.Cwd
+	a.Recall = raw.Recall
 	return nil
 }
 
@@ -335,9 +363,35 @@ func (h *shellHandler) runNativeCommand(timeoutCtx, ctx context.Context, command
 	return tools.ResultSuccess(formattedOutput)
 }
 
+type runShellBackgroundParams struct {
+	Cmd    string
+	Cwd    string
+	Recall bool
+}
+
 func (h *shellHandler) RunShellBackground(ctx context.Context, params RunShellBackgroundArgs) (*tools.ToolCallResult, error) {
+	return h.runShellBackground(ctx, runShellBackgroundParams{Cmd: params.Cmd, Cwd: params.Cwd})
+}
+
+func (h *shellHandler) RunShellBackgroundWithRecall(ctx context.Context, params RunShellBackgroundRecallArgs) (*tools.ToolCallResult, error) {
+	return h.runShellBackground(ctx, runShellBackgroundParams(params))
+}
+
+func (h *shellHandler) runShellBackground(ctx context.Context, params runShellBackgroundParams) (*tools.ToolCallResult, error) {
 	if strings.TrimSpace(params.Cmd) == "" {
 		return tools.ResultError(`Error: missing or empty "cmd" parameter. Pass the shell command as {"cmd": "..."}.`), nil
+	}
+
+	var recall tools.ToolRecallEmitter
+	if params.Recall {
+		if !h.recall {
+			return tools.ResultError(`Error: "recall" is not enabled for this shell toolset. Set recall: true on the shell toolset before requesting recall.`), nil
+		}
+		var ok bool
+		recall, ok = tools.ToolRecallEmitterFromContext(ctx)
+		if !ok {
+			return tools.ResultError(`Error: recall requested but no recall handler is available.`), nil
+		}
 	}
 
 	counter := h.jobCounter.Add(1)
@@ -356,12 +410,13 @@ func (h *shellHandler) RunShellBackground(ctx context.Context, params RunShellBa
 		output:    &bytes.Buffer{},
 		startTime: time.Now(),
 		done:      make(chan struct{}),
+		recall:    recall,
 	}
 
 	// The limitedWriter shares the job's outputMu so that readers
 	// (ViewBackgroundJob, ListBackgroundJobs) and the pipe-copy
 	// goroutines spawned by exec.Cmd use the same lock.
-	lw := &limitedWriter{mu: &job.outputMu, buf: job.output, maxSize: 10 * 1024 * 1024}
+	lw := &limitedWriter{mu: &job.outputMu, buf: job.output, maxSize: maxBackgroundJobOutputBytes}
 	cmd.Stdout = lw
 	cmd.Stderr = lw
 
@@ -384,8 +439,13 @@ func (h *shellHandler) RunShellBackground(ctx context.Context, params RunShellBa
 
 	go h.monitorJob(job, cmd)
 
-	return tools.ResultSuccess(fmt.Sprintf("Background job started with ID: %s\nCommand: %s\nWorking directory: %s",
-		jobID, params.Cmd, params.Cwd)), nil
+	var recallStatus string
+	if params.Recall {
+		recallStatus = "\nRecall: requested; a steering message will be sent when the job finishes."
+	}
+
+	return tools.ResultSuccess(fmt.Sprintf("Background job started with ID: %s\nCommand: %s\nWorking directory: %s%s",
+		jobID, params.Cmd, params.Cwd, recallStatus)), nil
 }
 
 func (h *shellHandler) monitorJob(job *backgroundJob, cmd *exec.Cmd) {
@@ -396,9 +456,8 @@ func (h *shellHandler) monitorJob(job *backgroundJob, cmd *exec.Cmd) {
 	err := cmd.Wait()
 
 	job.outputMu.Lock()
-	defer job.outputMu.Unlock()
-
 	if job.status.Load() == statusStopped {
+		job.outputMu.Unlock()
 		return
 	}
 
@@ -413,6 +472,19 @@ func (h *shellHandler) monitorJob(job *backgroundJob, cmd *exec.Cmd) {
 	} else {
 		job.exitCode = 0
 		job.status.Store(statusCompleted)
+	}
+
+	status := job.status.Load()
+	exitCode := job.exitCode
+	output := job.output.String()
+	recall := job.recall
+	job.outputMu.Unlock()
+
+	if recall != nil {
+		message := formatBackgroundJobRecall(job, status, exitCode, output)
+		if !recall(message) {
+			slog.Warn("Failed to enqueue background job recall", "job_id", job.id)
+		}
 	}
 }
 
@@ -469,7 +541,7 @@ func renderBackgroundJob(job *backgroundJob) string {
 		result.WriteString("<no output>\n")
 	} else {
 		result.WriteString(output)
-		if len(output) >= 10*1024*1024 {
+		if len(output) >= maxBackgroundJobOutputBytes {
 			result.WriteString("\n\n[Output truncated at 10MB limit]")
 		}
 	}
@@ -533,6 +605,22 @@ func (h *shellHandler) StopBackgroundJob(_ context.Context, params StopBackgroun
 	return tools.ResultSuccess(fmt.Sprintf("Job %s stopped successfully", params.JobID)), nil
 }
 
+func formatBackgroundJobRecall(job *backgroundJob, status int32, exitCode int, output string) string {
+	var result strings.Builder
+	fmt.Fprintf(&result, "Background job %s finished with status %s (exit code %d).\n", job.id, statusToString(status), exitCode)
+	fmt.Fprintf(&result, "Command: %s\n\n", job.cmd)
+	result.WriteString("--- Output ---\n")
+	if output == "" {
+		result.WriteString("<no output>\n")
+	} else {
+		result.WriteString(output)
+		if len(output) >= maxBackgroundJobOutputBytes {
+			result.WriteString("\n\n[Output truncated at 10MB limit]")
+		}
+	}
+	return result.String()
+}
+
 // reapSpawnedChild terminates a child that we've started but decided not
 // to run (e.g. follow-up setup failed) and waits for it so we don't leak a
 // zombie or its stdout/stderr pipes. SIGTERM is sent first; if the child
@@ -571,6 +659,9 @@ func CreateToolSet(ctx context.Context, toolset latest.Toolset, runConfig *confi
 	ts := New(env, runConfig)
 	if toolset.SudoAskpass != nil && *toolset.SudoAskpass {
 		ts.handler.sudoAskpass = true
+	}
+	if toolset.Recall != nil && *toolset.Recall {
+		ts.handler.recall = true
 	}
 	return ts, nil
 }
@@ -628,7 +719,7 @@ func formatCommandOutput(timeoutCtx, ctx context.Context, err error, rawOutput s
 }
 
 func (t *ToolSet) Instructions() string {
-	return `## Shell Tools
+	instructions := `## Shell Tools
 
 - Each call runs in a fresh shell session — no state persists between calls
 - Default timeout: 30s. Set "timeout" for longer operations (builds, tests)
@@ -641,6 +732,34 @@ func (t *ToolSet) Instructions() string {
 Use run_background_job for long-running processes (servers, watchers). Output capped at 10MB per job. All jobs auto-terminate when the agent stops.
 
 Use wait_background_job to block until a job finishes and retrieve its exit code and full output. Pass an optional timeout (seconds) to cap how long to wait; the job keeps running if the timeout fires.`
+	if t.handler.recall {
+		instructions += `
+
+When starting a background job, set "recall": true if you want the agent loop to be steered automatically with a short completion message and the job output when it finishes.`
+	}
+	return instructions
+}
+
+func (t *ToolSet) runBackgroundJobDescription() string {
+	description := `Starts a shell command in the background and returns immediately with a job ID. Use this for long-running processes like servers, watches, or any command that should run while other tasks are performed.`
+	if t.handler.recall {
+		description += ` Set recall=true to receive a steering message with the job output when it finishes.`
+	}
+	return description
+}
+
+func runShellBackgroundParameters(recall bool) any {
+	if recall {
+		return tools.MustSchemaFor[RunShellBackgroundRecallArgs]()
+	}
+	return tools.MustSchemaFor[RunShellBackgroundArgs]()
+}
+
+func (t *ToolSet) runBackgroundJobHandler() tools.ToolHandler {
+	if t.handler.recall {
+		return tools.NewHandler(t.handler.RunShellBackgroundWithRecall)
+	}
+	return tools.NewHandler(t.handler.RunShellBackground)
 }
 
 func (t *ToolSet) Tools(context.Context) ([]tools.Tool, error) {
@@ -658,10 +777,10 @@ func (t *ToolSet) Tools(context.Context) ([]tools.Tool, error) {
 		{
 			Name:                    ToolNameRunShellBackground,
 			Category:                "shell",
-			Description:             `Starts a shell command in the background and returns immediately with a job ID. Use this for long-running processes like servers, watches, or any command that should run while other tasks are performed.`,
-			Parameters:              tools.MustSchemaFor[RunShellBackgroundArgs](),
+			Description:             t.runBackgroundJobDescription(),
+			Parameters:              runShellBackgroundParameters(t.handler.recall),
 			OutputSchema:            tools.MustSchemaFor[string](),
-			Handler:                 tools.NewHandler(t.handler.RunShellBackground),
+			Handler:                 t.runBackgroundJobHandler(),
 			Annotations:             tools.ToolAnnotations{Title: "Background Job"},
 			AddDescriptionParameter: true,
 		},

--- a/pkg/tools/builtin/shell/shell.go
+++ b/pkg/tools/builtin/shell/shell.go
@@ -93,8 +93,10 @@ type backgroundJob struct {
 	exitCode     int
 	err          error
 	// done is closed by monitorJob when the job finishes (any terminal state).
-	done   chan struct{}
-	recall tools.ToolRecallEmitter
+	done chan struct{}
+	// rt is set only when the caller requested recall; monitorJob uses it
+	// to steer the agent loop once the job finishes.
+	rt tools.Runtime
 }
 
 // limitedWriter wraps a buffer and stops writing after maxSize bytes.
@@ -120,14 +122,17 @@ func (lw *limitedWriter) Write(p []byte) (n int, err error) {
 }
 
 type commandOutput struct {
-	emit tools.ToolOutputEmitter
+	emit func(output string)
 	mu   sync.Mutex
 	buf  bytes.Buffer
 }
 
-func newCommandOutput(ctx context.Context) *commandOutput {
-	emit, _ := tools.ToolOutputEmitterFromContext(ctx)
-	return &commandOutput{emit: emit}
+// newCommandOutput adapts rt.EmitOutput to the ctx-less io.Writer contract
+// of exec.Cmd; the closure scopes ctx to this command run.
+func newCommandOutput(ctx context.Context, rt tools.Runtime) *commandOutput {
+	return &commandOutput{emit: func(output string) {
+		rt.EmitOutput(ctx, output)
+	}}
 }
 
 func (o *commandOutput) Write(p []byte) (int, error) {
@@ -263,7 +268,7 @@ func statusToString(status int32) string {
 	return "unknown"
 }
 
-func (h *shellHandler) RunShell(ctx context.Context, params RunShellArgs) (*tools.ToolCallResult, error) {
+func (h *shellHandler) RunShell(ctx context.Context, params RunShellArgs, rt tools.Runtime) (*tools.ToolCallResult, error) {
 	if strings.TrimSpace(params.Cmd) == "" {
 		return tools.ResultError(`Error: missing or empty "cmd" parameter. Pass the shell command as {"cmd": "..."}.`), nil
 	}
@@ -293,7 +298,7 @@ func (h *shellHandler) RunShell(ctx context.Context, params RunShellArgs) (*tool
 
 	slog.DebugContext(ctx, "Executing native shell command", "command", params.Cmd, "cwd", cwd)
 
-	return h.runNativeCommand(timeoutCtx, ctx, params.Cmd, cwd, timeout), nil
+	return h.runNativeCommand(timeoutCtx, ctx, rt, params.Cmd, cwd, timeout), nil
 }
 
 // waitDelayAfterShellExit caps how long cmd.Wait() blocks on stdout/stderr
@@ -311,7 +316,7 @@ func (h *shellHandler) RunShell(ctx context.Context, params RunShellArgs) (*tool
 // shell itself produced is already flushed by the time it exits.
 const waitDelayAfterShellExit = 500 * time.Millisecond
 
-func (h *shellHandler) runNativeCommand(timeoutCtx, ctx context.Context, command, cwd string, timeout time.Duration) *tools.ToolCallResult {
+func (h *shellHandler) runNativeCommand(timeoutCtx, ctx context.Context, rt tools.Runtime, command, cwd string, timeout time.Duration) *tools.ToolCallResult {
 	// Cancellation is handled manually below (timeoutCtx + Process.Kill +
 	// process group + WaitDelay), so we use exec.Command rather than
 	// exec.CommandContext to keep that flow in one place.
@@ -322,7 +327,7 @@ func (h *shellHandler) runNativeCommand(timeoutCtx, ctx context.Context, command
 	cmd.SysProcAttr = platformSpecificSysProcAttr()
 	cmd.WaitDelay = waitDelayAfterShellExit
 
-	output := newCommandOutput(ctx)
+	output := newCommandOutput(ctx, rt)
 	cmd.Stdout = output
 	cmd.Stderr = output
 
@@ -369,28 +374,25 @@ type runShellBackgroundParams struct {
 	Recall bool
 }
 
-func (h *shellHandler) RunShellBackground(ctx context.Context, params RunShellBackgroundArgs) (*tools.ToolCallResult, error) {
-	return h.runShellBackground(ctx, runShellBackgroundParams{Cmd: params.Cmd, Cwd: params.Cwd})
+func (h *shellHandler) RunShellBackground(ctx context.Context, params RunShellBackgroundArgs, rt tools.Runtime) (*tools.ToolCallResult, error) {
+	return h.runShellBackground(ctx, rt, runShellBackgroundParams{Cmd: params.Cmd, Cwd: params.Cwd})
 }
 
-func (h *shellHandler) RunShellBackgroundWithRecall(ctx context.Context, params RunShellBackgroundRecallArgs) (*tools.ToolCallResult, error) {
-	return h.runShellBackground(ctx, runShellBackgroundParams(params))
+func (h *shellHandler) RunShellBackgroundWithRecall(ctx context.Context, params RunShellBackgroundRecallArgs, rt tools.Runtime) (*tools.ToolCallResult, error) {
+	return h.runShellBackground(ctx, rt, runShellBackgroundParams(params))
 }
 
-func (h *shellHandler) runShellBackground(ctx context.Context, params runShellBackgroundParams) (*tools.ToolCallResult, error) {
+func (h *shellHandler) runShellBackground(ctx context.Context, rt tools.Runtime, params runShellBackgroundParams) (*tools.ToolCallResult, error) {
 	if strings.TrimSpace(params.Cmd) == "" {
 		return tools.ResultError(`Error: missing or empty "cmd" parameter. Pass the shell command as {"cmd": "..."}.`), nil
 	}
 
-	var recall tools.ToolRecallEmitter
 	if params.Recall {
 		if !h.recall {
 			return tools.ResultError(`Error: "recall" is not enabled for this shell toolset. Set recall: true on the shell toolset before requesting recall.`), nil
 		}
-		var ok bool
-		recall, ok = tools.ToolRecallEmitterFromContext(ctx)
-		if !ok {
-			return tools.ResultError(`Error: recall requested but no recall handler is available.`), nil
+		if !rt.Supports(tools.CapabilityRecall) {
+			return tools.ResultError(`Error: recall requested but the host does not support recall.`), nil
 		}
 	}
 
@@ -410,7 +412,9 @@ func (h *shellHandler) runShellBackground(ctx context.Context, params runShellBa
 		output:    &bytes.Buffer{},
 		startTime: time.Now(),
 		done:      make(chan struct{}),
-		recall:    recall,
+	}
+	if params.Recall {
+		job.rt = rt
 	}
 
 	// The limitedWriter shares the job's outputMu so that readers
@@ -437,7 +441,9 @@ func (h *shellHandler) runShellBackground(ctx context.Context, params runShellBa
 	job.status.Store(statusRunning)
 	h.jobs.Store(jobID, job)
 
-	go h.monitorJob(job, cmd)
+	// The job outlives this tool call: keep ctx values (trace, session id)
+	// for the recall but drop cancellation.
+	go h.monitorJob(context.WithoutCancel(ctx), job, cmd)
 
 	var recallStatus string
 	if params.Recall {
@@ -448,7 +454,7 @@ func (h *shellHandler) runShellBackground(ctx context.Context, params runShellBa
 		jobID, params.Cmd, params.Cwd, recallStatus)), nil
 }
 
-func (h *shellHandler) monitorJob(job *backgroundJob, cmd *exec.Cmd) {
+func (h *shellHandler) monitorJob(ctx context.Context, job *backgroundJob, cmd *exec.Cmd) {
 	// close done after all fields are written so WaitBackgroundJob readers see
 	// the final state. Defers are LIFO: Unlock runs before close(done).
 	defer close(job.done)
@@ -477,13 +483,13 @@ func (h *shellHandler) monitorJob(job *backgroundJob, cmd *exec.Cmd) {
 	status := job.status.Load()
 	exitCode := job.exitCode
 	output := job.output.String()
-	recall := job.recall
+	rt := job.rt
 	job.outputMu.Unlock()
 
-	if recall != nil {
+	if rt != nil {
 		message := formatBackgroundJobRecall(job, status, exitCode, output)
-		if !recall(message) {
-			slog.Warn("Failed to enqueue background job recall", "job_id", job.id)
+		if err := rt.Recall(ctx, message); err != nil {
+			slog.WarnContext(ctx, "Failed to enqueue background job recall", "job_id", job.id, "error", err)
 		}
 	}
 }
@@ -757,9 +763,9 @@ func runShellBackgroundParameters(recall bool) any {
 
 func (t *ToolSet) runBackgroundJobHandler() tools.ToolHandler {
 	if t.handler.recall {
-		return tools.NewHandler(t.handler.RunShellBackgroundWithRecall)
+		return tools.NewRuntimeHandler(t.handler.RunShellBackgroundWithRecall)
 	}
-	return tools.NewHandler(t.handler.RunShellBackground)
+	return tools.NewRuntimeHandler(t.handler.RunShellBackground)
 }
 
 func (t *ToolSet) Tools(context.Context) ([]tools.Tool, error) {
@@ -770,7 +776,7 @@ func (t *ToolSet) Tools(context.Context) ([]tools.Tool, error) {
 			Description:             `Executes the given shell command in the user's default shell.`,
 			Parameters:              tools.MustSchemaFor[RunShellArgs](),
 			OutputSchema:            tools.MustSchemaFor[string](),
-			Handler:                 tools.NewHandler(t.handler.RunShell),
+			Handler:                 tools.NewRuntimeHandler(t.handler.RunShell),
 			Annotations:             tools.ToolAnnotations{Title: "Shell"},
 			AddDescriptionParameter: true,
 		},

--- a/pkg/tools/builtin/shell/shell_test.go
+++ b/pkg/tools/builtin/shell/shell_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
@@ -134,6 +135,16 @@ func TestRunShellBackgroundArgs_UnmarshalJSON_AcceptsCmdAndCommand(t *testing.T)
 	var blankCmd RunShellBackgroundArgs
 	require.NoError(t, json.Unmarshal([]byte(`{"cmd":"   ","command":"sleep 1"}`), &blankCmd))
 	assert.Equal(t, "sleep 1", blankCmd.Cmd)
+}
+
+func TestRunShellBackgroundRecallArgs_UnmarshalJSON_AcceptsRecall(t *testing.T) {
+	t.Parallel()
+
+	var withRecall RunShellBackgroundRecallArgs
+	require.NoError(t, json.Unmarshal([]byte(`{"command":"sleep 1","cwd":"/tmp","recall":true}`), &withRecall))
+	assert.Equal(t, "sleep 1", withRecall.Cmd)
+	assert.Equal(t, "/tmp", withRecall.Cwd)
+	assert.True(t, withRecall.Recall)
 }
 
 // Exercises the end-to-end dispatch path: a tool-call whose raw arguments
@@ -393,6 +404,106 @@ func TestShellTool_RunBackgroundJob(t *testing.T) {
 	result, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "echo test"})
 	require.NoError(t, err)
 	assert.Contains(t, result.Output, "Background job started with ID:")
+}
+
+func TestShellTool_RunBackgroundJobRecall(t *testing.T) {
+	t.Parallel()
+	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	tool.handler.recall = true
+	err := tool.Start(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tool.Stop(t.Context())
+	})
+
+	recalls := make(chan string, 1)
+	ctx := tools.WithToolRecallEmitter(t.Context(), func(message string) bool {
+		recalls <- message
+		return true
+	})
+	result, err := tool.handler.RunShellBackgroundWithRecall(ctx, RunShellBackgroundRecallArgs{Cmd: "echo recall-output", Recall: true})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "Recall: requested")
+
+	select {
+	case msg := <-recalls:
+		assert.Contains(t, msg, "Background job")
+		assert.Contains(t, msg, "finished with status completed")
+		assert.Contains(t, msg, "recall-output")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for background job recall")
+	}
+}
+
+func TestShellTool_RunBackgroundJobRecallRequiresConfig(t *testing.T) {
+	t.Parallel()
+	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	ctx := tools.WithToolRecallEmitter(t.Context(), func(string) bool { return true })
+
+	result, err := tool.handler.RunShellBackgroundWithRecall(ctx, RunShellBackgroundRecallArgs{Cmd: "echo test", Recall: true})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	assert.Contains(t, result.Output, "recall")
+	assert.Contains(t, result.Output, "not enabled")
+	assert.Equal(t, 0, tool.handler.jobs.Length())
+}
+
+func TestShellTool_RunBackgroundJobRecallRequiresCallback(t *testing.T) {
+	t.Parallel()
+	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	tool.handler.recall = true
+
+	result, err := tool.handler.RunShellBackgroundWithRecall(t.Context(), RunShellBackgroundRecallArgs{Cmd: "echo test", Recall: true})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	assert.Contains(t, result.Output, "no recall handler")
+	assert.Equal(t, 0, tool.handler.jobs.Length())
+}
+
+func TestCreateToolSetEnablesRecall(t *testing.T) {
+	t.Parallel()
+
+	recall := true
+	toolSet, err := CreateToolSet(t.Context(), latest.Toolset{Type: "shell", Recall: &recall}, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	require.NoError(t, err)
+
+	shellToolSet, ok := toolSet.(*ToolSet)
+	require.True(t, ok)
+	assert.True(t, shellToolSet.handler.recall)
+}
+
+func TestShellTool_RunBackgroundJobSchemaRecall(t *testing.T) {
+	t.Parallel()
+
+	withoutRecall := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	withoutTools, err := withoutRecall.Tools(t.Context())
+	require.NoError(t, err)
+	withoutSchema, err := tools.SchemaToMap(findShellTool(t, withoutTools, ToolNameRunShellBackground).Parameters)
+	require.NoError(t, err)
+	withoutProps, ok := withoutSchema["properties"].(map[string]any)
+	require.True(t, ok)
+	assert.NotContains(t, withoutProps, "recall")
+
+	withRecall := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	withRecall.handler.recall = true
+	withTools, err := withRecall.Tools(t.Context())
+	require.NoError(t, err)
+	withSchema, err := tools.SchemaToMap(findShellTool(t, withTools, ToolNameRunShellBackground).Parameters)
+	require.NoError(t, err)
+	withProps, ok := withSchema["properties"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, withProps, "recall")
+}
+
+func findShellTool(t *testing.T, toolList []tools.Tool, name string) tools.Tool {
+	t.Helper()
+	for _, tool := range toolList {
+		if tool.Name == name {
+			return tool
+		}
+	}
+	t.Fatalf("tool %q not found", name)
+	return tools.Tool{}
 }
 
 func TestShellTool_ListBackgroundJobs(t *testing.T) {

--- a/pkg/tools/builtin/shell/shell_test.go
+++ b/pkg/tools/builtin/shell/shell_test.go
@@ -41,7 +41,7 @@ func TestShellTool_HandlerEcho(t *testing.T) {
 	result, err := tool.handler.RunShell(t.Context(), RunShellArgs{
 		Cmd: "echo 'hello world'",
 		Cwd: "",
-	})
+	}, tools.NopRuntime{})
 	require.NoError(t, err)
 	assert.Contains(t, result.Output, "hello world")
 }
@@ -54,7 +54,7 @@ func TestShellTool_HandlerWithCwd(t *testing.T) {
 	result, err := tool.handler.RunShell(t.Context(), RunShellArgs{
 		Cmd: "pwd",
 		Cwd: tmpDir,
-	})
+	}, tools.NopRuntime{})
 	require.NoError(t, err)
 	// The output might contain extra newlines or other characters,
 	// so we just check if it contains the temp dir path
@@ -157,7 +157,7 @@ func TestShellTool_HandlerAcceptsCommandAlias(t *testing.T) {
 	var params RunShellArgs
 	require.NoError(t, json.Unmarshal([]byte(`{"command":"echo hello-from-alias"}`), &params))
 
-	result, err := tool.handler.RunShell(t.Context(), params)
+	result, err := tool.handler.RunShell(t.Context(), params, tools.NopRuntime{})
 	require.NoError(t, err)
 	assert.Contains(t, result.Output, "hello-from-alias")
 }
@@ -166,7 +166,7 @@ func TestShellTool_HandlerMissingCmdReturnsActionableError(t *testing.T) {
 	t.Parallel()
 	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
 
-	result, err := tool.handler.RunShell(t.Context(), RunShellArgs{})
+	result, err := tool.handler.RunShell(t.Context(), RunShellArgs{}, tools.NopRuntime{})
 	require.NoError(t, err)
 	assert.Contains(t, result.Output, `"cmd"`,
 		"error must name the expected parameter so the model can self-correct")
@@ -179,7 +179,7 @@ func TestShellTool_HandlerError(t *testing.T) {
 	result, err := tool.handler.RunShell(t.Context(), RunShellArgs{
 		Cmd: "command_that_does_not_exist",
 		Cwd: "",
-	})
+	}, tools.NopRuntime{})
 	require.NoError(t, err, "Handler should not return an error")
 	assert.Contains(t, result.Output, "Error executing command")
 }
@@ -221,7 +221,7 @@ func TestShellTool_WaitBackgroundJob_Completed(t *testing.T) {
 	require.NoError(t, tool.Start(t.Context()))
 	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
 
-	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "echo hello"})
+	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "echo hello"}, tools.NopRuntime{})
 	require.NoError(t, err)
 
 	// Retrieve the job ID from the map.
@@ -248,7 +248,7 @@ func TestShellTool_WaitBackgroundJob_FailedExit(t *testing.T) {
 	require.NoError(t, tool.Start(t.Context()))
 	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
 
-	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "exit 3"})
+	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "exit 3"}, tools.NopRuntime{})
 	require.NoError(t, err)
 
 	var jobID string
@@ -273,7 +273,7 @@ func TestShellTool_WaitBackgroundJob_AlreadyCompleted(t *testing.T) {
 	require.NoError(t, tool.Start(t.Context()))
 	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
 
-	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "echo done"})
+	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "echo done"}, tools.NopRuntime{})
 	require.NoError(t, err)
 
 	var jobID string
@@ -313,7 +313,7 @@ func TestShellTool_WaitBackgroundJob_Timeout(t *testing.T) {
 	require.NoError(t, tool.Start(t.Context()))
 	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
 
-	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "sleep 30"})
+	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "sleep 30"}, tools.NopRuntime{})
 	require.NoError(t, err)
 
 	var jobID string
@@ -342,7 +342,7 @@ func TestShellTool_WaitBackgroundJob_ContextCancelled(t *testing.T) {
 	require.NoError(t, tool.Start(t.Context()))
 	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
 
-	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "sleep 30"})
+	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "sleep 30"}, tools.NopRuntime{})
 	require.NoError(t, err)
 
 	var jobID string
@@ -369,7 +369,7 @@ func TestShellTool_WaitBackgroundJob_Stopped(t *testing.T) {
 	require.NoError(t, tool.Start(t.Context()))
 	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
 
-	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "sleep 30"})
+	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "sleep 30"}, tools.NopRuntime{})
 	require.NoError(t, err)
 
 	var jobID string
@@ -401,7 +401,7 @@ func TestShellTool_RunBackgroundJob(t *testing.T) {
 		_ = tool.Stop(t.Context())
 	})
 
-	result, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "echo test"})
+	result, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "echo test"}, tools.NopRuntime{})
 	require.NoError(t, err)
 	assert.Contains(t, result.Output, "Background job started with ID:")
 }
@@ -416,17 +416,13 @@ func TestShellTool_RunBackgroundJobRecall(t *testing.T) {
 		_ = tool.Stop(t.Context())
 	})
 
-	recalls := make(chan string, 1)
-	ctx := tools.WithToolRecallEmitter(t.Context(), func(message string) bool {
-		recalls <- message
-		return true
-	})
-	result, err := tool.handler.RunShellBackgroundWithRecall(ctx, RunShellBackgroundRecallArgs{Cmd: "echo recall-output", Recall: true})
+	rt := &recallRuntime{recalls: make(chan string, 1)}
+	result, err := tool.handler.RunShellBackgroundWithRecall(t.Context(), RunShellBackgroundRecallArgs{Cmd: "echo recall-output", Recall: true}, rt)
 	require.NoError(t, err)
 	assert.Contains(t, result.Output, "Recall: requested")
 
 	select {
-	case msg := <-recalls:
+	case msg := <-rt.recalls:
 		assert.Contains(t, msg, "Background job")
 		assert.Contains(t, msg, "finished with status completed")
 		assert.Contains(t, msg, "recall-output")
@@ -438,9 +434,8 @@ func TestShellTool_RunBackgroundJobRecall(t *testing.T) {
 func TestShellTool_RunBackgroundJobRecallRequiresConfig(t *testing.T) {
 	t.Parallel()
 	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
-	ctx := tools.WithToolRecallEmitter(t.Context(), func(string) bool { return true })
 
-	result, err := tool.handler.RunShellBackgroundWithRecall(ctx, RunShellBackgroundRecallArgs{Cmd: "echo test", Recall: true})
+	result, err := tool.handler.RunShellBackgroundWithRecall(t.Context(), RunShellBackgroundRecallArgs{Cmd: "echo test", Recall: true}, &recallRuntime{})
 	require.NoError(t, err)
 	require.True(t, result.IsError)
 	assert.Contains(t, result.Output, "recall")
@@ -453,11 +448,27 @@ func TestShellTool_RunBackgroundJobRecallRequiresCallback(t *testing.T) {
 	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
 	tool.handler.recall = true
 
-	result, err := tool.handler.RunShellBackgroundWithRecall(t.Context(), RunShellBackgroundRecallArgs{Cmd: "echo test", Recall: true})
+	result, err := tool.handler.RunShellBackgroundWithRecall(t.Context(), RunShellBackgroundRecallArgs{Cmd: "echo test", Recall: true}, tools.NopRuntime{})
 	require.NoError(t, err)
 	require.True(t, result.IsError)
-	assert.Contains(t, result.Output, "no recall handler")
+	assert.Contains(t, result.Output, "does not support recall")
 	assert.Equal(t, 0, tool.handler.jobs.Length())
+}
+
+// recallRuntime is a tools.Runtime stub that captures recall messages.
+type recallRuntime struct {
+	tools.NopRuntime
+
+	recalls chan string
+}
+
+func (r *recallRuntime) Recall(_ context.Context, message string) error {
+	r.recalls <- message
+	return nil
+}
+
+func (r *recallRuntime) Supports(c tools.Capability) bool {
+	return c == tools.CapabilityRecall
 }
 
 func TestCreateToolSetEnablesRecall(t *testing.T) {
@@ -516,7 +527,7 @@ func TestShellTool_ListBackgroundJobs(t *testing.T) {
 	})
 
 	// Start a background job first
-	_, err = tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "echo test"})
+	_, err = tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "echo test"}, tools.NopRuntime{})
 	require.NoError(t, err)
 
 	// No need to wait - ListBackgroundJobs shows jobs regardless of status
@@ -577,7 +588,7 @@ func TestShellTool_RelativeCwdResolvesAgainstWorkingDir(t *testing.T) {
 	result, err := tool.handler.RunShell(t.Context(), RunShellArgs{
 		Cmd: "pwd",
 		Cwd: "subdir",
-	})
+	}, tools.NopRuntime{})
 	require.NoError(t, err)
 	assert.Contains(t, result.Output, subdir,
 		"relative cwd must resolve against the configured workingDir, not the process cwd")
@@ -607,7 +618,7 @@ func TestShellTool_BackgroundedChildDoesNotBlockReturn(t *testing.T) {
 		// open for 30s. The tool must return as soon as the shell exits.
 		Cmd:     "sleep 30 &",
 		Timeout: 20,
-	})
+	}, tools.NopRuntime{})
 	elapsed := time.Since(start)
 
 	require.NoError(t, err)
@@ -642,7 +653,7 @@ func TestShellTool_DetachedBackgroundedChildDoesNotBlockReturn(t *testing.T) {
 			// it. Only cmd.WaitDelay can unblock Wait() here.
 			Cmd:     "setsid sleep 30 &",
 			Timeout: 20,
-		})
+		}, tools.NopRuntime{})
 	}()
 
 	select {

--- a/pkg/tools/builtin/tasks/tasks.go
+++ b/pkg/tools/builtin/tasks/tasks.go
@@ -459,7 +459,7 @@ func (t *ToolSet) listTasks(_ context.Context, params ListTasksArgs) (*tools.Too
 	return tools.ResultJSON(tasks), nil
 }
 
-func (t *ToolSet) nextTask(_ context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+func (t *ToolSet) nextTask(_ context.Context, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 

--- a/pkg/tools/builtin/tasks/tasks_test.go
+++ b/pkg/tools/builtin/tasks/tasks_test.go
@@ -392,7 +392,7 @@ func TestTasksTool_NextTask(t *testing.T) {
 	})
 	tool.createTask(t.Context(), CreateTaskArgs{Title: "Free low", Priority: "low"}) //nolint:errcheck // test setup
 
-	result, err := tool.nextTask(t.Context(), tools.ToolCall{})
+	result, err := tool.nextTask(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
 	require.NoError(t, err)
 
 	var task taskWithEffective
@@ -409,7 +409,7 @@ func TestTasksTool_NextTask_NoneAvailable(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(r1.Output), &task))
 	tool.updateTask(t.Context(), UpdateTaskArgs{ID: task.ID, Status: "done"}) //nolint:errcheck // test setup
 
-	result, err := tool.nextTask(t.Context(), tools.ToolCall{})
+	result, err := tool.nextTask(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
 	require.NoError(t, err)
 	assert.Contains(t, result.Output, "No actionable tasks")
 }

--- a/pkg/tools/builtin/todo/todo.go
+++ b/pkg/tools/builtin/todo/todo.go
@@ -320,7 +320,7 @@ func (h *todoHandler) incompleteReminder(ctx context.Context) string {
 	return b.String()
 }
 
-func (h *todoHandler) listTodos(ctx context.Context, _ tools.ToolCall) (*tools.ToolCallResult, error) {
+func (h *todoHandler) listTodos(ctx context.Context, _ tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 	todos := h.storage.All(ctx)
 	if todos == nil {
 		todos = []Todo{}

--- a/pkg/tools/builtin/todo/todo_test.go
+++ b/pkg/tools/builtin/todo/todo_test.go
@@ -100,7 +100,7 @@ func TestTodoTool_ListTodos(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	result, err := tool.handler.listTodos(t.Context(), tools.ToolCall{})
+	result, err := tool.handler.listTodos(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
 	require.NoError(t, err)
 
 	var output ListTodosOutput
@@ -123,7 +123,7 @@ func TestTodoTool_ListTodos_Empty(t *testing.T) {
 	t.Parallel()
 	tool := New()
 
-	result, err := tool.handler.listTodos(t.Context(), tools.ToolCall{})
+	result, err := tool.handler.listTodos(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
 	require.NoError(t, err)
 
 	var output ListTodosOutput

--- a/pkg/tools/codemode/codemode.go
+++ b/pkg/tools/codemode/codemode.go
@@ -84,8 +84,8 @@ func (c *codeModeTool) Tools(ctx context.Context) ([]tools.Tool, error) {
 		Category:    "code mode",
 		Description: prompt + strings.Join(functionsDoc, "\n"),
 		Parameters:  tools.MustSchemaFor[RunToolsWithJavascriptArgs](),
-		Handler: tools.NewHandler(func(ctx context.Context, args RunToolsWithJavascriptArgs) (*tools.ToolCallResult, error) {
-			result, err := c.runJavascript(ctx, args.Script)
+		Handler: tools.NewRuntimeHandler(func(ctx context.Context, args RunToolsWithJavascriptArgs, rt tools.Runtime) (*tools.ToolCallResult, error) {
+			result, err := c.runJavascript(ctx, rt, args.Script)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/tools/codemode/codemode_test.go
+++ b/pkg/tools/codemode/codemode_test.go
@@ -144,7 +144,7 @@ func TestCodeModeTool_CallHello(t *testing.T) {
 		Function: tools.FunctionCall{
 			Arguments: `{"script":"return hello_world();"}`,
 		},
-	})
+	}, tools.NopRuntime{})
 	require.NoError(t, err)
 
 	var scriptResult ScriptResult
@@ -180,7 +180,7 @@ func TestCodeModeTool_CallEcho(t *testing.T) {
 		Function: tools.FunctionCall{
 			Arguments: `{"script":"return echo({'message':'ECHO'});"}`,
 		},
-	})
+	}, tools.NopRuntime{})
 	require.NoError(t, err)
 
 	var scriptResult ScriptResult
@@ -275,7 +275,7 @@ func TestCodeModeTool_SuccessNoToolCalls(t *testing.T) {
 		Function: tools.FunctionCall{
 			Arguments: `{"script":"return get_data();"}`,
 		},
-	})
+	}, tools.NopRuntime{})
 	require.NoError(t, err)
 
 	var scriptResult ScriptResult
@@ -316,7 +316,7 @@ func TestCodeModeTool_FailureIncludesToolCalls(t *testing.T) {
 		Function: tools.FunctionCall{
 			Arguments: `{"script":"var a = first_tool(); var b = second_tool(); throw new Error('runtime error');"}`,
 		},
-	})
+	}, tools.NopRuntime{})
 	require.NoError(t, err)
 
 	var scriptResult ScriptResult
@@ -360,7 +360,7 @@ func TestCodeModeTool_FailureIncludesToolError(t *testing.T) {
 		Function: tools.FunctionCall{
 			Arguments: `{"script":"return failing_tool();"}`,
 		},
-	})
+	}, tools.NopRuntime{})
 	require.NoError(t, err)
 
 	var scriptResult ScriptResult
@@ -404,7 +404,7 @@ func TestCodeModeTool_FailureIncludesToolArguments(t *testing.T) {
 		Function: tools.FunctionCall{
 			Arguments: `{"script":"tool_with_args({'value': 'test123'}); throw new Error('forced error');"}`,
 		},
-	})
+	}, tools.NopRuntime{})
 	require.NoError(t, err)
 
 	var scriptResult ScriptResult

--- a/pkg/tools/codemode/exec.go
+++ b/pkg/tools/codemode/exec.go
@@ -41,7 +41,7 @@ func (t *toolCallTracker) record(info ToolCallInfo) {
 	t.calls = append(t.calls, info)
 }
 
-func (c *codeModeTool) runJavascript(ctx context.Context, script string) (ScriptResult, error) {
+func (c *codeModeTool) runJavascript(ctx context.Context, rt tools.Runtime, script string) (ScriptResult, error) {
 	vm := goja.New()
 	tracker := &toolCallTracker{}
 
@@ -83,7 +83,7 @@ func (c *codeModeTool) runJavascript(ctx context.Context, script string) (Script
 		}
 
 		for _, tool := range allTools {
-			_ = vm.Set(tool.Name, callTool(ctx, tool, tracker))
+			_ = vm.Set(tool.Name, callTool(ctx, rt, tool, tracker))
 		}
 	}
 
@@ -115,9 +115,12 @@ func (c *codeModeTool) runJavascript(ctx context.Context, script string) (Script
 	}, nil
 }
 
-func callTool(ctx context.Context, tool tools.Tool, tracker *toolCallTracker) func(args map[string]any) (string, error) {
+// callTool wraps a tool as a goja-callable function. rt is forwarded to the
+// inner handler so nested tools keep their runtime capabilities (streaming
+// output, recall) when invoked from a script.
+func callTool(ctx context.Context, rt tools.Runtime, tool tools.Tool, tracker *toolCallTracker) func(args map[string]any) (string, error) {
 	return func(args map[string]any) (string, error) {
-		output, filtered, err := invokeTool(ctx, tool, args)
+		output, filtered, err := invokeTool(ctx, rt, tool, args)
 
 		info := ToolCallInfo{
 			Name:      tool.Name,
@@ -136,7 +139,7 @@ func callTool(ctx context.Context, tool tools.Tool, tracker *toolCallTracker) fu
 
 // invokeTool calls a single tool handler, filtering out nil optional arguments.
 // It returns the output, the filtered arguments actually sent, and any error.
-func invokeTool(ctx context.Context, tool tools.Tool, args map[string]any) (string, map[string]any, error) {
+func invokeTool(ctx context.Context, rt tools.Runtime, tool tools.Tool, args map[string]any) (string, map[string]any, error) {
 	if tool.Handler == nil {
 		return "", args, fmt.Errorf("tool %q is not available in code mode", tool.Name)
 	}
@@ -166,7 +169,7 @@ func invokeTool(ctx context.Context, tool tools.Tool, args map[string]any) (stri
 			Name:      tool.Name,
 			Arguments: string(arguments),
 		},
-	})
+	}, rt)
 	if err != nil {
 		return "", filtered, err
 	}

--- a/pkg/tools/codemode/exec_test.go
+++ b/pkg/tools/codemode/exec_test.go
@@ -5,13 +5,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tools"
 )
 
 func TestRunJavascript(t *testing.T) {
 	t.Parallel()
 	tool := &codeModeTool{}
 
-	result, err := tool.runJavascript(t.Context(), `return "HELLO"`)
+	result, err := tool.runJavascript(t.Context(), tools.NopRuntime{}, `return "HELLO"`)
 	require.NoError(t, err)
 
 	assert.Equal(t, "HELLO", result.Value)
@@ -23,7 +25,7 @@ func TestRunJavascript_error(t *testing.T) {
 	t.Parallel()
 	tool := &codeModeTool{}
 
-	result, err := tool.runJavascript(t.Context(), `==`)
+	result, err := tool.runJavascript(t.Context(), tools.NopRuntime{}, `==`)
 	require.NoError(t, err)
 
 	assert.Equal(t, "SyntaxError: SyntaxError: (anonymous): Line 2:1 Unexpected token == (and 2 more errors)", result.Value)
@@ -35,7 +37,7 @@ func TestRunJavascript_console(t *testing.T) {
 	t.Parallel()
 	tool := &codeModeTool{}
 
-	result, err := tool.runJavascript(t.Context(), `console.log("to stdout"); console.error("to stderr"); return "RESULT";`)
+	result, err := tool.runJavascript(t.Context(), tools.NopRuntime{}, `console.log("to stdout"); console.error("to stderr"); return "RESULT";`)
 	require.NoError(t, err)
 
 	assert.Equal(t, "RESULT", result.Value)
@@ -47,7 +49,7 @@ func TestRunJavascript_no_result(t *testing.T) {
 	t.Parallel()
 	tool := &codeModeTool{}
 
-	result, err := tool.runJavascript(t.Context(), ``)
+	result, err := tool.runJavascript(t.Context(), tools.NopRuntime{}, ``)
 	require.NoError(t, err)
 
 	assert.Empty(t, result.Value)

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -705,7 +705,7 @@ func (ts *Toolset) refreshPromptCache(ctx context.Context) {
 	}
 }
 
-func (ts *Toolset) callTool(ctx context.Context, toolCall tools.ToolCall) (*tools.ToolCallResult, error) {
+func (ts *Toolset) callTool(ctx context.Context, toolCall tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 	slog.DebugContext(ctx, "Calling MCP tool", "tool", toolCall.Function.Name, "arguments", toolCall.Function.Arguments)
 
 	toolCall.Function.Arguments = cmp.Or(toolCall.Function.Arguments, "{}")

--- a/pkg/tools/mcp/mcp_test.go
+++ b/pkg/tools/mcp/mcp_test.go
@@ -174,7 +174,7 @@ func TestToolsAndCallToolRoundTrip(t *testing.T) {
 					Name:      exposed[0].Name,
 					Arguments: `{}`,
 				},
-			})
+			}, tools.NopRuntime{})
 			require.NoError(t, err)
 			assert.Equal(t, tt.serverToolName, capturedName,
 				"callTool() must forward the original (unprefixed) tool name to the server")
@@ -257,7 +257,7 @@ func TestCallToolStripsToolsetNamePrefix(t *testing.T) {
 					Name:      tt.calledToolName,
 					Arguments: `{}`,
 				},
-			})
+			}, tools.NopRuntime{})
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantForwardName, capturedName)
@@ -313,7 +313,7 @@ func TestCallToolStripsNullArguments(t *testing.T) {
 					Name:      "test_tool",
 					Arguments: tt.arguments,
 				},
-			})
+			}, tools.NopRuntime{})
 
 			require.NoError(t, err)
 			assert.Equal(t, "ok", result.Output)
@@ -605,7 +605,7 @@ func TestCallToolRecoversFromErrSessionMissing(t *testing.T) {
 			Name:      "test_tool",
 			Arguments: `{"key": "value"}`,
 		},
-	})
+	}, tools.NopRuntime{})
 
 	require.NoError(t, err)
 	assert.Equal(t, "recovered", result.Output)

--- a/pkg/tools/runtime.go
+++ b/pkg/tools/runtime.go
@@ -1,0 +1,54 @@
+package tools
+
+import (
+	"context"
+	"errors"
+)
+
+// Capability identifies an optional runtime facility a tool can probe for
+// via [Runtime.Supports] before relying on it.
+type Capability string
+
+const (
+	// CapabilityOutput indicates [Runtime.EmitOutput] streams incremental
+	// output to a live consumer (UI, event feed).
+	CapabilityOutput Capability = "output"
+	// CapabilityRecall indicates [Runtime.Recall] can inject messages into
+	// a running agent loop.
+	CapabilityRecall Capability = "recall"
+)
+
+// Runtime is the tool-side handle to the hosting agent runtime, passed
+// explicitly to every [ToolHandler]. Implementations must remain valid after
+// the handler returns so background work can hold the handle; every method
+// takes ctx from the caller instead of capturing one.
+//
+// Hosts without an agent loop pass [NopRuntime].
+type Runtime interface {
+	// EmitOutput streams incremental output for the current tool call.
+	EmitOutput(ctx context.Context, output string)
+	// Recall injects a message into the agent loop, waking it if idle.
+	// Typically called when background work completes after the tool call
+	// that started it has already returned.
+	Recall(ctx context.Context, message string) error
+	// Supports reports whether the host provides the named capability,
+	// letting tools fail fast before starting background work.
+	Supports(capability Capability) bool
+}
+
+// ErrRecallNotSupported is returned by [Runtime.Recall] implementations that
+// cannot steer an agent loop.
+var ErrRecallNotSupported = errors.New("recall is not supported by this host")
+
+// NopRuntime is the [Runtime] for hosts without an agent loop (slash-command
+// expansion, prompt templates, tests). EmitOutput is a no-op, Recall fails
+// with [ErrRecallNotSupported], and no capability is supported.
+type NopRuntime struct{}
+
+var _ Runtime = NopRuntime{}
+
+func (NopRuntime) EmitOutput(context.Context, string) {}
+
+func (NopRuntime) Recall(context.Context, string) error { return ErrRecallNotSupported }
+
+func (NopRuntime) Supports(Capability) bool { return false }

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -50,7 +50,15 @@ type ToolHandler func(ctx context.Context, toolCall ToolCall) (*ToolCallResult, 
 // command output or other long-running progress is available.
 type ToolOutputEmitter func(output string)
 
-type toolOutputEmitterKey struct{}
+// ToolRecallEmitter receives messages that should be injected back into the
+// running agent loop, typically when background work completes after the tool
+// call that started it has already returned.
+type ToolRecallEmitter func(message string) bool
+
+type (
+	toolOutputEmitterKey struct{}
+	toolRecallEmitterKey struct{}
+)
 
 // WithToolOutputEmitter returns a context carrying emit as the callback used
 // by tool handlers to stream incremental output. A nil emitter leaves ctx
@@ -69,6 +77,22 @@ func ToolOutputEmitterFromContext(ctx context.Context) (ToolOutputEmitter, bool)
 	return emit, ok
 }
 
+// WithToolRecallEmitter returns a context carrying emit as the callback used
+// by tool handlers to steer the running agent loop when background work
+// finishes. A nil emitter leaves ctx unchanged.
+func WithToolRecallEmitter(ctx context.Context, emit ToolRecallEmitter) context.Context {
+	if emit == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, toolRecallEmitterKey{}, emit)
+}
+
+// ToolRecallEmitterFromContext returns the recall emitter attached to ctx, if any.
+func ToolRecallEmitterFromContext(ctx context.Context) (ToolRecallEmitter, bool) {
+	emit, ok := ctx.Value(toolRecallEmitterKey{}).(ToolRecallEmitter)
+	return emit, ok
+}
+
 // EmitOutput streams output through the emitter in ctx. It returns false when
 // no emitter is attached or output is empty.
 func EmitOutput(ctx context.Context, output string) bool {
@@ -81,6 +105,19 @@ func EmitOutput(ctx context.Context, output string) bool {
 	}
 	emit(output)
 	return true
+}
+
+// EmitRecall sends message through the recall emitter in ctx. It returns false
+// when no emitter is attached, message is empty, or the emitter rejects it.
+func EmitRecall(ctx context.Context, message string) bool {
+	if message == "" {
+		return false
+	}
+	emit, ok := ToolRecallEmitterFromContext(ctx)
+	if !ok {
+		return false
+	}
+	return emit(message)
 }
 
 type ToolCall struct {

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -23,7 +23,16 @@ type ToolSet interface {
 // tool_input_repaired log entry so per-(model, tool) repair rates can be
 // tracked.
 func NewHandler[T any](fn func(context.Context, T) (*ToolCallResult, error)) ToolHandler {
-	return func(ctx context.Context, toolCall ToolCall) (*ToolCallResult, error) {
+	return NewRuntimeHandler(func(ctx context.Context, params T, _ Runtime) (*ToolCallResult, error) {
+		return fn(ctx, params)
+	})
+}
+
+// NewRuntimeHandler is [NewHandler] for tools that talk back to the hosting
+// runtime (streaming output, recall). The typed function additionally
+// receives the per-call [Runtime] handle.
+func NewRuntimeHandler[T any](fn func(context.Context, T, Runtime) (*ToolCallResult, error)) ToolHandler {
+	return func(ctx context.Context, toolCall ToolCall, rt Runtime) (*ToolCallResult, error) {
 		var params T
 		args := toolCall.Function.Arguments
 		if args == "" {
@@ -39,86 +48,13 @@ func NewHandler[T any](fn func(context.Context, T) (*ToolCallResult, error)) Too
 		if err != nil {
 			return nil, err
 		}
-		return fn(ctx, params)
+		return fn(ctx, params, rt)
 	}
 }
 
-type ToolHandler func(ctx context.Context, toolCall ToolCall) (*ToolCallResult, error)
-
-// ToolOutputEmitter receives incremental output from a running tool. Tool
-// handlers can retrieve the emitter from their context and call it whenever
-// command output or other long-running progress is available.
-type ToolOutputEmitter func(output string)
-
-// ToolRecallEmitter receives messages that should be injected back into the
-// running agent loop, typically when background work completes after the tool
-// call that started it has already returned.
-type ToolRecallEmitter func(message string) bool
-
-type (
-	toolOutputEmitterKey struct{}
-	toolRecallEmitterKey struct{}
-)
-
-// WithToolOutputEmitter returns a context carrying emit as the callback used
-// by tool handlers to stream incremental output. A nil emitter leaves ctx
-// unchanged.
-func WithToolOutputEmitter(ctx context.Context, emit ToolOutputEmitter) context.Context {
-	if emit == nil {
-		return ctx
-	}
-	return context.WithValue(ctx, toolOutputEmitterKey{}, emit)
-}
-
-// ToolOutputEmitterFromContext returns the incremental-output emitter attached
-// to ctx, if any.
-func ToolOutputEmitterFromContext(ctx context.Context) (ToolOutputEmitter, bool) {
-	emit, ok := ctx.Value(toolOutputEmitterKey{}).(ToolOutputEmitter)
-	return emit, ok
-}
-
-// WithToolRecallEmitter returns a context carrying emit as the callback used
-// by tool handlers to steer the running agent loop when background work
-// finishes. A nil emitter leaves ctx unchanged.
-func WithToolRecallEmitter(ctx context.Context, emit ToolRecallEmitter) context.Context {
-	if emit == nil {
-		return ctx
-	}
-	return context.WithValue(ctx, toolRecallEmitterKey{}, emit)
-}
-
-// ToolRecallEmitterFromContext returns the recall emitter attached to ctx, if any.
-func ToolRecallEmitterFromContext(ctx context.Context) (ToolRecallEmitter, bool) {
-	emit, ok := ctx.Value(toolRecallEmitterKey{}).(ToolRecallEmitter)
-	return emit, ok
-}
-
-// EmitOutput streams output through the emitter in ctx. It returns false when
-// no emitter is attached or output is empty.
-func EmitOutput(ctx context.Context, output string) bool {
-	if output == "" {
-		return false
-	}
-	emit, ok := ToolOutputEmitterFromContext(ctx)
-	if !ok {
-		return false
-	}
-	emit(output)
-	return true
-}
-
-// EmitRecall sends message through the recall emitter in ctx. It returns false
-// when no emitter is attached, message is empty, or the emitter rejects it.
-func EmitRecall(ctx context.Context, message string) bool {
-	if message == "" {
-		return false
-	}
-	emit, ok := ToolRecallEmitterFromContext(ctx)
-	if !ok {
-		return false
-	}
-	return emit(message)
-}
+// ToolHandler executes a single tool call. rt is the handle back to the
+// hosting runtime; hosts without one pass [NopRuntime].
+type ToolHandler func(ctx context.Context, toolCall ToolCall, rt Runtime) (*ToolCallResult, error)
 
 type ToolCall struct {
 	ID       string       `json:"id,omitempty"`

--- a/pkg/tools/tools_test.go
+++ b/pkg/tools/tools_test.go
@@ -29,7 +29,7 @@ func TestNewHandler_WithArguments(t *testing.T) {
 			Name:      "greet",
 			Arguments: `{"name":"world"}`,
 		},
-	})
+	}, NopRuntime{})
 	require.NoError(t, err)
 	assert.Equal(t, "hello world", result.Output)
 }
@@ -48,7 +48,7 @@ func TestNewHandler_EmptyArguments(t *testing.T) {
 			Name:      "get_memories",
 			Arguments: "",
 		},
-	})
+	}, NopRuntime{})
 	require.NoError(t, err)
 	assert.Equal(t, "ok", result.Output)
 }
@@ -67,7 +67,7 @@ func TestNewHandler_EmptyObjectArguments(t *testing.T) {
 			Name:      "list_things",
 			Arguments: "{}",
 		},
-	})
+	}, NopRuntime{})
 	require.NoError(t, err)
 	assert.Equal(t, "ok", result.Output)
 }
@@ -86,7 +86,7 @@ func TestNewHandler_InvalidArguments(t *testing.T) {
 			Name:      "broken",
 			Arguments: `{"unterminated`,
 		},
-	})
+	}, NopRuntime{})
 	require.Error(t, err)
 }
 
@@ -116,7 +116,7 @@ func TestNewHandler_DelegatesToAijson(t *testing.T) {
 			Name:      "read_multiple_files",
 			Arguments: `{"paths":"only.txt"}`,
 		},
-	})
+	}, NopRuntime{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"only.txt"}, got.Paths)
 }
@@ -140,7 +140,7 @@ func TestNewHandler_EmitsRepairTelemetry(t *testing.T) {
 			Name:      "read_multiple_files",
 			Arguments: `{"paths":"only.txt"}`,
 		},
-	})
+	}, NopRuntime{})
 	require.NoError(t, err)
 
 	out := buf.String()
@@ -173,7 +173,7 @@ func TestNewHandler_NoTelemetryOnValidInput(t *testing.T) {
 			Name:      "read_multiple_files",
 			Arguments: `{"paths":["a.txt","b.txt"]}`,
 		},
-	})
+	}, NopRuntime{})
 	require.NoError(t, err)
 	assert.NotContains(t, buf.String(), "tool_input_repaired")
 }


### PR DESCRIPTION
## Summary

### Shell background job recall
- add `recall: true` shell toolset config that exposes a `recall` parameter only on the recall-enabled background-job schema
- send background-job completion output back through runtime recall, steering active runs or waking idle sessions through the session manager
- document shell recall and add an example config

### Unified `tools.Runtime` handle
Reviewing the recall plumbing surfaced a design smell: tool→runtime communication went through two context keys (`ToolOutputEmitter`, `ToolRecallEmitter`), each with its own `With*`/`FromContext`/`Emit*` boilerplate — invisible in the handler signature and needing ad-hoc lifetime tricks (`context.WithoutCancel` + closure capture) for background work. Both are replaced with a single capability handle passed explicitly to every handler:

- `tools.ToolHandler` is now `func(ctx, ToolCall, rt Runtime)`; runtime-managed handlers (`toolexec.ToolHandler`) grow the same parameter, unifying the two tool APIs on one capability surface
- `Runtime` methods (`EmitOutput`, `Recall`, `Supports`) take ctx per call and stay valid after the handler returns, so background jobs hold the handle instead of a captured closure — no contexts stored in structs
- `NopRuntime` serves hosts without an agent loop (slash commands, prompt expansion, tests); `Supports()` lets tools fail fast before starting background work
- `NewHandler` keeps its signature for the ~68 tools that don't talk back; `NewRuntimeHandler` is the variant for those that do (shell streaming/recall)
- codemode forwards the handle into script-invoked tools, preserving the nested-capability inheritance the ctx transport gave implicitly

New capabilities (elicitation, progress, sampling) now land as one interface method + one nop, instead of five declarations and a context key.

## Validation
- `task build`
- `task test`
- `task lint`

Note: full `task test` fails on the unrelated live provider test `TestOpenAIAliasProvider_LiveAPI/moonshot` (provider 404, reproduces on clean tree).
