### PR TITLE
feat: run tool dispatcher calls in parallel

### DIFF
--- a/pkg/runtime/toolexec/dispatcher.go
+++ b/pkg/runtime/toolexec/dispatcher.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -60,11 +61,10 @@ const (
 // observed by the dispatcher.
 //
 // Canceled and StopRun are mutually exclusive in practice but signal
-// different things to the caller: cancellation halts the current batch
-// silently (the run loop continues so the synthesised tool error
-// responses can be sent back to the model on the next turn); StopRun
-// also terminates the agent's run loop with a user-visible reason
-// produced by a post_tool_use hook deny verdict.
+// different things to the caller: cancellation cancels sibling calls in
+// the current batch while letting the run loop continue with tool error
+// responses; StopRun also terminates the agent's run loop with a
+// user-visible reason produced by a post_tool_use hook deny verdict.
 type CallOutcome struct {
 	Canceled    bool
 	StopRun     bool
@@ -74,6 +74,9 @@ type CallOutcome struct {
 // Emitter receives the events the [Dispatcher] emits while processing a
 // batch of tool calls. Runtimes typically implement this by sending typed
 // events to their event channel.
+//
+// Implementations must be safe for concurrent use: the dispatcher runs
+// independent tool calls from the same batch in parallel.
 //
 // The dispatcher emits the events below. Runtime-managed handlers
 // (registered via [Dispatcher.Handlers]) emit any additional runtime-specific
@@ -164,17 +167,27 @@ type Dispatcher struct {
 	// handoff, change_model, ...). Tools not in this map are routed to
 	// their toolset Handler.
 	Handlers map[string]ToolHandler
+
+	confirmationMu sync.Mutex
+	approvalMu     sync.Mutex
 }
 
-// Process runs every tool call in calls in order, emitting events through
-// em.
+var (
+	errBatchCanceledByUser = errors.New("tool batch canceled by user")
+	errBatchStoppedByHook  = errors.New("tool batch stopped by post_tool_use hook")
+)
+
+// Process runs every tool call in calls, emitting events through em. Calls in
+// the same model batch are independent and execute in parallel; interactive
+// confirmations are still serialized because resume decisions are not keyed by
+// tool-call ID.
 //
 // Returns (stopRun, message) when a post_tool_use hook signalled a
 // terminating verdict during this batch; the run loop then fans out the
 // standard Error / notification / on_error stanzas before exiting.
 // (false, "") in every other path — including user cancellation, which
-// halts the *batch* but keeps the loop alive so the synthesised tool
-// error responses can be sent back to the model on the next turn.
+// halts the *batch* but keeps the loop alive so the tool error responses can
+// be sent back to the model on the next turn.
 func (d *Dispatcher) Process(ctx context.Context, sess *session.Session, calls []tools.ToolCall, agentTools []tools.Tool, em Emitter) (stopRun bool, stopMessage string) {
 	a := d.AgentFor(sess)
 	slog.DebugContext(ctx, "Processing tool calls", "agent", a.Name(), "call_count", len(calls))
@@ -184,29 +197,29 @@ func (d *Dispatcher) Process(ctx context.Context, sess *session.Session, calls [
 		toolByName[t.Name] = t
 	}
 
-	// synthesizeRemaining adds error responses for tool calls we won't
-	// run because the batch was halted (user cancellation or post-tool
-	// stopRun). Orphan function calls without matching outputs are
-	// rejected by the Responses API, so we surface them as errors
-	// rather than dropping them.
-	synthesizeRemaining := func(remaining []tools.ToolCall, reason string) {
-		for _, rc := range remaining {
-			c := d.newCall(sess, em, a, rc, toolByName)
-			c.errorResponse(ctx, reason)
-		}
-	}
+	batchCtx, cancelBatch := context.WithCancelCause(ctx)
+	defer cancelBatch(nil)
 
+	outcomes := make([]CallOutcome, len(calls))
+	var stopOnce sync.Once
+	var wg sync.WaitGroup
 	for i, tc := range calls {
-		c := d.newCall(sess, em, a, tc, toolByName)
-		outcome := c.run(ctx)
-		switch {
-		case outcome.Canceled:
-			synthesizeRemaining(calls[i+1:],
-				"The tool call was canceled because a previous tool call in the same batch was canceled by the user.")
-			return false, ""
-		case outcome.StopRun:
-			synthesizeRemaining(calls[i+1:],
-				"The tool call was skipped because a post_tool_use hook signalled run termination.")
+		wg.Go(func() {
+			c := d.newCall(sess, em, a, tc, toolByName)
+			outcome := c.run(batchCtx)
+			outcomes[i] = outcome
+			switch {
+			case outcome.Canceled:
+				stopOnce.Do(func() { cancelBatch(errBatchCanceledByUser) })
+			case outcome.StopRun:
+				stopOnce.Do(func() { cancelBatch(errBatchStoppedByHook) })
+			}
+		})
+	}
+	wg.Wait()
+
+	for _, outcome := range outcomes {
+		if outcome.StopRun {
 			return true, outcome.StopMessage
 		}
 	}
@@ -287,6 +300,13 @@ func (c *call) run(ctx context.Context) CallOutcome {
 	defer span.End()
 
 	slog.DebugContext(ctx, "Processing tool call", "agent", c.a.Name(), "tool", c.tc.Function.Name, "session_id", c.sess.ID)
+
+	if ctx.Err() != nil {
+		msg := c.cancellationMessage(ctx)
+		c.errorResponse(ctx, msg)
+		span.SetStatus(codes.Ok, msg)
+		return c.cancellationOutcome(ctx)
+	}
 
 	// After a handoff the model may hallucinate tools it saw earlier in
 	// the conversation. Reject unknown tools with an error response so it
@@ -371,20 +391,9 @@ func (c *call) approveAndRun(ctx context.Context, runTool func() CallOutcome) Ca
 		// DecisionAllow / "" → advisory; fall through to Decide().
 	}
 
-	var checkers []NamedChecker
-	if c.d.Permissions != nil {
-		checkers = c.d.Permissions(c.sess)
-	}
-
 	// readOnlyHint is intentionally false here so the pre_tool_use hook
 	// gets a turn before the read-only fast-path applies.
-	decision := Decide(
-		c.sess.ToolsApproved,
-		checkers,
-		c.tc.Function.Name,
-		ParseToolInput(c.tc.Function.Arguments),
-		false,
-	)
+	decision := c.permissionDecision(false)
 
 	switch decision.Outcome {
 	case OutcomeAllow:
@@ -416,6 +425,49 @@ func (c *call) approveAndRun(ctx context.Context, runTool func() CallOutcome) Ca
 		return runTool()
 	}
 	return c.askUser(ctx, runTool)
+}
+
+func (c *call) permissionDecision(readOnlyHint bool) PermissionDecision {
+	c.d.approvalMu.Lock()
+	defer c.d.approvalMu.Unlock()
+
+	var checkers []NamedChecker
+	if c.d.Permissions != nil {
+		checkers = c.d.Permissions(c.sess)
+	}
+	return Decide(
+		c.sess.ToolsApproved,
+		checkers,
+		c.tc.Function.Name,
+		ParseToolInput(c.tc.Function.Arguments),
+		readOnlyHint,
+	)
+}
+
+func (c *call) autoApprovalAfterConfirmationWait() (PermissionDecision, bool) {
+	if c.preYoloResult != nil && c.preYoloResult.Decision == hooks.DecisionAsk {
+		return PermissionDecision{}, false
+	}
+	decision := c.permissionDecision(c.tool.Annotations.ReadOnlyHint)
+	return decision, decision.Outcome == OutcomeAllow
+}
+
+func (c *call) cancellationMessage(ctx context.Context) string {
+	switch {
+	case errors.Is(context.Cause(ctx), errBatchCanceledByUser):
+		return "The tool call was canceled because another tool call in the same batch was canceled by the user."
+	case errors.Is(context.Cause(ctx), errBatchStoppedByHook):
+		return "The tool call was skipped because a post_tool_use hook signalled run termination."
+	default:
+		return "The tool call was canceled by the user."
+	}
+}
+
+func (c *call) cancellationOutcome(ctx context.Context) CallOutcome {
+	if errors.Is(context.Cause(ctx), errBatchStoppedByHook) {
+		return CallOutcome{}
+	}
+	return CallOutcome{Canceled: true}
 }
 
 // consultPreToolUsePreYolo dispatches the preempt-yolo lane of the
@@ -602,6 +654,25 @@ func (c *call) askUser(ctx context.Context, runTool func() CallOutcome) CallOutc
 		return CallOutcome{}
 	}
 
+	// ResumeRequest has no tool-call ID, so only one confirmation can be
+	// visible and waiting on the shared channel at a time.
+	c.d.confirmationMu.Lock()
+
+	if ctx.Err() != nil {
+		c.d.confirmationMu.Unlock()
+		slog.DebugContext(ctx, "Context cancelled before confirmation", "tool", c.tc.Function.Name, "session_id", c.sess.ID)
+		c.notifyApproval(ctx, ApprovalDecisionCanceled, ApprovalSourceContextCanceled)
+		c.errorResponse(ctx, c.cancellationMessage(ctx))
+		return c.cancellationOutcome(ctx)
+	}
+
+	if decision, ok := c.autoApprovalAfterConfirmationWait(); ok {
+		c.d.confirmationMu.Unlock()
+		c.logAllow(decision)
+		c.notifyApproval(ctx, ApprovalDecisionAllow, allowSourceForDecision(decision))
+		return runTool()
+	}
+
 	slog.DebugContext(ctx, "Tools not approved, waiting for resume", "tool", c.tc.Function.Name, "session_id", c.sess.ID)
 	c.em.EmitToolCallConfirmation(c.tc, c.tool, c.a.Name(), c.confirmationMetadata(hookMeta))
 
@@ -611,12 +682,14 @@ func (c *call) askUser(ctx context.Context, runTool func() CallOutcome) CallOutc
 
 	select {
 	case req := <-c.d.Resume:
+		c.d.confirmationMu.Unlock()
 		return c.handleResume(ctx, req, runTool)
 	case <-ctx.Done():
+		c.d.confirmationMu.Unlock()
 		slog.DebugContext(ctx, "Context cancelled while waiting for resume", "tool", c.tc.Function.Name, "session_id", c.sess.ID)
 		c.notifyApproval(ctx, ApprovalDecisionCanceled, ApprovalSourceContextCanceled)
-		c.errorResponse(ctx, "The tool call was canceled by the user.")
-		return CallOutcome{Canceled: true}
+		c.errorResponse(ctx, c.cancellationMessage(ctx))
+		return c.cancellationOutcome(ctx)
 	}
 }
 
@@ -710,7 +783,9 @@ func (c *call) handleResume(ctx context.Context, req ResumeRequest, runTool func
 		return runTool()
 	case ResumeTypeApproveSession:
 		slog.DebugContext(ctx, "Resume signal received, approving session", "tool", c.tc.Function.Name, "session_id", c.sess.ID)
+		c.d.approvalMu.Lock()
 		c.sess.ToolsApproved = true
+		c.d.approvalMu.Unlock()
 		c.notifyApproval(ctx, ApprovalDecisionAllow, ApprovalSourceUserApprovedSession)
 		return runTool()
 	case ResumeTypeApproveTool:
@@ -718,12 +793,14 @@ func (c *call) handleResume(ctx context.Context, req ResumeRequest, runTool func
 		if approvedTool == "" {
 			approvedTool = c.tc.Function.Name
 		}
+		c.d.approvalMu.Lock()
 		if c.sess.Permissions == nil {
 			c.sess.Permissions = &session.PermissionsConfig{}
 		}
 		if !slices.Contains(c.sess.Permissions.Allow, approvedTool) {
 			c.sess.Permissions.Allow = append(c.sess.Permissions.Allow, approvedTool)
 		}
+		c.d.approvalMu.Unlock()
 		slog.DebugContext(ctx, "Resume signal received, approving tool permanently", "tool", approvedTool, "session_id", c.sess.ID)
 		c.notifyApproval(ctx, ApprovalDecisionAllow, ApprovalSourceUserApprovedTool)
 		return runTool()
@@ -864,9 +941,10 @@ func (c *call) applyToolResponseTransform(ctx context.Context, payload string, i
 // recorded as an error.
 func (c *call) translateError(ctx context.Context, span trace.Span, err error) *tools.ToolCallResult {
 	if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+		msg := c.cancellationMessage(ctx)
 		slog.DebugContext(ctx, "Tool handler canceled by context", "tool", c.tc.Function.Name, "agent", c.a.Name(), "session_id", c.sess.ID)
-		span.SetStatus(codes.Ok, "tool handler canceled by user")
-		return tools.ResultError("The tool call was canceled by the user.")
+		span.SetStatus(codes.Ok, msg)
+		return tools.ResultError(msg)
 	}
 	span.RecordError(err)
 	span.SetStatus(codes.Error, "tool handler error")

--- a/pkg/runtime/toolexec/dispatcher_test.go
+++ b/pkg/runtime/toolexec/dispatcher_test.go
@@ -2,7 +2,10 @@ package toolexec_test
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,6 +23,8 @@ import (
 // channel signals when a confirmation event lands so cancellation tests
 // don't need to busy-wait.
 type captureEmitter struct {
+	mu               sync.Mutex
+	confirmedOnce    sync.Once
 	calls            []tools.ToolCall
 	outputs          []outputRecord
 	responses        []responseRecord
@@ -47,14 +52,20 @@ type hookBlockRecord struct {
 }
 
 func (e *captureEmitter) EmitToolCall(tc tools.ToolCall, _ tools.Tool, _ string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	e.calls = append(e.calls, tc)
 }
 
 func (e *captureEmitter) EmitToolCallOutput(toolCallID string, _ tools.Tool, output, _ string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	e.outputs = append(e.outputs, outputRecord{ToolCallID: toolCallID, Output: output})
 }
 
 func (e *captureEmitter) EmitToolCallResponse(toolCallID string, _ tools.Tool, result *tools.ToolCallResult, output, _ string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	e.responses = append(e.responses, responseRecord{
 		ToolCallID: toolCallID,
 		Output:     output,
@@ -63,23 +74,24 @@ func (e *captureEmitter) EmitToolCallResponse(toolCallID string, _ tools.Tool, r
 }
 
 func (e *captureEmitter) EmitToolCallConfirmation(tc tools.ToolCall, _ tools.Tool, _ string, metadata map[string]string) {
+	e.mu.Lock()
 	e.confirmations = append(e.confirmations, tc)
 	e.confirmationMeta = append(e.confirmationMeta, metadata)
+	e.mu.Unlock()
 	if e.confirmed != nil {
-		select {
-		case <-e.confirmed:
-			// already closed
-		default:
-			close(e.confirmed)
-		}
+		e.confirmedOnce.Do(func() { close(e.confirmed) })
 	}
 }
 
 func (e *captureEmitter) EmitHookBlocked(tc tools.ToolCall, _ tools.Tool, message, _ string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	e.hookBlocks = append(e.hookBlocks, hookBlockRecord{ToolCall: tc, Message: message})
 }
 
 func (e *captureEmitter) EmitMessageAdded(_ string, msg *session.Message, _ string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	e.messages = append(e.messages, msg)
 }
 
@@ -116,6 +128,67 @@ func TestDispatcher_RoutesToToolsetHandler(t *testing.T) {
 	require.Len(t, em.responses, 1)
 	assert.Equal(t, `hello {"x":1}`, em.responses[0].Output)
 	assert.False(t, em.responses[0].IsError)
+}
+
+func TestDispatcher_RunsToolHandlersInParallel(t *testing.T) {
+	t.Parallel()
+	a := newAgent()
+	sess := session.New()
+	sess.ToolsApproved = true
+
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	var running atomic.Int32
+	var maxRunning atomic.Int32
+	tool := tools.Tool{
+		Name: "slow",
+		Handler: func(ctx context.Context, tc tools.ToolCall) (*tools.ToolCallResult, error) {
+			current := running.Add(1)
+			for {
+				observed := maxRunning.Load()
+				if current <= observed || maxRunning.CompareAndSwap(observed, current) {
+					break
+				}
+			}
+			started <- tc.ID
+			defer running.Add(-1)
+			select {
+			case <-release:
+				return tools.ResultSuccess("done " + tc.ID), nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+	}
+
+	d := &toolexec.Dispatcher{AgentFor: func(*session.Session) *agent.Agent { return a }}
+	em := &captureEmitter{}
+	done := make(chan struct{})
+	go func() {
+		d.Process(t.Context(), sess, []tools.ToolCall{
+			{ID: "a", Function: tools.FunctionCall{Name: "slow", Arguments: `{}`}},
+			{ID: "b", Function: tools.FunctionCall{Name: "slow", Arguments: `{}`}},
+		}, []tools.Tool{tool}, em)
+		close(done)
+	}()
+
+	for range 2 {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for both tool handlers to start")
+		}
+	}
+	close(release)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Process to finish")
+	}
+
+	assert.GreaterOrEqual(t, maxRunning.Load(), int32(2))
+	require.Len(t, em.responses, 2)
 }
 
 func TestDispatcher_EmitsToolOutputFromHandlerContext(t *testing.T) {
@@ -245,7 +318,7 @@ func TestDispatcher_UnknownToolEmitsErrorResponse(t *testing.T) {
 	assert.Contains(t, em.responses[0].Output, "not available")
 }
 
-func TestDispatcher_UserCancellationStopsBatchAndSynthesizesRemaining(t *testing.T) {
+func TestDispatcher_UserCancellationStopsBatchAndErrorsAllCalls(t *testing.T) {
 	t.Parallel()
 	a := newAgent()
 	sess := session.New()
@@ -264,9 +337,9 @@ func TestDispatcher_UserCancellationStopsBatchAndSynthesizesRemaining(t *testing
 	}
 
 	// Cancel as soon as the dispatcher asks for confirmation on the first
-	// call. The remaining two calls in the batch must receive synthetic
-	// error responses so the conversation history stays consistent (the
-	// Responses API rejects orphaned tool calls).
+	// call. Every call in the batch must receive an error response so the
+	// conversation history stays consistent (the Responses API rejects
+	// orphaned tool calls).
 	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 	go func() {
@@ -284,10 +357,8 @@ func TestDispatcher_UserCancellationStopsBatchAndSynthesizesRemaining(t *testing
 	require.Len(t, em.responses, 3, "every call must produce a response")
 	for _, r := range em.responses {
 		assert.True(t, r.IsError, "every cancelled call must surface as an error response")
+		assert.Contains(t, r.Output, "canceled")
 	}
-	assert.Contains(t, em.responses[0].Output, "canceled by the user")
-	assert.Contains(t, em.responses[1].Output, "previous tool call")
-	assert.Contains(t, em.responses[2].Output, "previous tool call")
 }
 
 func TestDispatcher_ResumeApproveRunsTool(t *testing.T) {

--- a/pkg/runtime/toolexec/doc.go
+++ b/pkg/runtime/toolexec/doc.go
@@ -5,13 +5,11 @@
 //
 // The package currently provides:
 //
+//   - Dispatcher: runs tool-call batches, including approval flow, hook
+//     dispatch, tracing, telemetry, and event emission.
 //   - LoopDetector: detects consecutive identical tool-call batches so the
 //     runtime can break degenerate loops where the model is not making
 //     progress.
 //   - ResolveModelOverride: extracts the per-toolset model override that
 //     should apply to the next LLM turn from a batch of tool calls.
-//
-// Future extractions (approval flow, hooks dispatch, tool handler
-// registry) belong here so that the runtime keeps shrinking toward
-// pure orchestration.
 package toolexec

--- a/pkg/runtime/toolexec/helpers_test.go
+++ b/pkg/runtime/toolexec/helpers_test.go
@@ -2,6 +2,7 @@ package toolexec_test
 
 import (
 	"context"
+	"sync"
 
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/config/latest"
@@ -30,6 +31,7 @@ func newDenyChecker(toolName string) *permissions.Checker {
 // fires (the field doubles as a witness that post_tool_use
 // participated at all).
 type stubHookDispatcher struct {
+	mu                sync.Mutex
 	on                map[hooks.EventType]*hooks.Result
 	lastPostToolInput *hooks.Input
 	// dispatched records every event the dispatcher asked us to fire,
@@ -39,6 +41,8 @@ type stubHookDispatcher struct {
 }
 
 func (s *stubHookDispatcher) Dispatch(_ context.Context, _ *agent.Agent, event hooks.EventType, in *hooks.Input) *hooks.Result {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.dispatched = append(s.dispatched, event)
 	if event == hooks.EventPostToolUse {
 		s.lastPostToolInput = in


### PR DESCRIPTION
## Summary
- Run tool calls from a model batch concurrently in the toolexec dispatcher
- Serialize interactive confirmations while keeping auto-approved calls parallel
- Add concurrency-safe dispatcher tests and docs updates

## Validation
- go test ./pkg/runtime/toolexec
- go test -race ./pkg/runtime/toolexec
- go test -race ./pkg/runtime
- task lint
- task --force build
- env -u DEEPSEEK_API_KEY -u CEREBRAS_API_KEY -u FIREWORKS_API_KEY -u TOGETHER_API_KEY -u HF_TOKEN -u MOONSHOT_API_KEY -u AI_GATEWAY_API_KEY -u CLOUDFLARE_API_TOKEN -u CLOUDFLARE_ACCOUNT_ID -u CLOUDFLARE_GATEWAY_ID task test

Note: a plain task test initially hit a live Moonshot alias API 404 because MOONSHOT_API_KEY was set locally; rerunning with live-provider env vars unset passed.