### PR TITLE
docs: document lean TUI steering support

### DIFF
--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -57,6 +57,8 @@ settings:
 
 Omit `lean` or set it to `false` to keep the full TUI as the default. You can still use `--lean` for a single run, or `--lean=false` to use the full TUI when `settings.lean` is enabled.
 
+The lean TUI supports **steering**: messages submitted while the agent is running are queued and delivered to the active session. Pending steering messages appear with muted styling at the end of the live stream so you can see what will be sent next.
+
 ## Slash Commands
 
 Type `/` during a session to see available commands, or press <kbd>Ctrl</kbd>+<kbd>K</kbd> for the command palette:


### PR DESCRIPTION
Document the steering capability added to the lean TUI in PR #3474.

The lean TUI now accepts messages while the agent is running — they are queued and delivered to the active session, with pending messages displayed in muted styling at the end of the live stream. The previous docs did not mention this behaviour.

**PRs reviewed:** #3474, #3473, #3472, #3468, #3467, #3466, #3464, #3463, #3461, #3460, #3458, #3457, #3455, #3454, #3453, #3421  
**Doc changes required:** #3474 only — all other PRs had already updated docs or required no doc changes.