### PR TITLE
feat(tui): list and drop attached files from the /context dialog

### DIFF
--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -81,7 +81,8 @@ Type `/` during a session to see available commands, or press <kbd>Ctrl</kbd>+<k
 | `/attach`          | Attach a file to your message                                                        |
 | `/shell`           | Open a shell                                                                         |
 | `/star`            | Star/unstar the current session                                                      |
-| `/context`         | Show a context-window breakdown: estimated tokens per category (system prompt, tool definitions, prompt files, messages, tool results, compaction summary) |
+| `/context`         | Show a context-window breakdown: estimated tokens per category (system prompt, tool definitions, prompt files, messages, tool results, compaction summary), plus a per-file inventory of attached files and prompt files. Select an attached file with the arrow keys and press <kbd>d</kbd> to drop it |
+| `/drop`            | Remove an attached file from the session context (`/drop <path>`, or `/drop` alone to review and drop from the `/context` dialog)  |
 | `/cost`            | Show cost breakdown for this session                                                 |
 | `/eval`            | Create an evaluation report                                                          |
 | `/pause`           | Pause/resume the runtime loop. While the agent is mid-request, the resize handle shows "Pausing…" until the in-flight request completes; once the loop is blocked the indicator changes to "⏸ Paused". Run `/pause` again to resume. |
@@ -184,6 +185,8 @@ Explain what the code in @pkg/agent/agent.go does
 ```
 
 The agent receives the full file contents in a structured `<attachments>` block, while the UI shows just the reference.
+
+Attached files are also recorded on the session so sub-agents spawned by task transfer can read them. To review what is attached, open `/context`: the dialog lists every attached file (and resolved prompt file) with a per-file token estimate. Use <kbd>↑</kbd>/<kbd>↓</kbd> to select an attached file and press <kbd>d</kbd> (or <kbd>x</kbd>/<kbd>Del</kbd>) to drop it, or run `/drop <path>` directly. Dropping stops sharing the file with sub-agents and skills; content already inlined in earlier messages stays in the conversation until compaction, and the file can always be re-attached with `@` or `/attach`.
 
 ## Runtime Model Switching
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -913,6 +914,68 @@ func (a *App) ContextBreakdown(ctx context.Context) (*runtime.ContextBreakdown, 
 		return nil, fmt.Errorf("context breakdown: %w", runtime.ErrUnsupported)
 	}
 	return cp.ContextBreakdown(ctx, a.Session())
+}
+
+// DropAttachedFile removes a file from the current session's attached files
+// and returns the absolute path that was dropped. The path is resolved
+// against the session's attachment list: exact match first, then the
+// absolute form of a relative path, then a unique base-name match. Dropping
+// stops the file from being propagated to future sub-agent delegations and
+// skill prompts; content already inlined in past messages is unaffected.
+//
+// Attached files are in-memory session state (recording them never touches
+// the store either), so the store sync afterwards is best-effort: it only
+// refreshes stores that snapshot the attachment list and a failure does not
+// undo the drop.
+func (a *App) DropAttachedFile(ctx context.Context, path string) (string, error) {
+	sess := a.Session()
+	if sess == nil {
+		return "", errors.New("no active session")
+	}
+	resolved, err := resolveAttachedFile(sess.AttachedFilesSnapshot(), path)
+	if err != nil {
+		return "", err
+	}
+	if !sess.RemoveAttachedFile(resolved) {
+		return "", fmt.Errorf("file is not attached to this session: %s", resolved)
+	}
+	if store := a.runtime.SessionStore(); store != nil {
+		if err := store.UpdateSession(ctx, sess); err != nil {
+			slog.WarnContext(ctx, "Failed to sync session store after dropping attachment", "session_id", sess.ID, "path", resolved, "error", err)
+		}
+	}
+	return resolved, nil
+}
+
+// resolveAttachedFile maps user input to one recorded attachment path.
+func resolveAttachedFile(attached []string, path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", errors.New("no file specified")
+	}
+	if len(attached) == 0 {
+		return "", errors.New("no files are attached to this session")
+	}
+	if slices.Contains(attached, path) {
+		return path, nil
+	}
+	if abs, err := filepath.Abs(path); err == nil && slices.Contains(attached, abs) {
+		return abs, nil
+	}
+	var matches []string
+	for _, candidate := range attached {
+		if filepath.Base(candidate) == path {
+			matches = append(matches, candidate)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return "", fmt.Errorf("file is not attached to this session: %s", path)
+	default:
+		return "", fmt.Errorf("%q matches %d attached files, use the full path", path, len(matches))
+	}
 }
 
 // PermissionsInfo returns combined permissions info from team and session.

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -520,4 +521,85 @@ func TestApp_InjectUserMessage(t *testing.T) {
 	default:
 		t.Fatal("expected a SendMsg to be emitted")
 	}
+}
+
+func TestApp_DropAttachedFile(t *testing.T) {
+	t.Parallel()
+
+	newAppWithAttachments := func(store session.Store, paths ...string) (*App, *session.Session) {
+		sess := session.New(session.WithAttachedFiles(paths))
+		return New(t.Context(), &mockRuntime{store: store}, sess), sess
+	}
+
+	t.Run("drops by exact path and syncs the store", func(t *testing.T) {
+		t.Parallel()
+		store := session.NewInMemorySessionStore()
+		app, sess := newAppWithAttachments(store, "/abs/foo.go", "/abs/bar.go")
+
+		dropped, err := app.DropAttachedFile(t.Context(), "/abs/foo.go")
+		require.NoError(t, err)
+		assert.Equal(t, "/abs/foo.go", dropped)
+		assert.Equal(t, []string{"/abs/bar.go"}, sess.AttachedFilesSnapshot())
+
+		stored, err := store.GetSession(t.Context(), sess.ID)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"/abs/bar.go"}, stored.AttachedFilesSnapshot())
+	})
+
+	t.Run("drops by unique base name", func(t *testing.T) {
+		t.Parallel()
+		app, sess := newAppWithAttachments(nil, "/abs/dir/foo.go", "/abs/dir/bar.go")
+
+		dropped, err := app.DropAttachedFile(t.Context(), "foo.go")
+		require.NoError(t, err)
+		assert.Equal(t, "/abs/dir/foo.go", dropped)
+		assert.Equal(t, []string{"/abs/dir/bar.go"}, sess.AttachedFilesSnapshot())
+	})
+
+	t.Run("rejects ambiguous base names", func(t *testing.T) {
+		t.Parallel()
+		app, sess := newAppWithAttachments(nil, "/abs/a/foo.go", "/abs/b/foo.go")
+
+		_, err := app.DropAttachedFile(t.Context(), "foo.go")
+		require.ErrorContains(t, err, "matches 2 attached files")
+		assert.Len(t, sess.AttachedFilesSnapshot(), 2)
+	})
+
+	t.Run("rejects unknown files and blank input", func(t *testing.T) {
+		t.Parallel()
+		app, _ := newAppWithAttachments(nil, "/abs/foo.go")
+
+		_, err := app.DropAttachedFile(t.Context(), "/abs/other.go")
+		require.ErrorContains(t, err, "not attached")
+
+		_, err = app.DropAttachedFile(t.Context(), "   ")
+		require.ErrorContains(t, err, "no file specified")
+	})
+
+	t.Run("reports when nothing is attached", func(t *testing.T) {
+		t.Parallel()
+		app, _ := newAppWithAttachments(nil)
+
+		_, err := app.DropAttachedFile(t.Context(), "foo.go")
+		require.ErrorContains(t, err, "no files are attached")
+	})
+
+	t.Run("returns error when no session", func(t *testing.T) {
+		t.Parallel()
+		app := &App{runtime: &mockRuntime{}}
+
+		_, err := app.DropAttachedFile(t.Context(), "foo.go")
+		require.ErrorContains(t, err, "no active session")
+	})
+}
+
+func TestResolveAttachedFile_RelativePath(t *testing.T) {
+	t.Parallel()
+
+	abs, err := filepath.Abs("notes.md")
+	require.NoError(t, err)
+
+	resolved, err := resolveAttachedFile([]string{abs}, "notes.md")
+	require.NoError(t, err)
+	assert.Equal(t, abs, resolved)
 }

--- a/pkg/runtime/context_breakdown.go
+++ b/pkg/runtime/context_breakdown.go
@@ -28,6 +28,19 @@ func (c *ContextCategory) add(tokens int64) {
 	c.Items++
 }
 
+// ContextFile describes one file contributing to the context window, with
+// the estimated token footprint of its current on-disk content.
+type ContextFile struct {
+	// Path is the file's absolute location on disk.
+	Path string `json:"path"`
+	// Tokens is the estimated in-context footprint of the file. It is 0
+	// for files whose content never reaches the prompt inline (unsupported
+	// types, oversized text files) and for missing files.
+	Tokens int64 `json:"tokens"`
+	// Missing marks files that can no longer be read from disk.
+	Missing bool `json:"missing,omitempty"`
+}
+
 // ContextBreakdown describes the estimated composition of the prompt the
 // runtime would send on the next model call, broken down by category. All
 // token counts are estimates produced by [compaction.EstimateMessageTokens]
@@ -50,6 +63,17 @@ type ContextBreakdown struct {
 	// CompactionSummary covers the synthetic message that carries the
 	// latest compaction summary, when the session has been compacted.
 	CompactionSummary ContextCategory `json:"compaction_summary"`
+
+	// PromptFileItems details the individual files behind the PromptFiles
+	// category, in resolution order.
+	PromptFileItems []ContextFile `json:"prompt_file_items,omitempty"`
+	// AttachedFiles lists the files attached to the session (/attach,
+	// @-mentions), in attach order. Their content was inlined into user
+	// messages at send time, so their tokens are already counted in the
+	// Messages category; the per-file numbers here are re-estimated from
+	// the current on-disk content and are informational, not an extra
+	// bucket in TotalTokens.
+	AttachedFiles []ContextFile `json:"attached_files,omitempty"`
 
 	// ContextLimit is the resolved context window of the effective model,
 	// or 0 when it cannot be determined (harness-backed agents, models
@@ -126,7 +150,8 @@ func (r *LocalRuntime) ContextBreakdown(ctx context.Context, sess *session.Sessi
 		b.ToolDefinitions.add(estimateToolDefinitionTokens(&agentTools[i]))
 	}
 
-	b.PromptFiles = r.promptFilesCategory(ctx, a.AddPromptFiles())
+	b.PromptFiles, b.PromptFileItems = r.promptFilesCategory(ctx, a.AddPromptFiles())
+	b.AttachedFiles = attachedFilesInventory(ctx, estimator, sess.AttachedFilesSnapshot())
 
 	return b, nil
 }
@@ -156,10 +181,14 @@ func estimateToolDefinitionTokens(tool *tools.Tool) int64 {
 // staged kit, keyed off the runtime working directory the hooks executor is
 // built with) and sizes the joined contents as the single system message the
 // hook would produce. Items counts the files found, not the names configured.
-func (r *LocalRuntime) promptFilesCategory(ctx context.Context, names []string) ContextCategory {
+// The returned files detail the same lookup per resolved path; their
+// individual estimates each carry the per-message overhead the category
+// counts once, so their sum can slightly exceed the category total.
+func (r *LocalRuntime) promptFilesCategory(ctx context.Context, names []string) (ContextCategory, []ContextFile) {
 	var category ContextCategory
+	var files []ContextFile
 	if len(names) == 0 {
-		return category
+		return category, nil
 	}
 	home, _ := os.UserHomeDir() // empty string disables the home-dir lookup
 	var parts []string
@@ -172,14 +201,77 @@ func (r *LocalRuntime) promptFilesCategory(ctx context.Context, names []string) 
 			}
 			parts = append(parts, string(content))
 			category.Items++
+			files = append(files, ContextFile{
+				Path: path,
+				Tokens: compaction.EstimateMessageTokens(&chat.Message{
+					Role:    chat.MessageRoleSystem,
+					Content: string(content),
+				}),
+			})
 		}
 	}
 	if len(parts) == 0 {
-		return category
+		return category, files
 	}
 	category.Tokens = compaction.EstimateMessageTokens(&chat.Message{
 		Role:    chat.MessageRoleSystem,
 		Content: strings.Join(parts, "\n\n"),
 	})
-	return category
+	return category, files
+}
+
+// attachedFilesInventory sizes each file attached to the session from its
+// current on-disk content. Files that disappeared or became unreadable are
+// kept in the inventory (marked missing) so users can spot and drop dangling
+// references.
+func attachedFilesInventory(ctx context.Context, estimator compaction.Estimator, paths []string) []ContextFile {
+	if len(paths) == 0 {
+		return nil
+	}
+	files := make([]ContextFile, 0, len(paths))
+	for _, path := range paths {
+		file := ContextFile{Path: path}
+		if fi, err := os.Stat(path); err != nil || !fi.Mode().IsRegular() {
+			file.Missing = true
+		} else {
+			file.Tokens = attachedFileTokens(ctx, estimator, path, fi.Size())
+		}
+		files = append(files, file)
+	}
+	return files
+}
+
+// attachedFileTokens estimates the in-context footprint of one attached
+// file, mirroring how the attachment pipeline shipped it: text files are
+// inlined verbatim (when under the inline size cap), supported binary types
+// (images, PDFs) travel as binary parts sized by the estimator's flat
+// attachment charge, and anything else never reaches the prompt inline.
+func attachedFileTokens(ctx context.Context, estimator compaction.Estimator, path string, size int64) int64 {
+	switch {
+	case chat.IsTextFile(path):
+		if size > chat.MaxInlineFileSize {
+			return 0
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			slog.WarnContext(ctx, "Context breakdown: failed to read attached file", "path", path, "error", err)
+			return 0
+		}
+		return estimator.EstimateMessageTokens(&chat.Message{
+			Role:    chat.MessageRoleUser,
+			Content: string(content),
+		})
+	case chat.IsSupportedMimeType(chat.DetectMimeType(path)):
+		// A synthetic document part with inline data stands in for the real
+		// binary attachment so the estimator applies its flat per-attachment
+		// charge, mirroring how the sent message is sized.
+		return estimator.EstimateMessageTokens(&chat.Message{
+			Role: chat.MessageRoleUser,
+			MultiContent: []chat.MessagePart{
+				{Type: chat.MessagePartTypeDocument, Document: &chat.Document{Source: chat.DocumentSource{InlineData: []byte{0}}}},
+			},
+		})
+	default:
+		return 0
+	}
 }

--- a/pkg/runtime/context_breakdown_test.go
+++ b/pkg/runtime/context_breakdown_test.go
@@ -203,6 +203,109 @@ func TestContextBreakdown_NoPromptFiles(t *testing.T) {
 	require.NoError(t, err)
 	assert.Zero(t, b.PromptFiles.Items)
 	assert.Zero(t, b.PromptFiles.Tokens)
+	assert.Empty(t, b.PromptFileItems)
+}
+
+func TestContextBreakdown_PromptFileItems(t *testing.T) {
+	t.Parallel()
+
+	promptDir := t.TempDir()
+	promptFile := "PROMPT_ITEMS_TEST.md"
+	promptContent := "Be concise. Prefer tables over prose when reporting results."
+	require.NoError(t, os.WriteFile(filepath.Join(promptDir, promptFile), []byte(promptContent), 0o600))
+
+	rt := newBreakdownRuntime(t, agent.WithAddPromptFiles([]string{promptFile}))
+	rt.workingDir = promptDir
+
+	b, err := rt.ContextBreakdown(t.Context(), session.New(session.WithUserMessage("hi")))
+	require.NoError(t, err)
+
+	require.Len(t, b.PromptFileItems, 1)
+	item := b.PromptFileItems[0]
+	assert.Equal(t, filepath.Join(promptDir, promptFile), item.Path)
+	assert.False(t, item.Missing)
+	expected := compaction.EstimateMessageTokens(&chat.Message{
+		Role:    chat.MessageRoleSystem,
+		Content: promptContent,
+	})
+	assert.Equal(t, expected, item.Tokens)
+}
+
+func TestContextBreakdown_AttachedFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	textPath := filepath.Join(dir, "notes.md")
+	textContent := "Attached notes: the retry loop lives in pkg/runtime and backs off exponentially."
+	require.NoError(t, os.WriteFile(textPath, []byte(textContent), 0o600))
+	missingPath := filepath.Join(dir, "deleted.txt")
+
+	rt := newBreakdownRuntime(t)
+	sess := session.New(session.WithUserMessage("hello"))
+	sess.AddAttachedFile(textPath)
+	sess.AddAttachedFile(missingPath)
+
+	b, err := rt.ContextBreakdown(t.Context(), sess)
+	require.NoError(t, err)
+
+	require.Len(t, b.AttachedFiles, 2)
+
+	text := b.AttachedFiles[0]
+	assert.Equal(t, textPath, text.Path)
+	assert.False(t, text.Missing)
+	expected := compaction.EstimateMessageTokens(&chat.Message{
+		Role:    chat.MessageRoleUser,
+		Content: textContent,
+	})
+	assert.Equal(t, expected, text.Tokens)
+
+	missing := b.AttachedFiles[1]
+	assert.Equal(t, missingPath, missing.Path)
+	assert.True(t, missing.Missing)
+	assert.Zero(t, missing.Tokens)
+
+	// Attached-file estimates detail content already counted in Messages;
+	// they must not inflate the estimated prompt total.
+	assert.Equal(t,
+		b.SystemPrompt.Tokens+b.ToolDefinitions.Tokens+b.PromptFiles.Tokens+
+			b.Messages.Tokens+b.ToolResults.Tokens+b.CompactionSummary.Tokens,
+		b.TotalTokens())
+}
+
+func TestContextBreakdown_NoAttachedFiles(t *testing.T) {
+	t.Parallel()
+
+	rt := newBreakdownRuntime(t)
+	b, err := rt.ContextBreakdown(t.Context(), session.New(session.WithUserMessage("hi")))
+	require.NoError(t, err)
+	assert.Empty(t, b.AttachedFiles)
+}
+
+func TestAttachedFileTokens_Kinds(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	estimator := compaction.Estimator{}
+
+	// A minimal valid PNG header makes content sniffing classify the file
+	// as a supported binary type, which is sized as a flat attachment charge.
+	pngPath := filepath.Join(dir, "shot.png")
+	pngHeader := append([]byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, make([]byte, 64)...)
+	require.NoError(t, os.WriteFile(pngPath, pngHeader, 0o600))
+	binaryTokens := attachedFileTokens(t.Context(), estimator, pngPath, int64(len(pngHeader)))
+	expectedBinary := compaction.EstimateMessageTokens(&chat.Message{
+		Role: chat.MessageRoleUser,
+		MultiContent: []chat.MessagePart{
+			{Type: chat.MessagePartTypeDocument, Document: &chat.Document{Source: chat.DocumentSource{InlineData: []byte{0}}}},
+		},
+	})
+	assert.Equal(t, expectedBinary, binaryTokens)
+
+	// Text files above the inline cap were never inlined, so they
+	// contribute nothing.
+	textPath := filepath.Join(dir, "big.txt")
+	require.NoError(t, os.WriteFile(textPath, []byte("content"), 0o600))
+	assert.Zero(t, attachedFileTokens(t.Context(), estimator, textPath, chat.MaxInlineFileSize+1))
 }
 
 func TestEstimateToolDefinitionTokens(t *testing.T) {

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -737,6 +737,21 @@ func (s *Session) AddAttachedFile(absPath string) {
 	s.AttachedFiles = append(s.AttachedFiles, absPath)
 }
 
+// RemoveAttachedFile removes absPath from the session's attached files and
+// reports whether it was present. Removing a path only stops it from being
+// propagated to future sub-agent delegations and skill prompts; file content
+// already inlined in past messages is untouched.
+func (s *Session) RemoveAttachedFile(absPath string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	i := slices.Index(s.AttachedFiles, absPath)
+	if i < 0 {
+		return false
+	}
+	s.AttachedFiles = slices.Delete(s.AttachedFiles, i, i+1)
+	return true
+}
+
 // AttachedFilesSnapshot returns a copy of the session's attached file paths.
 // Callers may freely mutate the returned slice without affecting the session.
 func (s *Session) AttachedFilesSnapshot() []string {

--- a/pkg/session/session_options_test.go
+++ b/pkg/session/session_options_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWithWorkingDir_SetsAllowedDirectories(t *testing.T) {
@@ -105,6 +106,45 @@ func TestAddAttachedFile(t *testing.T) {
 		s.AddAttachedFile("/abs/foo.go")
 		snap := s.AttachedFilesSnapshot()
 		snap[0] = "mutated"
+		assert.Equal(t, []string{"/abs/foo.go"}, s.AttachedFilesSnapshot())
+	})
+}
+
+func TestRemoveAttachedFile(t *testing.T) {
+	t.Parallel()
+	t.Run("removes and reports presence", func(t *testing.T) {
+		t.Parallel()
+		s := New()
+		s.AddAttachedFile("/abs/foo.go")
+		s.AddAttachedFile("/abs/bar.go")
+		s.AddAttachedFile("/abs/baz.go")
+
+		assert.True(t, s.RemoveAttachedFile("/abs/bar.go"))
+		assert.Equal(t, []string{"/abs/foo.go", "/abs/baz.go"}, s.AttachedFilesSnapshot())
+	})
+
+	t.Run("reports absent paths", func(t *testing.T) {
+		t.Parallel()
+		s := New()
+		s.AddAttachedFile("/abs/foo.go")
+		assert.False(t, s.RemoveAttachedFile("/abs/other.go"))
+		assert.False(t, s.RemoveAttachedFile(""))
+		assert.Equal(t, []string{"/abs/foo.go"}, s.AttachedFilesSnapshot())
+	})
+
+	t.Run("no-op on empty list", func(t *testing.T) {
+		t.Parallel()
+		s := New()
+		assert.False(t, s.RemoveAttachedFile("/abs/foo.go"))
+		assert.Empty(t, s.AttachedFilesSnapshot())
+	})
+
+	t.Run("file can be re-attached after removal", func(t *testing.T) {
+		t.Parallel()
+		s := New()
+		s.AddAttachedFile("/abs/foo.go")
+		require.True(t, s.RemoveAttachedFile("/abs/foo.go"))
+		s.AddAttachedFile("/abs/foo.go")
 		assert.Equal(t, []string{"/abs/foo.go"}, s.AttachedFilesSnapshot())
 	})
 }

--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -129,6 +129,22 @@ func builtInSessionCommands() []Item {
 			},
 		},
 		{
+			ID:           "session.drop",
+			Label:        "Drop",
+			SlashCommand: "/drop",
+			Description:  "Remove an attached file from the session context (usage: /drop [path])",
+			Category:     "Session",
+			Immediate:    true,
+			Execute: func(arg string) tea.Cmd {
+				if arg = strings.TrimSpace(arg); arg != "" {
+					return core.CmdHandler(messages.DropAttachedFileMsg{Path: arg})
+				}
+				// Without an argument, the /context dialog is the inventory
+				// from which attachments can be reviewed and dropped.
+				return core.CmdHandler(messages.ShowContextDialogMsg{})
+			},
+		},
+		{
 			ID:           "session.cost",
 			Label:        "Cost",
 			SlashCommand: "/cost",

--- a/pkg/tui/commands/commands_test.go
+++ b/pkg/tui/commands/commands_test.go
@@ -134,6 +134,25 @@ func TestParseSlashCommand_OtherCommands(t *testing.T) {
 		assert.True(t, ok)
 	})
 
+	t.Run("drop command with path", func(t *testing.T) {
+		t.Parallel()
+		cmd := parser.Parse("/drop notes.md")
+		require.NotNil(t, cmd)
+		msg := cmd()
+		dropMsg, ok := msg.(messages.DropAttachedFileMsg)
+		require.True(t, ok)
+		assert.Equal(t, "notes.md", dropMsg.Path)
+	})
+
+	t.Run("drop command without path opens the context dialog", func(t *testing.T) {
+		t.Parallel()
+		cmd := parser.Parse("/drop")
+		require.NotNil(t, cmd)
+		msg := cmd()
+		_, ok := msg.(messages.ShowContextDialogMsg)
+		assert.True(t, ok)
+	})
+
 	t.Run("effort command with level", func(t *testing.T) {
 		t.Parallel()
 		cmd := parser.Parse("/effort high")

--- a/pkg/tui/dialog/context.go
+++ b/pkg/tui/dialog/context.go
@@ -3,6 +3,8 @@ package dialog
 import (
 	"fmt"
 	"image/color"
+	"path/filepath"
+	"slices"
 	"strings"
 
 	"charm.land/bubbles/v2/key"
@@ -10,11 +12,13 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/atotto/clipboard"
 
+	pathx "github.com/docker/docker-agent/pkg/path"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/tui/components/notification"
 	"github.com/docker/docker-agent/pkg/tui/components/scrollview"
 	"github.com/docker/docker-agent/pkg/tui/core"
 	"github.com/docker/docker-agent/pkg/tui/core/layout"
+	"github.com/docker/docker-agent/pkg/tui/messages"
 	"github.com/docker/docker-agent/pkg/tui/styles"
 )
 
@@ -28,20 +32,30 @@ type contextDialog struct {
 	breakdown  *runtime.ContextBreakdown
 	keyMap     contextDialogKeyMap
 	scrollview *scrollview.Model
+
+	// selected indexes breakdown.AttachedFiles; -1 when the inventory has
+	// nothing to select.
+	selected int
+	// attachedLines maps each attached file to its line index in the
+	// scrollable content region. Rebuilt on every render and used to keep
+	// the selection visible while navigating.
+	attachedLines []int
 }
 
 type contextDialogKeyMap struct {
-	Close, Copy key.Binding
+	Close, Copy, Up, Down, Drop key.Binding
 }
 
 // NewContextDialog creates the /context dialog showing the estimated
-// context-window composition by category.
+// context-window composition by category, plus the per-file inventory of
+// attached files (droppable) and prompt files.
 func NewContextDialog(breakdown *runtime.ContextBreakdown) Dialog {
 	if breakdown == nil {
 		breakdown = &runtime.ContextBreakdown{}
 	}
-	return &contextDialog{
+	d := &contextDialog{
 		breakdown: breakdown,
+		selected:  -1,
 		scrollview: scrollview.New(
 			scrollview.WithKeyMap(scrollview.ReadOnlyScrollKeyMap()),
 			scrollview.WithReserveScrollbarSpace(true),
@@ -49,30 +63,86 @@ func NewContextDialog(breakdown *runtime.ContextBreakdown) Dialog {
 		keyMap: contextDialogKeyMap{
 			Close: key.NewBinding(key.WithKeys("esc", "enter", "q"), key.WithHelp("Esc", "close")),
 			Copy:  key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "copy")),
+			Up:    key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("↑", "select")),
+			Down:  key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓", "select")),
+			Drop:  key.NewBinding(key.WithKeys("d", "x", "backspace", "delete"), key.WithHelp("d", "drop")),
 		},
 	}
+	if len(breakdown.AttachedFiles) > 0 {
+		d.selected = 0
+	}
+	return d
 }
 
 func (d *contextDialog) Init() tea.Cmd { return nil }
 
 func (d *contextDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
+		if cmd, handled := d.handleKey(keyMsg); handled {
+			return d, cmd
+		}
+	}
 	if handled, cmd := d.scrollview.Update(msg); handled {
 		return d, cmd
 	}
-	switch msg := msg.(type) {
-	case tea.WindowSizeMsg:
+	if msg, ok := msg.(tea.WindowSizeMsg); ok {
 		cmd := d.SetSize(msg.Width, msg.Height)
 		return d, cmd
-	case tea.KeyPressMsg:
-		switch {
-		case key.Matches(msg, d.keyMap.Close):
-			return d, core.CmdHandler(CloseDialogMsg{})
-		case key.Matches(msg, d.keyMap.Copy):
-			_ = clipboard.WriteAll(d.renderPlainText())
-			return d, notification.SuccessCmd("Context breakdown copied to clipboard.")
-		}
 	}
 	return d, nil
+}
+
+// handleKey processes dialog-level keys. Up/Down are claimed for selection
+// only while attached files are listed; without them the keys fall through
+// to the scrollview and keep their plain scrolling behavior.
+func (d *contextDialog) handleKey(msg tea.KeyPressMsg) (tea.Cmd, bool) {
+	hasAttached := len(d.breakdown.AttachedFiles) > 0
+	switch {
+	case key.Matches(msg, d.keyMap.Close):
+		return core.CmdHandler(CloseDialogMsg{}), true
+	case key.Matches(msg, d.keyMap.Copy):
+		_ = clipboard.WriteAll(d.renderPlainText())
+		return notification.SuccessCmd("Context breakdown copied to clipboard."), true
+	case key.Matches(msg, d.keyMap.Up) && hasAttached:
+		d.moveSelection(-1)
+		return nil, true
+	case key.Matches(msg, d.keyMap.Down) && hasAttached:
+		d.moveSelection(1)
+		return nil, true
+	case key.Matches(msg, d.keyMap.Drop) && hasAttached:
+		return d.dropSelected(), true
+	}
+	return nil, false
+}
+
+// moveSelection moves the attached-file selection by delta, clamped to the
+// list bounds, and scrolls the selected row into view.
+func (d *contextDialog) moveSelection(delta int) {
+	n := len(d.breakdown.AttachedFiles)
+	if n == 0 {
+		return
+	}
+	d.selected = min(max(d.selected+delta, 0), n-1)
+	if d.selected < len(d.attachedLines) {
+		d.scrollview.EnsureLineVisible(d.attachedLines[d.selected])
+	}
+}
+
+// dropSelected removes the selected attached file from the local inventory
+// and asks the app to drop it from the session. The local removal is
+// optimistic, mirroring the session-browser delete flow; the handler reports
+// success or failure through a notification.
+func (d *contextDialog) dropSelected() tea.Cmd {
+	files := d.breakdown.AttachedFiles
+	if d.selected < 0 || d.selected >= len(files) {
+		return nil
+	}
+	path := files[d.selected].Path
+	d.breakdown.AttachedFiles = slices.Delete(files, d.selected, d.selected+1)
+	if d.selected >= len(d.breakdown.AttachedFiles) {
+		d.selected = len(d.breakdown.AttachedFiles) - 1
+	}
+	return core.CmdHandler(messages.DropAttachedFileMsg{Path: path})
 }
 
 func (d *contextDialog) dialogSize() (dialogWidth, maxHeight, contentWidth int) {
@@ -172,9 +242,17 @@ const (
 	contextRowMarker = "■"
 )
 
+// contextHeaderLines is the number of fixed (non-scrolling) lines at the top
+// of the dialog: title (with its meta line) + separator + spacer.
+const contextHeaderLines = 3
+
 // contextEstimateNote labels every figure in the dialog as an estimate, as
 // the counts come from a heuristic rather than the provider's tokenizer.
 const contextEstimateNote = "Token counts are estimates; the provider's tokenizer may count differently."
+
+// contextDropNote explains the scope of dropping an attachment: the file
+// stops being shared forward, but past messages keep their inlined copy.
+const contextDropNote = "Dropping a file removes it from the session's attachment list (sub-agents and skills stop receiving it); content already inlined in past messages stays until compaction."
 
 // categoryColors returns the per-category accent colors, aligned with the
 // order of contextRows. Hues are used categorically (Error's rose tint
@@ -216,10 +294,118 @@ func (d *contextDialog) renderContent(contentWidth, maxHeight int) string {
 		lines = append(lines, renderContextRow(&row, scale, labelWidth, markerColor(i, row, colors)))
 	}
 
+	lines = d.appendInventory(lines, scale, contentWidth)
+
 	lines = append(lines, "")
 	lines = append(lines, wrapMutedLines(contextEstimateNote, contentWidth)...)
+	if len(b.AttachedFiles) > 0 {
+		lines = append(lines, wrapMutedLines(contextDropNote, contentWidth)...)
+	}
 
 	return d.applyScrolling(lines, contentWidth, maxHeight)
+}
+
+// appendInventory renders the per-file inventory under the category rows:
+// the session's attached files (selectable, droppable) and the resolved
+// prompt files (config-driven, read-only). Empty sections are omitted. The
+// content-region line index of every attached row is recorded so navigation
+// can keep the selection visible.
+func (d *contextDialog) appendInventory(lines []string, scale int64, contentWidth int) []string {
+	d.attachedLines = d.attachedLines[:0]
+	b := d.breakdown
+	labelWidth := fileLabelWidth(b)
+
+	if len(b.AttachedFiles) > 0 {
+		lines = append(lines, "", sectionStyle().Render("Attached files"))
+		for i := range b.AttachedFiles {
+			d.attachedLines = append(d.attachedLines, len(lines)-contextHeaderLines)
+			lines = append(lines, renderContextFileRow(&b.AttachedFiles[i], scale, labelWidth, contentWidth, i == d.selected))
+		}
+	}
+	if len(b.PromptFileItems) > 0 {
+		lines = append(lines, "", sectionStyle().Render("Prompt files"))
+		for i := range b.PromptFileItems {
+			lines = append(lines, renderContextFileRow(&b.PromptFileItems[i], scale, labelWidth, contentWidth, false))
+		}
+	}
+	return lines
+}
+
+// fileLabelWidth returns the display width of the inventory file-name
+// column, sized to the longest base name across both sections and clamped
+// so one long name cannot push the token columns off screen.
+func fileLabelWidth(b *runtime.ContextBreakdown) int {
+	width := 0
+	for _, files := range [][]runtime.ContextFile{b.AttachedFiles, b.PromptFileItems} {
+		for i := range files {
+			width = max(width, lipgloss.Width(filepath.Base(files[i].Path)))
+		}
+	}
+	return min(max(width, 4), 24)
+}
+
+// truncateName shortens name to maxWidth display cells, ellipsizing the end.
+func truncateName(name string, maxWidth int) string {
+	if lipgloss.Width(name) <= maxWidth {
+		return name
+	}
+	r := []rune(name)
+	for len(r) > 0 && lipgloss.Width(string(r))+1 > maxWidth {
+		r = r[:len(r)-1]
+	}
+	return string(r) + "…"
+}
+
+// renderContextFileRow renders one inventory line:
+// "▶ main.go   2.1K   2%  ~/proj/main.go".
+func renderContextFileRow(file *runtime.ContextFile, scale int64, labelWidth, contentWidth int, selected bool) string {
+	prefix := "  "
+	nameStyle := labelStyle()
+	if selected {
+		prefix = accentStyle().Render("▶ ")
+		nameStyle = nameStyle.Foreground(styles.Highlight)
+	}
+	name := truncateName(filepath.Base(file.Path), labelWidth)
+	pad := strings.Repeat(" ", max(0, labelWidth-lipgloss.Width(name)))
+
+	line := fmt.Sprintf("%s%s%s  %s  %s",
+		prefix,
+		nameStyle.Render(name),
+		pad,
+		valueStyle().Render(padRight(fileTokensLabel(file))),
+		valueStyle().Render(fmt.Sprintf("%4s", percentLabel(file.Tokens, scale))))
+
+	if suffix := filePathSuffix(file, contentWidth-lipgloss.Width(line)-2); suffix != "" {
+		line += "  " + suffix
+	}
+	return line
+}
+
+// fileTokensLabel formats a file's token estimate, "-" when it contributes
+// nothing inline (missing, binary-unsupported, or oversized files).
+func fileTokensLabel(file *runtime.ContextFile) string {
+	if file.Tokens <= 0 {
+		return "-"
+	}
+	return formatTokenCount(file.Tokens)
+}
+
+// filePathSuffix renders the muted, home-shortened path (plus a missing
+// marker) that trails a file row, truncated to the available width. The
+// path is omitted when there is no room for a meaningful fragment.
+func filePathSuffix(file *runtime.ContextFile, available int) string {
+	const missingMark = "(missing)"
+	var parts []string
+	if file.Missing {
+		available -= lipgloss.Width(missingMark) + 1
+	}
+	if available >= 8 {
+		parts = append(parts, styles.MutedStyle.Render(truncatePath(pathx.ShortenHome(file.Path), available)))
+	}
+	if file.Missing {
+		parts = append(parts, styles.ErrorStyle.Render(missingMark))
+	}
+	return strings.Join(parts, " ")
 }
 
 // wrapMutedLines wraps text to width in the muted style and returns the
@@ -326,23 +512,31 @@ func renderContextRow(row *contextRow, scale int64, labelWidth int, markerCol co
 }
 
 func (d *contextDialog) applyScrolling(allLines []string, contentWidth, maxHeight int) string {
-	const headerLines = 3 // title + separator + space
 	const footerLines = 2 // space + help
 
-	visibleLines := max(1, maxHeight-headerLines-footerLines-4)
-	contentLines := allLines[headerLines:]
+	visibleLines := max(1, maxHeight-contextHeaderLines-footerLines-4)
+	contentLines := allLines[contextHeaderLines:]
 
 	regionWidth := contentWidth + d.scrollview.ReservedCols()
 	d.scrollview.SetSize(regionWidth, visibleLines)
 
 	dialogRow, dialogCol := d.Position()
-	d.scrollview.SetPosition(dialogCol+3, dialogRow+2+headerLines)
+	d.scrollview.SetPosition(dialogCol+3, dialogRow+2+contextHeaderLines)
 	d.scrollview.SetContent(contentLines, len(contentLines))
 
-	parts := make([]string, 0, headerLines+3)
-	parts = append(parts, allLines[:headerLines]...)
-	parts = append(parts, d.scrollview.View(), "", RenderHelpKeys(regionWidth, "↑↓", "scroll", "c", "copy", "Esc", "close"))
+	parts := make([]string, 0, contextHeaderLines+3)
+	parts = append(parts, allLines[:contextHeaderLines]...)
+	parts = append(parts, d.scrollview.View(), "", RenderHelpKeys(regionWidth, d.helpKeys()...))
 	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+}
+
+// helpKeys returns the footer bindings; the selection/drop pair appears
+// only while attached files are listed.
+func (d *contextDialog) helpKeys() []string {
+	if len(d.breakdown.AttachedFiles) > 0 {
+		return []string{"↑↓", "select", "d", "drop", "c", "copy", "Esc", "close"}
+	}
+	return []string{"↑↓", "scroll", "c", "copy", "Esc", "close"}
 }
 
 // ---------------------------------------------------------------------------
@@ -372,6 +566,28 @@ func (d *contextDialog) renderPlainText() string {
 		lines = append(lines, line)
 	}
 
+	if len(b.AttachedFiles) > 0 {
+		lines = append(lines, "", "Attached files")
+		for i := range b.AttachedFiles {
+			lines = append(lines, plainFileLine(&b.AttachedFiles[i], scale))
+		}
+	}
+	if len(b.PromptFileItems) > 0 {
+		lines = append(lines, "", "Prompt files")
+		for i := range b.PromptFileItems {
+			lines = append(lines, plainFileLine(&b.PromptFileItems[i], scale))
+		}
+	}
+
 	lines = append(lines, "", contextEstimateNote)
 	return strings.Join(lines, "\n")
+}
+
+// plainFileLine formats one inventory file for the clipboard copy.
+func plainFileLine(file *runtime.ContextFile, scale int64) string {
+	line := fmt.Sprintf("%-8s %4s  %s", fileTokensLabel(file), percentLabel(file.Tokens, scale), file.Path)
+	if file.Missing {
+		line += " (missing)"
+	}
+	return line
 }

--- a/pkg/tui/dialog/context_test.go
+++ b/pkg/tui/dialog/context_test.go
@@ -3,11 +3,13 @@ package dialog
 import (
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/tui/messages"
 )
 
 func testBreakdown() *runtime.ContextBreakdown {
@@ -21,6 +23,19 @@ func testBreakdown() *runtime.ContextBreakdown {
 		ContextLimit:      128_000,
 		Model:             "openai/gpt-4o",
 	}
+}
+
+func testBreakdownWithFiles() *runtime.ContextBreakdown {
+	b := testBreakdown()
+	b.AttachedFiles = []runtime.ContextFile{
+		{Path: "/proj/main.go", Tokens: 2100},
+		{Path: "/proj/docs/readme.md", Tokens: 300},
+		{Path: "/tmp/deleted.txt", Missing: true},
+	}
+	b.PromptFileItems = []runtime.ContextFile{
+		{Path: "/proj/AGENTS.md", Tokens: 600},
+	}
+	return b
 }
 
 func TestNewContextDialog(t *testing.T) {
@@ -163,4 +178,145 @@ func TestContextDialogPlainText(t *testing.T) {
 	assert.Contains(t, text, "Free space")
 	assert.Contains(t, text, "estimates")
 	assert.NotContains(t, text, "\x1b[", "plain text must carry no ANSI escapes")
+}
+
+// ---------------------------------------------------------------------------
+// File inventory (attached files, prompt files)
+// ---------------------------------------------------------------------------
+
+func TestContextDialogViewInventory(t *testing.T) {
+	t.Parallel()
+
+	dialog := NewContextDialog(testBreakdownWithFiles())
+	dialog.SetSize(120, 50)
+	view := dialog.View()
+
+	assert.Contains(t, view, "Attached files")
+	assert.Contains(t, view, "main.go")
+	assert.Contains(t, view, "readme.md")
+	assert.Contains(t, view, "deleted.txt")
+	assert.Contains(t, view, "(missing)")
+	assert.Contains(t, view, "Prompt files")
+	assert.Contains(t, view, "AGENTS.md")
+	assert.Contains(t, view, "drop", "help must advertise the drop key")
+}
+
+func TestContextDialogViewNoInventory(t *testing.T) {
+	t.Parallel()
+
+	dialog := NewContextDialog(testBreakdown())
+	dialog.SetSize(100, 50)
+	view := dialog.View()
+
+	assert.NotContains(t, view, "Attached files")
+	assert.NotContains(t, view, "drop")
+}
+
+func keyPress(key rune) tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: key, Text: string(key)}
+}
+
+func TestContextDialogSelectionNavigation(t *testing.T) {
+	t.Parallel()
+
+	d := NewContextDialog(testBreakdownWithFiles()).(*contextDialog)
+	d.SetSize(100, 50)
+	d.View()
+
+	require.Equal(t, 0, d.selected, "selection starts on the first attached file")
+
+	d.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	assert.Equal(t, 1, d.selected)
+
+	d.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	d.Update(tea.KeyPressMsg{Code: tea.KeyDown}) // clamped at the last row
+	assert.Equal(t, 2, d.selected)
+
+	d.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	d.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	d.Update(tea.KeyPressMsg{Code: tea.KeyUp}) // clamped at the first row
+	assert.Equal(t, 0, d.selected)
+}
+
+func TestContextDialogDropSelected(t *testing.T) {
+	t.Parallel()
+
+	d := NewContextDialog(testBreakdownWithFiles()).(*contextDialog)
+	d.SetSize(100, 50)
+	d.View()
+
+	d.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	_, cmd := d.Update(keyPress('d'))
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	dropMsg, ok := msg.(messages.DropAttachedFileMsg)
+	require.True(t, ok, "expected DropAttachedFileMsg, got %T", msg)
+	assert.Equal(t, "/proj/docs/readme.md", dropMsg.Path)
+
+	// The row is removed optimistically and the selection stays in bounds.
+	require.Len(t, d.breakdown.AttachedFiles, 2)
+	assert.Equal(t, "/proj/main.go", d.breakdown.AttachedFiles[0].Path)
+	assert.Equal(t, "/tmp/deleted.txt", d.breakdown.AttachedFiles[1].Path)
+	assert.Equal(t, 1, d.selected)
+}
+
+func TestContextDialogDropLastAttachment(t *testing.T) {
+	t.Parallel()
+
+	b := testBreakdown()
+	b.AttachedFiles = []runtime.ContextFile{{Path: "/proj/only.go", Tokens: 10}}
+	d := NewContextDialog(b).(*contextDialog)
+	d.SetSize(100, 50)
+	d.View()
+
+	_, cmd := d.Update(keyPress('x'))
+	require.NotNil(t, cmd)
+	assert.Empty(t, d.breakdown.AttachedFiles)
+	assert.Equal(t, -1, d.selected)
+
+	// Further drop/navigation keys are inert and must not panic; up/down
+	// fall back to scrolling.
+	_, cmd = d.Update(keyPress('d'))
+	assert.Nil(t, cmd)
+	d.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	assert.Equal(t, -1, d.selected)
+
+	view := d.View()
+	assert.NotContains(t, view, "Attached files")
+}
+
+func TestContextDialogPlainTextInventory(t *testing.T) {
+	t.Parallel()
+
+	d := &contextDialog{breakdown: testBreakdownWithFiles()}
+	text := d.renderPlainText()
+
+	assert.Contains(t, text, "Attached files")
+	assert.Contains(t, text, "/proj/main.go")
+	assert.Contains(t, text, "2.1K")
+	assert.Contains(t, text, "/tmp/deleted.txt (missing)")
+	assert.Contains(t, text, "Prompt files")
+	assert.Contains(t, text, "/proj/AGENTS.md")
+	assert.NotContains(t, text, "\x1b[", "plain text must carry no ANSI escapes")
+}
+
+func TestTruncateName(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "short.go", truncateName("short.go", 24))
+	assert.Equal(t, "a_very_long_file_name_w…", truncateName("a_very_long_file_name_with_suffix.go", 24))
+	assert.LessOrEqual(t, lipgloss.Width(truncateName("日本語の長いファイル名.md", 10)), 10)
+}
+
+func TestFileLabelWidthClamped(t *testing.T) {
+	t.Parallel()
+
+	b := &runtime.ContextBreakdown{
+		AttachedFiles: []runtime.ContextFile{{Path: "/p/a_very_long_file_name_that_exceeds_the_column_cap.go"}},
+	}
+	assert.Equal(t, 24, fileLabelWidth(b))
+
+	b = &runtime.ContextBreakdown{AttachedFiles: []runtime.ContextFile{{Path: "/p/a.go"}}}
+	assert.Equal(t, 4, fileLabelWidth(b))
 }

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -7,6 +7,7 @@ import (
 	neturl "net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	goruntime "runtime"
 	"strings"
 	"time"
@@ -471,6 +472,16 @@ func (m *appModel) handleShowContextDialog() (tea.Model, tea.Cmd) {
 		}
 		return dialog.OpenDialogMsg{Model: dialog.NewContextDialog(breakdown)}
 	}
+}
+
+// handleDropAttachedFile removes an attached file from the current session
+// so it stops being shared with sub-agents and skill prompts.
+func (m *appModel) handleDropAttachedFile(path string) (tea.Model, tea.Cmd) {
+	dropped, err := m.application.DropAttachedFile(m.ctx(), path)
+	if err != nil {
+		return m, notification.ErrorCmd(fmt.Sprintf("Failed to drop attachment: %v", err))
+	}
+	return m, notification.SuccessCmd(fmt.Sprintf("Dropped %s from the session context.", filepath.Base(dropped)))
 }
 
 func (m *appModel) handleShowPermissionsDialog() (tea.Model, tea.Cmd) {

--- a/pkg/tui/messages/session.go
+++ b/pkg/tui/messages/session.go
@@ -101,4 +101,9 @@ type (
 
 	// SendAttachmentMsg is a message for the first message with an attachment.
 	SendAttachmentMsg struct{ Content *session.Message }
+
+	// DropAttachedFileMsg removes a previously attached file from the
+	// current session so it stops being shared with sub-agents. Path may be
+	// an exact recorded path, a relative path, or a unique base name.
+	DropAttachedFileMsg struct{ Path string }
 )

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1086,6 +1086,9 @@ func (m *appModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case messages.ShowContextDialogMsg:
 		return m.handleShowContextDialog()
 
+	case messages.DropAttachedFileMsg:
+		return m.handleDropAttachedFile(msg.Path)
+
 	case messages.ShowPermissionsDialogMsg:
 		return m.handleShowPermissionsDialog()
 


### PR DESCRIPTION
Closes #3435. Builds on the `/context` dialog from #3432: an Aider-style inventory to see which files are in context and remove them.

## Changes

| Area | Change |
|------|--------|
| `/context` dialog | New "Attached files" and "Prompt files" sections, one row per file with a token estimate. Up/Down selects an attached file, `d`/`x`/`del` drops it (optimistic removal, same pattern as the session browser delete) |
| `/drop` command | `/drop <path>` drops directly, resolving exact path, then relative path, then unique base name (ambiguity is rejected). Bare `/drop` opens the `/context` dialog |
| `runtime.ContextBreakdown` | New `AttachedFiles` and `PromptFileItems` inventories (`ContextFile{Path, Tokens, Missing}`) |
| `session.Session` | New `RemoveAttachedFile`, symmetric with `AddAttachedFile` |
| Docs | Command table rows and a short paragraph under File Attachments |

```
Attached files
▶ main.go      2.1K    2%  /proj/main.go
  readme.md    300    <1%  /proj/docs/readme.md
  deleted.txt  -       -   /tmp/deleted.txt (missing)

Prompt files
  AGENTS.md    600    <1%  /proj/AGENTS.md
```

## Behavior notes

- Per-file estimates mirror the send pipeline: inlined text uses the calibrated heuristic, supported binaries use the flat attachment charge, oversized or unsupported files show `-`. They detail content already counted in Messages, so the estimated total is unchanged.
- Missing files stay listed and droppable, so dangling references can be cleaned up.
- Dropping stops propagation to sub-agents and skill prompts; content already inlined in past messages stays until compaction (a note in the dialog says so). Re-attaching via `@` or `/attach` works as before.
- Prompt files are config-driven and re-injected every turn, so they are listed read-only.

## Testing

- Unit tests: session removal, breakdown inventory (text, binary, missing, oversized), dialog rendering, navigation and drop, `/drop` parsing, `App.DropAttachedFile` resolution.
- `go build ./...`, full test suite, `golangci-lint run` and `go run ./lint .` are clean.
