### PR TITLE
fix: support steering in lean TUI

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -817,6 +817,11 @@ func (a *App) Resume(req runtime.ResumeRequest) {
 	a.runtime.Resume(a.ctx(), req)
 }
 
+// Steer queues a user message for mid-turn injection into the running agent.
+func (a *App) Steer(ctx context.Context, msg runtime.QueuedMessage) error {
+	return a.runtime.Steer(ctx, msg)
+}
+
 // TogglePause toggles whether the runtime loop is paused at iteration
 // boundaries. The second return value is false if the underlying runtime
 // doesn't support pausing (e.g. remote runtimes), in which case the first

--- a/pkg/leantui/events.go
+++ b/pkg/leantui/events.go
@@ -15,10 +15,16 @@ import (
 func (m *model) handleEvent(ctx context.Context, ev any) {
 	switch e := ev.(type) {
 	case msgtypes.SendMsg:
-		m.submit(ctx, e.Content)
+		if e.BypassQueue {
+			m.submit(ctx, e.Content, submitOptions{busyMode: busySubmitSteer})
+		} else {
+			m.submitFollowUp(ctx, e.Content)
+		}
 	case *runtime.StreamStartedEvent:
 		m.busy = true
 		m.trackStreamStarted(e.SessionID)
+	case *runtime.UserMessageEvent:
+		m.handleUserMessageEvent(e)
 	case *runtime.StreamStoppedEvent:
 		m.trackStreamStopped()
 		m.handleStreamStopped(ctx)
@@ -92,6 +98,19 @@ func (m *model) handleEvent(ctx context.Context, ev any) {
 	}
 }
 
+func (m *model) handleUserMessageEvent(e *runtime.UserMessageEvent) {
+	if m.consumeIgnoredUserEcho(e.Message) {
+		return
+	}
+	if pending, ok := m.consumePendingUser(pendingUserSteer, e.Message); ok {
+		m.transcript.flushPending()
+		m.addUserEcho(pending.display)
+		return
+	}
+	m.transcript.flushPending()
+	m.addUserEcho(e.Message)
+}
+
 func (m *model) handleStreamStopped(ctx context.Context) {
 	if m.finishBusy(ctx) {
 		return
@@ -120,8 +139,14 @@ func (m *model) finishBusy(ctx context.Context) bool {
 
 	if len(m.queue) > 0 {
 		next := m.queue[0]
+		m.queue[0] = pendingUserMessage{}
 		m.queue = m.queue[1:]
-		m.startRun(ctx, next, nil)
+		if pending, ok := m.consumePendingUser(pendingUserFollowUp, next.content); ok {
+			next.display = pending.display
+		}
+		m.addUserEcho(next.display)
+		m.ignoreUserEcho(next.content)
+		m.startRun(ctx, next.content, nil)
 		return true
 	}
 	return false

--- a/pkg/leantui/leantui.go
+++ b/pkg/leantui/leantui.go
@@ -80,7 +80,9 @@ func Run(ctx context.Context, cfg Config) error {
 		}
 		m.sendFirstMessage(loopCtx, first, cfg.FirstMessageAttachment)
 	}
-	m.queue = append(m.queue, cfg.QueuedMessages...)
+	for _, msg := range cfg.QueuedMessages {
+		m.enqueueFollowUp(msg, msg)
+	}
 
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
@@ -152,7 +154,9 @@ type model struct {
 	busy         bool
 	spinnerFrame int
 	runCancel    context.CancelFunc
-	queue        []string
+	queue        []pendingUserMessage
+	pendingUsers []pendingUserMessage
+	ignoredUsers []string
 
 	confirm *confirmState
 
@@ -205,7 +209,7 @@ func (m *model) render() {
 func (m *model) renderFinal() {
 	m.transcript.flushPending()
 	m.render()
-	m.r.eraseBelow(len(m.transcript.lines(m.width, m.spinnerFrame, m.busy, m.sessionState)))
+	m.r.eraseBelow(len(m.transcript.lines(m.width, m.spinnerFrame, m.busy, m.sessionState, m.pendingUsers)))
 }
 
 func (m *model) commitWelcome() {

--- a/pkg/leantui/render.go
+++ b/pkg/leantui/render.go
@@ -11,15 +11,24 @@ import (
 // renderUserLines renders a submitted user message as committed scrollback,
 // echoing it with the same prompt marker used by the input box.
 func renderUserLines(text string, width int) []string {
+	return renderUserLinesWith(text, width, stAccent(), stPrimary())
+}
+
+func renderPendingUserLines(text string, width int) []string {
+	muted := stMuted()
+	return renderUserLinesWith(text, width, muted, muted)
+}
+
+func renderUserLinesWith(text string, width int, promptStyle, textStyle lipgloss.Style) []string {
 	text = strings.TrimRight(text, "\n")
 	wrapped := wrapANSI(text, width-promptWidth)
 	out := make([]string, 0, len(wrapped))
 	for i, line := range wrapped {
-		prefix := stAccent().Render(promptText)
+		prefix := promptStyle.Render(promptText)
 		if i > 0 {
 			prefix = continuation
 		}
-		out = append(out, prefix+stPrimary().Render(line))
+		out = append(out, prefix+textStyle.Render(line))
 	}
 	return out
 }

--- a/pkg/leantui/stream_test.go
+++ b/pkg/leantui/stream_test.go
@@ -77,7 +77,7 @@ func TestConversationLinesShowsSpinnerWhenBusy(t *testing.T) {
 	t.Parallel()
 	m := bareModel(24)
 	m.busy = true
-	lines := m.transcript.lines(80, m.spinnerFrame, m.busy, m.sessionState)
+	lines := m.transcript.lines(80, m.spinnerFrame, m.busy, m.sessionState, nil)
 	assert.Contains(t, strings.Join(lines, ""), "Working")
 }
 

--- a/pkg/leantui/transcript.go
+++ b/pkg/leantui/transcript.go
@@ -13,10 +13,23 @@ var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "�
 
 type blockKind int
 
+type pendingUserKind int
+
 const (
 	blockReasoning blockKind = iota
 	blockAssistant
 )
+
+const (
+	pendingUserSteer pendingUserKind = iota
+	pendingUserFollowUp
+)
+
+type pendingUserMessage struct {
+	display string
+	content string
+	kind    pendingUserKind
+}
 
 // pendingBlock accumulates the text of the block currently being streamed.
 type pendingBlock struct {
@@ -116,9 +129,10 @@ func (t *transcript) finishTool(e *runtime.ToolCallResponseEvent, sessionState s
 }
 
 // lines renders everything that scrolls: finalized blocks, the in-progress
-// streamed block, and any running tool calls. A blank line separates each
-// entry. The spinner is shown only while busy with nothing yet streaming.
-func (t *transcript) lines(width, spinnerFrame int, busy bool, sessionState service.SessionStateReader) []string {
+// streamed block, running tool calls, and user messages waiting to be accepted
+// by the runtime. A blank line separates each entry. The spinner is shown only
+// while busy with nothing yet streaming.
+func (t *transcript) lines(width, spinnerFrame int, busy bool, sessionState service.SessionStateReader, pendingUsers []pendingUserMessage) []string {
 	var lines []string
 	for _, b := range t.blocks {
 		lines = append(lines, b.lines(width)...)
@@ -134,6 +148,10 @@ func (t *transcript) lines(width, spinnerFrame int, busy bool, sessionState serv
 	})
 	if busy && t.pending == nil && t.toolz.empty() {
 		lines = append(lines, spinnerLine(spinnerFrame), "")
+	}
+	for _, msg := range pendingUsers {
+		lines = append(lines, renderPendingUserLines(msg.display, width)...)
+		lines = append(lines, "")
 	}
 	return lines
 }

--- a/pkg/leantui/update.go
+++ b/pkg/leantui/update.go
@@ -89,6 +89,8 @@ func (m *model) handleInterrupt() {
 			m.runCancel()
 		}
 		m.queue = nil
+		m.pendingUsers = nil
+		m.ignoredUsers = nil
 		m.transcript.addBlock(func(int) []string { return []string{stWarning().Render("⏹ Cancelled")} })
 	case !m.editor.isEmpty():
 		m.editor.reset()
@@ -102,11 +104,11 @@ func (m *model) handleEnter(ctx context.Context) {
 	if m.ac.active {
 		if cmd, ok := m.ac.current(); ok {
 			m.ac.dismiss()
-			m.submit(ctx, "/"+cmd.name)
+			m.submitEditor(ctx, "/"+cmd.name)
 			return
 		}
 	}
-	m.submit(ctx, m.editor.text())
+	m.submitEditor(ctx, m.editor.text())
 }
 
 func (m *model) handleTab() {
@@ -178,32 +180,48 @@ func (m *model) reportThinkingLevelError(action string, err error) {
 	m.addNotice("✗ ", fmt.Sprintf("Failed to %s thinking level: %v", action, err), stError())
 }
 
-func (m *model) submit(ctx context.Context, text string) {
+type busySubmitMode int
+
+const (
+	busySubmitSteer busySubmitMode = iota
+	busySubmitQueue
+)
+
+type submitOptions struct {
+	fromEditor bool
+	busyMode   busySubmitMode
+}
+
+func (m *model) submitEditor(ctx context.Context, text string) {
+	m.submit(ctx, text, submitOptions{fromEditor: true, busyMode: busySubmitSteer})
+}
+
+func (m *model) submitFollowUp(ctx context.Context, text string) {
+	m.submit(ctx, text, submitOptions{busyMode: busySubmitQueue})
+}
+
+func (m *model) submit(ctx context.Context, text string, opts submitOptions) {
 	trimmed := strings.TrimSpace(text)
 	if trimmed == "" {
 		return
 	}
-	m.editor.rememberHistory(trimmed)
-	m.editor.reset()
-	m.ac.dismiss()
+	if opts.fromEditor {
+		m.editor.rememberHistory(trimmed)
+		m.editor.reset()
+		m.ac.dismiss()
+	}
 
-	if strings.HasPrefix(trimmed, "/") && m.handleSlash(ctx, trimmed) {
+	if strings.HasPrefix(trimmed, "/") && m.handleSlash(ctx, trimmed, opts.busyMode) {
 		return
 	}
 
-	m.addUserEcho(trimmed)
-
-	if m.app.IsReadOnly() {
-		m.addNotice("⚠ ", "This session is read-only.", stWarning())
-		return
-	}
-	m.enqueueOrRun(ctx, trimmed)
+	m.dispatchUserMessage(ctx, trimmed, trimmed, opts.busyMode)
 }
 
 // handleSlash dispatches a slash command. It returns true when the command was
 // fully handled (built-in, skill, or agent command) and false when the input
 // should be treated as a normal message.
-func (m *model) handleSlash(ctx context.Context, text string) bool {
+func (m *model) handleSlash(ctx context.Context, text string, mode busySubmitMode) bool {
 	name, rest := splitCommand(text)
 	switch name {
 	case "exit", "quit":
@@ -237,31 +255,45 @@ func (m *model) handleSlash(ctx context.Context, text string) bool {
 	}
 
 	if _, _, ok := m.app.LookupCommand(ctx, text); ok {
-		m.addUserEcho(text)
-		m.enqueueOrRun(ctx, m.app.ResolveInput(ctx, text))
+		m.dispatchUserMessage(ctx, text, m.app.ResolveInput(ctx, text), mode)
 		return true
 	}
 
 	if resolved, err := m.app.ResolveSkillCommand(ctx, text); err == nil && resolved != "" {
-		m.addUserEcho(text)
-		m.enqueueOrRun(ctx, resolved)
+		m.dispatchUserMessage(ctx, text, resolved, mode)
 		return true
 	}
 
 	return false
 }
 
-// enqueueOrRun starts a run immediately when idle, or queues the message to run
-// after the current response finishes.
-func (m *model) enqueueOrRun(ctx context.Context, message string) {
+func (m *model) dispatchUserMessage(ctx context.Context, display, content string, mode busySubmitMode) {
 	if m.app.IsReadOnly() {
+		m.addUserEcho(display)
+		m.addNotice("⚠ ", "This session is read-only.", stWarning())
 		return
 	}
 	if m.busy {
-		m.queue = append(m.queue, message)
+		if mode == busySubmitSteer {
+			if err := m.app.Steer(ctx, runtime.QueuedMessage{Content: content}); err != nil {
+				m.addNotice("⚠ ", "Could not steer current response: "+err.Error(), stWarning())
+				return
+			}
+			m.addPendingUser(display, content, pendingUserSteer)
+			return
+		}
+		m.enqueueFollowUp(display, content)
 		return
 	}
-	m.startRun(ctx, message, nil)
+	m.addUserEcho(display)
+	m.ignoreUserEcho(content)
+	m.startRun(ctx, content, nil)
+}
+
+func (m *model) enqueueFollowUp(display, content string) {
+	msg := pendingUserMessage{display: display, content: content, kind: pendingUserFollowUp}
+	m.queue = append(m.queue, msg)
+	m.pendingUsers = append(m.pendingUsers, msg)
 }
 
 func (m *model) sendFirstMessage(ctx context.Context, msg, attachPath string) {
@@ -273,20 +305,22 @@ func (m *model) sendFirstMessage(ctx context.Context, msg, attachPath string) {
 	}
 
 	trimmed := strings.TrimSpace(msg)
-	switch {
-	case trimmed != "":
-		m.addUserEcho(trimmed)
-	case len(atts) > 0:
-		m.addNotice("", "(attached "+atts[0].Name+")", stMuted())
-	default:
-		return
-	}
-
 	content := msg
 	if strings.HasPrefix(trimmed, "/") {
 		if resolved := m.app.ResolveInput(ctx, trimmed); resolved != "" {
 			content = resolved
 		}
+	}
+
+	switch {
+	case trimmed != "":
+		m.addUserEcho(trimmed)
+		m.ignoreUserEcho(content)
+	case len(atts) > 0:
+		m.addNotice("", "(attached "+atts[0].Name+")", stMuted())
+		m.ignoreUserEcho(content)
+	default:
+		return
 	}
 	m.startRun(ctx, content, atts)
 }
@@ -361,6 +395,8 @@ func (m *model) resetConversation() {
 	}
 	m.transcript.clearActive()
 	m.queue = nil
+	m.pendingUsers = nil
+	m.ignoredUsers = nil
 	m.busy = false
 	m.confirm = nil
 	m.usage.reset()
@@ -384,6 +420,40 @@ func (m *model) quit() {
 
 func (m *model) addUserEcho(text string) {
 	m.transcript.addBlock(func(w int) []string { return renderUserLines(text, w) })
+}
+
+func (m *model) addPendingUser(display, content string, kind pendingUserKind) {
+	m.pendingUsers = append(m.pendingUsers, pendingUserMessage{display: display, content: content, kind: kind})
+}
+
+func (m *model) consumePendingUser(kind pendingUserKind, content string) (pendingUserMessage, bool) {
+	for i, msg := range m.pendingUsers {
+		if msg.kind != kind || !samePendingUserContent(msg.content, content) {
+			continue
+		}
+		m.pendingUsers = append(m.pendingUsers[:i], m.pendingUsers[i+1:]...)
+		return msg, true
+	}
+	return pendingUserMessage{}, false
+}
+
+func samePendingUserContent(pending, emitted string) bool {
+	return pending == emitted || pending == strings.TrimSuffix(emitted, "\n")
+}
+
+func (m *model) ignoreUserEcho(content string) {
+	m.ignoredUsers = append(m.ignoredUsers, content)
+}
+
+func (m *model) consumeIgnoredUserEcho(content string) bool {
+	for i, msg := range m.ignoredUsers {
+		if msg != content {
+			continue
+		}
+		m.ignoredUsers = append(m.ignoredUsers[:i], m.ignoredUsers[i+1:]...)
+		return true
+	}
+	return false
 }
 
 func (m *model) addNotice(prefix, text string, style lipgloss.Style) {

--- a/pkg/leantui/update_test.go
+++ b/pkg/leantui/update_test.go
@@ -2,6 +2,7 @@ package leantui
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,6 +24,8 @@ type cycleThinkingRuntime struct {
 	cycleCalls int
 	setCalls   int
 	setLevel   effort.Level
+	steered    []runtime.QueuedMessage
+	steerErr   error
 }
 
 func (r *cycleThinkingRuntime) CurrentAgentInfo(context.Context) runtime.CurrentAgentInfo {
@@ -82,9 +85,15 @@ func (r *cycleThinkingRuntime) UpdateSessionTitle(_ context.Context, sess *sessi
 func (r *cycleThinkingRuntime) TitleGenerator(context.Context) *sessiontitle.Generator { return nil }
 func (r *cycleThinkingRuntime) Close() error                                           { return nil }
 func (r *cycleThinkingRuntime) Stop()                                                  {}
-func (r *cycleThinkingRuntime) Steer(context.Context, runtime.QueuedMessage) error     { return nil }
-func (r *cycleThinkingRuntime) FollowUp(context.Context, runtime.QueuedMessage) error  { return nil }
-func (r *cycleThinkingRuntime) QueueStatus() runtime.QueueStatus                       { return runtime.QueueStatus{} }
+func (r *cycleThinkingRuntime) Steer(_ context.Context, msg runtime.QueuedMessage) error {
+	if r.steerErr != nil {
+		return r.steerErr
+	}
+	r.steered = append(r.steered, msg)
+	return nil
+}
+func (r *cycleThinkingRuntime) FollowUp(context.Context, runtime.QueuedMessage) error { return nil }
+func (r *cycleThinkingRuntime) QueueStatus() runtime.QueueStatus                      { return runtime.QueueStatus{} }
 
 func (r *cycleThinkingRuntime) TogglePause(context.Context) (bool, error) {
 	return false, nil
@@ -162,4 +171,48 @@ func TestEffortCommandRejectsUnknownLevel(t *testing.T) {
 	assert.Zero(t, rt.setCalls)
 	assert.Empty(t, m.status.thinking)
 	assert.Len(t, m.transcript.blocks, 1)
+}
+
+func TestEditorSubmitWhileBusySteersAndRendersAtStreamEnd(t *testing.T) {
+	t.Parallel()
+	rt := &cycleThinkingRuntime{}
+	m := bareModel(24)
+	m.app = app.New(t.Context(), rt, session.New())
+	m.busy = true
+	m.transcript.appendPending(blockAssistant, "assistant is still streaming")
+	m.editor.setText("turn left")
+
+	m.handleEnter(t.Context())
+
+	if assert.Len(t, rt.steered, 1) {
+		assert.Equal(t, "turn left", rt.steered[0].Content)
+	}
+	assert.Empty(t, m.queue)
+	assert.Len(t, m.pendingUsers, 1)
+
+	joined := strings.Join(m.transcript.lines(80, 0, true, m.sessionState, m.pendingUsers), "\n")
+	assistantAt := strings.Index(joined, "assistant is still streaming")
+	steerAt := strings.Index(joined, "turn left")
+	assert.NotEqual(t, -1, assistantAt)
+	assert.NotEqual(t, -1, steerAt)
+	assert.Less(t, assistantAt, steerAt)
+}
+
+func TestSteeredUserEventConfirmsPendingAfterAssistant(t *testing.T) {
+	t.Parallel()
+	m := bareModel(24)
+	m.busy = true
+	m.transcript.appendPending(blockAssistant, "assistant response")
+	m.addPendingUser("/change", "resolved steering prompt", pendingUserSteer)
+
+	m.handleEvent(t.Context(), runtime.UserMessage("resolved steering prompt\n", "session", nil, 1))
+
+	assert.Empty(t, m.pendingUsers)
+	assert.Len(t, m.transcript.blocks, 2)
+	joined := strings.Join(m.transcript.lines(80, 0, true, m.sessionState, nil), "\n")
+	assistantAt := strings.Index(joined, "assistant response")
+	steerAt := strings.Index(joined, "/change")
+	assert.NotEqual(t, -1, assistantAt)
+	assert.NotEqual(t, -1, steerAt)
+	assert.Less(t, assistantAt, steerAt)
 }

--- a/pkg/leantui/view.go
+++ b/pkg/leantui/view.go
@@ -6,7 +6,7 @@ package leantui
 func (m *model) buildLines() (lines []string, cursorLine, cursorCol int) {
 	width := m.width
 
-	lines = m.transcript.lines(width, m.spinnerFrame, m.busy, m.sessionState)
+	lines = m.transcript.lines(width, m.spinnerFrame, m.busy, m.sessionState, m.pendingUsers)
 
 	lines = append(lines, m.ac.render(width)...)
 


### PR DESCRIPTION
## Summary
- route busy lean TUI editor submissions through the runtime steering queue
- render pending steering/follow-up messages at the end of the live stream with muted styling
- reconcile runtime user-message confirmations so pending steering messages do not duplicate

## Tests
- go test ./pkg/app ./pkg/leantui ./pkg/tui/page/chat
- task lint
- task --force build
- task test *(fails in pkg/model/provider: TestOpenAIAliasProvider_LiveAPI/moonshot returns HTTP 404 / permission denied for kimi-k2-0905-preview)*