### PR TITLE
fix(session): accept legacy agentName JSON key when unmarshaling Message

### DIFF
--- a/docs/features/evaluation/index.md
+++ b/docs/features/evaluation/index.md
@@ -69,7 +69,6 @@ Each eval file is a JSON session that captures a complete conversation. The key 
   "messages": [
     {
       "message": {
-        "agentFilename": "./agent.yaml",
         "message": {
           "role": "user",
           "content": "How many files in the local folder?"
@@ -78,7 +77,7 @@ Each eval file is a JSON session that captures a complete conversation. The key 
     },
     {
       "message": {
-        "agentName": "root",
+        "agent_name": "root",
         "message": {
           "role": "assistant",
           "tool_calls": [
@@ -96,7 +95,7 @@ Each eval file is a JSON session that captures a complete conversation. The key 
     },
     {
       "message": {
-        "agentName": "root",
+        "agent_name": "root",
         "message": {
           "role": "assistant",
           "content": "There are 2 files in the local folder..."

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -282,6 +282,25 @@ type Message struct {
 	Implicit bool `json:"implicit,omitempty"`
 }
 
+// UnmarshalJSON accepts both the current "agent_name" key and the legacy
+// "agentName" key emitted by exports prior to the rename.
+func (m *Message) UnmarshalJSON(data []byte) error {
+	type message Message // alias to avoid infinite recursion
+	var v struct {
+		message
+
+		LegacyAgentName string `json:"agentName"`
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	if v.AgentName == "" {
+		v.AgentName = v.LegacyAgentName
+	}
+	*m = Message(v.message)
+	return nil
+}
+
 func ImplicitUserMessage(content string) *Message {
 	return ImplicitUserMessageAt(time.Now(), content)
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -283,21 +283,22 @@ type Message struct {
 }
 
 // UnmarshalJSON accepts both the current "agent_name" key and the legacy
-// "agentName" key emitted by exports prior to the rename.
+// "agentName" key emitted by exports prior to the rename. When "agent_name"
+// is absent or empty, a non-empty legacy value wins; absent and empty are
+// deliberately not distinguished since no producer emits both keys.
 func (m *Message) UnmarshalJSON(data []byte) error {
 	type message Message // alias to avoid infinite recursion
-	var v struct {
-		message
+	aux := struct {
+		*message
 
 		LegacyAgentName string `json:"agentName"`
-	}
-	if err := json.Unmarshal(data, &v); err != nil {
+	}{message: (*message)(m)}
+	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
-	if v.AgentName == "" {
-		v.AgentName = v.LegacyAgentName
+	if m.AgentName == "" {
+		m.AgentName = aux.LegacyAgentName
 	}
-	*m = Message(v.message)
 	return nil
 }
 

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -362,6 +362,57 @@ func TestGetLastUserMessages(t *testing.T) {
 	})
 }
 
+func TestMessageUnmarshalJSONAgentNameCompat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "current key",
+			input: `{"agent_name":"root","message":{"role":"user","content":"hi"}}`,
+			want:  "root",
+		},
+		{
+			name:  "legacy key",
+			input: `{"agentName":"root","message":{"role":"user","content":"hi"}}`,
+			want:  "root",
+		},
+		{
+			name:  "current key wins over legacy",
+			input: `{"agent_name":"new","agentName":"old","message":{"role":"user","content":"hi"}}`,
+			want:  "new",
+		},
+		{
+			name:  "no agent name",
+			input: `{"message":{"role":"user","content":"hi"}}`,
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var msg Message
+			require.NoError(t, json.Unmarshal([]byte(tt.input), &msg))
+			assert.Equal(t, tt.want, msg.AgentName)
+			assert.Equal(t, "hi", msg.Message.Content)
+		})
+	}
+
+	t.Run("marshal emits agent_name", func(t *testing.T) {
+		t.Parallel()
+
+		out, err := json.Marshal(Message{AgentName: "root"})
+		require.NoError(t, err)
+		assert.Contains(t, string(out), `"agent_name":"root"`)
+		assert.NotContains(t, string(out), "agentName")
+	})
+}
+
 func TestEvalCriteriaUnmarshalJSON(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -386,6 +386,11 @@ func TestMessageUnmarshalJSONAgentNameCompat(t *testing.T) {
 			want:  "new",
 		},
 		{
+			name:  "legacy wins over empty current key",
+			input: `{"agent_name":"","agentName":"old","message":{"role":"user","content":"hi"}}`,
+			want:  "old",
+		},
+		{
 			name:  "no agent name",
 			input: `{"message":{"role":"user","content":"hi"}}`,
 			want:  "",
@@ -402,6 +407,35 @@ func TestMessageUnmarshalJSONAgentNameCompat(t *testing.T) {
 			assert.Equal(t, "hi", msg.Message.Content)
 		})
 	}
+
+	t.Run("null leaves receiver untouched", func(t *testing.T) {
+		t.Parallel()
+
+		msg := Message{AgentName: "root", Message: chat.Message{Content: "hi"}}
+		require.NoError(t, json.Unmarshal([]byte(`null`), &msg))
+		assert.Equal(t, "root", msg.AgentName)
+		assert.Equal(t, "hi", msg.Message.Content)
+	})
+
+	t.Run("legacy session document", func(t *testing.T) {
+		t.Parallel()
+
+		// Mirrors a pre-rename session export as loaded by the evaluation package.
+		legacy := `{
+			"id": "41b179a2-ed19-4ae2-a45d-95775aaa90f7",
+			"messages": [
+				{"message": {"agentName": "", "message": {"role": "user", "content": "How many files?"}}},
+				{"message": {"agentName": "root", "message": {"role": "assistant", "content": "Two."}}}
+			]
+		}`
+
+		var sess Session
+		require.NoError(t, json.Unmarshal([]byte(legacy), &sess))
+		require.Len(t, sess.Messages, 2)
+		assert.Empty(t, sess.Messages[0].Message.AgentName)
+		assert.Equal(t, "root", sess.Messages[1].Message.AgentName)
+		assert.Equal(t, "Two.", sess.Messages[1].Message.Message.Content)
+	})
 
 	t.Run("marshal emits agent_name", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
PR #3471 renamed the JSON tag on `session.Message.AgentName` from `agentName` to `agent_name`. However, contrary to that PR's description, Go's `encoding/json` does *not* perform case-insensitive matching between `agentName` and a field tagged `agent_name` — the two differ by more than case. As a result, any previously exported session files or evaluation JSON documents that used the old key silently dropped the agent name on load.

This PR adds a compatibility `UnmarshalJSON` on `session.Message` that accepts both `agentName` and `agent_name`. The new canonical `agent_name` key wins when both are present; decoding is done through a pointer-aliased struct to preserve the stock null-handling and field-merging semantics without recursion. Marshaling is unchanged and still emits only `agent_name`. Unit tests cover the legacy key, the new key, both keys present at once, and a realistic end-to-end legacy session document. The evaluation docs example is updated to the canonical key.

No breaking changes. Existing sessions written with `agent_name` are unaffected; sessions written with the old `agentName` key now round-trip correctly.