### PR TITLE
Split background jobs into separate toolset

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -1963,6 +1963,7 @@
             "memory",
             "filesystem",
             "shell",
+            "background_jobs",
             "tasks",
             "plan",
             "session_plan",
@@ -2184,7 +2185,7 @@
         },
         "recall": {
           "type": "boolean",
-          "description": "Opt in to background-job recall for the shell toolset (only valid for type 'shell'). When enabled, run_background_job exposes a recall boolean parameter. If the agent sets recall=true for a background job, the runtime injects a steering message with a short completion sentence and the job output when the job finishes. Default false."
+          "description": "Opt in to background-job recall for the background_jobs toolset (only valid for type 'background_jobs'). When enabled, run_background_job exposes a recall boolean parameter. If the agent sets recall=true for a background job, the runtime injects a steering message with a short completion sentence and the job output when the job finishes. Default false."
         },
         "safer": {
           "type": "boolean",
@@ -2300,6 +2301,7 @@
                 "memory",
                 "filesystem",
                 "shell",
+                "background_jobs",
                 "tasks",
                 "plan",
                 "session_plan",

--- a/docs/concepts/tools/index.md
+++ b/docs/concepts/tools/index.md
@@ -29,7 +29,8 @@ docker-agent ships with several built-in tools that require no external dependen
 | Tool | Description |
 | --- | --- |
 | [Filesystem](../../tools/filesystem/index.md) | Read, write, list, search, and navigate files and directories |
-| [Shell](../../tools/shell/index.md) | Execute synchronous and background shell commands |
+| [Shell](../../tools/shell/index.md) | Execute shell commands synchronously |
+| [Background Jobs](../../tools/background-jobs/index.md) | Run and manage long-running shell commands |
 | [Think](../../tools/think/index.md) | Step-by-step reasoning scratchpad for planning and decision-making |
 | [Todo](../../tools/todo/index.md) | Task list management for complex multi-step workflows |
 | [Tasks](../../tools/tasks/index.md) | Persistent task database shared across sessions |

--- a/docs/configuration/tools/index.md
+++ b/docs/configuration/tools/index.md
@@ -18,7 +18,8 @@ Built-in tools are included with docker-agent and require no external dependenci
 | Type | Description | Page |
 | --- | --- | --- |
 | `filesystem` | Read, write, list, search, navigate | [Filesystem](../../tools/filesystem/index.md) |
-| `shell` | Execute shell commands (sync + background jobs) | [Shell](../../tools/shell/index.md) |
+| `shell` | Execute shell commands synchronously | [Shell](../../tools/shell/index.md) |
+| `background_jobs` | Run and manage long-running shell commands | [Background Jobs](../../tools/background-jobs/index.md) |
 | `think` | Reasoning scratchpad | [Think](../../tools/think/index.md) |
 | `plan` | Shared persistent scratchpad for multi-agent collaboration | [Plan](../../tools/plan/index.md) |
 | `session_plan` | Per-session markdown plan for the draft-review-execute workflow | [Session Plan](../../tools/session_plan/index.md) |
@@ -47,6 +48,7 @@ Built-in tools are included with docker-agent and require no external dependenci
 toolsets:
   - type: filesystem
   - type: shell
+  - type: background_jobs
   - type: think
   - type: todo
   - type: memory

--- a/docs/tools/background-jobs/index.md
+++ b/docs/tools/background-jobs/index.md
@@ -1,0 +1,89 @@
+---
+title: "Background Jobs Tool"
+description: "Run and manage long-running shell commands."
+keywords: docker agent, ai agents, tools, toolsets, background jobs, shell
+linkTitle: "Background Jobs"
+weight: 21
+canonical: https://docs.docker.com/ai/docker-agent/tools/background-jobs/
+---
+
+_Run and manage long-running shell commands._
+
+## Overview
+
+The `background_jobs` toolset starts shell commands that should keep running while the agent continues with other work, such as local servers, file watchers, long builds, or test suites. It returns a job ID immediately, captures combined stdout/stderr up to 10 MB per job, and terminates all running jobs when the agent session ends.
+
+Use the [`shell`](../shell/index.md) toolset for short synchronous commands. Add both toolsets when an agent needs both synchronous commands and long-running processes.
+
+## Configuration
+
+```yaml
+toolsets:
+  - type: shell
+  - type: background_jobs
+```
+
+### Options
+
+| Property       | Type    | Description                                                                                                                                          |
+| -------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `env`    | object  | Environment variables to set for all background job commands.                                                                                        |
+| `recall` | boolean | Let `run_background_job` expose a `recall` parameter so jobs can steer the agent when they finish (see [Background job recall](#background-job-recall)). Default `false`. |
+
+### Custom Environment Variables
+
+```yaml
+toolsets:
+  - type: background_jobs
+    env:
+      MY_VAR: "value"
+      PATH: "${env.PATH}:/custom/bin"
+```
+
+### Background job recall
+
+Set `recall: true` to let the `run_background_job` tool expose a `recall` boolean parameter:
+
+```yaml
+toolsets:
+  - type: background_jobs
+    recall: true
+```
+
+When the agent starts a background job with `recall: true`, docker-agent sends a steering message back into the running agent loop after the job finishes. The message contains a short completion sentence and the job output, so the agent can react without polling `view_background_job`.
+
+Use recall for finite background work where completion matters (for example, a long build or test suite). Avoid it for servers and watchers that are expected to run until stopped. See [`examples/shell_recall.yaml`](https://github.com/docker/docker-agent/blob/main/examples/shell_recall.yaml) for a complete configuration.
+
+## Available Tools
+
+The background jobs toolset exposes five tools:
+
+| Tool Name              | Description                                                                                    |
+| ---------------------- | ---------------------------------------------------------------------------------------------- |
+| `run_background_job`   | Start a command asynchronously and return a job ID immediately. Use for servers/watchers/etc. |
+| `list_background_jobs` | List all background jobs with their status, runtime, and metadata.                             |
+| `view_background_job`  | View the buffered output and status of a specific background job by ID.                        |
+| `stop_background_job`  | Stop a running background job. Child processes are terminated too.                             |
+| `wait_background_job`  | Block until a job finishes and return its exit code and output. Safe on already-finished jobs. |
+
+### `run_background_job` parameters
+
+| Parameter | Type    | Required | Description                                                                                                                                 |
+| --------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cmd`     | string  | ✓        | The shell command to execute in the background.                                                                                             |
+| `cwd`     | string  | ✗        | Working directory to run the command in (default: `.`).                                                                                     |
+| `recall`  | boolean | ✗        | Only available when the `background_jobs` toolset has `recall: true`. When true, send a steering message with the job output when it finishes. |
+
+`view_background_job` and `stop_background_job` each take a single required `job_id` string returned by `run_background_job` or `list_background_jobs`.
+
+### `wait_background_job` parameters
+
+| Parameter | Type    | Required | Description                                                                                                    |
+| --------- | ------- | -------- | -------------------------------------------------------------------------------------------------------------- |
+| `job_id`  | string  | ✓        | Job ID returned by `run_background_job` or `list_background_jobs`.                                             |
+| `timeout` | integer | ✗        | Maximum seconds to wait (default: `60`). If the job is still running when the limit fires, the tool returns the current output with a notice and the job continues in the background. |
+
+> [!WARNING]
+> **Safety**
+>
+> Background jobs run shell commands with the same access as the agent process. Stop servers and watchers when they are no longer needed, and use [Sandbox Mode](../../configuration/sandbox/index.md) for additional isolation.

--- a/docs/tools/shell/index.md
+++ b/docs/tools/shell/index.md
@@ -11,9 +11,9 @@ _Execute arbitrary shell commands in the user's environment._
 
 ## Overview
 
-The shell tool allows agents to execute arbitrary shell commands. This is one of the most powerful tools — it lets agents run builds, install dependencies, query APIs, and interact with the system. Each call runs in a fresh, isolated shell session — no state persists between calls.
+The shell tool allows agents to execute arbitrary shell commands synchronously. This is one of the most powerful tools — it lets agents run builds, install dependencies, query APIs, and interact with the system. Each call runs in a fresh, isolated shell session — no state persists between calls.
 
-Commands have a default 30-second timeout and require user confirmation unless `--yolo` is used.
+Commands have a default 30-second timeout and require user confirmation unless `--yolo` is used. For servers, watchers, and other long-running commands, add the [`background_jobs`](../background-jobs/index.md) toolset alongside `shell`.
 
 ## Configuration
 
@@ -27,7 +27,6 @@ toolsets:
 | Property       | Type    | Description                                                                                          |
 | -------------- | ------- | --------------------------------------------------------------------------------------------------- |
 | `env`          | object  | Environment variables to set for all shell commands                                                 |
-| `recall`       | boolean | Let `run_background_job` expose a `recall` parameter so jobs can steer the agent when they finish (see [Background job recall](#background-job-recall)). Default `false`. |
 | `safer`        | boolean | Detect destructive shell commands and force confirmation regardless of `--yolo` or permission rules (see [Safer mode](#safer-mode)). Default `false`. |
 | `sudo_askpass` | boolean | Opt in to prompting for a `sudo` password (see [Sudo support](#sudo-support)). Default `false`.     |
 
@@ -40,20 +39,6 @@ toolsets:
       MY_VAR: "value"
       PATH: "${env.PATH}:/custom/bin"
 ```
-
-### Background job recall
-
-Set `recall: true` to let the `run_background_job` tool expose a `recall` boolean parameter:
-
-```yaml
-toolsets:
-  - type: shell
-    recall: true
-```
-
-When the agent starts a background job with `recall: true`, docker-agent sends a steering message back into the running agent loop after the job finishes. The message contains a short completion sentence and the job output, so the agent can react without polling `view_background_job`.
-
-Use recall for finite background work where completion matters (for example, a long build or test suite). Avoid it for servers and watchers that are expected to run until stopped. See [`examples/shell_recall.yaml`](https://github.com/docker/docker-agent/blob/main/examples/shell_recall.yaml) for a complete configuration.
 
 ### Safer mode
 
@@ -99,23 +84,16 @@ Notes and limitations:
 - Interactive UI only. In headless / non-interactive runs the prompt is declined automatically and `sudo` fails as before.
 - Only a bare `sudo ...` invocation in a POSIX shell (`sh`, `bash`, `zsh`, ...) is handled. `sudo` called by absolute path (`/usr/bin/sudo`), via `env sudo`, from inside a nested script, or under a non-POSIX shell (e.g. `fish`) is not intercepted and behaves as before.
 - Caching is `sudo`'s own. Because each shell tool call runs in a fresh shell with no controlling terminal, `sudo`'s credential cache does not persist across separate tool calls: you are prompted once per shell command that uses `sudo`. Within a single command, multiple `sudo` calls (e.g. `sudo a && sudo b`) usually share one prompt, subject to `sudo`'s own timestamp configuration.
-- The prompt must be answered within the command's timeout; raise the `timeout` parameter for `sudo` commands that may wait on input. Background jobs (`run_background_job`) are wired too, but their prompt only works while the originating turn is still active.
+- The prompt must be answered within the command's timeout; raise the `timeout` parameter for `sudo` commands that may wait on input.
 - Prompts are serialized: if a single command runs two `sudo` calls in parallel (e.g. `sudo a & sudo b`), the second waits for the first prompt to be answered rather than opening two dialogs at once.
 
 ## Available Tools
 
-The shell toolset exposes six tools:
+The shell toolset exposes one tool:
 
-| Tool Name              | Description                                                                                    |
-| ---------------------- | ---------------------------------------------------------------------------------------------- |
-| `shell`                | Run a command synchronously and return its combined output when it finishes.                   |
-| `run_background_job`   | Start a command asynchronously and return a job ID immediately. Use for servers/watchers/etc. |
-| `list_background_jobs` | List all background jobs with their status, runtime, and metadata.                             |
-| `view_background_job`  | View the buffered output and status of a specific background job by ID.                        |
-| `stop_background_job`  | Stop a running background job. Child processes are terminated too.                             |
-| `wait_background_job`  | Block until a job finishes and return its exit code and output. Safe on already-finished jobs. |
-
-Background job output is captured up to 10 MB per job. All background jobs are automatically terminated when the agent session ends.
+| Tool Name | Description                                                                  |
+| --------- | ---------------------------------------------------------------------------- |
+| `shell`   | Run a command synchronously and return its combined output when it finishes. |
 
 ### `shell` parameters
 
@@ -124,23 +102,6 @@ Background job output is captured up to 10 MB per job. All background jobs are a
 | `cmd`     | string  | ✓        | The shell command to execute.                                             |
 | `cwd`     | string  | ✗        | Working directory to run the command in (default: `.`).                   |
 | `timeout` | integer | ✗        | Per-call execution timeout in seconds (default: `30`).                    |
-
-### `run_background_job` parameters
-
-| Parameter | Type   | Required | Description                                                             |
-| --------- | ------ | -------- | ----------------------------------------------------------------------- |
-| `cmd`     | string  | ✓        | The shell command to execute in the background.                         |
-| `cwd`     | string  | ✗        | Working directory to run the command in (default: `.`).                 |
-| `recall`  | boolean | ✗        | Only available when the shell toolset has `recall: true`. When true, send a steering message with the job output when the job finishes. |
-
-`view_background_job` and `stop_background_job` each take a single required `job_id` string returned by `run_background_job` or `list_background_jobs`.
-
-### `wait_background_job` parameters
-
-| Parameter | Type    | Required | Description                                                                                                    |
-| --------- | ------- | -------- | -------------------------------------------------------------------------------------------------------------- |
-| `job_id`  | string  | ✓        | Job ID returned by `run_background_job` or `list_background_jobs`.                                             |
-| `timeout` | integer | ✗        | Maximum seconds to wait (default: `60`). If the job is still running when the limit fires, the tool returns the current output with a notice and the job continues in the background. |
 
 > [!WARNING]
 > **Safety**

--- a/examples/README.md
+++ b/examples/README.md
@@ -57,14 +57,16 @@ an `instruction`.
 ## Built-in toolsets
 
 Examples that wire up one of the toolsets shipped with docker-agent
-(`filesystem`, `shell`, `todo`, `think`, `memory`, `fetch`, `script`,
-`user_prompt`, `api`, `openapi`, `rag`, `model_picker`, …).
+(`filesystem`, `shell`, `background_jobs`, `todo`, `think`, `memory`,
+`fetch`, `script`, `user_prompt`, `api`, `openapi`, `rag`, `model_picker`, …).
 
 ### Filesystem & shell
 
 | File | What it shows |
 |------|---------------|
 | [`shell.yaml`](shell.yaml) | Plain `shell` toolset. |
+| [`background_jobs.yaml`](background_jobs.yaml) | `background_jobs` toolset for servers, watchers, and other long-running commands. |
+| [`shell_recall.yaml`](shell_recall.yaml) | `background_jobs` with recall enabled for finite long-running commands. |
 | [`docker-wiki.yaml`](docker-wiki.yaml) | OpenWiki-inspired documentation agent that initializes and updates a `docker-wiki/` directory with `/init`, `/update`, and `/status` commands. |
 | [`shell_safer.yaml`](shell_safer.yaml) | Shell toolset wired with the `safer_shell` builtin under `pre_tool_use` with `preempt_yolo: true` — destructive commands force confirmation regardless of `--yolo`; known-safe reads pass through silently. |
 | [`filesystem.yaml`](filesystem.yaml) | Plain `filesystem` toolset. |

--- a/examples/background_jobs.yaml
+++ b/examples/background_jobs.yaml
@@ -1,0 +1,10 @@
+agents:
+  root:
+    model: openai/gpt-4o
+    description: Run and manage long-running shell commands.
+    instruction: |
+      Use the `background_jobs` tools for servers, watchers, and other commands
+      that should continue running while you work. Use `shell` for short commands.
+    toolsets:
+      - type: shell
+      - type: background_jobs

--- a/examples/shell_recall.yaml
+++ b/examples/shell_recall.yaml
@@ -7,4 +7,5 @@ agents:
       Avoid recall for servers and watchers that are meant to keep running.
     toolsets:
       - type: shell
+      - type: background_jobs
         recall: true

--- a/examples/tic-tac-toe-mcp.yaml
+++ b/examples/tic-tac-toe-mcp.yaml
@@ -42,6 +42,7 @@ agents:
     add_environment_info: true
     toolsets:
       - type: shell
+      - type: background_jobs
       - type: filesystem
       - type: mcp
         remote:

--- a/examples/tic-tac-toe.yaml
+++ b/examples/tic-tac-toe.yaml
@@ -42,6 +42,7 @@ agents:
     add_environment_info: true
     toolsets:
       - type: shell
+      - type: background_jobs
       - type: filesystem
       - type: a2a
         url: http://localhost:8080/

--- a/pkg/config/builtin-agents/coder.yaml
+++ b/pkg/config/builtin-agents/coder.yaml
@@ -93,6 +93,7 @@ agents:
     toolsets:
       - type: filesystem
       - type: shell
+      - type: background_jobs
       - type: todo
       - type: fetch
     commands:

--- a/pkg/config/builtin-agents/default.yaml
+++ b/pkg/config/builtin-agents/default.yaml
@@ -29,4 +29,5 @@ agents:
     toolsets:
       - type: filesystem
       - type: shell
+      - type: background_jobs
       - type: fetch

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -1325,7 +1325,7 @@ type Toolset struct {
 	URL     string            `json:"url,omitempty"`
 	Headers map[string]string `json:"headers,omitempty"`
 
-	// For `shell`, `script`, `mcp` or `lsp` tools
+	// For `shell`, `background_jobs`, `script`, `mcp` or `lsp` tools
 	Env map[string]string `json:"env,omitempty"`
 
 	// For the `todo` tool
@@ -1419,10 +1419,11 @@ type Toolset struct {
 	// nil/false keeps the default behaviour (sudo has no TTY and fails fast).
 	SudoAskpass *bool `json:"sudo_askpass,omitempty" yaml:"sudo_askpass,omitempty"`
 
-	// For the `shell` toolset — opt in to background-job recall. When enabled,
-	// run_background_job exposes a recall boolean parameter. If the agent sets
-	// recall:true on a background job, the runtime injects a steering message
-	// with a short completion sentence and the job output when the job finishes.
+	// For the `background_jobs` toolset — opt in to background-job recall. When
+	// enabled, run_background_job exposes a recall boolean parameter. If the
+	// agent sets recall:true on a background job, the runtime injects a steering
+	// message with a short completion sentence and the job output when the job
+	// finishes.
 	Recall *bool `json:"recall,omitempty" yaml:"recall,omitempty"`
 
 	// For the `shell` toolset — opt in to destructive-command detection.

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -238,8 +238,8 @@ func (t *Toolset) validate() error {
 	if err := validatePathRootEntries("deny_list", t.DenyList); err != nil {
 		return err
 	}
-	if len(t.Env) > 0 && (t.Type != "shell" && t.Type != "script" && t.Type != "mcp" && t.Type != "lsp") {
-		return errors.New("env can only be used with type 'shell', 'script', 'mcp' or 'lsp'")
+	if len(t.Env) > 0 && (t.Type != "shell" && t.Type != "background_jobs" && t.Type != "script" && t.Type != "mcp" && t.Type != "lsp") {
+		return errors.New("env can only be used with type 'shell', 'background_jobs', 'script', 'mcp' or 'lsp'")
 	}
 	if len(t.FileTypes) > 0 && t.Type != "lsp" {
 		return errors.New("file_types can only be used with type 'lsp'")
@@ -268,8 +268,8 @@ func (t *Toolset) validate() error {
 	if t.SudoAskpass != nil && t.Type != "shell" {
 		return errors.New("sudo_askpass can only be used with type 'shell'")
 	}
-	if t.Recall != nil && t.Type != "shell" {
-		return errors.New("recall can only be used with type 'shell'")
+	if t.Recall != nil && t.Type != "background_jobs" {
+		return errors.New("recall can only be used with type 'background_jobs'")
 	}
 	if t.Safer != nil && t.Type != "shell" {
 		return errors.New("safer can only be used with type 'shell'")
@@ -338,6 +338,8 @@ func (t *Toolset) validate() error {
 
 	switch t.Type {
 	case "shell":
+		// no additional validation needed
+	case "background_jobs":
 		// no additional validation needed
 	case "memory":
 		// path is optional; defaults to ~/.cagent/memory/<agent-name>/memory.db

--- a/pkg/config/toolset_validate_test.go
+++ b/pkg/config/toolset_validate_test.go
@@ -170,7 +170,7 @@ agents:
 			wantErr: "",
 		},
 		{
-			name: "sudo_askpass on non-shell toolset is rejected",
+			name: "sudo_askpass on unsupported toolset is rejected",
 			config: `
 agents:
   root:
@@ -209,7 +209,31 @@ func TestToolset_Validate_Recall(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "recall on shell is allowed",
+			name: "recall on background jobs is allowed",
+			config: `
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: background_jobs
+        recall: true
+`,
+			wantErr: "",
+		},
+		{
+			name: "recall false on background jobs is allowed",
+			config: `
+agents:
+  root:
+    model: "openai/gpt-4"
+    toolsets:
+      - type: background_jobs
+        recall: false
+`,
+			wantErr: "",
+		},
+		{
+			name: "recall on shell toolset is rejected",
 			config: `
 agents:
   root:
@@ -218,22 +242,10 @@ agents:
       - type: shell
         recall: true
 `,
-			wantErr: "",
+			wantErr: "recall can only be used with type 'background_jobs'",
 		},
 		{
-			name: "recall false on shell is allowed",
-			config: `
-agents:
-  root:
-    model: "openai/gpt-4"
-    toolsets:
-      - type: shell
-        recall: false
-`,
-			wantErr: "",
-		},
-		{
-			name: "recall on non-shell toolset is rejected",
+			name: "recall on non-background-jobs toolset is rejected",
 			config: `
 agents:
   root:
@@ -242,7 +254,7 @@ agents:
       - type: filesystem
         recall: true
 `,
-			wantErr: "recall can only be used with type 'shell'",
+			wantErr: "recall can only be used with type 'background_jobs'",
 		},
 	}
 

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -25,11 +25,11 @@ import (
 	"github.com/docker/docker-agent/pkg/telemetry/genai"
 	"github.com/docker/docker-agent/pkg/tools"
 	bgagent "github.com/docker/docker-agent/pkg/tools/builtin/agent"
+	"github.com/docker/docker-agent/pkg/tools/builtin/backgroundjobs"
 	"github.com/docker/docker-agent/pkg/tools/builtin/handoff"
 	"github.com/docker/docker-agent/pkg/tools/builtin/modelpicker"
 	"github.com/docker/docker-agent/pkg/tools/builtin/sessioncontext"
 	"github.com/docker/docker-agent/pkg/tools/builtin/sessionplan"
-	"github.com/docker/docker-agent/pkg/tools/builtin/shell"
 	"github.com/docker/docker-agent/pkg/tools/builtin/skills"
 	"github.com/docker/docker-agent/pkg/tools/builtin/transfertask"
 	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
@@ -403,7 +403,7 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 	ls.loopDetector = toolexec.NewLoopDetector(loopThreshold,
 		bgagent.ToolNameViewBackgroundAgent,
 		bgagent.ToolNameListBackgroundAgents,
-		shell.ToolNameViewBackgroundJob,
+		backgroundjobs.ToolNameViewBackgroundJob,
 	)
 
 	for {

--- a/pkg/runtime/toolexec/loop_detector_test.go
+++ b/pkg/runtime/toolexec/loop_detector_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/tools"
 	bgagent "github.com/docker/docker-agent/pkg/tools/builtin/agent"
-	"github.com/docker/docker-agent/pkg/tools/builtin/shell"
+	"github.com/docker/docker-agent/pkg/tools/builtin/backgroundjobs"
 )
 
 func TestLoopDetector(t *testing.T) {
@@ -131,7 +131,7 @@ func TestLoopDetector(t *testing.T) {
 		{
 			name:        "mixed batch with exempt and non exempt tools still counts",
 			threshold:   2,
-			exemptTools: []string{bgagent.ToolNameViewBackgroundAgent, shell.ToolNameViewBackgroundJob},
+			exemptTools: []string{bgagent.ToolNameViewBackgroundAgent, backgroundjobs.ToolNameViewBackgroundJob},
 			batches: [][]tools.ToolCall{
 				makeCalls(bgagent.ToolNameViewBackgroundAgent, `{"task_id":"agent_task_123"}`, "read_file", `{"path":"a.txt"}`),
 				makeCalls(bgagent.ToolNameViewBackgroundAgent, `{"task_id":"agent_task_123"}`, "read_file", `{"path":"a.txt"}`),
@@ -142,10 +142,10 @@ func TestLoopDetector(t *testing.T) {
 		{
 			name:        "exempt shell background job polling does not count as a loop",
 			threshold:   2,
-			exemptTools: []string{shell.ToolNameViewBackgroundJob},
+			exemptTools: []string{backgroundjobs.ToolNameViewBackgroundJob},
 			batches: [][]tools.ToolCall{
-				makeCalls(shell.ToolNameViewBackgroundJob, `{"job_id":"job_1"}`),
-				makeCalls(shell.ToolNameViewBackgroundJob, `{"job_id":"job_1"}`),
+				makeCalls(backgroundjobs.ToolNameViewBackgroundJob, `{"job_id":"job_1"}`),
+				makeCalls(backgroundjobs.ToolNameViewBackgroundJob, `{"job_id":"job_1"}`),
 			},
 			wantTrip:  false,
 			wantCount: 0,

--- a/pkg/teamloader/readonly_integration_test.go
+++ b/pkg/teamloader/readonly_integration_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
-// shellToolNames returns the names of the tools exposed by ts.
-func shellToolNames(t *testing.T, ts tools.ToolSet) []string {
+// toolNames returns the names of the tools exposed by ts.
+func toolNames(t *testing.T, ts tools.ToolSet) []string {
 	t.Helper()
 	all, err := ts.Tools(t.Context())
 	require.NoError(t, err)
@@ -30,7 +30,7 @@ func TestGetToolsForAgent_ToolsetReadOnly(t *testing.T) {
 	a := &latest.AgentConfig{
 		Instruction: "test",
 		Toolsets: []latest.Toolset{
-			{Type: "shell", ReadOnly: true},
+			{Type: "background_jobs", ReadOnly: true},
 		},
 	}
 
@@ -44,7 +44,7 @@ func TestGetToolsForAgent_ToolsetReadOnly(t *testing.T) {
 	require.Empty(t, warnings)
 	require.Len(t, got, 1)
 
-	names := shellToolNames(t, got[0])
+	names := toolNames(t, got[0])
 	assert.ElementsMatch(t, []string{"list_background_jobs", "view_background_job", "wait_background_job"}, names)
 }
 
@@ -57,7 +57,7 @@ func TestGetToolsForAgent_AgentReadOnly(t *testing.T) {
 		Instruction: "test",
 		ReadOnly:    true,
 		Toolsets: []latest.Toolset{
-			{Type: "shell"},
+			{Type: "background_jobs"},
 		},
 	}
 
@@ -71,7 +71,7 @@ func TestGetToolsForAgent_AgentReadOnly(t *testing.T) {
 	require.Empty(t, warnings)
 	require.Len(t, got, 1)
 
-	names := shellToolNames(t, got[0])
+	names := toolNames(t, got[0])
 	assert.ElementsMatch(t, []string{"list_background_jobs", "view_background_job", "wait_background_job"}, names)
 }
 
@@ -82,6 +82,7 @@ func TestGetToolsForAgent_NoReadOnlyKeepsAllTools(t *testing.T) {
 		Instruction: "test",
 		Toolsets: []latest.Toolset{
 			{Type: "shell"},
+			{Type: "background_jobs"},
 		},
 	}
 
@@ -93,11 +94,14 @@ func TestGetToolsForAgent_NoReadOnlyKeepsAllTools(t *testing.T) {
 
 	got, warnings := getToolsForAgent(t.Context(), a, ".", &runConfig, testToolsetRegistry(), "test-config", expander)
 	require.Empty(t, warnings)
-	require.Len(t, got, 1)
+	require.Len(t, got, 2)
 
-	names := shellToolNames(t, got[0])
+	shellNames := toolNames(t, got[0])
+	assert.ElementsMatch(t, []string{"shell"}, shellNames)
+
+	backgroundNames := toolNames(t, got[1])
 	assert.ElementsMatch(t, []string{
-		"shell", "run_background_job", "list_background_jobs",
+		"run_background_job", "list_background_jobs",
 		"view_background_job", "stop_background_job", "wait_background_job",
-	}, names)
+	}, backgroundNames)
 }

--- a/pkg/teamloader/registry_test.go
+++ b/pkg/teamloader/registry_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/builtin/backgroundjobs"
 	"github.com/docker/docker-agent/pkg/tools/builtin/fetch"
 	"github.com/docker/docker-agent/pkg/tools/builtin/lsp"
 	"github.com/docker/docker-agent/pkg/tools/builtin/shell"
@@ -23,6 +24,9 @@ func testToolsetRegistry() ToolsetRegistry {
 	return NewToolsetRegistry(map[string]ToolsetCreator{
 		"shell": func(ctx context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 			return shell.CreateToolSet(ctx, toolset, runConfig)
+		},
+		"background_jobs": func(ctx context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
+			return backgroundjobs.CreateToolSet(ctx, toolset, runConfig)
 		},
 		"mcp": func(ctx context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 			return mcptool.CreateToolSet(ctx, toolset, runConfig)
@@ -40,6 +44,24 @@ func TestCreateShellTool(t *testing.T) {
 	t.Parallel()
 	toolset := latest.Toolset{
 		Type: "shell",
+	}
+
+	registry := testToolsetRegistry()
+
+	runConfig := &config.RuntimeConfig{
+		Config:              config.Config{WorkingDir: t.TempDir()},
+		EnvProviderForTests: environment.NewOsEnvProvider(),
+	}
+
+	tool, err := registry.CreateTool(t.Context(), toolset, ".", runConfig, "test-agent")
+	require.NoError(t, err)
+	require.NotNil(t, tool)
+}
+
+func TestCreateBackgroundJobsTool(t *testing.T) {
+	t.Parallel()
+	toolset := latest.Toolset{
+		Type: "background_jobs",
 	}
 
 	registry := testToolsetRegistry()

--- a/pkg/teamloader/toolsets/toolsets.go
+++ b/pkg/teamloader/toolsets/toolsets.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker-agent/pkg/tools/a2a"
 	agenttool "github.com/docker/docker-agent/pkg/tools/builtin/agent"
 	"github.com/docker/docker-agent/pkg/tools/builtin/api"
+	"github.com/docker/docker-agent/pkg/tools/builtin/backgroundjobs"
 	"github.com/docker/docker-agent/pkg/tools/builtin/fetch"
 	"github.com/docker/docker-agent/pkg/tools/builtin/filesystem"
 	"github.com/docker/docker-agent/pkg/tools/builtin/lsp"
@@ -59,6 +60,9 @@ func DefaultToolsetCreators() map[string]teamloader.ToolsetCreator {
 		},
 		"shell": func(ctx context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 			return shell.CreateToolSet(ctx, toolset, runConfig)
+		},
+		"background_jobs": func(ctx context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
+			return backgroundjobs.CreateToolSet(ctx, toolset, runConfig)
 		},
 		"script": func(ctx context.Context, toolset latest.Toolset, _ string, runConfig *config.RuntimeConfig, _ string) (tools.ToolSet, error) {
 			return shell.CreateScriptToolSet(ctx, toolset, runConfig)

--- a/pkg/tools/builtin/backgroundjobs/backgroundjobs.go
+++ b/pkg/tools/builtin/backgroundjobs/backgroundjobs.go
@@ -1,0 +1,607 @@
+// Package backgroundjobs exposes the built-in background_jobs toolset.
+package backgroundjobs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/docker/docker-agent/pkg/concurrent"
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/shellpath"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+const (
+	// ToolNameRunBackgroundJob starts a shell command asynchronously.
+	ToolNameRunBackgroundJob = "run_background_job"
+	// ToolNameListBackgroundJobs lists known background jobs.
+	ToolNameListBackgroundJobs = "list_background_jobs"
+	// ToolNameViewBackgroundJob renders one background job's status and output.
+	ToolNameViewBackgroundJob = "view_background_job"
+	// ToolNameStopBackgroundJob stops a running background job.
+	ToolNameStopBackgroundJob = "stop_background_job"
+	// ToolNameWaitBackgroundJob waits for a background job to finish.
+	ToolNameWaitBackgroundJob = "wait_background_job"
+
+	maxBackgroundJobOutputBytes = 10 * 1024 * 1024
+)
+
+// ToolSet manages long-running shell commands.
+type ToolSet struct {
+	handler *backgroundJobsHandler
+}
+
+// Verify interface compliance
+var (
+	_ tools.ToolSet      = (*ToolSet)(nil)
+	_ tools.Startable    = (*ToolSet)(nil)
+	_ tools.Instructable = (*ToolSet)(nil)
+)
+
+type backgroundJobsHandler struct {
+	shell           string
+	shellArgsPrefix []string
+	env             []string
+	workingDir      string
+	jobs            *concurrent.Map[string, *backgroundJob]
+	jobCounter      atomic.Int64
+	recall          bool
+}
+
+const (
+	statusRunning int32 = iota
+	statusCompleted
+	statusStopped
+	statusFailed
+)
+
+type backgroundJob struct {
+	id           string
+	cmd          string
+	cwd          string
+	process      *os.Process
+	processGroup *processGroup
+	outputMu     sync.RWMutex
+	output       *bytes.Buffer
+	startTime    time.Time
+	status       atomic.Int32
+	exitCode     int
+	err          error
+	done         chan struct{}
+	rt           tools.Runtime
+}
+
+// limitedWriter wraps a buffer and stops writing after maxSize bytes. It uses
+// an external mutex so readers of the underlying buffer can share the same lock.
+type limitedWriter struct {
+	mu      *sync.RWMutex
+	buf     *bytes.Buffer
+	written int64
+	maxSize int64
+}
+
+func (lw *limitedWriter) Write(p []byte) (int, error) {
+	lw.mu.Lock()
+	defer lw.mu.Unlock()
+
+	if remaining := lw.maxSize - lw.written; remaining > 0 {
+		toWrite := min(int64(len(p)), remaining)
+		lw.buf.Write(p[:toWrite]) // bytes.Buffer.Write never errors
+		lw.written += toWrite
+	}
+	return len(p), nil
+}
+
+// RunBackgroundJobArgs contains the parameters for run_background_job.
+type RunBackgroundJobArgs struct {
+	Cmd string `json:"cmd" jsonschema:"Shell command to run in background"`
+	Cwd string `json:"cwd,omitempty" jsonschema:"Working directory (default \".\")"`
+}
+
+// RunBackgroundJobRecallArgs contains the parameters for run_background_job when recall is enabled.
+type RunBackgroundJobRecallArgs struct {
+	Cmd    string `json:"cmd" jsonschema:"Shell command to run in background"`
+	Cwd    string `json:"cwd,omitempty" jsonschema:"Working directory (default \".\")"`
+	Recall bool   `json:"recall,omitempty" jsonschema:"Ask to be recalled with a steering message when the background job finishes"`
+}
+
+// UnmarshalJSON accepts both "cmd" (canonical) and "command" (common alias),
+// mirroring the shell tool's command parameter.
+func (a *RunBackgroundJobArgs) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Cmd     string `json:"cmd"`
+		Command string `json:"command"`
+		Cwd     string `json:"cwd"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	a.Cmd = preferNonBlank(raw.Cmd, raw.Command)
+	a.Cwd = raw.Cwd
+	return nil
+}
+
+// UnmarshalJSON accepts both "cmd" (canonical) and "command" (common alias),
+// mirroring the shell tool's command parameter.
+func (a *RunBackgroundJobRecallArgs) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Cmd     string `json:"cmd"`
+		Command string `json:"command"`
+		Cwd     string `json:"cwd"`
+		Recall  bool   `json:"recall"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	a.Cmd = preferNonBlank(raw.Cmd, raw.Command)
+	a.Cwd = raw.Cwd
+	a.Recall = raw.Recall
+	return nil
+}
+
+func preferNonBlank(primary, fallback string) string {
+	if strings.TrimSpace(primary) != "" {
+		return primary
+	}
+	return fallback
+}
+
+// ViewBackgroundJobArgs contains the parameters for view_background_job.
+type ViewBackgroundJobArgs struct {
+	JobID string `json:"job_id" jsonschema:"Background job ID"`
+}
+
+// StopBackgroundJobArgs contains the parameters for stop_background_job.
+type StopBackgroundJobArgs struct {
+	JobID string `json:"job_id" jsonschema:"Background job ID"`
+}
+
+// WaitBackgroundJobArgs contains the parameters for wait_background_job.
+type WaitBackgroundJobArgs struct {
+	JobID   string `json:"job_id" jsonschema:"Background job ID"`
+	Timeout int    `json:"timeout,omitempty" jsonschema:"Maximum seconds to wait (default 60). Returns current output with a timeout notice if the job is still running when the limit is reached."`
+}
+
+var statusStrings = map[int32]string{
+	statusRunning:   "running",
+	statusCompleted: "completed",
+	statusStopped:   "stopped",
+	statusFailed:    "failed",
+}
+
+func statusToString(status int32) string {
+	if s, ok := statusStrings[status]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+type runBackgroundJobParams struct {
+	Cmd    string
+	Cwd    string
+	Recall bool
+}
+
+func (h *backgroundJobsHandler) RunBackgroundJob(ctx context.Context, params RunBackgroundJobArgs, rt tools.Runtime) (*tools.ToolCallResult, error) {
+	return h.runBackgroundJob(ctx, rt, runBackgroundJobParams{Cmd: params.Cmd, Cwd: params.Cwd})
+}
+
+func (h *backgroundJobsHandler) RunBackgroundJobWithRecall(ctx context.Context, params RunBackgroundJobRecallArgs, rt tools.Runtime) (*tools.ToolCallResult, error) {
+	return h.runBackgroundJob(ctx, rt, runBackgroundJobParams(params))
+}
+
+func (h *backgroundJobsHandler) runBackgroundJob(ctx context.Context, rt tools.Runtime, params runBackgroundJobParams) (*tools.ToolCallResult, error) {
+	if strings.TrimSpace(params.Cmd) == "" {
+		return tools.ResultError(`Error: missing or empty "cmd" parameter. Pass the shell command as {"cmd": "..."}.`), nil
+	}
+
+	if params.Recall {
+		if !h.recall {
+			return tools.ResultError(`Error: "recall" is not enabled for this background_jobs toolset. Set recall: true on the background_jobs toolset before requesting recall.`), nil
+		}
+		if !rt.Supports(tools.CapabilityRecall) {
+			return tools.ResultError(`Error: recall requested but the host does not support recall.`), nil
+		}
+	}
+
+	counter := h.jobCounter.Add(1)
+	jobID := fmt.Sprintf("job_%d_%d", time.Now().Unix(), counter)
+
+	cmd := exec.Command(h.shell, append(h.shellArgsPrefix, params.Cmd)...) //nolint:noctx // background jobs intentionally outlive the request context
+	cmd.Env = h.env
+	cmd.Dir = h.resolveWorkDir(params.Cwd)
+	cmd.SysProcAttr = platformSpecificSysProcAttr()
+
+	job := &backgroundJob{
+		id:        jobID,
+		cmd:       params.Cmd,
+		cwd:       params.Cwd,
+		output:    &bytes.Buffer{},
+		startTime: time.Now(),
+		done:      make(chan struct{}),
+	}
+	if params.Recall {
+		job.rt = rt
+	}
+
+	lw := &limitedWriter{mu: &job.outputMu, buf: job.output, maxSize: maxBackgroundJobOutputBytes}
+	cmd.Stdout = lw
+	cmd.Stderr = lw
+
+	if err := cmd.Start(); err != nil {
+		return tools.ResultError(fmt.Sprintf("Error starting background command: %s", err)), nil
+	}
+
+	pg, err := createProcessGroup(cmd.Process)
+	if err != nil {
+		reapSpawnedChild(cmd, pg)
+		return tools.ResultError(fmt.Sprintf("Error creating process group: %s", err)), nil
+	}
+
+	job.process = cmd.Process
+	job.processGroup = pg
+	job.status.Store(statusRunning)
+	h.jobs.Store(jobID, job)
+
+	go h.monitorJob(context.WithoutCancel(ctx), job, cmd)
+
+	var recallStatus string
+	if params.Recall {
+		recallStatus = "\nRecall: requested; a steering message will be sent when the job finishes."
+	}
+
+	return tools.ResultSuccess(fmt.Sprintf("Background job started with ID: %s\nCommand: %s\nWorking directory: %s%s",
+		jobID, params.Cmd, params.Cwd, recallStatus)), nil
+}
+
+func (h *backgroundJobsHandler) monitorJob(ctx context.Context, job *backgroundJob, cmd *exec.Cmd) {
+	defer close(job.done)
+
+	err := cmd.Wait()
+
+	job.outputMu.Lock()
+	if job.status.Load() == statusStopped {
+		job.outputMu.Unlock()
+		return
+	}
+
+	if err != nil {
+		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
+			job.exitCode = exitErr.ExitCode()
+		} else {
+			job.exitCode = -1
+		}
+		job.status.Store(statusFailed)
+		job.err = err
+	} else {
+		job.exitCode = 0
+		job.status.Store(statusCompleted)
+	}
+
+	status := job.status.Load()
+	exitCode := job.exitCode
+	output := job.output.String()
+	rt := job.rt
+	job.outputMu.Unlock()
+
+	if rt != nil {
+		message := formatBackgroundJobRecall(job, status, exitCode, output)
+		if err := rt.Recall(ctx, message); err != nil {
+			slog.WarnContext(ctx, "Failed to enqueue background job recall", "job_id", job.id, "error", err)
+		}
+	}
+}
+
+func (h *backgroundJobsHandler) ListBackgroundJobs(_ context.Context, _ map[string]any) (*tools.ToolCallResult, error) {
+	var output strings.Builder
+	output.WriteString("Background Jobs:\n\n")
+
+	jobCount := 0
+	h.jobs.Range(func(jobID string, job *backgroundJob) bool {
+		jobCount++
+		status := job.status.Load()
+		elapsed := time.Since(job.startTime).Round(time.Second)
+
+		fmt.Fprintf(&output, "ID: %s\n", jobID)
+		fmt.Fprintf(&output, "  Command: %s\n", job.cmd)
+		fmt.Fprintf(&output, "  Status: %s\n", statusToString(status))
+		fmt.Fprintf(&output, "  Runtime: %s\n", elapsed)
+		if status != statusRunning {
+			job.outputMu.RLock()
+			fmt.Fprintf(&output, "  Exit Code: %d\n", job.exitCode)
+			job.outputMu.RUnlock()
+		}
+		output.WriteString("\n")
+		return true
+	})
+
+	if jobCount == 0 {
+		output.WriteString("No background jobs found.\n")
+	}
+
+	return tools.ResultSuccess(output.String()), nil
+}
+
+func renderBackgroundJob(job *backgroundJob) string {
+	status := job.status.Load()
+
+	job.outputMu.RLock()
+	output := job.output.String()
+	exitCode := job.exitCode
+	job.outputMu.RUnlock()
+
+	var result strings.Builder
+	fmt.Fprintf(&result, "Job ID: %s\n", job.id)
+	fmt.Fprintf(&result, "Command: %s\n", job.cmd)
+	fmt.Fprintf(&result, "Status: %s\n", statusToString(status))
+	fmt.Fprintf(&result, "Runtime: %s\n", time.Since(job.startTime).Round(time.Second))
+	switch status {
+	case statusCompleted, statusFailed:
+		fmt.Fprintf(&result, "Exit Code: %d\n", exitCode)
+	}
+	result.WriteString("\n--- Output ---\n")
+	if output == "" {
+		result.WriteString("<no output>\n")
+	} else {
+		result.WriteString(output)
+		if len(output) >= maxBackgroundJobOutputBytes {
+			result.WriteString("\n\n[Output truncated at 10MB limit]")
+		}
+	}
+	return result.String()
+}
+
+func (h *backgroundJobsHandler) ViewBackgroundJob(_ context.Context, params ViewBackgroundJobArgs) (*tools.ToolCallResult, error) {
+	job, exists := h.jobs.Load(params.JobID)
+	if !exists {
+		return tools.ResultError("Job not found: " + params.JobID), nil
+	}
+	return tools.ResultSuccess(renderBackgroundJob(job)), nil
+}
+
+const defaultWaitTimeout = 60 * time.Second
+
+func (h *backgroundJobsHandler) WaitBackgroundJob(ctx context.Context, params WaitBackgroundJobArgs) (*tools.ToolCallResult, error) {
+	job, exists := h.jobs.Load(params.JobID)
+	if !exists {
+		return tools.ResultError("Job not found: " + params.JobID), nil
+	}
+
+	timeout := defaultWaitTimeout
+	if params.Timeout > 0 {
+		timeout = time.Duration(params.Timeout) * time.Second
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-job.done:
+		status := statusStrings[job.status.Load()]
+		header := fmt.Sprintf("Job %s %s.\n\n", job.id, status)
+		return tools.ResultSuccess(header + renderBackgroundJob(job)), nil
+	case <-timer.C:
+		header := fmt.Sprintf("Timed out after %s waiting for job %s; it is still running.\n\n",
+			timeout.Round(time.Second), job.id)
+		return tools.ResultSuccess(header + renderBackgroundJob(job)), nil
+	case <-ctx.Done():
+		return tools.ResultError(fmt.Sprintf("Wait cancelled for job %s: %s", job.id, ctx.Err())), nil
+	}
+}
+
+func (h *backgroundJobsHandler) StopBackgroundJob(_ context.Context, params StopBackgroundJobArgs) (*tools.ToolCallResult, error) {
+	job, exists := h.jobs.Load(params.JobID)
+	if !exists {
+		return tools.ResultError("Job not found: " + params.JobID), nil
+	}
+
+	if !job.status.CompareAndSwap(statusRunning, statusStopped) {
+		currentStatus := job.status.Load()
+		return tools.ResultError(fmt.Sprintf("Job %s is not running (current status: %s)", params.JobID, statusToString(currentStatus))), nil
+	}
+
+	if err := kill(job.process, job.processGroup); err != nil {
+		return tools.ResultError(fmt.Sprintf("Job %s marked as stopped, but error killing process: %s", params.JobID, err)), nil
+	}
+
+	return tools.ResultSuccess(fmt.Sprintf("Job %s stopped successfully", params.JobID)), nil
+}
+
+func formatBackgroundJobRecall(job *backgroundJob, status int32, exitCode int, output string) string {
+	var result strings.Builder
+	fmt.Fprintf(&result, "Background job %s finished with status %s (exit code %d).\n", job.id, statusToString(status), exitCode)
+	fmt.Fprintf(&result, "Command: %s\n\n", job.cmd)
+	result.WriteString("--- Output ---\n")
+	if output == "" {
+		result.WriteString("<no output>\n")
+	} else {
+		result.WriteString(output)
+		if len(output) >= maxBackgroundJobOutputBytes {
+			result.WriteString("\n\n[Output truncated at 10MB limit]")
+		}
+	}
+	return result.String()
+}
+
+func reapSpawnedChild(cmd *exec.Cmd, pg *processGroup) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = kill(cmd.Process, pg)
+
+	done := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		_ = cmd.Process.Kill()
+		<-done
+	}
+}
+
+// CreateToolSet builds the background_jobs toolset from config.
+func CreateToolSet(ctx context.Context, toolset latest.Toolset, runConfig *config.RuntimeConfig) (tools.ToolSet, error) {
+	env, err := toolsetEnv(ctx, toolset, runConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	ts := New(env, runConfig)
+	if toolset.Recall != nil && *toolset.Recall {
+		ts.handler.recall = true
+	}
+	return ts, nil
+}
+
+func toolsetEnv(ctx context.Context, toolset latest.Toolset, runConfig *config.RuntimeConfig) ([]string, error) {
+	env, err := environment.ExpandAll(ctx, environment.ToValues(toolset.Env), runConfig.EnvProvider())
+	if err != nil {
+		return nil, fmt.Errorf("failed to expand the toolset's environment variables: %w", err)
+	}
+	return append(os.Environ(), env...), nil
+}
+
+// New creates a background_jobs toolset with the supplied environment.
+func New(env []string, runConfig *config.RuntimeConfig) *ToolSet {
+	shell, argsPrefix := shellpath.DetectShell()
+
+	handler := &backgroundJobsHandler{
+		shell:           shell,
+		shellArgsPrefix: argsPrefix,
+		env:             env,
+		jobs:            concurrent.NewMap[string, *backgroundJob](),
+		workingDir:      runConfig.WorkingDir,
+	}
+
+	return &ToolSet{handler: handler}
+}
+
+func (h *backgroundJobsHandler) resolveWorkDir(cwd string) string {
+	if cwd == "" || cwd == "." {
+		return h.workingDir
+	}
+	if !filepath.IsAbs(cwd) {
+		return filepath.Clean(filepath.Join(h.workingDir, cwd))
+	}
+	return cwd
+}
+
+func (t *ToolSet) Instructions() string {
+	instructions := `## Background Job Tools
+
+Use run_background_job for long-running processes (servers, watchers). Output capped at 10MB per job. All jobs auto-terminate when the agent stops.
+
+Use wait_background_job to block until a job finishes and retrieve its exit code and full output. Pass an optional timeout (seconds) to cap how long to wait; the job keeps running if the timeout fires.`
+	if t.handler.recall {
+		instructions += `
+
+When starting a background job, set "recall": true if you want the agent loop to be steered automatically with a short completion message and the job output when it finishes.`
+	}
+	return instructions
+}
+
+func (t *ToolSet) runBackgroundJobDescription() string {
+	description := `Starts a shell command in the background and returns immediately with a job ID. Use this for long-running processes like servers, watches, or any command that should run while other tasks are performed.`
+	if t.handler.recall {
+		description += ` Set recall=true to receive a steering message with the job output when it finishes.`
+	}
+	return description
+}
+
+func runBackgroundJobParameters(recall bool) any {
+	if recall {
+		return tools.MustSchemaFor[RunBackgroundJobRecallArgs]()
+	}
+	return tools.MustSchemaFor[RunBackgroundJobArgs]()
+}
+
+func (t *ToolSet) runBackgroundJobHandler() tools.ToolHandler {
+	if t.handler.recall {
+		return tools.NewRuntimeHandler(t.handler.RunBackgroundJobWithRecall)
+	}
+	return tools.NewRuntimeHandler(t.handler.RunBackgroundJob)
+}
+
+func (t *ToolSet) Tools(context.Context) ([]tools.Tool, error) {
+	return []tools.Tool{
+		{
+			Name:                    ToolNameRunBackgroundJob,
+			Category:                "background_jobs",
+			Description:             t.runBackgroundJobDescription(),
+			Parameters:              runBackgroundJobParameters(t.handler.recall),
+			OutputSchema:            tools.MustSchemaFor[string](),
+			Handler:                 t.runBackgroundJobHandler(),
+			Annotations:             tools.ToolAnnotations{Title: "Background Job"},
+			AddDescriptionParameter: true,
+		},
+		{
+			Name:                    ToolNameListBackgroundJobs,
+			Category:                "background_jobs",
+			Description:             `Lists all background jobs with their status, runtime, and other information.`,
+			OutputSchema:            tools.MustSchemaFor[string](),
+			Handler:                 tools.NewHandler(t.handler.ListBackgroundJobs),
+			Annotations:             tools.ToolAnnotations{Title: "List Background Jobs", ReadOnlyHint: true},
+			AddDescriptionParameter: true,
+		},
+		{
+			Name:                    ToolNameViewBackgroundJob,
+			Category:                "background_jobs",
+			Description:             `Views the output and status of a specific background job by job ID.`,
+			Parameters:              tools.MustSchemaFor[ViewBackgroundJobArgs](),
+			OutputSchema:            tools.MustSchemaFor[string](),
+			Handler:                 tools.NewHandler(t.handler.ViewBackgroundJob),
+			Annotations:             tools.ToolAnnotations{Title: "View Background Job Output", ReadOnlyHint: true},
+			AddDescriptionParameter: true,
+		},
+		{
+			Name:                    ToolNameStopBackgroundJob,
+			Category:                "background_jobs",
+			Description:             `Stops a running background job by job ID. The process and all its child processes will be terminated.`,
+			Parameters:              tools.MustSchemaFor[StopBackgroundJobArgs](),
+			OutputSchema:            tools.MustSchemaFor[string](),
+			Handler:                 tools.NewHandler(t.handler.StopBackgroundJob),
+			Annotations:             tools.ToolAnnotations{Title: "Stop Background Job"},
+			AddDescriptionParameter: true,
+		},
+		{
+			Name:                    ToolNameWaitBackgroundJob,
+			Category:                "background_jobs",
+			Description:             `Blocks until a background job completes (or the optional timeout expires) and returns its exit code and captured output. Safe to call on an already-finished job — returns the cached result immediately. Use this instead of polling view_background_job in a loop.`,
+			Parameters:              tools.MustSchemaFor[WaitBackgroundJobArgs](),
+			OutputSchema:            tools.MustSchemaFor[string](),
+			Handler:                 tools.NewHandler(t.handler.WaitBackgroundJob),
+			Annotations:             tools.ToolAnnotations{Title: "Wait for Background Job", ReadOnlyHint: true},
+			AddDescriptionParameter: true,
+		},
+	}, nil
+}
+
+func (t *ToolSet) Start(context.Context) error {
+	return nil
+}
+
+func (t *ToolSet) Stop(context.Context) error {
+	t.handler.jobs.Range(func(_ string, job *backgroundJob) bool {
+		if job.status.CompareAndSwap(statusRunning, statusStopped) {
+			_ = kill(job.process, job.processGroup)
+		}
+		return true
+	})
+	return nil
+}

--- a/pkg/tools/builtin/backgroundjobs/backgroundjobs_test.go
+++ b/pkg/tools/builtin/backgroundjobs/backgroundjobs_test.go
@@ -1,0 +1,423 @@
+package backgroundjobs
+
+import (
+	"context"
+	"encoding/json"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+func newTestTool(t *testing.T) *ToolSet {
+	t.Helper()
+	return New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+}
+
+func TestRunBackgroundJobArgs_UnmarshalJSON_AcceptsCmdAndCommand(t *testing.T) {
+	t.Parallel()
+
+	var viaCmd RunBackgroundJobArgs
+	require.NoError(t, json.Unmarshal([]byte(`{"cmd":"sleep 1","cwd":"/tmp"}`), &viaCmd))
+	assert.Equal(t, "sleep 1", viaCmd.Cmd)
+	assert.Equal(t, "/tmp", viaCmd.Cwd)
+
+	var viaCommand RunBackgroundJobArgs
+	require.NoError(t, json.Unmarshal([]byte(`{"command":"sleep 1"}`), &viaCommand))
+	assert.Equal(t, "sleep 1", viaCommand.Cmd)
+
+	var blankCmd RunBackgroundJobArgs
+	require.NoError(t, json.Unmarshal([]byte(`{"cmd":"   ","command":"sleep 1"}`), &blankCmd))
+	assert.Equal(t, "sleep 1", blankCmd.Cmd)
+}
+
+func TestRunBackgroundJobRecallArgs_UnmarshalJSON_AcceptsRecall(t *testing.T) {
+	t.Parallel()
+
+	var withRecall RunBackgroundJobRecallArgs
+	require.NoError(t, json.Unmarshal([]byte(`{"command":"sleep 1","cwd":"/tmp","recall":true}`), &withRecall))
+	assert.Equal(t, "sleep 1", withRecall.Cmd)
+	assert.Equal(t, "/tmp", withRecall.Cwd)
+	assert.True(t, withRecall.Recall)
+}
+
+func TestBackgroundJobsTool_OutputSchema(t *testing.T) {
+	t.Parallel()
+	tool := newTestTool(t)
+
+	allTools, err := tool.Tools(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, allTools)
+
+	for _, tool := range allTools {
+		assert.NotNil(t, tool.OutputSchema)
+	}
+}
+
+func TestBackgroundJobsTool_ParametersAreObjects(t *testing.T) {
+	t.Parallel()
+	tool := newTestTool(t)
+
+	allTools, err := tool.Tools(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, allTools)
+
+	for _, tool := range allTools {
+		m, err := tools.SchemaToMap(tool.Parameters)
+		require.NoError(t, err)
+		assert.Equal(t, "object", m["type"])
+	}
+}
+
+func TestBackgroundJobsTool_WaitBackgroundJob_Completed(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell semantics; skipped on Windows")
+	}
+	tool := newTestTool(t)
+	require.NoError(t, tool.Start(t.Context()))
+	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
+
+	_, err := tool.handler.RunBackgroundJob(t.Context(), RunBackgroundJobArgs{Cmd: "echo hello"}, tools.NopRuntime{})
+	require.NoError(t, err)
+
+	var jobID string
+	tool.handler.jobs.Range(func(id string, _ *backgroundJob) bool {
+		jobID = id
+		return false
+	})
+	require.NotEmpty(t, jobID)
+
+	result, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: jobID})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "completed")
+	assert.Contains(t, result.Output, "Exit Code: 0")
+	assert.Contains(t, result.Output, "hello")
+}
+
+func TestBackgroundJobsTool_WaitBackgroundJob_FailedExit(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell semantics; skipped on Windows")
+	}
+	tool := newTestTool(t)
+	require.NoError(t, tool.Start(t.Context()))
+	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
+
+	_, err := tool.handler.RunBackgroundJob(t.Context(), RunBackgroundJobArgs{Cmd: "exit 3"}, tools.NopRuntime{})
+	require.NoError(t, err)
+
+	var jobID string
+	tool.handler.jobs.Range(func(id string, _ *backgroundJob) bool {
+		jobID = id
+		return false
+	})
+	require.NotEmpty(t, jobID)
+
+	result, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: jobID})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "failed")
+	assert.Contains(t, result.Output, "Exit Code: 3")
+}
+
+func TestBackgroundJobsTool_WaitBackgroundJob_AlreadyCompleted(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell semantics; skipped on Windows")
+	}
+	tool := newTestTool(t)
+	require.NoError(t, tool.Start(t.Context()))
+	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
+
+	_, err := tool.handler.RunBackgroundJob(t.Context(), RunBackgroundJobArgs{Cmd: "echo done"}, tools.NopRuntime{})
+	require.NoError(t, err)
+
+	var jobID string
+	tool.handler.jobs.Range(func(id string, _ *backgroundJob) bool {
+		jobID = id
+		return false
+	})
+	require.NotEmpty(t, jobID)
+
+	result1, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: jobID})
+	require.NoError(t, err)
+	assert.Contains(t, result1.Output, "completed")
+
+	result2, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: jobID})
+	require.NoError(t, err)
+	assert.Contains(t, result2.Output, "completed")
+	assert.Contains(t, result2.Output, "Exit Code: 0")
+}
+
+func TestBackgroundJobsTool_WaitBackgroundJob_UnknownID(t *testing.T) {
+	t.Parallel()
+	tool := newTestTool(t)
+
+	result, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: "job_does_not_exist"})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "Job not found")
+}
+
+func TestBackgroundJobsTool_WaitBackgroundJob_Timeout(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("sleep not available on Windows cmd")
+	}
+	tool := newTestTool(t)
+	require.NoError(t, tool.Start(t.Context()))
+	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
+
+	_, err := tool.handler.RunBackgroundJob(t.Context(), RunBackgroundJobArgs{Cmd: "sleep 30"}, tools.NopRuntime{})
+	require.NoError(t, err)
+
+	var jobID string
+	tool.handler.jobs.Range(func(id string, _ *backgroundJob) bool {
+		jobID = id
+		return false
+	})
+	require.NotEmpty(t, jobID)
+
+	start := time.Now()
+	result, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: jobID, Timeout: 1})
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "Timed out")
+	assert.Contains(t, result.Output, "still running")
+	assert.Less(t, elapsed, 5*time.Second)
+}
+
+func TestBackgroundJobsTool_WaitBackgroundJob_ContextCancelled(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("sleep not available on Windows cmd")
+	}
+	tool := newTestTool(t)
+	require.NoError(t, tool.Start(t.Context()))
+	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
+
+	_, err := tool.handler.RunBackgroundJob(t.Context(), RunBackgroundJobArgs{Cmd: "sleep 30"}, tools.NopRuntime{})
+	require.NoError(t, err)
+
+	var jobID string
+	tool.handler.jobs.Range(func(id string, _ *backgroundJob) bool {
+		jobID = id
+		return false
+	})
+	require.NotEmpty(t, jobID)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	result, err := tool.handler.WaitBackgroundJob(ctx, WaitBackgroundJobArgs{JobID: jobID, Timeout: 60})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "cancelled")
+}
+
+func TestBackgroundJobsTool_WaitBackgroundJob_Stopped(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("sleep not available on Windows cmd")
+	}
+	tool := newTestTool(t)
+	require.NoError(t, tool.Start(t.Context()))
+	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
+
+	_, err := tool.handler.RunBackgroundJob(t.Context(), RunBackgroundJobArgs{Cmd: "sleep 30"}, tools.NopRuntime{})
+	require.NoError(t, err)
+
+	var jobID string
+	tool.handler.jobs.Range(func(id string, _ *backgroundJob) bool {
+		jobID = id
+		return false
+	})
+	require.NotEmpty(t, jobID)
+
+	go func() {
+		_, _ = tool.handler.StopBackgroundJob(t.Context(), StopBackgroundJobArgs{JobID: jobID})
+	}()
+
+	result, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: jobID, Timeout: 10})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "stopped")
+	assert.NotContains(t, result.Output, "Exit Code:",
+		"stopped jobs should not show an exit code")
+}
+
+func TestBackgroundJobsTool_RunBackgroundJob(t *testing.T) {
+	t.Parallel()
+	tool := newTestTool(t)
+	require.NoError(t, tool.Start(t.Context()))
+	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
+
+	result, err := tool.handler.RunBackgroundJob(t.Context(), RunBackgroundJobArgs{Cmd: "echo test"}, tools.NopRuntime{})
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "Background job started with ID:")
+}
+
+func TestBackgroundJobsTool_RunBackgroundJobRecall(t *testing.T) {
+	t.Parallel()
+	tool := newTestTool(t)
+	tool.handler.recall = true
+	require.NoError(t, tool.Start(t.Context()))
+	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
+
+	rt := &recallRuntime{recalls: make(chan string, 1)}
+	result, err := tool.handler.RunBackgroundJobWithRecall(t.Context(), RunBackgroundJobRecallArgs{Cmd: "echo recall-output", Recall: true}, rt)
+	require.NoError(t, err)
+	assert.Contains(t, result.Output, "Recall: requested")
+
+	select {
+	case msg := <-rt.recalls:
+		assert.Contains(t, msg, "Background job")
+		assert.Contains(t, msg, "finished with status completed")
+		assert.Contains(t, msg, "recall-output")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for background job recall")
+	}
+}
+
+func TestBackgroundJobsTool_RunBackgroundJobRecallRequiresConfig(t *testing.T) {
+	t.Parallel()
+	tool := newTestTool(t)
+
+	result, err := tool.handler.RunBackgroundJobWithRecall(t.Context(), RunBackgroundJobRecallArgs{Cmd: "echo test", Recall: true}, &recallRuntime{})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	assert.Contains(t, result.Output, "recall")
+	assert.Contains(t, result.Output, "not enabled")
+	assert.Equal(t, 0, tool.handler.jobs.Length())
+}
+
+func TestBackgroundJobsTool_RunBackgroundJobRecallRequiresCallback(t *testing.T) {
+	t.Parallel()
+	tool := newTestTool(t)
+	tool.handler.recall = true
+
+	result, err := tool.handler.RunBackgroundJobWithRecall(t.Context(), RunBackgroundJobRecallArgs{Cmd: "echo test", Recall: true}, tools.NopRuntime{})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	assert.Contains(t, result.Output, "does not support recall")
+	assert.Equal(t, 0, tool.handler.jobs.Length())
+}
+
+type recallRuntime struct {
+	tools.NopRuntime
+
+	recalls chan string
+}
+
+func (r *recallRuntime) Recall(_ context.Context, message string) error {
+	r.recalls <- message
+	return nil
+}
+
+func (r *recallRuntime) Supports(c tools.Capability) bool {
+	return c == tools.CapabilityRecall
+}
+
+func TestCreateToolSetEnablesRecall(t *testing.T) {
+	t.Parallel()
+
+	recall := true
+	toolSet, err := CreateToolSet(t.Context(), latest.Toolset{Type: "background_jobs", Recall: &recall}, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+	require.NoError(t, err)
+
+	backgroundJobsToolSet, ok := toolSet.(*ToolSet)
+	require.True(t, ok)
+	assert.True(t, backgroundJobsToolSet.handler.recall)
+}
+
+func TestBackgroundJobsTool_RunBackgroundJobSchemaRecall(t *testing.T) {
+	t.Parallel()
+
+	withoutRecall := newTestTool(t)
+	withoutTools, err := withoutRecall.Tools(t.Context())
+	require.NoError(t, err)
+	withoutSchema, err := tools.SchemaToMap(findTool(t, withoutTools, ToolNameRunBackgroundJob).Parameters)
+	require.NoError(t, err)
+	withoutProps, ok := withoutSchema["properties"].(map[string]any)
+	require.True(t, ok)
+	assert.NotContains(t, withoutProps, "recall")
+
+	withRecall := newTestTool(t)
+	withRecall.handler.recall = true
+	withTools, err := withRecall.Tools(t.Context())
+	require.NoError(t, err)
+	withSchema, err := tools.SchemaToMap(findTool(t, withTools, ToolNameRunBackgroundJob).Parameters)
+	require.NoError(t, err)
+	withProps, ok := withSchema["properties"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, withProps, "recall")
+}
+
+func findTool(t *testing.T, toolList []tools.Tool, name string) tools.Tool {
+	t.Helper()
+	for _, tool := range toolList {
+		if tool.Name == name {
+			return tool
+		}
+	}
+	t.Fatalf("tool %q not found", name)
+	return tools.Tool{}
+}
+
+func TestBackgroundJobsTool_ListBackgroundJobs(t *testing.T) {
+	t.Parallel()
+	tool := newTestTool(t)
+	require.NoError(t, tool.Start(t.Context()))
+	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
+
+	_, err := tool.handler.RunBackgroundJob(t.Context(), RunBackgroundJobArgs{Cmd: "echo test"}, tools.NopRuntime{})
+	require.NoError(t, err)
+
+	listResult, err := tool.handler.ListBackgroundJobs(t.Context(), nil)
+
+	require.NoError(t, err)
+	assert.Contains(t, listResult.Output, "Background Jobs:")
+	assert.Contains(t, listResult.Output, "ID: job_")
+}
+
+func TestBackgroundJobsTool_Instructions(t *testing.T) {
+	t.Parallel()
+
+	tool := newTestTool(t)
+
+	instructions := tool.Instructions()
+
+	assert.Contains(t, instructions, "Background Job Tools")
+	assert.Contains(t, instructions, "run_background_job")
+}
+
+func TestResolveWorkDir(t *testing.T) {
+	t.Parallel()
+
+	workingDir := "/configured/project"
+	h := &backgroundJobsHandler{workingDir: workingDir}
+
+	tests := []struct {
+		name     string
+		cwd      string
+		expected string
+	}{
+		{name: "empty defaults to workingDir", cwd: "", expected: workingDir},
+		{name: "dot defaults to workingDir", cwd: ".", expected: workingDir},
+		{name: "absolute path unchanged", cwd: "/tmp/other", expected: "/tmp/other"},
+		{name: "relative path joined with workingDir", cwd: "src/pkg", expected: "/configured/project/src/pkg"},
+		{name: "relative with dot prefix", cwd: "./subdir", expected: "/configured/project/subdir"},
+		{name: "relative with parent traversal", cwd: "../sibling", expected: "/configured/sibling"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, h.resolveWorkDir(tt.cwd))
+		})
+	}
+}

--- a/pkg/tools/builtin/backgroundjobs/cmd_js.go
+++ b/pkg/tools/builtin/backgroundjobs/cmd_js.go
@@ -1,0 +1,23 @@
+//go:build js
+
+package backgroundjobs
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+type processGroup struct{}
+
+func platformSpecificSysProcAttr() *syscall.SysProcAttr {
+	return nil
+}
+
+func createProcessGroup(_ *os.Process) (*processGroup, error) {
+	return &processGroup{}, nil
+}
+
+func kill(_ *os.Process, _ *processGroup) error {
+	return errors.New("background_jobs: process termination not supported on js/wasm")
+}

--- a/pkg/tools/builtin/backgroundjobs/cmd_unix.go
+++ b/pkg/tools/builtin/backgroundjobs/cmd_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows && !js
+
+package backgroundjobs
+
+import (
+	"os"
+	"syscall"
+)
+
+type processGroup struct{}
+
+func platformSpecificSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true}
+}
+
+func createProcessGroup(_ *os.Process) (*processGroup, error) {
+	return &processGroup{}, nil
+}
+
+func kill(proc *os.Process, _ *processGroup) error {
+	return syscall.Kill(-proc.Pid, syscall.SIGTERM)
+}

--- a/pkg/tools/builtin/backgroundjobs/cmd_windows.go
+++ b/pkg/tools/builtin/backgroundjobs/cmd_windows.go
@@ -1,0 +1,69 @@
+package backgroundjobs
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type processGroup struct {
+	jobHandle     windows.Handle
+	processHandle windows.Handle
+}
+
+func platformSpecificSysProcAttr() *syscall.SysProcAttr {
+	return nil
+}
+
+func createProcessGroup(proc *os.Process) (*processGroup, error) {
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+		},
+	}
+	if _, err := windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info))); err != nil {
+		_ = windows.CloseHandle(job)
+		return nil, err
+	}
+
+	handle, err := windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE, false, uint32(proc.Pid))
+	if err != nil {
+		_ = windows.CloseHandle(job)
+		return nil, err
+	}
+
+	if err := windows.AssignProcessToJobObject(job, handle); err != nil {
+		_ = windows.CloseHandle(handle)
+		_ = windows.CloseHandle(job)
+		return nil, err
+	}
+
+	return &processGroup{
+		jobHandle:     job,
+		processHandle: handle,
+	}, nil
+}
+
+func kill(proc *os.Process, pg *processGroup) error {
+	if pg != nil {
+		if pg.processHandle != 0 {
+			_ = windows.CloseHandle(pg.processHandle)
+		}
+		if pg.jobHandle != 0 {
+			_ = windows.CloseHandle(pg.jobHandle)
+		}
+	}
+
+	return proc.Kill()
+}

--- a/pkg/tools/builtin/doc.go
+++ b/pkg/tools/builtin/doc.go
@@ -1,22 +1,23 @@
 // Package builtin contains the stock tool implementations shipped with
 // docker-agent. Each tool lives in its own sub-package:
 //
-//   - filesystem — file read/write/edit/search/list/tree
-//   - shell      — shell command execution, background jobs
-//   - lsp        — Language Server Protocol client tools
-//   - think      — structured thinking/scratchpad
-//   - todo       — task list management
-//   - fetch      — HTTP fetch with domain restrictions
-//   - handoff    — conversation handoff between agents
-//   - transfertask — task delegation to sub-agents
-//   - skills     — skill runner
-//   - tasks      — persistent task management
-//   - memory     — persistent agent memory (sqlite)
-//   - rag        — retrieval-augmented generation (sqlite)
-//   - modelpicker — runtime model switching
-//   - userprompt — ask the user for input
-//   - api        — external API tool
-//   - openapi    — OpenAPI spec-driven tool
-//   - openurl    — open a fixed URL in the user's browser
-//   - deferred   — deferred toolset wrapper
+//   - filesystem      — file read/write/edit/search/list/tree
+//   - shell           — shell command execution
+//   - backgroundjobs  — long-running shell background jobs
+//   - lsp             — Language Server Protocol client tools
+//   - think           — structured thinking/scratchpad
+//   - todo            — task list management
+//   - fetch           — HTTP fetch with domain restrictions
+//   - handoff         — conversation handoff between agents
+//   - transfertask    — task delegation to sub-agents
+//   - skills          — skill runner
+//   - tasks           — persistent task management
+//   - memory          — persistent agent memory (sqlite)
+//   - rag             — retrieval-augmented generation (sqlite)
+//   - modelpicker     — runtime model switching
+//   - userprompt      — ask the user for input
+//   - api             — external API tool
+//   - openapi         — OpenAPI spec-driven tool
+//   - openurl         — open a fixed URL in the user's browser
+//   - deferred        — deferred toolset wrapper
 package builtin

--- a/pkg/tools/builtin/shell/shell.go
+++ b/pkg/tools/builtin/shell/shell.go
@@ -5,7 +5,6 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -13,13 +12,11 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/docker/docker-agent/pkg/concurrent"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
@@ -27,18 +24,9 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
-const (
-	ToolNameShell              = "shell"
-	ToolNameRunShellBackground = "run_background_job"
-	ToolNameListBackgroundJobs = "list_background_jobs"
-	ToolNameViewBackgroundJob  = "view_background_job"
-	ToolNameStopBackgroundJob  = "stop_background_job"
-	ToolNameWaitBackgroundJob  = "wait_background_job"
+const ToolNameShell = "shell"
 
-	maxBackgroundJobOutputBytes = 10 * 1024 * 1024
-)
-
-// ToolSet provides shell command execution capabilities.
+// ToolSet provides synchronous shell command execution.
 type ToolSet struct {
 	handler *shellHandler
 }
@@ -57,9 +45,6 @@ type shellHandler struct {
 	env             []string
 	timeout         time.Duration
 	workingDir      string
-	jobs            *concurrent.Map[string, *backgroundJob]
-	jobCounter      atomic.Int64
-	recall          bool
 
 	// sudoAskpass opts this toolset into the one-time sudo privilege
 	// escalation flow (SUDO_ASKPASS bridged to the elicitation handler).
@@ -69,56 +54,6 @@ type shellHandler struct {
 	askpassMu          sync.Mutex
 	askpassStarted     bool
 	askpass            *askpassServer
-}
-
-// Job status constants
-const (
-	statusRunning int32 = iota
-	statusCompleted
-	statusStopped
-	statusFailed
-)
-
-// backgroundJob tracks a background shell command
-type backgroundJob struct {
-	id           string
-	cmd          string
-	cwd          string
-	process      *os.Process
-	processGroup *processGroup
-	outputMu     sync.RWMutex
-	output       *bytes.Buffer
-	startTime    time.Time
-	status       atomic.Int32
-	exitCode     int
-	err          error
-	// done is closed by monitorJob when the job finishes (any terminal state).
-	done chan struct{}
-	// rt is set only when the caller requested recall; monitorJob uses it
-	// to steer the agent loop once the job finishes.
-	rt tools.Runtime
-}
-
-// limitedWriter wraps a buffer and stops writing after maxSize bytes.
-// It uses an external mutex (mu) so that readers of the underlying buffer
-// can share the same lock.
-type limitedWriter struct {
-	mu      *sync.RWMutex
-	buf     *bytes.Buffer
-	written int64
-	maxSize int64
-}
-
-func (lw *limitedWriter) Write(p []byte) (n int, err error) {
-	lw.mu.Lock()
-	defer lw.mu.Unlock()
-
-	if remaining := lw.maxSize - lw.written; remaining > 0 {
-		toWrite := min(int64(len(p)), remaining)
-		lw.buf.Write(p[:toWrite]) // bytes.Buffer.Write never errors
-		lw.written += toWrite
-	}
-	return len(p), nil // always report full write
 }
 
 type commandOutput struct {
@@ -184,51 +119,6 @@ func (a *RunShellArgs) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-type RunShellBackgroundArgs struct {
-	Cmd string `json:"cmd" jsonschema:"Shell command to run in background"`
-	Cwd string `json:"cwd,omitempty" jsonschema:"Working directory (default \".\")"`
-}
-
-type RunShellBackgroundRecallArgs struct {
-	Cmd    string `json:"cmd" jsonschema:"Shell command to run in background"`
-	Cwd    string `json:"cwd,omitempty" jsonschema:"Working directory (default \".\")"`
-	Recall bool   `json:"recall,omitempty" jsonschema:"Ask to be recalled with a steering message when the background job finishes"`
-}
-
-// UnmarshalJSON accepts both "cmd" (canonical) and "command" (common alias),
-// mirroring RunShellArgs.UnmarshalJSON. See its comment for rationale.
-func (a *RunShellBackgroundArgs) UnmarshalJSON(data []byte) error {
-	var raw struct {
-		Cmd     string `json:"cmd"`
-		Command string `json:"command"`
-		Cwd     string `json:"cwd"`
-	}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-	a.Cmd = preferNonBlank(raw.Cmd, raw.Command)
-	a.Cwd = raw.Cwd
-	return nil
-}
-
-// UnmarshalJSON accepts both "cmd" (canonical) and "command" (common alias),
-// mirroring RunShellArgs.UnmarshalJSON. See its comment for rationale.
-func (a *RunShellBackgroundRecallArgs) UnmarshalJSON(data []byte) error {
-	var raw struct {
-		Cmd     string `json:"cmd"`
-		Command string `json:"command"`
-		Cwd     string `json:"cwd"`
-		Recall  bool   `json:"recall"`
-	}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-	a.Cmd = preferNonBlank(raw.Cmd, raw.Command)
-	a.Cwd = raw.Cwd
-	a.Recall = raw.Recall
-	return nil
-}
-
 // preferNonBlank returns primary when it has a non-whitespace character;
 // otherwise it returns fallback. The chosen value is returned unmodified so
 // that whitespace inside a legitimate command (e.g. trailing newlines in a
@@ -238,34 +128,6 @@ func preferNonBlank(primary, fallback string) string {
 		return primary
 	}
 	return fallback
-}
-
-type ViewBackgroundJobArgs struct {
-	JobID string `json:"job_id" jsonschema:"Background job ID"`
-}
-
-type StopBackgroundJobArgs struct {
-	JobID string `json:"job_id" jsonschema:"Background job ID"`
-}
-
-type WaitBackgroundJobArgs struct {
-	JobID   string `json:"job_id" jsonschema:"Background job ID"`
-	Timeout int    `json:"timeout,omitempty" jsonschema:"Maximum seconds to wait (default 60). Returns current output with a timeout notice if the job is still running when the limit is reached."`
-}
-
-// statusStrings maps job status constants to their string representations
-var statusStrings = map[int32]string{
-	statusRunning:   "running",
-	statusCompleted: "completed",
-	statusStopped:   "stopped",
-	statusFailed:    "failed",
-}
-
-func statusToString(status int32) string {
-	if s, ok := statusStrings[status]; ok {
-		return s
-	}
-	return "unknown"
 }
 
 func (h *shellHandler) RunShell(ctx context.Context, params RunShellArgs, rt tools.Runtime) (*tools.ToolCallResult, error) {
@@ -368,265 +230,6 @@ func (h *shellHandler) runNativeCommand(timeoutCtx, ctx context.Context, rt tool
 	return tools.ResultSuccess(formattedOutput)
 }
 
-type runShellBackgroundParams struct {
-	Cmd    string
-	Cwd    string
-	Recall bool
-}
-
-func (h *shellHandler) RunShellBackground(ctx context.Context, params RunShellBackgroundArgs, rt tools.Runtime) (*tools.ToolCallResult, error) {
-	return h.runShellBackground(ctx, rt, runShellBackgroundParams{Cmd: params.Cmd, Cwd: params.Cwd})
-}
-
-func (h *shellHandler) RunShellBackgroundWithRecall(ctx context.Context, params RunShellBackgroundRecallArgs, rt tools.Runtime) (*tools.ToolCallResult, error) {
-	return h.runShellBackground(ctx, rt, runShellBackgroundParams(params))
-}
-
-func (h *shellHandler) runShellBackground(ctx context.Context, rt tools.Runtime, params runShellBackgroundParams) (*tools.ToolCallResult, error) {
-	if strings.TrimSpace(params.Cmd) == "" {
-		return tools.ResultError(`Error: missing or empty "cmd" parameter. Pass the shell command as {"cmd": "..."}.`), nil
-	}
-
-	if params.Recall {
-		if !h.recall {
-			return tools.ResultError(`Error: "recall" is not enabled for this shell toolset. Set recall: true on the shell toolset before requesting recall.`), nil
-		}
-		if !rt.Supports(tools.CapabilityRecall) {
-			return tools.ResultError(`Error: recall requested but the host does not support recall.`), nil
-		}
-	}
-
-	counter := h.jobCounter.Add(1)
-	jobID := fmt.Sprintf("job_%d_%d", time.Now().Unix(), counter)
-
-	bgCmd, bgEnv := h.applyAskpass(ctx, params.Cmd)
-	cmd := exec.Command(h.shell, append(h.shellArgsPrefix, bgCmd)...) //nolint:noctx // RunShellBackground intentionally outlives the request context
-	cmd.Env = bgEnv
-	cmd.Dir = h.resolveWorkDir(params.Cwd)
-	cmd.SysProcAttr = platformSpecificSysProcAttr()
-
-	job := &backgroundJob{
-		id:        jobID,
-		cmd:       params.Cmd,
-		cwd:       params.Cwd,
-		output:    &bytes.Buffer{},
-		startTime: time.Now(),
-		done:      make(chan struct{}),
-	}
-	if params.Recall {
-		job.rt = rt
-	}
-
-	// The limitedWriter shares the job's outputMu so that readers
-	// (ViewBackgroundJob, ListBackgroundJobs) and the pipe-copy
-	// goroutines spawned by exec.Cmd use the same lock.
-	lw := &limitedWriter{mu: &job.outputMu, buf: job.output, maxSize: maxBackgroundJobOutputBytes}
-	cmd.Stdout = lw
-	cmd.Stderr = lw
-
-	if err := cmd.Start(); err != nil {
-		return tools.ResultError(fmt.Sprintf("Error starting background command: %s", err)), nil
-	}
-
-	pg, err := createProcessGroup(cmd.Process)
-	if err != nil {
-		// Successfully started the child but couldn't install it in its own
-		// process group: clean it up before bailing out.
-		reapSpawnedChild(cmd, pg)
-		return tools.ResultError(fmt.Sprintf("Error creating process group: %s", err)), nil
-	}
-
-	job.process = cmd.Process
-	job.processGroup = pg
-	job.status.Store(statusRunning)
-	h.jobs.Store(jobID, job)
-
-	// The job outlives this tool call: keep ctx values (trace, session id)
-	// for the recall but drop cancellation.
-	go h.monitorJob(context.WithoutCancel(ctx), job, cmd)
-
-	var recallStatus string
-	if params.Recall {
-		recallStatus = "\nRecall: requested; a steering message will be sent when the job finishes."
-	}
-
-	return tools.ResultSuccess(fmt.Sprintf("Background job started with ID: %s\nCommand: %s\nWorking directory: %s%s",
-		jobID, params.Cmd, params.Cwd, recallStatus)), nil
-}
-
-func (h *shellHandler) monitorJob(ctx context.Context, job *backgroundJob, cmd *exec.Cmd) {
-	// close done after all fields are written so WaitBackgroundJob readers see
-	// the final state. Defers are LIFO: Unlock runs before close(done).
-	defer close(job.done)
-
-	err := cmd.Wait()
-
-	job.outputMu.Lock()
-	if job.status.Load() == statusStopped {
-		job.outputMu.Unlock()
-		return
-	}
-
-	if err != nil {
-		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
-			job.exitCode = exitErr.ExitCode()
-		} else {
-			job.exitCode = -1
-		}
-		job.status.Store(statusFailed)
-		job.err = err
-	} else {
-		job.exitCode = 0
-		job.status.Store(statusCompleted)
-	}
-
-	status := job.status.Load()
-	exitCode := job.exitCode
-	output := job.output.String()
-	rt := job.rt
-	job.outputMu.Unlock()
-
-	if rt != nil {
-		message := formatBackgroundJobRecall(job, status, exitCode, output)
-		if err := rt.Recall(ctx, message); err != nil {
-			slog.WarnContext(ctx, "Failed to enqueue background job recall", "job_id", job.id, "error", err)
-		}
-	}
-}
-
-func (h *shellHandler) ListBackgroundJobs(_ context.Context, _ map[string]any) (*tools.ToolCallResult, error) {
-	var output strings.Builder
-	output.WriteString("Background Jobs:\n\n")
-
-	jobCount := 0
-	h.jobs.Range(func(jobID string, job *backgroundJob) bool {
-		jobCount++
-		status := job.status.Load()
-		elapsed := time.Since(job.startTime).Round(time.Second)
-
-		fmt.Fprintf(&output, "ID: %s\n", jobID)
-		fmt.Fprintf(&output, "  Command: %s\n", job.cmd)
-		fmt.Fprintf(&output, "  Status: %s\n", statusToString(status))
-		fmt.Fprintf(&output, "  Runtime: %s\n", elapsed)
-		if status != statusRunning {
-			job.outputMu.RLock()
-			fmt.Fprintf(&output, "  Exit Code: %d\n", job.exitCode)
-			job.outputMu.RUnlock()
-		}
-		output.WriteString("\n")
-		return true
-	})
-
-	if jobCount == 0 {
-		output.WriteString("No background jobs found.\n")
-	}
-
-	return tools.ResultSuccess(output.String()), nil
-}
-
-// renderBackgroundJob formats the current state of a background job for tool output.
-func renderBackgroundJob(job *backgroundJob) string {
-	status := job.status.Load()
-
-	job.outputMu.RLock()
-	output := job.output.String()
-	exitCode := job.exitCode
-	job.outputMu.RUnlock()
-
-	var result strings.Builder
-	fmt.Fprintf(&result, "Job ID: %s\n", job.id)
-	fmt.Fprintf(&result, "Command: %s\n", job.cmd)
-	fmt.Fprintf(&result, "Status: %s\n", statusToString(status))
-	fmt.Fprintf(&result, "Runtime: %s\n", time.Since(job.startTime).Round(time.Second))
-	switch status {
-	case statusCompleted, statusFailed:
-		fmt.Fprintf(&result, "Exit Code: %d\n", exitCode)
-	}
-	result.WriteString("\n--- Output ---\n")
-	if output == "" {
-		result.WriteString("<no output>\n")
-	} else {
-		result.WriteString(output)
-		if len(output) >= maxBackgroundJobOutputBytes {
-			result.WriteString("\n\n[Output truncated at 10MB limit]")
-		}
-	}
-	return result.String()
-}
-
-func (h *shellHandler) ViewBackgroundJob(_ context.Context, params ViewBackgroundJobArgs) (*tools.ToolCallResult, error) {
-	job, exists := h.jobs.Load(params.JobID)
-	if !exists {
-		return tools.ResultError("Job not found: " + params.JobID), nil
-	}
-	return tools.ResultSuccess(renderBackgroundJob(job)), nil
-}
-
-// defaultWaitTimeout is used by WaitBackgroundJob when no timeout is supplied.
-const defaultWaitTimeout = 60 * time.Second
-
-func (h *shellHandler) WaitBackgroundJob(ctx context.Context, params WaitBackgroundJobArgs) (*tools.ToolCallResult, error) {
-	job, exists := h.jobs.Load(params.JobID)
-	if !exists {
-		return tools.ResultError("Job not found: " + params.JobID), nil
-	}
-
-	timeout := defaultWaitTimeout
-	if params.Timeout > 0 {
-		timeout = time.Duration(params.Timeout) * time.Second
-	}
-
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-
-	select {
-	case <-job.done:
-		status := statusStrings[job.status.Load()]
-		header := fmt.Sprintf("Job %s %s.\n\n", job.id, status)
-		return tools.ResultSuccess(header + renderBackgroundJob(job)), nil
-	case <-timer.C:
-		header := fmt.Sprintf("Timed out after %s waiting for job %s; it is still running.\n\n",
-			timeout.Round(time.Second), job.id)
-		return tools.ResultSuccess(header + renderBackgroundJob(job)), nil
-	case <-ctx.Done():
-		return tools.ResultError(fmt.Sprintf("Wait cancelled for job %s: %s", job.id, ctx.Err())), nil
-	}
-}
-
-func (h *shellHandler) StopBackgroundJob(_ context.Context, params StopBackgroundJobArgs) (*tools.ToolCallResult, error) {
-	job, exists := h.jobs.Load(params.JobID)
-	if !exists {
-		return tools.ResultError("Job not found: " + params.JobID), nil
-	}
-
-	if !job.status.CompareAndSwap(statusRunning, statusStopped) {
-		currentStatus := job.status.Load()
-		return tools.ResultError(fmt.Sprintf("Job %s is not running (current status: %s)", params.JobID, statusToString(currentStatus))), nil
-	}
-
-	if err := kill(job.process, job.processGroup); err != nil {
-		return tools.ResultError(fmt.Sprintf("Job %s marked as stopped, but error killing process: %s", params.JobID, err)), nil
-	}
-
-	return tools.ResultSuccess(fmt.Sprintf("Job %s stopped successfully", params.JobID)), nil
-}
-
-func formatBackgroundJobRecall(job *backgroundJob, status int32, exitCode int, output string) string {
-	var result strings.Builder
-	fmt.Fprintf(&result, "Background job %s finished with status %s (exit code %d).\n", job.id, statusToString(status), exitCode)
-	fmt.Fprintf(&result, "Command: %s\n\n", job.cmd)
-	result.WriteString("--- Output ---\n")
-	if output == "" {
-		result.WriteString("<no output>\n")
-	} else {
-		result.WriteString(output)
-		if len(output) >= maxBackgroundJobOutputBytes {
-			result.WriteString("\n\n[Output truncated at 10MB limit]")
-		}
-	}
-	return result.String()
-}
-
 // reapSpawnedChild terminates a child that we've started but decided not
 // to run (e.g. follow-up setup failed) and waits for it so we don't leak a
 // zombie or its stdout/stderr pipes. SIGTERM is sent first; if the child
@@ -652,24 +255,28 @@ func reapSpawnedChild(cmd *exec.Cmd, pg *processGroup) {
 
 // CreateToolSet is used by the tools registry.
 func CreateToolSet(ctx context.Context, toolset latest.Toolset, runConfig *config.RuntimeConfig) (tools.ToolSet, error) {
-	env, err := environment.ExpandAll(ctx, environment.ToValues(toolset.Env), runConfig.EnvProvider())
+	env, err := toolsetEnv(ctx, toolset, runConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to expand the tool's environment variables: %w", err)
+		return nil, err
 	}
-	// Prepend os.Environ() so spawned processes inherit the host environment
-	// while the configured toolset env still wins on key collisions
-	// (exec.Cmd dedupes with last-wins). EnvProvider is used only to expand
-	// ${...} references in toolset.Env.
-	env = append(os.Environ(), env...)
 
 	ts := New(env, runConfig)
 	if toolset.SudoAskpass != nil && *toolset.SudoAskpass {
 		ts.handler.sudoAskpass = true
 	}
-	if toolset.Recall != nil && *toolset.Recall {
-		ts.handler.recall = true
-	}
 	return ts, nil
+}
+
+func toolsetEnv(ctx context.Context, toolset latest.Toolset, runConfig *config.RuntimeConfig) ([]string, error) {
+	env, err := environment.ExpandAll(ctx, environment.ToValues(toolset.Env), runConfig.EnvProvider())
+	if err != nil {
+		return nil, fmt.Errorf("failed to expand the toolset's environment variables: %w", err)
+	}
+	// Prepend os.Environ() so spawned processes inherit the host environment
+	// while the configured toolset env still wins on key collisions
+	// (exec.Cmd dedupes with last-wins). EnvProvider is used only to expand
+	// ${...} references in toolset.Env.
+	return append(os.Environ(), env...), nil
 }
 
 // New creates a new shell toolset.
@@ -681,7 +288,6 @@ func New(env []string, runConfig *config.RuntimeConfig) *ToolSet {
 		shellArgsPrefix: argsPrefix,
 		env:             env,
 		timeout:         30 * time.Second,
-		jobs:            concurrent.NewMap[string, *backgroundJob](),
 		workingDir:      runConfig.WorkingDir,
 	}
 
@@ -725,47 +331,13 @@ func formatCommandOutput(timeoutCtx, ctx context.Context, err error, rawOutput s
 }
 
 func (t *ToolSet) Instructions() string {
-	instructions := `## Shell Tools
+	return `## Shell Tools
 
 - Each call runs in a fresh shell session — no state persists between calls
 - Default timeout: 30s. Set "timeout" for longer operations (builds, tests)
 - Use "cwd" parameter instead of cd within commands
 - Combine operations with pipes, redirections, and heredocs
-- Non-zero exit codes return error info with output; timed-out commands are terminated
-
-### Background Jobs
-
-Use run_background_job for long-running processes (servers, watchers). Output capped at 10MB per job. All jobs auto-terminate when the agent stops.
-
-Use wait_background_job to block until a job finishes and retrieve its exit code and full output. Pass an optional timeout (seconds) to cap how long to wait; the job keeps running if the timeout fires.`
-	if t.handler.recall {
-		instructions += `
-
-When starting a background job, set "recall": true if you want the agent loop to be steered automatically with a short completion message and the job output when it finishes.`
-	}
-	return instructions
-}
-
-func (t *ToolSet) runBackgroundJobDescription() string {
-	description := `Starts a shell command in the background and returns immediately with a job ID. Use this for long-running processes like servers, watches, or any command that should run while other tasks are performed.`
-	if t.handler.recall {
-		description += ` Set recall=true to receive a steering message with the job output when it finishes.`
-	}
-	return description
-}
-
-func runShellBackgroundParameters(recall bool) any {
-	if recall {
-		return tools.MustSchemaFor[RunShellBackgroundRecallArgs]()
-	}
-	return tools.MustSchemaFor[RunShellBackgroundArgs]()
-}
-
-func (t *ToolSet) runBackgroundJobHandler() tools.ToolHandler {
-	if t.handler.recall {
-		return tools.NewRuntimeHandler(t.handler.RunShellBackgroundWithRecall)
-	}
-	return tools.NewRuntimeHandler(t.handler.RunShellBackground)
+- Non-zero exit codes return error info with output; timed-out commands are terminated`
 }
 
 func (t *ToolSet) Tools(context.Context) ([]tools.Tool, error) {
@@ -778,55 +350,6 @@ func (t *ToolSet) Tools(context.Context) ([]tools.Tool, error) {
 			OutputSchema:            tools.MustSchemaFor[string](),
 			Handler:                 tools.NewRuntimeHandler(t.handler.RunShell),
 			Annotations:             tools.ToolAnnotations{Title: "Shell"},
-			AddDescriptionParameter: true,
-		},
-		{
-			Name:                    ToolNameRunShellBackground,
-			Category:                "shell",
-			Description:             t.runBackgroundJobDescription(),
-			Parameters:              runShellBackgroundParameters(t.handler.recall),
-			OutputSchema:            tools.MustSchemaFor[string](),
-			Handler:                 t.runBackgroundJobHandler(),
-			Annotations:             tools.ToolAnnotations{Title: "Background Job"},
-			AddDescriptionParameter: true,
-		},
-		{
-			Name:                    ToolNameListBackgroundJobs,
-			Category:                "shell",
-			Description:             `Lists all background jobs with their status, runtime, and other information.`,
-			OutputSchema:            tools.MustSchemaFor[string](),
-			Handler:                 tools.NewHandler(t.handler.ListBackgroundJobs),
-			Annotations:             tools.ToolAnnotations{Title: "List Background Jobs", ReadOnlyHint: true},
-			AddDescriptionParameter: true,
-		},
-		{
-			Name:                    ToolNameViewBackgroundJob,
-			Category:                "shell",
-			Description:             `Views the output and status of a specific background job by job ID.`,
-			Parameters:              tools.MustSchemaFor[ViewBackgroundJobArgs](),
-			OutputSchema:            tools.MustSchemaFor[string](),
-			Handler:                 tools.NewHandler(t.handler.ViewBackgroundJob),
-			Annotations:             tools.ToolAnnotations{Title: "View Background Job Output", ReadOnlyHint: true},
-			AddDescriptionParameter: true,
-		},
-		{
-			Name:                    ToolNameStopBackgroundJob,
-			Category:                "shell",
-			Description:             `Stops a running background job by job ID. The process and all its child processes will be terminated.`,
-			Parameters:              tools.MustSchemaFor[StopBackgroundJobArgs](),
-			OutputSchema:            tools.MustSchemaFor[string](),
-			Handler:                 tools.NewHandler(t.handler.StopBackgroundJob),
-			Annotations:             tools.ToolAnnotations{Title: "Stop Background Job"},
-			AddDescriptionParameter: true,
-		},
-		{
-			Name:                    ToolNameWaitBackgroundJob,
-			Category:                "shell",
-			Description:             `Blocks until a background job completes (or the optional timeout expires) and returns its exit code and captured output. Safe to call on an already-finished job — returns the cached result immediately. Use this instead of polling view_background_job in a loop.`,
-			Parameters:              tools.MustSchemaFor[WaitBackgroundJobArgs](),
-			OutputSchema:            tools.MustSchemaFor[string](),
-			Handler:                 tools.NewHandler(t.handler.WaitBackgroundJob),
-			Annotations:             tools.ToolAnnotations{Title: "Wait for Background Job", ReadOnlyHint: true},
 			AddDescriptionParameter: true,
 		},
 	}, nil
@@ -845,16 +368,6 @@ func (t *ToolSet) Start(context.Context) error {
 }
 
 func (t *ToolSet) Stop(context.Context) error {
-	// Terminate all running background jobs
-	t.handler.jobs.Range(func(_ string, job *backgroundJob) bool {
-		if job.status.CompareAndSwap(statusRunning, statusStopped) {
-			_ = kill(job.process, job.processGroup)
-		}
-		return true
-	})
-
-	// Tear down the sudo askpass helper (socket + wrapper script), if started.
 	t.handler.stopAskpass()
-
 	return nil
 }

--- a/pkg/tools/builtin/shell/shell_test.go
+++ b/pkg/tools/builtin/shell/shell_test.go
@@ -1,7 +1,6 @@
 package shell
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -14,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/config"
-	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
@@ -119,34 +117,6 @@ func TestRunShellArgs_UnmarshalJSON_AcceptsCmdAndCommand(t *testing.T) {
 	}
 }
 
-func TestRunShellBackgroundArgs_UnmarshalJSON_AcceptsCmdAndCommand(t *testing.T) {
-	t.Parallel()
-
-	var viaCmd RunShellBackgroundArgs
-	require.NoError(t, json.Unmarshal([]byte(`{"cmd":"sleep 1","cwd":"/tmp"}`), &viaCmd))
-	assert.Equal(t, "sleep 1", viaCmd.Cmd)
-	assert.Equal(t, "/tmp", viaCmd.Cwd)
-
-	var viaCommand RunShellBackgroundArgs
-	require.NoError(t, json.Unmarshal([]byte(`{"command":"sleep 1"}`), &viaCommand))
-	assert.Equal(t, "sleep 1", viaCommand.Cmd)
-
-	// A blank "cmd" must not shadow a valid "command" alias.
-	var blankCmd RunShellBackgroundArgs
-	require.NoError(t, json.Unmarshal([]byte(`{"cmd":"   ","command":"sleep 1"}`), &blankCmd))
-	assert.Equal(t, "sleep 1", blankCmd.Cmd)
-}
-
-func TestRunShellBackgroundRecallArgs_UnmarshalJSON_AcceptsRecall(t *testing.T) {
-	t.Parallel()
-
-	var withRecall RunShellBackgroundRecallArgs
-	require.NoError(t, json.Unmarshal([]byte(`{"command":"sleep 1","cwd":"/tmp","recall":true}`), &withRecall))
-	assert.Equal(t, "sleep 1", withRecall.Cmd)
-	assert.Equal(t, "/tmp", withRecall.Cwd)
-	assert.True(t, withRecall.Recall)
-}
-
 // Exercises the end-to-end dispatch path: a tool-call whose raw arguments
 // use "command" instead of "cmd" must execute normally rather than return
 // the missing-parameter error.
@@ -212,330 +182,14 @@ func TestShellTool_ParametersAreObjects(t *testing.T) {
 	}
 }
 
-func TestShellTool_WaitBackgroundJob_Completed(t *testing.T) {
-	t.Parallel()
-	if runtime.GOOS == "windows" {
-		t.Skip("POSIX shell semantics; skipped on Windows")
-	}
-	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
-	require.NoError(t, tool.Start(t.Context()))
-	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
-
-	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "echo hello"}, tools.NopRuntime{})
-	require.NoError(t, err)
-
-	// Retrieve the job ID from the map.
-	var jobID string
-	tool.handler.jobs.Range(func(id string, _ *backgroundJob) bool {
-		jobID = id
-		return false
-	})
-	require.NotEmpty(t, jobID)
-
-	result, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: jobID})
-	require.NoError(t, err)
-	assert.Contains(t, result.Output, "completed")
-	assert.Contains(t, result.Output, "Exit Code: 0")
-	assert.Contains(t, result.Output, "hello")
-}
-
-func TestShellTool_WaitBackgroundJob_FailedExit(t *testing.T) {
-	t.Parallel()
-	if runtime.GOOS == "windows" {
-		t.Skip("POSIX shell semantics; skipped on Windows")
-	}
-	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
-	require.NoError(t, tool.Start(t.Context()))
-	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
-
-	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "exit 3"}, tools.NopRuntime{})
-	require.NoError(t, err)
-
-	var jobID string
-	tool.handler.jobs.Range(func(id string, _ *backgroundJob) bool {
-		jobID = id
-		return false
-	})
-	require.NotEmpty(t, jobID)
-
-	result, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: jobID})
-	require.NoError(t, err)
-	assert.Contains(t, result.Output, "failed")
-	assert.Contains(t, result.Output, "Exit Code: 3")
-}
-
-func TestShellTool_WaitBackgroundJob_AlreadyCompleted(t *testing.T) {
-	t.Parallel()
-	if runtime.GOOS == "windows" {
-		t.Skip("POSIX shell semantics; skipped on Windows")
-	}
-	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
-	require.NoError(t, tool.Start(t.Context()))
-	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
-
-	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "echo done"}, tools.NopRuntime{})
-	require.NoError(t, err)
-
-	var jobID string
-	tool.handler.jobs.Range(func(id string, _ *backgroundJob) bool {
-		jobID = id
-		return false
-	})
-	require.NotEmpty(t, jobID)
-
-	// First wait — blocks until the job finishes.
-	result1, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: jobID})
-	require.NoError(t, err)
-	assert.Contains(t, result1.Output, "completed")
-
-	// Second wait on an already-finished job must return immediately with the cached result.
-	result2, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: jobID})
-	require.NoError(t, err)
-	assert.Contains(t, result2.Output, "completed")
-	assert.Contains(t, result2.Output, "Exit Code: 0")
-}
-
-func TestShellTool_WaitBackgroundJob_UnknownID(t *testing.T) {
+func TestShellTool_OnlyExposesShell(t *testing.T) {
 	t.Parallel()
 	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
 
-	result, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: "job_does_not_exist"})
+	allTools, err := tool.Tools(t.Context())
 	require.NoError(t, err)
-	assert.Contains(t, result.Output, "Job not found")
-}
-
-func TestShellTool_WaitBackgroundJob_Timeout(t *testing.T) {
-	t.Parallel()
-	if runtime.GOOS == "windows" {
-		t.Skip("sleep not available on Windows cmd")
-	}
-	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
-	require.NoError(t, tool.Start(t.Context()))
-	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
-
-	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "sleep 30"}, tools.NopRuntime{})
-	require.NoError(t, err)
-
-	var jobID string
-	tool.handler.jobs.Range(func(id string, _ *backgroundJob) bool {
-		jobID = id
-		return false
-	})
-	require.NotEmpty(t, jobID)
-
-	start := time.Now()
-	result, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: jobID, Timeout: 1})
-	elapsed := time.Since(start)
-
-	require.NoError(t, err)
-	assert.Contains(t, result.Output, "Timed out")
-	assert.Contains(t, result.Output, "still running")
-	assert.Less(t, elapsed, 5*time.Second)
-}
-
-func TestShellTool_WaitBackgroundJob_ContextCancelled(t *testing.T) {
-	t.Parallel()
-	if runtime.GOOS == "windows" {
-		t.Skip("sleep not available on Windows cmd")
-	}
-	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
-	require.NoError(t, tool.Start(t.Context()))
-	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
-
-	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "sleep 30"}, tools.NopRuntime{})
-	require.NoError(t, err)
-
-	var jobID string
-	tool.handler.jobs.Range(func(id string, _ *backgroundJob) bool {
-		jobID = id
-		return false
-	})
-	require.NotEmpty(t, jobID)
-
-	ctx, cancel := context.WithCancel(t.Context())
-	cancel() // cancel immediately
-
-	result, err := tool.handler.WaitBackgroundJob(ctx, WaitBackgroundJobArgs{JobID: jobID, Timeout: 60})
-	require.NoError(t, err)
-	assert.Contains(t, result.Output, "cancelled")
-}
-
-func TestShellTool_WaitBackgroundJob_Stopped(t *testing.T) {
-	t.Parallel()
-	if runtime.GOOS == "windows" {
-		t.Skip("sleep not available on Windows cmd")
-	}
-	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
-	require.NoError(t, tool.Start(t.Context()))
-	t.Cleanup(func() { _ = tool.Stop(t.Context()) })
-
-	_, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "sleep 30"}, tools.NopRuntime{})
-	require.NoError(t, err)
-
-	var jobID string
-	tool.handler.jobs.Range(func(id string, _ *backgroundJob) bool {
-		jobID = id
-		return false
-	})
-	require.NotEmpty(t, jobID)
-
-	// Stop the job in a separate goroutine to unblock the wait.
-	go func() {
-		_, _ = tool.handler.StopBackgroundJob(t.Context(), StopBackgroundJobArgs{JobID: jobID})
-	}()
-
-	result, err := tool.handler.WaitBackgroundJob(t.Context(), WaitBackgroundJobArgs{JobID: jobID, Timeout: 10})
-	require.NoError(t, err)
-	assert.Contains(t, result.Output, "stopped")
-	assert.NotContains(t, result.Output, "Exit Code:",
-		"stopped jobs should not show an exit code")
-}
-
-// Minimal tests for background job features
-func TestShellTool_RunBackgroundJob(t *testing.T) {
-	t.Parallel()
-	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
-	err := tool.Start(t.Context())
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = tool.Stop(t.Context())
-	})
-
-	result, err := tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "echo test"}, tools.NopRuntime{})
-	require.NoError(t, err)
-	assert.Contains(t, result.Output, "Background job started with ID:")
-}
-
-func TestShellTool_RunBackgroundJobRecall(t *testing.T) {
-	t.Parallel()
-	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
-	tool.handler.recall = true
-	err := tool.Start(t.Context())
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = tool.Stop(t.Context())
-	})
-
-	rt := &recallRuntime{recalls: make(chan string, 1)}
-	result, err := tool.handler.RunShellBackgroundWithRecall(t.Context(), RunShellBackgroundRecallArgs{Cmd: "echo recall-output", Recall: true}, rt)
-	require.NoError(t, err)
-	assert.Contains(t, result.Output, "Recall: requested")
-
-	select {
-	case msg := <-rt.recalls:
-		assert.Contains(t, msg, "Background job")
-		assert.Contains(t, msg, "finished with status completed")
-		assert.Contains(t, msg, "recall-output")
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for background job recall")
-	}
-}
-
-func TestShellTool_RunBackgroundJobRecallRequiresConfig(t *testing.T) {
-	t.Parallel()
-	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
-
-	result, err := tool.handler.RunShellBackgroundWithRecall(t.Context(), RunShellBackgroundRecallArgs{Cmd: "echo test", Recall: true}, &recallRuntime{})
-	require.NoError(t, err)
-	require.True(t, result.IsError)
-	assert.Contains(t, result.Output, "recall")
-	assert.Contains(t, result.Output, "not enabled")
-	assert.Equal(t, 0, tool.handler.jobs.Length())
-}
-
-func TestShellTool_RunBackgroundJobRecallRequiresCallback(t *testing.T) {
-	t.Parallel()
-	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
-	tool.handler.recall = true
-
-	result, err := tool.handler.RunShellBackgroundWithRecall(t.Context(), RunShellBackgroundRecallArgs{Cmd: "echo test", Recall: true}, tools.NopRuntime{})
-	require.NoError(t, err)
-	require.True(t, result.IsError)
-	assert.Contains(t, result.Output, "does not support recall")
-	assert.Equal(t, 0, tool.handler.jobs.Length())
-}
-
-// recallRuntime is a tools.Runtime stub that captures recall messages.
-type recallRuntime struct {
-	tools.NopRuntime
-
-	recalls chan string
-}
-
-func (r *recallRuntime) Recall(_ context.Context, message string) error {
-	r.recalls <- message
-	return nil
-}
-
-func (r *recallRuntime) Supports(c tools.Capability) bool {
-	return c == tools.CapabilityRecall
-}
-
-func TestCreateToolSetEnablesRecall(t *testing.T) {
-	t.Parallel()
-
-	recall := true
-	toolSet, err := CreateToolSet(t.Context(), latest.Toolset{Type: "shell", Recall: &recall}, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
-	require.NoError(t, err)
-
-	shellToolSet, ok := toolSet.(*ToolSet)
-	require.True(t, ok)
-	assert.True(t, shellToolSet.handler.recall)
-}
-
-func TestShellTool_RunBackgroundJobSchemaRecall(t *testing.T) {
-	t.Parallel()
-
-	withoutRecall := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
-	withoutTools, err := withoutRecall.Tools(t.Context())
-	require.NoError(t, err)
-	withoutSchema, err := tools.SchemaToMap(findShellTool(t, withoutTools, ToolNameRunShellBackground).Parameters)
-	require.NoError(t, err)
-	withoutProps, ok := withoutSchema["properties"].(map[string]any)
-	require.True(t, ok)
-	assert.NotContains(t, withoutProps, "recall")
-
-	withRecall := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
-	withRecall.handler.recall = true
-	withTools, err := withRecall.Tools(t.Context())
-	require.NoError(t, err)
-	withSchema, err := tools.SchemaToMap(findShellTool(t, withTools, ToolNameRunShellBackground).Parameters)
-	require.NoError(t, err)
-	withProps, ok := withSchema["properties"].(map[string]any)
-	require.True(t, ok)
-	assert.Contains(t, withProps, "recall")
-}
-
-func findShellTool(t *testing.T, toolList []tools.Tool, name string) tools.Tool {
-	t.Helper()
-	for _, tool := range toolList {
-		if tool.Name == name {
-			return tool
-		}
-	}
-	t.Fatalf("tool %q not found", name)
-	return tools.Tool{}
-}
-
-func TestShellTool_ListBackgroundJobs(t *testing.T) {
-	t.Parallel()
-	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
-	err := tool.Start(t.Context())
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = tool.Stop(t.Context())
-	})
-
-	// Start a background job first
-	_, err = tool.handler.RunShellBackground(t.Context(), RunShellBackgroundArgs{Cmd: "echo test"}, tools.NopRuntime{})
-	require.NoError(t, err)
-
-	// No need to wait - ListBackgroundJobs shows jobs regardless of status
-	listResult, err := tool.handler.ListBackgroundJobs(t.Context(), nil)
-
-	require.NoError(t, err)
-	assert.Contains(t, listResult.Output, "Background Jobs:")
-	assert.Contains(t, listResult.Output, "ID: job_")
+	require.Len(t, allTools, 1)
+	assert.Equal(t, ToolNameShell, allTools[0].Name)
 }
 
 func TestShellTool_Instructions(t *testing.T) {
@@ -545,8 +199,8 @@ func TestShellTool_Instructions(t *testing.T) {
 
 	instructions := tool.Instructions()
 
-	// Check that native instructions are returned
 	assert.Contains(t, instructions, "Shell Tools")
+	assert.NotContains(t, instructions, "run_background_job")
 }
 
 func TestResolveWorkDir(t *testing.T) {


### PR DESCRIPTION
## Summary
- move background job tools and process-management code into a new background_jobs toolset/package
- leave the shell toolset exposing only the synchronous shell tool
- update schema, default configs, examples, and docs for background_jobs

## Validation
- task build
- task --force lint
- env -u MOONSHOT_API_KEY task test