### PR TITLE
fix(gemini): stringify non-string enum values in tool schemas

### DIFF
--- a/pkg/model/provider/gemini/client.go
+++ b/pkg/model/provider/gemini/client.go
@@ -564,6 +564,7 @@ func ConvertParametersToSchema(params any) (*genai.Schema, error) {
 	}
 
 	normalizeTypeFields(m)
+	normalizeEnumValues(m)
 
 	var schema *genai.Schema
 	if err := tools.ConvertSchema(m, &schema); err != nil {
@@ -608,6 +609,52 @@ func pickNonNullType(typeArr []any) string {
 		}
 	}
 	return "string"
+}
+
+// normalizeEnumValues recursively converts non-string enum values to strings.
+// The Gemini API only accepts string enum values, so schemas like
+// {"enum": [true]} (e.g. GitHub MCP issue_write) would fail to convert.
+func normalizeEnumValues(m map[string]any) {
+	if enumArr, ok := m["enum"].([]any); ok {
+		m["enum"] = stringifyEnumValues(enumArr)
+	}
+
+	if props, ok := m["properties"].(map[string]any); ok {
+		for _, prop := range props {
+			if propMap, ok := prop.(map[string]any); ok {
+				normalizeEnumValues(propMap)
+			}
+		}
+	}
+
+	if items, ok := m["items"].(map[string]any); ok {
+		normalizeEnumValues(items)
+	}
+
+	if anyOf, ok := m["anyOf"].([]any); ok {
+		for _, sub := range anyOf {
+			if subMap, ok := sub.(map[string]any); ok {
+				normalizeEnumValues(subMap)
+			}
+		}
+	}
+}
+
+func stringifyEnumValues(values []any) []string {
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		switch t := v.(type) {
+		case string:
+			out = append(out, t)
+		case nil:
+			// Nullability is expressed via the type, not an enum value.
+		default:
+			if b, err := json.Marshal(t); err == nil {
+				out = append(out, string(b))
+			}
+		}
+	}
+	return out
 }
 
 // CreateChatCompletionStream creates a streaming chat completion request

--- a/pkg/model/provider/schema_test.go
+++ b/pkg/model/provider/schema_test.go
@@ -132,6 +132,80 @@ func TestSchemaForGemini(t *testing.T) {
 }`, string(schemaJSON))
 }
 
+// TestNonStringEnumSchemaForGemini makes sure non-string enum values are
+// converted to strings. genai.Schema declares enum as []string and the Gemini
+// API rejects non-string enum values, so schemas like the GitHub MCP
+// issue_write tool ("enum": [true]) would otherwise fail.
+// See https://github.com/docker/docker-agent/issues/3477
+func TestNonStringEnumSchemaForGemini(t *testing.T) {
+	t.Parallel()
+	parameters := parseFunctionParameters(t, `
+{
+    "type": "object",
+    "properties": {
+      "issue_fields": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "delete": {
+              "type": "boolean",
+              "enum": [true],
+              "description": "Unset the field"
+            },
+            "priority": {
+              "type": "number",
+              "enum": [1, 2.5]
+            },
+            "state": {
+              "anyOf": [
+                {"type": "string", "enum": ["open", null]},
+                {"type": "number", "enum": [0]}
+              ]
+            }
+          }
+        }
+      }
+    }
+}`)
+
+	schema, err := gemini.ConvertParametersToSchema(parameters)
+	require.NoError(t, err)
+
+	schemaJSON, err := json.Marshal(schema)
+	require.NoError(t, err)
+	assert.JSONEq(t, `
+{
+    "type": "object",
+    "properties": {
+      "issue_fields": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "delete": {
+              "type": "boolean",
+              "enum": ["true"],
+              "description": "Unset the field"
+            },
+            "priority": {
+              "type": "number",
+              "enum": ["1", "2.5"]
+            },
+            "state": {
+              "type": "object",
+              "anyOf": [
+                {"type": "string", "enum": ["open"]},
+                {"type": "number", "enum": ["0"]}
+              ]
+            }
+          }
+        }
+      }
+    }
+}`, string(schemaJSON))
+}
+
 func TestEmptyMapSchemaForAnthropic(t *testing.T) {
 	t.Parallel()
 	shema, err := anthropic.ConvertParametersToSchema(map[string]any{})


### PR DESCRIPTION
Fixes #3477

## Summary

Gemini models failed with any MCP tool whose JSON Schema declares non-string enum values. The GitHub MCP `issue_write` tool declares `issue_fields[].delete` as `{"type": "boolean", "enum": [true]}`, which made every run fail with:

```
model failed: json: cannot unmarshal bool into Go struct field Schema.properties.items.properties.enum of type string
```

## Cause

| Item | Detail |
| --- | --- |
| Location | `pkg/model/provider/gemini/client.go`, `ConvertParametersToSchema` |
| Mechanism | Tool schemas are unmarshaled into `genai.Schema`, whose `Enum` field is `[]string` |
| Trigger | Any non-string enum value, e.g. `"enum": [true]` in GitHub MCP `issue_write` |
| API contract | The Gemini API itself only accepts string enum values (a request with `"enum": [true]` is rejected with `Invalid value at '...enum[0]' (TYPE_STRING)`), so stringifying matches the wire format the API expects |

```
MCP tool schema ("enum": [true])
        |
        v
ConvertParametersToSchema
        |-- normalizeTypeFields   (existing)
        |-- normalizeEnumValues   (new: [true] -> ["true"])
        v
genai.Schema (Enum []string)  -->  Gemini API  -->  tool call {"delete": true}
```

## Fix

`normalizeEnumValues` runs next to the existing `normalizeTypeFields` during schema conversion:

- string values: unchanged
- bool and number values: stringified via `json.Marshal` (`true` becomes `"true"`, `1` becomes `"1"`, `2.5` becomes `"2.5"`)
- `null` values: dropped (nullability is expressed via the type, not an enum value)
- recurses into `properties`, `items`, and `anyOf` (the only sub-schema fields declared by `genai.Schema`)

The property type is preserved (`boolean` stays `boolean`), so Gemini still emits natively typed arguments (`"delete": true`) and MCP servers receive the expected types.

## Validation

| Check | Result |
| --- | --- |
| Unit test with bool, number, anyOf and null enum values | pass |
| Real `issue_write` schema from `github/github-mcp-server` with `gemini-3.5-flash` (model from the report), live API | pass, tool call `{"delete": true, "field_name": "Priority", ...}` |
| All 114 real GitHub MCP tool schema snapshots converted | pass |
| All 114 tools sent in a single live request | accepted, coherent tool call |
| Same 114 schemas on `main` | only `issue_write.snap` fails, confirming the fix covers the whole breakage |
| End-to-end `docker-agent run` with a stdio MCP server exposing the schema | tool round-trip succeeds |
| Build, `golangci-lint`, custom lint | clean |
