### PR TITLE
fix: update stale Anthropic model IDs in examples

### DIFF
--- a/examples/42.yaml
+++ b/examples/42.yaml
@@ -1,6 +1,6 @@
 agents:
   root:
-    model: anthropic/claude-3-7-sonnet-20250219
+    model: anthropic/claude-sonnet-4-5
     description: "Douglas Adams-style witty AI assistant"
     instruction: |
       You are an AI assistant with the distinctive voice and style of Douglas Adams' "The Hitchhiker's Guide to the Galaxy." Your responses should capture the book's characteristic blend of absurdist humor, witty observations, and deadpan delivery of the most outlandish concepts.

--- a/examples/background_agents.yaml
+++ b/examples/background_agents.yaml
@@ -7,7 +7,7 @@
 
 agents:
   root:
-    model: anthropic/claude-sonnet-4-0
+    model: anthropic/claude-sonnet-4-5
     description: Research coordinator that dispatches work in parallel
     instruction: |
       You are a research coordinator. When the user asks a question:
@@ -37,7 +37,7 @@ agents:
         ref: docker:duckduckgo
 
   code_analyst:
-    model: anthropic/claude-sonnet-4-0
+    model: anthropic/claude-sonnet-4-5
     description: Analyses local code and provides technical insights
     instruction: |
       You are a code analyst. Read the codebase to answer technical

--- a/examples/code.yaml
+++ b/examples/code.yaml
@@ -61,5 +61,5 @@ agents:
 models:
   claude:
     provider: anthropic
-    model: claude-sonnet-4-0
+    model: claude-sonnet-4-5
     max_tokens: 64000

--- a/examples/compose-secrets.yaml
+++ b/examples/compose-secrets.yaml
@@ -29,7 +29,7 @@
 
 agents:
   root:
-    model: anthropic/claude-sonnet-4-0
+    model: anthropic/claude-sonnet-4-5
     description: A helpful assistant running with Docker Compose secrets
     instruction: |
       You are a helpful assistant. Your API key was securely provided

--- a/examples/dev-team.yaml
+++ b/examples/dev-team.yaml
@@ -1,7 +1,7 @@
 models:
   model:
     provider: anthropic
-    model: claude-sonnet-4-0
+    model: claude-sonnet-4-5
     max_tokens: 64000
 
 agents:

--- a/examples/diag.yaml
+++ b/examples/diag.yaml
@@ -1,6 +1,6 @@
 agents:
   root:
-    model: anthropic/claude-sonnet-4-0
+    model: anthropic/claude-sonnet-4-5
     description: Expert developer specialized in log analysis and diagnostics
     instruction: |
       You are a diagnostic expert focused on analyzing log files and identifying issues. Your primary responsibilities are:

--- a/examples/doc_generator.yaml
+++ b/examples/doc_generator.yaml
@@ -38,5 +38,5 @@ agents:
 models:
   claude:
     provider: anthropic
-    model: claude-sonnet-4-0
+    model: claude-sonnet-4-5
     max_tokens: 64000

--- a/examples/env_placeholders.yaml
+++ b/examples/env_placeholders.yaml
@@ -23,7 +23,7 @@
 
 agents:
   root:
-    model: anthropic/claude-sonnet-4-0
+    model: anthropic/claude-sonnet-4-5
     description: "Agent demonstrating environment variable placeholder expansion"
     instruction: |
       You are a helpful assistant that responds to user requests.

--- a/examples/fallback_models.yaml
+++ b/examples/fallback_models.yaml
@@ -14,7 +14,7 @@
 agents:
   # Minimal fallback configuration - just specify models, defaults handle the rest
   root:
-    model: anthropic/claude-sonnet-4-0
+    model: anthropic/claude-sonnet-4-5
     fallback:
       models:
         - openai/gpt-4o
@@ -36,7 +36,7 @@ agents:
 # Example with explicit configuration (for power users):
 # agents:
 #   root:
-#     model: anthropic/claude-sonnet-4-0
+#     model: anthropic/claude-sonnet-4-5
 #     fallback:
 #       models:
 #         - fast_backup

--- a/examples/fetch_docker.yaml
+++ b/examples/fetch_docker.yaml
@@ -1,6 +1,6 @@
 agents:
   root:
-    model: anthropic/claude-3-7-sonnet-20250219
+    model: anthropic/claude-sonnet-4-5
     description: An agent that fetches and summarizes web content
     instruction: |
       You are a web content analyzer that fetches web pages and provides concise summaries.

--- a/examples/github-toon.yaml
+++ b/examples/github-toon.yaml
@@ -1,6 +1,6 @@
 agents:
   root:
-    model: anthropic/claude-sonnet-4-0
+    model: anthropic/claude-sonnet-4-5
     description: GitHub Agent - Help with GitHub using MCP tools
     instruction: You are a helpful assistant that can help with all things GitHub
     toolsets:

--- a/examples/github.yaml
+++ b/examples/github.yaml
@@ -16,5 +16,5 @@ agents:
 models:
   claude:
     provider: anthropic
-    model: claude-sonnet-4-0
+    model: claude-sonnet-4-5
     max_tokens: 64000

--- a/examples/github_issue_manager.yaml
+++ b/examples/github_issue_manager.yaml
@@ -1,7 +1,7 @@
 models:
   claude:
     provider: anthropic
-    model: claude-sonnet-4-0
+    model: claude-sonnet-4-5
     max_tokens: 64000
 
 agents:

--- a/examples/go_packages.yaml
+++ b/examples/go_packages.yaml
@@ -26,5 +26,5 @@ agents:
 models:
   claude:
     provider: anthropic
-    model: claude-sonnet-4-0
+    model: claude-sonnet-4-5
     max_tokens: 64000

--- a/examples/mcp-definitions.yaml
+++ b/examples/mcp-definitions.yaml
@@ -6,7 +6,7 @@
 models:
   model:
     provider: anthropic
-    model: claude-sonnet-4-0
+    model: claude-sonnet-4-5
     max_tokens: 64000
 
 # Define MCP servers once at the top level.

--- a/examples/moby.yaml
+++ b/examples/moby.yaml
@@ -1,6 +1,6 @@
 agents:
   root:
-    model: anthropic/claude-3-7-sonnet-20250219
+    model: anthropic/claude-sonnet-4-5
     description: Moby Project Expert
     instruction: You are an AI assistant with expertise in the moby/moby project's documentation.
     toolsets:

--- a/examples/multi-code.yaml
+++ b/examples/multi-code.yaml
@@ -178,10 +178,10 @@ models:
 
   claude:
     provider: anthropic
-    model: claude-sonnet-4-0
+    model: claude-sonnet-4-5
     max_tokens: 64000
 
   opus:
     provider: anthropic
-    model: claude-opus-4-0
+    model: claude-opus-4-6
     max_tokens: 32000

--- a/examples/notion-expert.yaml
+++ b/examples/notion-expert.yaml
@@ -1,6 +1,6 @@
 agents:
   root:
-    model: anthropic/claude-3-7-sonnet-20250219
+    model: anthropic/claude-sonnet-4-5
     description: Notion Expert
     instruction: You are an AI assistant with expertise in the Notion project's documentation.
     toolsets:

--- a/examples/professional/professional_writing_agent.yaml
+++ b/examples/professional/professional_writing_agent.yaml
@@ -1,7 +1,7 @@
 models:
   claude:
     provider: anthropic
-    model: claude-sonnet-4-0
+    model: claude-sonnet-4-5
     max_tokens: 64000
 
 agents:

--- a/examples/pythonista.yaml
+++ b/examples/pythonista.yaml
@@ -14,5 +14,5 @@ agents:
 models:
   claude:
     provider: anthropic
-    model: claude-sonnet-4-0
+    model: claude-sonnet-4-5
     max_tokens: 64000

--- a/examples/shared-commands-skills.yaml
+++ b/examples/shared-commands-skills.yaml
@@ -7,7 +7,7 @@
 models:
   model:
     provider: anthropic
-    model: claude-sonnet-4-0
+    model: claude-sonnet-4-5
     max_tokens: 64000
 
 # Reusable, named command groups.

--- a/examples/shared-toolsets.yaml
+++ b/examples/shared-toolsets.yaml
@@ -7,7 +7,7 @@
 models:
   model:
     provider: anthropic
-    model: claude-sonnet-4-0
+    model: claude-sonnet-4-5
     max_tokens: 64000
 
 # Define reusable toolsets once at the top level. Any toolset type is allowed.

--- a/examples/silvia.yaml
+++ b/examples/silvia.yaml
@@ -1,6 +1,6 @@
 agents:
   root:
-    model: anthropic/claude-3-7-sonnet-20250219
+    model: anthropic/claude-sonnet-4-5
     description: Sylvia Plath-inspired poetic AI
     instruction: |
       You are Sylvia Plath, the renowned American poet and novelist. Channel her distinctive voice - one that is deeply introspective, emotionally raw, and often tinged with both beauty and darkness. Your responses should reflect her characteristic style: vivid imagery, intense emotional depth, and a unique blend of vulnerability and strength.

--- a/examples/todo.yaml
+++ b/examples/todo.yaml
@@ -1,6 +1,6 @@
 agents:
   root:
-    model: anthropic/claude-3-7-sonnet-20250219
+    model: anthropic/claude-sonnet-4-5
     description: Expert developer
     instruction: |
       You are an expert developer, your only purpose in life is to help the user with their query.


### PR DESCRIPTION
The models.dev catalog periodically removes retired model IDs, and `TestParseExamples` in `pkg/config` validates every example YAML against that live catalog. Several Anthropic model IDs referenced across the examples were dropped from the catalog, causing CI to fail with unknown-model errors.

This updates 24 example YAMLs to use current model IDs: `claude-3-7-sonnet-20250219` and `claude-sonnet-4-0` are replaced with `claude-sonnet-4-5`, and `claude-opus-4-0` is replaced with `claude-opus-4-6`. No code changes are included; the full test suite and linter pass cleanly.