### PR TITLE
fix: backfill SafetyPolicy on session resume with --yolo

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -827,7 +827,10 @@ func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadRes
 		sess, err = sessStore.GetSession(ctx, resolvedID)
 		switch {
 		case err == nil:
-			sess.ToolsApproved = req.ToolsApproved
+			// Via the option, not a raw field write: WithToolsApproved
+			// backfills SafetyPolicy=unsafe so safer_shell honours --yolo
+			// on resumed sessions too.
+			session.WithToolsApproved(req.ToolsApproved)(sess)
 			sess.HideToolResults = req.HideToolResults
 
 			// Apply any stored model overrides from the session

--- a/cmd/root/run_session_test.go
+++ b/cmd/root/run_session_test.go
@@ -51,6 +51,43 @@ func TestCreateLocalRuntimeAndSession_ExplicitExistingIDResumes(t *testing.T) {
 	assert.Equal(t, "existing", sess.ID)
 }
 
+// Resuming with --yolo a session created without it backfills
+// SafetyPolicy=unsafe (issue #3479), so safer_shell stays silent like on
+// fresh --yolo sessions.
+func TestCreateLocalRuntimeAndSession_ResumeWithYoloBackfillsSafetyPolicy(t *testing.T) {
+	t.Parallel()
+
+	store := session.NewInMemorySessionStore()
+	require.NoError(t, store.AddSession(t.Context(), session.New(session.WithID("existing"))))
+
+	f := &runExecFlags{}
+	req := runtime.CreateSessionRequest{AgentName: "root", ResumeSessionID: "existing", ToolsApproved: true}
+
+	_, sess, err := f.createLocalRuntimeAndSession(t.Context(), newSessionTestLoadResult(), req, store)
+	require.NoError(t, err)
+	assert.True(t, sess.ToolsApproved)
+	assert.Equal(t, session.SafetyPolicyUnsafe, sess.SafetyPolicy)
+}
+
+// An explicit stored SafetyPolicy survives a --yolo resume: the backfill
+// only applies when the policy is empty.
+func TestCreateLocalRuntimeAndSession_ResumeKeepsExplicitSafetyPolicy(t *testing.T) {
+	t.Parallel()
+
+	store := session.NewInMemorySessionStore()
+	require.NoError(t, store.AddSession(t.Context(), session.New(
+		session.WithID("existing"),
+		session.WithSafetyPolicy(session.SafetyPolicySafer),
+	)))
+
+	f := &runExecFlags{}
+	req := runtime.CreateSessionRequest{AgentName: "root", ResumeSessionID: "existing", ToolsApproved: true}
+
+	_, sess, err := f.createLocalRuntimeAndSession(t.Context(), newSessionTestLoadResult(), req, store)
+	require.NoError(t, err)
+	assert.Equal(t, session.SafetyPolicySafer, sess.SafetyPolicy)
+}
+
 // A relative ref (e.g. -1) is resume-only: it must resolve against existing
 // sessions and never creates one.
 func TestCreateLocalRuntimeAndSession_RelativeRefDoesNotCreate(t *testing.T) {


### PR DESCRIPTION
## Summary
- The resume path assigned `sess.ToolsApproved` directly, skipping the `WithToolsApproved` backfill — `safer_shell` treated `--yolo` resumes of non-yolo sessions as `strict` and prompted despite the flag.
- Apply the option instead of the raw field write; tests cover the backfill and that an explicit stored policy survives a `--yolo` resume.

Fixes #3479.