### PR TITLE
fix: compaction data loss on empty summary + honest compaction outcome reporting

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1218,7 +1218,11 @@ func (a *App) CompactSession(ctx context.Context, cancel context.CancelFunc, add
 			a.sendEvent(ctx, event)
 		}
 		if !completed && ctx.Err() == nil {
-			a.sendEvent(ctx, runtime.SessionCompaction(sess.ID, "completed", agentName))
+			// The compaction never emitted its started/completed pair (e.g. a
+			// pre_compact / before_compaction hook vetoed it). Synthesize the
+			// terminal event so the TUI unsticks, but report it as skipped —
+			// nothing was compacted.
+			a.sendEvent(ctx, runtime.SessionCompactionCompleted(sess.ID, runtime.CompactionOutcomeSkipped, agentName))
 		}
 	}()
 }

--- a/pkg/compaction/scenarios_test.go
+++ b/pkg/compaction/scenarios_test.go
@@ -1,0 +1,107 @@
+package compaction
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// Scenario: reasoning tokens exceeding output tokens must not produce a
+// negative "reported" size; the estimator should fall back to the
+// heuristic instead of returning a negative estimate.
+func TestScenario_EstimateMessageTokens_ReasoningExceedsOutput(t *testing.T) {
+	msg := &chat.Message{
+		Role:    chat.MessageRoleAssistant,
+		Content: strings.Repeat("x", 350), // ~100 heuristic tokens
+		Usage: &chat.Usage{
+			OutputTokens:    10,
+			ReasoningTokens: 50, // provider glitch or pure-reasoning turn
+		},
+	}
+	got := EstimateMessageTokens(msg)
+	assert.Positive(t, got, "estimate must never be negative or zero")
+	assert.Equal(t, int64(float64(350)/charsPerToken)+perMessageOverhead, got,
+		"should fall back to the heuristic when reported <= 0")
+}
+
+// Scenario: an anchor whose prompt count is zero but output is non-zero is
+// treated as in-between content; calibration must not divide by zero or
+// produce a wild scale.
+func TestScenario_NewEstimator_OutputOnlyUsage(t *testing.T) {
+	msgs := []chat.Message{
+		{Role: chat.MessageRoleUser, Content: strings.Repeat("u", 4000)},
+		{Role: chat.MessageRoleAssistant, Content: "a", Usage: &chat.Usage{OutputTokens: 5}},
+		{Role: chat.MessageRoleUser, Content: strings.Repeat("v", 4000)},
+	}
+	e := NewSliceEstimator(msgs)
+	assert.InDelta(t, 1.0, e.Scale(), 0, "no usable anchors -> neutral estimator")
+}
+
+// Scenario: consecutive anchors with a compaction in between (prompt shrank)
+// must be discarded, not fold a negative delta into the ratio.
+func TestScenario_NewEstimator_CompactionBetweenAnchors(t *testing.T) {
+	msgs := []chat.Message{
+		{Role: chat.MessageRoleAssistant, Model: "m", Usage: &chat.Usage{InputTokens: 50_000, OutputTokens: 100}},
+		{Role: chat.MessageRoleTool, Content: strings.Repeat("t", 4000)},
+		// Compaction happened: prompt dropped from 50k to 2k.
+		{Role: chat.MessageRoleAssistant, Model: "m", Usage: &chat.Usage{InputTokens: 2_000, OutputTokens: 100}},
+	}
+	e := NewSliceEstimator(msgs)
+	assert.InDelta(t, 1.0, e.Scale(), 0, "negative window delta must be discarded")
+}
+
+// Scenario: SplitIndexForKeep on a conversation that ends with a huge tool
+// result larger than the keep budget. The kept tail should snap to a
+// user/assistant boundary (never start on the tool message), or keep
+// nothing at all.
+func TestScenario_SplitIndexForKeep_HugeTrailingToolResult(t *testing.T) {
+	msgs := []chat.Message{
+		{Role: chat.MessageRoleUser, Content: "question"},
+		{Role: chat.MessageRoleAssistant, Content: "calling tool", ToolCalls: []tools.ToolCall{{}}},
+		{Role: chat.MessageRoleTool, Content: strings.Repeat("t", 400_000)}, // ~114k tokens
+	}
+	idx := SplitIndexForKeep(msgs, 20_000)
+	if idx < len(msgs) {
+		role := msgs[idx].Role
+		assert.True(t, role == chat.MessageRoleUser || role == chat.MessageRoleAssistant,
+			"kept tail must start on a user/assistant boundary, got %q", role)
+	}
+	// The tool result exceeds the budget on its own, so nothing can be
+	// kept: idx == len(msgs) (compact everything).
+	assert.Equal(t, len(msgs), idx)
+}
+
+// Scenario: a kept-tail boundary must never split an assistant tool-call
+// message from its tool results.
+func TestScenario_SplitIndexForKeep_NeverOrphansToolResults(t *testing.T) {
+	big := strings.Repeat("x", 3500) // ~1000 tokens each
+	var msgs []chat.Message
+	for range 20 {
+		msgs = append(msgs,
+			chat.Message{Role: chat.MessageRoleUser, Content: big},
+			chat.Message{Role: chat.MessageRoleAssistant, Content: big, ToolCalls: []tools.ToolCall{{ID: "c"}}},
+			chat.Message{Role: chat.MessageRoleTool, ToolCallID: "c", Content: big},
+			chat.Message{Role: chat.MessageRoleAssistant, Content: big},
+		)
+	}
+	for budget := int64(500); budget <= 30_000; budget += 777 {
+		idx := SplitIndexForKeep(msgs, budget)
+		if idx < len(msgs) {
+			assert.NotEqual(t, chat.MessageRoleTool, msgs[idx].Role,
+				"budget %d: kept tail starts on a tool result", budget)
+		}
+	}
+}
+
+// Scenario: threshold values above 1 (user misconfiguration like 1.5 or 90
+// meaning "90%") silently fall back to the default instead of erroring.
+func TestScenario_ShouldCompact_ThresholdAboveOne(t *testing.T) {
+	// 95k tokens of a 100k window, user config "compaction_threshold: 95"
+	// (meant 0.95). Falls back to 0.9 -> compacts at 91k.
+	assert.True(t, ShouldCompact(91_000, 0, 0, 100_000, 95))
+	assert.False(t, ShouldCompact(89_000, 0, 0, 100_000, 95))
+}

--- a/pkg/runtime/compaction_scenarios_test.go
+++ b/pkg/runtime/compaction_scenarios_test.go
@@ -23,7 +23,11 @@ func collectCompactionEvents(t *testing.T, rt *LocalRuntime, sess *session.Sessi
 	for ev := range events {
 		switch e := ev.(type) {
 		case *SessionCompactionEvent:
-			kinds = append(kinds, "compaction:"+e.Status)
+			if e.Status == "completed" && e.Outcome != "" {
+				kinds = append(kinds, "compaction:completed:"+e.Outcome)
+			} else {
+				kinds = append(kinds, "compaction:"+e.Status)
+			}
 		case *SessionSummaryEvent:
 			kinds = append(kinds, "summary")
 		case *ErrorEvent:
@@ -41,9 +45,9 @@ func twoMessageSession() *session.Session {
 }
 
 // Scenario: when the model definition can't be resolved (unknown model, no
-// provider_opts), doCompact emits started -> error -> completed; the
-// started/completed pairing is what UIs use for spinner logic.
-func TestScenario_CompactionFailure_EmitsErrorAndCompleted(t *testing.T) {
+// provider_opts), doCompact emits started -> error -> completed with a
+// "failed" outcome so UIs don't announce success after an error.
+func TestScenario_CompactionFailure_ReportsFailedOutcome(t *testing.T) {
 	t.Parallel()
 
 	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
@@ -57,15 +61,17 @@ func TestScenario_CompactionFailure_EmitsErrorAndCompleted(t *testing.T) {
 	sess := twoMessageSession()
 	kinds := collectCompactionEvents(t, rt, sess)
 
-	// The started/completed pairing is preserved for spinner logic.
-	assert.Equal(t, []string{"compaction:started", "error", "compaction:completed"}, kinds)
+	// The started/completed pairing is preserved for spinner logic, but
+	// the terminal event now reports the failure.
+	assert.Equal(t, []string{"compaction:started", "error", "compaction:completed:failed"}, kinds)
 	assert.Len(t, sess.Messages, 2, "failed compaction must not modify the session")
 }
 
 // Scenario: when the summary model returns an empty response, the
 // compaction must be a no-op: the session is left untouched (an empty
 // model response must NOT fall back to the conversation's own last
-// assistant message — that would wipe real history).
+// assistant message — that would wipe real history) and the terminal
+// event reports "skipped".
 func TestScenario_EmptySummary_IsNoOp(t *testing.T) {
 	t.Parallel()
 
@@ -81,8 +87,9 @@ func TestScenario_EmptySummary_IsNoOp(t *testing.T) {
 	sess := twoMessageSession()
 	kinds := collectCompactionEvents(t, rt, sess)
 
-	assert.Equal(t, []string{"compaction:started", "compaction:completed"}, kinds)
-	assert.Len(t, sess.Messages, 2, "an empty model response must leave the session unmodified")
+	assert.Equal(t, []string{"compaction:started", "compaction:completed:skipped"}, kinds,
+		"a no-summary no-op must not look like a successful compaction")
+	assert.Len(t, sess.Messages, 2, "a no-summary response must leave the session unmodified")
 }
 
 // Scenario: session token bookkeeping right after a successful compaction.

--- a/pkg/runtime/compaction_scenarios_test.go
+++ b/pkg/runtime/compaction_scenarios_test.go
@@ -1,0 +1,121 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/team"
+)
+
+// collectCompactionEvents runs compactWithReason and returns the ordered
+// event kinds relevant to compaction UX.
+func collectCompactionEvents(t *testing.T, rt *LocalRuntime, sess *session.Session) (kinds []string) {
+	t.Helper()
+	events := make(chan Event, 256) // ample headroom: a blocked sink would deadlock the test
+	rt.compactWithReason(t.Context(), sess, "", compactionReasonManual, NewChannelSink(events))
+	close(events)
+	for ev := range events {
+		switch e := ev.(type) {
+		case *SessionCompactionEvent:
+			kinds = append(kinds, "compaction:"+e.Status)
+		case *SessionSummaryEvent:
+			kinds = append(kinds, "summary")
+		case *ErrorEvent:
+			kinds = append(kinds, "error")
+		}
+	}
+	return kinds
+}
+
+func twoMessageSession() *session.Session {
+	return session.New(session.WithMessages([]session.Item{
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "hi"}}),
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "hello"}}),
+	}))
+}
+
+// Scenario: when the model definition can't be resolved (unknown model, no
+// provider_opts), doCompact emits started -> error -> completed; the
+// started/completed pairing is what UIs use for spinner logic.
+func TestScenario_CompactionFailure_EmitsErrorAndCompleted(t *testing.T) {
+	t.Parallel()
+
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	root := agent.New("root", "test", agent.WithModel(prov))
+	rt, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root)),
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStore{}), // context limit unresolvable -> failure
+	)
+	require.NoError(t, err)
+
+	sess := twoMessageSession()
+	kinds := collectCompactionEvents(t, rt, sess)
+
+	// The started/completed pairing is preserved for spinner logic.
+	assert.Equal(t, []string{"compaction:started", "error", "compaction:completed"}, kinds)
+	assert.Len(t, sess.Messages, 2, "failed compaction must not modify the session")
+}
+
+// Scenario: when the summary model returns an empty response, the
+// compaction must be a no-op: the session is left untouched (an empty
+// model response must NOT fall back to the conversation's own last
+// assistant message — that would wipe real history).
+func TestScenario_EmptySummary_IsNoOp(t *testing.T) {
+	t.Parallel()
+
+	emptySummaryStream := newStreamBuilder().AddStopWithUsage(1, 0).Build()
+	prov := &queueProvider{id: "test/mock-model", streams: []chat.MessageStream{emptySummaryStream}}
+	root := agent.New("root", "test", agent.WithModel(prov))
+	rt, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root)),
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStoreWithLimit{limit: 100_000}),
+	)
+	require.NoError(t, err)
+
+	sess := twoMessageSession()
+	kinds := collectCompactionEvents(t, rt, sess)
+
+	assert.Equal(t, []string{"compaction:started", "compaction:completed"}, kinds)
+	assert.Len(t, sess.Messages, 2, "an empty model response must leave the session unmodified")
+}
+
+// Scenario: session token bookkeeping right after a successful compaction.
+// InputTokens is reset to the summary size only; the kept-tail messages
+// still enter the next prompt but are not accounted for until the next
+// model call reports real usage. Verifies the value is at least sane
+// (non-negative, much smaller than before).
+func TestScenario_PostCompactionTokenAccounting(t *testing.T) {
+	t.Parallel()
+
+	summaryStream := newStreamBuilder().AddContent("the summary").AddStopWithUsage(50, 7).Build()
+	prov := &queueProvider{id: "test/mock-model", streams: []chat.MessageStream{summaryStream}}
+	root := agent.New("root", "test", agent.WithModel(prov))
+	rt, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root)),
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStoreWithLimit{limit: 100_000}),
+	)
+	require.NoError(t, err)
+
+	// A session with a big kept tail: two large recent messages.
+	big := strings.Repeat("x", 40_000) // ~11.4k tokens each
+	sess := session.New(session.WithMessages([]session.Item{
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: big}}),
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: big}}),
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "recent question"}}),
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "recent answer"}}),
+	}))
+	sess.SetUsage(90_000, 500)
+
+	kinds := collectCompactionEvents(t, rt, sess)
+	require.Contains(t, kinds, "summary")
+
+	in, out := sess.Usage()
+	assert.Equal(t, int64(7), in, "InputTokens after compaction = summary output tokens only (kept tail unaccounted)")
+	assert.Zero(t, out)
+}

--- a/pkg/runtime/compaction_scenarios_test.go
+++ b/pkg/runtime/compaction_scenarios_test.go
@@ -71,25 +71,36 @@ func TestScenario_CompactionFailure_ReportsFailedOutcome(t *testing.T) {
 // compaction must be a no-op: the session is left untouched (an empty
 // model response must NOT fall back to the conversation's own last
 // assistant message — that would wipe real history) and the terminal
-// event reports "skipped".
+// event reports "skipped". Whitespace-only responses take the same path.
 func TestScenario_EmptySummary_IsNoOp(t *testing.T) {
 	t.Parallel()
 
-	emptySummaryStream := newStreamBuilder().AddStopWithUsage(1, 0).Build()
-	prov := &queueProvider{id: "test/mock-model", streams: []chat.MessageStream{emptySummaryStream}}
-	root := agent.New("root", "test", agent.WithModel(prov))
-	rt, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root)),
-		WithSessionCompaction(false),
-		WithModelStore(mockModelStoreWithLimit{limit: 100_000}),
-	)
-	require.NoError(t, err)
+	tests := []struct {
+		name   string
+		stream *mockStream
+	}{
+		{"empty response", newStreamBuilder().AddStopWithUsage(1, 0).Build()},
+		{"whitespace-only response", newStreamBuilder().AddContent("\n \t\n").AddStopWithUsage(1, 2).Build()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			prov := &queueProvider{id: "test/mock-model", streams: []chat.MessageStream{tt.stream}}
+			root := agent.New("root", "test", agent.WithModel(prov))
+			rt, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root)),
+				WithSessionCompaction(false),
+				WithModelStore(mockModelStoreWithLimit{limit: 100_000}),
+			)
+			require.NoError(t, err)
 
-	sess := twoMessageSession()
-	kinds := collectCompactionEvents(t, rt, sess)
+			sess := twoMessageSession()
+			kinds := collectCompactionEvents(t, rt, sess)
 
-	assert.Equal(t, []string{"compaction:started", "compaction:completed:skipped"}, kinds,
-		"a no-summary no-op must not look like a successful compaction")
-	assert.Len(t, sess.Messages, 2, "a no-summary response must leave the session unmodified")
+			assert.Equal(t, []string{"compaction:started", "compaction:completed:skipped"}, kinds,
+				"a no-summary no-op must not look like a successful compaction")
+			assert.Len(t, sess.Messages, 2, "a no-summary response must leave the session unmodified")
+		})
+	}
 }
 
 // Scenario: session token bookkeeping right after a successful compaction.

--- a/pkg/runtime/compactor/compactor.go
+++ b/pkg/runtime/compactor/compactor.go
@@ -348,17 +348,19 @@ func firstKeptSessionIndex(sess *session.Session, sessIndices []int, splitIdx in
 	return sessIndices[splitIdx]
 }
 
-// lastAssistantContentAfter returns the content of the last assistant
-// message appended to sess after the first seedLen items, or "" when
-// the run produced none. sess is the throwaway compaction sub-session,
-// owned exclusively by the caller once RunAgent has returned.
+// lastAssistantContentAfter returns the content of the last non-empty
+// assistant message appended to sess after the first seedLen items, or
+// "" when the run produced none. Whitespace-only replies are skipped
+// so a trailing blank token doesn't hide an earlier valid summary.
+// sess is the throwaway compaction sub-session, owned exclusively by
+// the caller once RunAgent has returned.
 func lastAssistantContentAfter(sess *session.Session, seedLen int) string {
 	for i := len(sess.Messages) - 1; i >= seedLen; i-- {
 		item := sess.Messages[i]
 		if item.IsMessage() && item.Message.Message.Role == chat.MessageRoleAssistant {
-			// Whitespace-only output is no summary; trimming keeps it on
-			// the no-op path.
-			return strings.TrimSpace(item.Message.Message.Content)
+			if trimmed := strings.TrimSpace(item.Message.Message.Content); trimmed != "" {
+				return trimmed
+			}
 		}
 	}
 	return ""

--- a/pkg/runtime/compactor/compactor.go
+++ b/pkg/runtime/compactor/compactor.go
@@ -216,13 +216,23 @@ func RunLLM(ctx context.Context, args LLMArgs) (result *Result, err error) {
 		session.WithTitle("Generating summary"),
 		session.WithMessages(toItems(messages)),
 	)
+	seedLen := len(compactionSession.Messages)
 
 	if err := args.RunAgent(ctx, compactionAgent, compactionSession); err != nil {
 		return nil, fmt.Errorf("run compaction agent: %w", err)
 	}
 
-	summary := compactionSession.GetLastAssistantMessageContent()
+	// Only assistant content produced by the summarization run counts as
+	// the summary. The session was seeded with the conversation being
+	// summarized, so GetLastAssistantMessageContent would fall back to the
+	// conversation's own last assistant reply when the model returned an
+	// empty response — and that bogus "summary" would then replace the
+	// real history. Scanning past the seed makes an empty model response
+	// a no-op instead.
+	summary := lastAssistantContentAfter(compactionSession, seedLen)
 	if summary == "" {
+		slog.WarnContext(ctx, "Compaction skipped: summarization model produced no summary",
+			"session_id", args.Session.ID, "model", summaryModel.ID().String())
 		return nil, nil
 	}
 
@@ -335,6 +345,20 @@ func firstKeptSessionIndex(sess *session.Session, sessIndices []int, splitIdx in
 		return len(sess.Messages)
 	}
 	return sessIndices[splitIdx]
+}
+
+// lastAssistantContentAfter returns the content of the last assistant
+// message appended to sess after the first seedLen items, or "" when
+// the run produced none. sess is the throwaway compaction sub-session,
+// owned exclusively by the caller once RunAgent has returned.
+func lastAssistantContentAfter(sess *session.Session, seedLen int) string {
+	for i := len(sess.Messages) - 1; i >= seedLen; i-- {
+		item := sess.Messages[i]
+		if item.IsMessage() && item.Message.Message.Role == chat.MessageRoleAssistant {
+			return item.Message.Message.Content
+		}
+	}
+	return ""
 }
 
 // toItems wraps a flat slice of chat messages into session items so a

--- a/pkg/runtime/compactor/compactor.go
+++ b/pkg/runtime/compactor/compactor.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -355,7 +356,9 @@ func lastAssistantContentAfter(sess *session.Session, seedLen int) string {
 	for i := len(sess.Messages) - 1; i >= seedLen; i-- {
 		item := sess.Messages[i]
 		if item.IsMessage() && item.Message.Message.Role == chat.MessageRoleAssistant {
-			return item.Message.Message.Content
+			// Whitespace-only output is no summary; trimming keeps it on
+			// the no-op path.
+			return strings.TrimSpace(item.Message.Message.Content)
 		}
 	}
 	return ""

--- a/pkg/runtime/compactor/compactor_test.go
+++ b/pkg/runtime/compactor/compactor_test.go
@@ -202,6 +202,77 @@ func TestComputeFirstKeptEntry(t *testing.T) {
 	})
 }
 
+func TestLastAssistantContentAfter(t *testing.T) {
+	t.Parallel()
+
+	newMsg := func(role chat.MessageRole, content string) session.Item {
+		return session.NewMessageItem(&session.Message{
+			Message: chat.Message{Role: role, Content: content},
+		})
+	}
+
+	tests := []struct {
+		name     string
+		messages []session.Item
+		seedLen  int
+		want     string
+	}{
+		{
+			name:     "no messages after seed",
+			messages: []session.Item{newMsg(chat.MessageRoleAssistant, "seed reply")},
+			seedLen:  1,
+			want:     "",
+		},
+		{
+			name: "seed assistant reply is never picked up",
+			messages: []session.Item{
+				newMsg(chat.MessageRoleAssistant, "stale reply"),
+				newMsg(chat.MessageRoleUser, "summarize"),
+			},
+			seedLen: 2,
+			want:    "",
+		},
+		{
+			name: "summary is trimmed",
+			messages: []session.Item{
+				newMsg(chat.MessageRoleUser, "summarize"),
+				newMsg(chat.MessageRoleAssistant, "  summary \n"),
+			},
+			seedLen: 1,
+			want:    "summary",
+		},
+		{
+			name: "whitespace-only trailing reply does not hide an earlier summary",
+			messages: []session.Item{
+				newMsg(chat.MessageRoleUser, "summarize"),
+				newMsg(chat.MessageRoleAssistant, "real summary"),
+				newMsg(chat.MessageRoleTool, "tool result"),
+				newMsg(chat.MessageRoleAssistant, "\n \t"),
+			},
+			seedLen: 1,
+			want:    "real summary",
+		},
+		{
+			name: "all whitespace-only replies yield no summary",
+			messages: []session.Item{
+				newMsg(chat.MessageRoleUser, "summarize"),
+				newMsg(chat.MessageRoleAssistant, " "),
+				newMsg(chat.MessageRoleAssistant, "\n"),
+			},
+			seedLen: 1,
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sess := session.New(session.WithMessages(tt.messages))
+			assert.Equal(t, tt.want, lastAssistantContentAfter(sess, tt.seedLen))
+		})
+	}
+}
+
 func TestGatherCompactionInput_NoPriorSummary(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runtime/compactor/scenarios_test.go
+++ b/pkg/runtime/compactor/scenarios_test.go
@@ -1,0 +1,152 @@
+package compactor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+// Scenario: second-round compaction over a session that already contains a
+// summary with a kept tail. CompactionInput's sessIndices are
+// non-monotonic in this case (synthetic summary -> old kept tail ->
+// post-summary conversation); verify that the FirstKeptEntry computed
+// for the SECOND summary partitions the conversation with no message
+// both summarized and kept, and none lost.
+func TestScenario_SecondRoundCompaction_PartitionIsExact(t *testing.T) {
+	t.Parallel()
+
+	big := strings.Repeat("x", 35_000) // ~10k tokens each
+	msg := func(role chat.MessageRole, content string) session.Item {
+		return session.NewMessageItem(&session.Message{Message: chat.Message{Role: role, Content: content}})
+	}
+
+	items := []session.Item{
+		msg(chat.MessageRoleUser, "m0"),             // 0: folded into old summary
+		msg(chat.MessageRoleAssistant, "m1"),        // 1: folded into old summary
+		msg(chat.MessageRoleUser, "m2"),             // 2: old kept tail
+		msg(chat.MessageRoleAssistant, "m3"),        // 3: old kept tail
+		{Summary: "old summary", FirstKeptEntry: 2}, // 4: prior compaction
+		msg(chat.MessageRoleUser, big+"m5"),         // 5
+		msg(chat.MessageRoleAssistant, big+"m6"),    // 6
+		msg(chat.MessageRoleUser, big+"m7"),         // 7
+		msg(chat.MessageRoleAssistant, "m8"),        // 8
+	}
+	sess := session.New(session.WithMessages(items))
+
+	messages, sessIndices := gatherCompactionInput(sess)
+	// synthetic summary(->4), m2(->2), m3(->3), m5..m8(->5..8)
+	require.Equal(t, []int{4, 2, 3, 5, 6, 7, 8}, sessIndices)
+	require.Contains(t, messages[0].Content, "Session Summary: old summary")
+
+	// Keep budget of 20k (contextLimit 100k) keeps roughly the last two
+	// big messages; everything else is summarized.
+	firstKept := ComputeFirstKeptEntry(sess, 100_000)
+	require.Greater(t, firstKept, 4, "kept tail should start after the old summary item")
+	require.Less(t, firstKept, len(items), "something should be kept")
+
+	// Simulate the runtime applying the new summary.
+	sess.ApplyCompaction(100, 0, session.Item{Summary: "new summary", FirstKeptEntry: firstKept})
+
+	// Reconstruct what the next prompt will contain via a third
+	// CompactionInput round (mirrors buildSessionSummaryMessages).
+	after, afterIdx := gatherCompactionInput(sess)
+	require.Contains(t, after[0].Content, "Session Summary: new summary")
+
+	// Every original message must be either folded (index < firstKept in
+	// the kept-tail sense) or kept verbatim — never both, never lost.
+	keptContents := map[string]bool{}
+	for _, m := range after[1:] {
+		keptContents[m.Content] = true
+	}
+	for i := firstKept; i < len(items)-1; i++ { // -1: the new summary item itself
+		if items[i].IsMessage() {
+			assert.True(t, keptContents[items[i].Message.Message.Content],
+				"message at session index %d must be kept verbatim", i)
+		}
+	}
+	for _, idx := range afterIdx[1:] {
+		assert.GreaterOrEqual(t, idx, firstKept,
+			"no message before FirstKeptEntry may leak into the reconstructed prompt")
+	}
+}
+
+// Scenario: manual /compact on a tiny session (everything fits the keep
+// budget). SplitIndexForKeep returns len(messages) -> everything is
+// summarized, nothing kept. Verify the sentinel maps to
+// len(sess.Messages) and doesn't panic or point at a bogus index.
+func TestScenario_TinySessionCompactsEverything(t *testing.T) {
+	t.Parallel()
+
+	items := []session.Item{
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "hi"}}),
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "hello"}}),
+	}
+	sess := session.New(session.WithMessages(items))
+	firstKept := ComputeFirstKeptEntry(sess, 100_000)
+	assert.Equal(t, len(sess.Messages), firstKept, "compact-everything sentinel")
+}
+
+// Scenario: messages appended between the FirstKeptEntry snapshot and
+// ApplyCompaction (steered input racing a compaction) must survive:
+// they land inside the kept-tail window, never inside the summarized
+// range.
+func TestScenario_MessagesAppendedDuringCompactionAreKept(t *testing.T) {
+	t.Parallel()
+
+	items := []session.Item{
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "hi"}}),
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "hello"}}),
+	}
+	sess := session.New(session.WithMessages(items))
+
+	// Snapshot: compact everything (sentinel = len at snapshot time).
+	firstKept := ComputeFirstKeptEntry(sess, 100_000)
+	require.Equal(t, 2, firstKept)
+
+	// A steered user message races in before the summary is applied.
+	sess.AddMessage(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "raced steer"}})
+	sess.ApplyCompaction(10, 0, session.Item{Summary: "sum", FirstKeptEntry: firstKept})
+
+	msgs, _ := gatherCompactionInput(sess)
+	require.Len(t, msgs, 2, "summary + raced message")
+	assert.Contains(t, msgs[0].Content, "Session Summary: sum")
+	assert.Equal(t, "raced steer", msgs[1].Content, "the raced message must be preserved verbatim")
+}
+
+// Scenario: a prior summary at the very front of the summarizer input is
+// dropped when the summarization budget is too tight — the new summary
+// then loses everything the old one contained. Documents current
+// (lossy) behavior.
+func TestScenario_TightBudgetDropsPriorSummaryFromInput(t *testing.T) {
+	t.Parallel()
+
+	big := strings.Repeat("x", 40_000) // ~11.4k tokens
+	items := []session.Item{
+		{Summary: "IMPORTANT old facts", FirstKeptEntry: 0},
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: big + "recent1"}}),
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: big + "recent2"}}),
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: big + "recent3"}}),
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "tail"}}),
+	}
+	sess := session.New(session.WithMessages(items))
+
+	// context 16k: summary budget 4k, keep budget 3.2k, available ~11.8k.
+	msgs, _ := extractMessages(sess, nil, 16_000, "")
+
+	var sawOldSummary bool
+	for _, m := range msgs {
+		if strings.Contains(m.Content, "IMPORTANT old facts") {
+			sawOldSummary = true
+		}
+	}
+	// Current behavior: front-truncation drops the prior summary. If this
+	// assertion starts failing, the lossy behavior was fixed — update the
+	// probe.
+	assert.False(t, sawOldSummary,
+		"documents current behavior: tight budgets silently drop the prior summary from the summarizer input")
+}

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -502,6 +502,9 @@ func SessionCompaction(sessionID, status, agentName string) Event {
 // SessionCompactionCompleted is the terminal counterpart of a "started"
 // [SessionCompaction] event, carrying the outcome ("applied", "skipped"
 // or "failed") so consumers can render an honest completion signal.
+// A "completed" event may arrive without a preceding "started" when a
+// pre-compaction hook vetoes the operation; consumers replaying the
+// event stream should tolerate the unpaired terminal event.
 func SessionCompactionCompleted(sessionID, outcome, agentName string) Event {
 	return &SessionCompactionEvent{
 		Type:         "session_compaction",

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -468,12 +468,26 @@ func SessionSummary(sessionID, summary, agentName string, firstKeptEntry int) Ev
 
 func (e *SessionSummaryEvent) GetSessionID() string { return e.SessionID }
 
+// Outcome values carried by a "completed" [SessionCompactionEvent].
+const (
+	CompactionOutcomeApplied = "applied"
+	CompactionOutcomeSkipped = "skipped"
+	CompactionOutcomeFailed  = "failed"
+)
+
 type SessionCompactionEvent struct {
 	AgentContext
 
 	Type      string `json:"type"`
 	SessionID string `json:"session_id"`
 	Status    string `json:"status"`
+	// Outcome qualifies a "completed" status: "applied" (a summary
+	// replaced part of the history), "skipped" (no-op: nothing to
+	// compact or the model produced no summary), or "failed" (an error
+	// was emitted). Empty on "started" events and events from older
+	// servers; consumers should treat empty as "applied" for backward
+	// compatibility.
+	Outcome string `json:"outcome,omitempty"`
 }
 
 func SessionCompaction(sessionID, status, agentName string) Event {
@@ -481,6 +495,19 @@ func SessionCompaction(sessionID, status, agentName string) Event {
 		Type:         "session_compaction",
 		SessionID:    sessionID,
 		Status:       status,
+		AgentContext: newAgentContext(agentName),
+	}
+}
+
+// SessionCompactionCompleted is the terminal counterpart of a "started"
+// [SessionCompaction] event, carrying the outcome ("applied", "skipped"
+// or "failed") so consumers can render an honest completion signal.
+func SessionCompactionCompleted(sessionID, outcome, agentName string) Event {
+	return &SessionCompactionEvent{
+		Type:         "session_compaction",
+		SessionID:    sessionID,
+		Status:       "completed",
+		Outcome:      outcome,
 		AgentContext: newAgentContext(agentName),
 	}
 }

--- a/pkg/runtime/session_compaction.go
+++ b/pkg/runtime/session_compaction.go
@@ -77,8 +77,14 @@ func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *
 
 	slog.DebugContext(ctx, "Generating summary for session", "session_id", sess.ID, "reason", reason)
 	events.Emit(SessionCompaction(sess.ID, "started", a.Name()))
+	// outcome qualifies the terminal "completed" event: "applied" when a
+	// summary was written to the session, "skipped" for no-ops (nothing
+	// to compact, empty model output), "failed" when an error was
+	// emitted. UIs use it to avoid announcing success for a compaction
+	// that did nothing.
+	outcome := CompactionOutcomeApplied
 	defer func() {
-		events.Emit(SessionCompaction(sess.ID, "completed", a.Name()))
+		events.Emit(SessionCompactionCompleted(sess.ID, outcome, a.Name()))
 	}()
 
 	// Choose the strategy: a hook-supplied summary if before_compaction
@@ -89,6 +95,7 @@ func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *
 			slog.ErrorContext(ctx, "Failed to generate session summary",
 				"error", "model definition unavailable")
 			events.Emit(ErrorForSession(sess.ID, "Failed to get model definition"))
+			outcome = CompactionOutcomeFailed
 			return
 		}
 
@@ -103,10 +110,12 @@ func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *
 		if err != nil {
 			slog.ErrorContext(ctx, "Failed to generate session summary", "error", err)
 			events.Emit(ErrorForSession(sess.ID, err.Error()))
+			outcome = CompactionOutcomeFailed
 			return
 		}
 		if result == nil {
 			// Empty summary — bail without applying anything.
+			outcome = CompactionOutcomeSkipped
 			return
 		}
 	}

--- a/pkg/tui/page/chat/runtime_events.go
+++ b/pkg/tui/page/chat/runtime_events.go
@@ -134,13 +134,24 @@ func (p *chatPage) handleRuntimeEvent(msg tea.Msg) (bool, tea.Cmd) {
 	case *runtime.SessionCompactionEvent:
 		if msg.Status == "completed" {
 			p.msgCancel = nil
-			return true, tea.Batch(
+			cmds := []tea.Cmd{
 				p.setWorking(false),
 				p.setPendingResponse(false),
 				p.processNextQueuedMessage(),
-				notification.SuccessCmd("Session compacted successfully."),
 				p.messages.ScrollToBottom(),
-			)
+			}
+			// Only announce success when a summary was actually applied.
+			// "failed" already surfaced an ErrorEvent; "skipped" means the
+			// compaction was a no-op (nothing to compact, hook veto, empty
+			// model output). Empty outcome (older servers) keeps the legacy
+			// success toast.
+			switch msg.Outcome {
+			case "", runtime.CompactionOutcomeApplied:
+				cmds = append(cmds, notification.SuccessCmd("Session compacted successfully."))
+			case runtime.CompactionOutcomeSkipped:
+				cmds = append(cmds, notification.InfoCmd("Session compaction skipped."))
+			}
+			return true, tea.Batch(cmds...)
 		}
 		return true, nil
 


### PR DESCRIPTION
## What

Four commits from a scenario-driven review of the session-compaction code:

1. **fix: compaction no longer replaces history with a stale reply on empty summary** — `compactor.RunLLM` read the summary via `GetLastAssistantMessageContent()` on a sub-session seeded with the conversation being summarized. When the summarization model returned an empty response (rate limit, token cap, flaky local model), the conversation's own last assistant message was applied as the "summary", silently wiping the compacted history. Fixed by only counting assistant content appended after the seed; an empty response is now a no-op. Regression tests included.

2. **fix: report compaction outcome (applied/skipped/failed) on the completed event** — `doCompact` emitted an identical "completed" event whether a summary was applied, the compaction no-opped, or it failed, so the TUI announced "Session compacted successfully." even right after an error. The completed `SessionCompactionEvent` now carries an `Outcome` field (shared `CompactionOutcome*` constants); the TUI only toasts success for applied (empty outcome = backward compat with older servers), info for skipped, silent for failed (the ErrorEvent already surfaced). Hook-vetoed compactions synthesized by the App are reported as skipped.

3. **test: add compaction edge-case scenario tests** — estimator guards (reasoning > output tokens, output-only usage, compaction between anchors), kept-tail boundary snapping (never starts on a tool result), threshold misconfiguration fallback, and documentation of the lossy prior-summary drop under tight summarization budgets.

4. **fix: treat a whitespace-only compaction summary as a no-op** — trimmed at the extraction point so whitespace-only model output takes the skip path.

## Why

Empty summarizer responses were corrupting session history (data loss), and failed/no-op compactions were indistinguishable from successful ones for users and event consumers.

## Backward compatibility

`Outcome` is `omitempty`-additive on the wire; all consumers verified (chat TUI, leantui, app, remote client). Empty outcome from older servers keeps legacy behavior. Every commit builds and tests green individually.

## Testing

- Regression test reproduces the data-loss bug when the fix is reverted
- `task build`, `task test` (full suite), `task lint` all green; `-race` clean on runtime/session/compaction packages

Supersedes #3469.
