### PR TITLE
feat(shell): add wait_background_job tool

### DIFF
--- a/docs/tools/shell/index.md
+++ b/docs/tools/shell/index.md
@@ -89,7 +89,7 @@ Notes and limitations:
 
 ## Available Tools
 
-The shell toolset exposes five tools:
+The shell toolset exposes six tools:
 
 | Tool Name              | Description                                                                                    |
 | ---------------------- | ---------------------------------------------------------------------------------------------- |
@@ -98,6 +98,7 @@ The shell toolset exposes five tools:
 | `list_background_jobs` | List all background jobs with their status, runtime, and metadata.                             |
 | `view_background_job`  | View the buffered output and status of a specific background job by ID.                        |
 | `stop_background_job`  | Stop a running background job. Child processes are terminated too.                             |
+| `wait_background_job`  | Block until a job finishes and return its exit code and output. Safe on already-finished jobs. |
 
 Background job output is captured up to 10 MB per job. All background jobs are automatically terminated when the agent session ends.
 
@@ -117,6 +118,13 @@ Background job output is captured up to 10 MB per job. All background jobs are a
 | `cwd`     | string | ✗        | Working directory to run the command in (default: `.`).                 |
 
 `view_background_job` and `stop_background_job` each take a single required `job_id` string returned by `run_background_job` or `list_background_jobs`.
+
+### `wait_background_job` parameters
+
+| Parameter | Type    | Required | Description                                                                                                    |
+| --------- | ------- | -------- | -------------------------------------------------------------------------------------------------------------- |
+| `job_id`  | string  | ✓        | Job ID returned by `run_background_job` or `list_background_jobs`.                                             |
+| `timeout` | integer | ✗        | Maximum seconds to wait (default: `60`). If the job is still running when the limit fires, the tool returns the current output with a notice and the job continues in the background. |
 
 > [!WARNING]
 > **Safety**

--- a/pkg/teamloader/readonly_integration_test.go
+++ b/pkg/teamloader/readonly_integration_test.go
@@ -45,7 +45,7 @@ func TestGetToolsForAgent_ToolsetReadOnly(t *testing.T) {
 	require.Len(t, got, 1)
 
 	names := shellToolNames(t, got[0])
-	assert.ElementsMatch(t, []string{"list_background_jobs", "view_background_job"}, names)
+	assert.ElementsMatch(t, []string{"list_background_jobs", "view_background_job", "wait_background_job"}, names)
 }
 
 func TestGetToolsForAgent_AgentReadOnly(t *testing.T) {
@@ -72,7 +72,7 @@ func TestGetToolsForAgent_AgentReadOnly(t *testing.T) {
 	require.Len(t, got, 1)
 
 	names := shellToolNames(t, got[0])
-	assert.ElementsMatch(t, []string{"list_background_jobs", "view_background_job"}, names)
+	assert.ElementsMatch(t, []string{"list_background_jobs", "view_background_job", "wait_background_job"}, names)
 }
 
 func TestGetToolsForAgent_NoReadOnlyKeepsAllTools(t *testing.T) {
@@ -98,6 +98,6 @@ func TestGetToolsForAgent_NoReadOnlyKeepsAllTools(t *testing.T) {
 	names := shellToolNames(t, got[0])
 	assert.ElementsMatch(t, []string{
 		"shell", "run_background_job", "list_background_jobs",
-		"view_background_job", "stop_background_job",
+		"view_background_job", "stop_background_job", "wait_background_job",
 	}, names)
 }

--- a/pkg/tools/builtin/shell/shell.go
+++ b/pkg/tools/builtin/shell/shell.go
@@ -33,6 +33,7 @@ const (
 	ToolNameListBackgroundJobs = "list_background_jobs"
 	ToolNameViewBackgroundJob  = "view_background_job"
 	ToolNameStopBackgroundJob  = "stop_background_job"
+	ToolNameWaitBackgroundJob  = "wait_background_job"
 )
 
 // ToolSet provides shell command execution capabilities.
@@ -88,6 +89,8 @@ type backgroundJob struct {
 	status       atomic.Int32
 	exitCode     int
 	err          error
+	// done is closed by monitorJob when the job finishes (any terminal state).
+	done chan struct{}
 }
 
 // limitedWriter wraps a buffer and stops writing after maxSize bytes.
@@ -210,6 +213,11 @@ type ViewBackgroundJobArgs struct {
 
 type StopBackgroundJobArgs struct {
 	JobID string `json:"job_id" jsonschema:"Background job ID"`
+}
+
+type WaitBackgroundJobArgs struct {
+	JobID   string `json:"job_id" jsonschema:"Background job ID"`
+	Timeout int    `json:"timeout,omitempty" jsonschema:"Maximum seconds to wait (default 60). Returns current output with a timeout notice if the job is still running when the limit is reached."`
 }
 
 // statusStrings maps job status constants to their string representations
@@ -347,6 +355,7 @@ func (h *shellHandler) RunShellBackground(ctx context.Context, params RunShellBa
 		cwd:       params.Cwd,
 		output:    &bytes.Buffer{},
 		startTime: time.Now(),
+		done:      make(chan struct{}),
 	}
 
 	// The limitedWriter shares the job's outputMu so that readers
@@ -380,6 +389,10 @@ func (h *shellHandler) RunShellBackground(ctx context.Context, params RunShellBa
 }
 
 func (h *shellHandler) monitorJob(job *backgroundJob, cmd *exec.Cmd) {
+	// close done after all fields are written so WaitBackgroundJob readers see
+	// the final state. Defers are LIFO: Unlock runs before close(done).
+	defer close(job.done)
+
 	err := cmd.Wait()
 
 	job.outputMu.Lock()
@@ -433,12 +446,8 @@ func (h *shellHandler) ListBackgroundJobs(_ context.Context, _ map[string]any) (
 	return tools.ResultSuccess(output.String()), nil
 }
 
-func (h *shellHandler) ViewBackgroundJob(_ context.Context, params ViewBackgroundJobArgs) (*tools.ToolCallResult, error) {
-	job, exists := h.jobs.Load(params.JobID)
-	if !exists {
-		return tools.ResultError("Job not found: " + params.JobID), nil
-	}
-
+// renderBackgroundJob formats the current state of a background job for tool output.
+func renderBackgroundJob(job *backgroundJob) string {
 	status := job.status.Load()
 
 	job.outputMu.RLock()
@@ -451,7 +460,8 @@ func (h *shellHandler) ViewBackgroundJob(_ context.Context, params ViewBackgroun
 	fmt.Fprintf(&result, "Command: %s\n", job.cmd)
 	fmt.Fprintf(&result, "Status: %s\n", statusToString(status))
 	fmt.Fprintf(&result, "Runtime: %s\n", time.Since(job.startTime).Round(time.Second))
-	if status != statusRunning {
+	switch status {
+	case statusCompleted, statusFailed:
 		fmt.Fprintf(&result, "Exit Code: %d\n", exitCode)
 	}
 	result.WriteString("\n--- Output ---\n")
@@ -463,8 +473,46 @@ func (h *shellHandler) ViewBackgroundJob(_ context.Context, params ViewBackgroun
 			result.WriteString("\n\n[Output truncated at 10MB limit]")
 		}
 	}
+	return result.String()
+}
 
-	return tools.ResultSuccess(result.String()), nil
+func (h *shellHandler) ViewBackgroundJob(_ context.Context, params ViewBackgroundJobArgs) (*tools.ToolCallResult, error) {
+	job, exists := h.jobs.Load(params.JobID)
+	if !exists {
+		return tools.ResultError("Job not found: " + params.JobID), nil
+	}
+	return tools.ResultSuccess(renderBackgroundJob(job)), nil
+}
+
+// defaultWaitTimeout is used by WaitBackgroundJob when no timeout is supplied.
+const defaultWaitTimeout = 60 * time.Second
+
+func (h *shellHandler) WaitBackgroundJob(ctx context.Context, params WaitBackgroundJobArgs) (*tools.ToolCallResult, error) {
+	job, exists := h.jobs.Load(params.JobID)
+	if !exists {
+		return tools.ResultError("Job not found: " + params.JobID), nil
+	}
+
+	timeout := defaultWaitTimeout
+	if params.Timeout > 0 {
+		timeout = time.Duration(params.Timeout) * time.Second
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-job.done:
+		status := statusStrings[job.status.Load()]
+		header := fmt.Sprintf("Job %s %s.\n\n", job.id, status)
+		return tools.ResultSuccess(header + renderBackgroundJob(job)), nil
+	case <-timer.C:
+		header := fmt.Sprintf("Timed out after %s waiting for job %s; it is still running.\n\n",
+			timeout.Round(time.Second), job.id)
+		return tools.ResultSuccess(header + renderBackgroundJob(job)), nil
+	case <-ctx.Done():
+		return tools.ResultError(fmt.Sprintf("Wait cancelled for job %s: %s", job.id, ctx.Err())), nil
+	}
 }
 
 func (h *shellHandler) StopBackgroundJob(_ context.Context, params StopBackgroundJobArgs) (*tools.ToolCallResult, error) {
@@ -590,7 +638,9 @@ func (t *ToolSet) Instructions() string {
 
 ### Background Jobs
 
-Use run_background_job for long-running processes (servers, watchers). Output capped at 10MB per job. All jobs auto-terminate when the agent stops.`
+Use run_background_job for long-running processes (servers, watchers). Output capped at 10MB per job. All jobs auto-terminate when the agent stops.
+
+Use wait_background_job to block until a job finishes and retrieve its exit code and full output. Pass an optional timeout (seconds) to cap how long to wait; the job keeps running if the timeout fires.`
 }
 
 func (t *ToolSet) Tools(context.Context) ([]tools.Tool, error) {
@@ -642,6 +692,16 @@ func (t *ToolSet) Tools(context.Context) ([]tools.Tool, error) {
 			OutputSchema:            tools.MustSchemaFor[string](),
 			Handler:                 tools.NewHandler(t.handler.StopBackgroundJob),
 			Annotations:             tools.ToolAnnotations{Title: "Stop Background Job"},
+			AddDescriptionParameter: true,
+		},
+		{
+			Name:                    ToolNameWaitBackgroundJob,
+			Category:                "shell",
+			Description:             `Blocks until a background job completes (or the optional timeout expires) and returns its exit code and captured output. Safe to call on an already-finished job — returns the cached result immediately. Use this instead of polling view_background_job in a loop.`,
+			Parameters:              tools.MustSchemaFor[WaitBackgroundJobArgs](),
+			OutputSchema:            tools.MustSchemaFor[string](),
+			Handler:                 tools.NewHandler(t.handler.WaitBackgroundJob),
+			Annotations:             tools.ToolAnnotations{Title: "Wait for Background Job", ReadOnlyHint: true},
 			AddDescriptionParameter: true,
 		},
 	}, nil

--- a/pkg/tools/builtin/shell/shell_test.go
+++ b/pkg/tools/builtin/shell/shell_test.go
@@ -1,6 +1,7 @@
 package shell
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -198,6 +199,185 @@ func TestShellTool_ParametersAreObjects(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "object", m["type"])
 	}
+}
+
+func TestShellTool_WaitBackgroundJob_Completed(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell semantics; skipped on Windows")
+	}
+	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	require.NoError(t, tool.Start(t.Context()))
+	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
+
+	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "echo hello"})
+	require.NoError(t, err)
+
+	// Retrieve the job ID from the map.
+	var jobID string
+	tool.handler.jobs.Range(func(id string, _ *backgroundJob) bool {
+		jobID = id
+		return false
+	})
+	require.NotEmpty(t, jobID)
+
+	result, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: jobID})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "completed")
+	assert.Contains(t, result.Output, "Exit Code: 0")
+	assert.Contains(t, result.Output, "hello")
+}
+
+func TestShellTool_WaitBackgroundJob_FailedExit(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell semantics; skipped on Windows")
+	}
+	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	require.NoError(t, tool.Start(t.Context()))
+	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
+
+	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "exit 3"})
+	require.NoError(t, err)
+
+	var jobID string
+	tool.handler.jobs.Range(func(id string, _ *backgroundJob) bool {
+		jobID = id
+		return false
+	})
+	require.NotEmpty(t, jobID)
+
+	result, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: jobID})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "failed")
+	assert.Contains(t, result.Output, "Exit Code: 3")
+}
+
+func TestShellTool_WaitBackgroundJob_AlreadyCompleted(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell semantics; skipped on Windows")
+	}
+	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	require.NoError(t, tool.Start(t.Context()))
+	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
+
+	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "echo done"})
+	require.NoError(t, err)
+
+	var jobID string
+	tool.handler.jobs.Range(func(id string, _ *backgroundJob) bool {
+		jobID = id
+		return false
+	})
+	require.NotEmpty(t, jobID)
+
+	// First wait — blocks until the job finishes.
+	result1, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: jobID})
+	require.NoError(t, err)
+	assert.Contains(t, result1.Output, "completed")
+
+	// Second wait on an already-finished job must return immediately with the cached result.
+	result2, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: jobID})
+	require.NoError(t, err)
+	assert.Contains(t, result2.Output, "completed")
+	assert.Contains(t, result2.Output, "Exit Code: 0")
+}
+
+func TestShellTool_WaitBackgroundJob_UnknownID(t *testing.T) {
+	t.Parallel()
+	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+
+	result, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: "job_does_not_exist"})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "Job not found")
+}
+
+func TestShellTool_WaitBackgroundJob_Timeout(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("sleep not available on Windows cmd")
+	}
+	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	require.NoError(t, tool.Start(t.Context()))
+	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
+
+	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "sleep 30"})
+	require.NoError(t, err)
+
+	var jobID string
+	tool.handler.jobs.Range(func(id string, _ *backgroundJob) bool {
+		jobID = id
+		return false
+	})
+	require.NotEmpty(t, jobID)
+
+	start := time.Now()
+	result, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: jobID, Timeout: 1})
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "Timed out")
+	assert.Contains(t, result.Output, "still running")
+	assert.Less(t, elapsed, 5*time.Second)
+}
+
+func TestShellTool_WaitBackgroundJob_ContextCancelled(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("sleep not available on Windows cmd")
+	}
+	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	require.NoError(t, tool.Start(t.Context()))
+	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
+
+	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "sleep 30"})
+	require.NoError(t, err)
+
+	var jobID string
+	tool.handler.jobs.Range(func(id string, _ *backgroundJob) bool {
+		jobID = id
+		return false
+	})
+	require.NotEmpty(t, jobID)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel immediately
+
+	result, err := tool.handler.WaitBackgroundJob(ctx, WaitBackgroundJobArgs{JobID: jobID, Timeout: 60})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "cancelled")
+}
+
+func TestShellTool_WaitBackgroundJob_Stopped(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("sleep not available on Windows cmd")
+	}
+	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	require.NoError(t, tool.Start(t.Context()))
+	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
+
+	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "sleep 30"})
+	require.NoError(t, err)
+
+	var jobID string
+	tool.handler.jobs.Range(func(id string, _ *backgroundJob) bool {
+		jobID = id
+		return false
+	})
+	require.NotEmpty(t, jobID)
+
+	// Stop the job in a separate goroutine to unblock the wait.
+	go func() {
+		_, _ = tool.handler.StopBackgroundJob(t.Context(), StopBackgroundJobArgs{JobID: jobID})
+	}()
+
+	result, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: jobID, Timeout: 10})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "stopped")
+	assert.NotContains(t, result.Output, "Exit Code:",
+		"stopped jobs should not show an exit code")
 }
 
 // Minimal tests for background job features


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Adds a `wait_background_job` tool to the shell toolset that blocks until a background job finishes and returns its exit code and captured output.

Previously, agents had to poll `view_background_job` in a loop to know when a background job completed. The new tool blocks on a `done chan struct{}` closed by `monitorJob`, eliminating polling entirely. An optional `timeout` parameter (default 60 s) caps the wait; the job keeps running if the timeout fires and the tool returns the current output with a notice.

**Key changes:**
- `done chan struct{}` on `backgroundJob`, closed by `monitorJob` via a deferred close (LIFO: `Unlock` before `close`, so callers see fully written state)
- Extract `renderBackgroundJob()` helper; refactor `ViewBackgroundJob` to use it; fix pre-existing issue: stopped jobs no longer show `Exit Code: 0`
- `WaitBackgroundJob` handler with `ReadOnlyHint: true`; selects on `job.done / timer.C / ctx.Done`
- 7 tests: completed, failed-exit, already-completed, unknown-id, timeout, context-cancelled, stopped-then-wait
- Docs updated: six tools, `wait_background_job` parameters table

Closes #3462