### PR TITLE
fix: handle tx.Rollback error in database migrations

### DIFF
--- a/pkg/session/migrations.go
+++ b/pkg/session/migrations.go
@@ -146,8 +146,9 @@ func (m *MigrationManager) applyMigration(ctx context.Context, migration *Migrat
 		return err
 	}
 	defer func() {
-		// TODO: handle error
-		_ = tx.Rollback()
+		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			slog.ErrorContext(ctx, "failed to rollback migration transaction", "error", err)
+		}
 	}()
 
 	// Execute SQL migration if present


### PR DESCRIPTION
### What does this PR do?
This PR addresses a technical debt item by resolving the `TODO` in `pkg/session/migrations.go`. 

Previously, `_ = tx.Rollback()` silently swallowed all database rollback errors. If a legitimate failure occurred during the rollback (e.g., a dropped connection or locked database), the application would fail silently without logging the error.

### Changes made:
- Added explicit error handling for the deferred `tx.Rollback()` in `applyMigration`.
- The new code safely ignores `sql.ErrTxDone` (when the transaction successfully committed) but utilizes `slog` to properly capture and log any legitimate rollback failures, preventing silent state inconsistencies.
