### PR TITLE
feat(tui): per-sub-agent context accounting in the TUI

### DIFF
--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -100,7 +100,7 @@ Slash commands (both built-in and named) execute immediately when entered. Regul
 
 ### Agents Panel
 
-The sidebar's **Agents** section lists every agent in the team. The current agent is shown as a focus **card** (rendered in place at its position in the list) with its name, a wrapped description, its full `provider/model`, and a thinking line. Every other agent is shown as a compact **two-line row** — line 1 is the shortcut/spinner, the agent name (in its accent color), and a right-aligned thinking **gauge**; line 2 is the indented full `provider/model` — so a large team stays scannable while still showing each model. Agents are separated by a blank line so the two-line rows stay visually distinct. The effort **gauge** is the only visual language for thinking; the focus card and the Agent Inspector spell out the exact level alongside it. Left-click any agent to switch to it.
+The sidebar's **Agents** section lists every agent in the team. The current agent is shown as a focus **card** (rendered in place at its position in the list) with its name, a wrapped description, its full `provider/model`, and a thinking line. Every other agent is shown as a compact **two-line row** — line 1 is the shortcut/spinner, the agent name (in its accent color), and a right-aligned thinking **gauge**; line 2 is the indented full `provider/model` — so a large team stays scannable while still showing each model. Once an agent has run (in the main session, as a delegated sub-agent, or as a background agent task), line 2 also carries its latest **context usage** as a right-aligned percentage of its context window, so per-agent context accounting is visible at a glance across the whole team. Agents are separated by a blank line so the two-line rows stay visually distinct. The effort **gauge** is the only visual language for thinking; the focus card and the Agent Inspector spell out the exact level alongside it. Left-click any agent to switch to it.
 
 #### Agent inspector
 
@@ -115,6 +115,7 @@ The title is rendered in the agent's accent color. Sections appear in this order
 - **Description** — the agent's wrapped description.
 - **Live state** — a `● current agent` line when the inspected agent is the one currently running.
 - **Model / Fallback / Thinking** — the `provider/model`, any fallback models, and the gauge + value thinking line (omitted for models with no selectable thinking, e.g. harness-backed agents).
+- **Context** — the agent's latest known context usage, e.g. `Context: 12.8K of 128.0K tokens (10%)` (a bare token count when the context limit is unknown; omitted until the agent has run). Sub-agent and background-agent runs are accounted for.
 - **Sub-agents (N) / Handoffs (N) / Skills (N)** — compact, inline, comma-separated lists wrapped to the dialog width.
 - **Limits** — the configured per-agent limits that are set, e.g. `Limits: max-iter 50 · history 40 · max-tool-calls 5`.
 - **Options** — the enabled option flags, e.g. `Options: add-date · add-environment-info · redact-secrets`.

--- a/docs/tools/background-agents/index.md
+++ b/docs/tools/background-agents/index.md
@@ -76,6 +76,8 @@ agents:
 >
 > Use `background_agents` when your orchestrator needs to fan out work to multiple specialists in parallel — for example, researching several topics simultaneously or running independent code analyses side by side.
 
+In the TUI, each background task's token usage is accounted for live: the sidebar's Agents panel shows the sub-agent's context usage percentage on its roster row, the Agent Inspector shows its exact token counts, and the task's cost joins the session total.
+
 ## Using Harness Sub-Agents
 
 Background agents work equally well with [harness-backed sub-agents](../../features/harnesses/index.md) — sub-agents driven by external coding CLIs such as Claude Code or Codex. This lets you dispatch multiple independent coding tasks in parallel:

--- a/e2e/tui/background_agent_test.go
+++ b/e2e/tui/background_agent_test.go
@@ -1,0 +1,214 @@
+package tui_test
+
+import (
+	"context"
+	"io"
+	"os"
+	"sync"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/app"
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/model/provider/base"
+	"github.com/docker/docker-agent/pkg/modelsdev"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/team"
+	"github.com/docker/docker-agent/pkg/tools"
+	agenttool "github.com/docker/docker-agent/pkg/tools/builtin/agent"
+	"github.com/docker/docker-agent/pkg/tui"
+	"github.com/docker/docker-agent/pkg/tui/tuitest"
+)
+
+// This file covers the background-agent journey end to end through the real
+// TUI: a root agent dispatches a run_background_agent task, the worker's
+// sub-session runs on a detached goroutine (its events are dropped from the
+// live stream), and only the runtime's out-of-band forwarding can bring its
+// token usage back to the sidebar. Unlike the VCR-based scenarios in this
+// package, the model responses are scripted in-process: driving a
+// deterministic multi-agent tool-call flow through cassettes would couple the
+// test to HTTP wire details it does not care about.
+
+// scriptedStream replays a fixed sequence of streaming chunks.
+type scriptedStream struct {
+	responses []chat.MessageStreamResponse
+	idx       int
+}
+
+func (s *scriptedStream) Recv() (chat.MessageStreamResponse, error) {
+	if s.idx >= len(s.responses) {
+		return chat.MessageStreamResponse{}, io.EOF
+	}
+	resp := s.responses[s.idx]
+	s.idx++
+	return resp, nil
+}
+
+func (s *scriptedStream) Close() {}
+
+// scriptedProvider returns one scripted stream per model call, repeating the
+// last script if called more often. contextSize is exposed through
+// provider_opts so the runtime resolves a context limit without the
+// models.dev catalogue, which is what makes percentages computable.
+type scriptedProvider struct {
+	id          string
+	contextSize int64
+	scripts     [][]chat.MessageStreamResponse
+
+	mu   sync.Mutex
+	call int
+}
+
+func (p *scriptedProvider) ID() modelsdev.ID { return modelsdev.ParseIDOrZero(p.id) }
+
+func (p *scriptedProvider) CreateChatCompletionStream(context.Context, []chat.Message, []tools.Tool) (chat.MessageStream, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	i := min(p.call, len(p.scripts)-1)
+	p.call++
+	return &scriptedStream{responses: p.scripts[i]}, nil
+}
+
+func (p *scriptedProvider) BaseConfig() base.Config {
+	return base.Config{ModelConfig: latest.ModelConfig{
+		ProviderOpts: map[string]any{"context_size": p.contextSize},
+	}}
+}
+
+// toolCallScript scripts one turn that calls a single tool and stops with the
+// given usage.
+func toolCallScript(callID, toolName, args string, in, out int64) []chat.MessageStreamResponse {
+	return []chat.MessageStreamResponse{
+		{Choices: []chat.MessageStreamChoice{{Delta: chat.MessageDelta{ToolCalls: []tools.ToolCall{{
+			ID: callID, Type: "function", Function: tools.FunctionCall{Name: toolName},
+		}}}}}},
+		{Choices: []chat.MessageStreamChoice{{Delta: chat.MessageDelta{ToolCalls: []tools.ToolCall{{
+			ID: callID, Type: "function", Function: tools.FunctionCall{Arguments: args},
+		}}}}}},
+		{
+			Choices: []chat.MessageStreamChoice{{FinishReason: chat.FinishReasonToolCalls}},
+			Usage:   &chat.Usage{InputTokens: in, OutputTokens: out},
+		},
+	}
+}
+
+// contentScript scripts one plain-content turn that stops with the given usage.
+func contentScript(content string, in, out int64) []chat.MessageStreamResponse {
+	return []chat.MessageStreamResponse{
+		{Choices: []chat.MessageStreamChoice{{Delta: chat.MessageDelta{Content: content}}}},
+		{
+			Choices: []chat.MessageStreamChoice{{FinishReason: chat.FinishReasonStop}},
+			Usage:   &chat.Usage{InputTokens: in, OutputTokens: out},
+		},
+	}
+}
+
+// stubModelStore keeps the runtime off the network: no models.dev lookups, no
+// pricing. Context limits come from provider_opts instead.
+type stubModelStore struct{}
+
+func (stubModelStore) GetModel(context.Context, modelsdev.ID) (*modelsdev.Model, error) {
+	return nil, nil
+}
+func (stubModelStore) GetDatabase(context.Context) (*modelsdev.Database, error) { return nil, nil }
+
+// newBackgroundAgentTUI builds the real TUI over a real LocalRuntime whose
+// team is assembled programmatically: a root orchestrator with the
+// background_agents toolset and a worker sub-agent, both backed by scripted
+// providers. Tools are pre-approved so the dispatch needs no confirmation
+// dialog.
+func newBackgroundAgentTUI(t *testing.T, width, height int) *tuitest.Driver {
+	t.Helper()
+
+	isolateState(t)
+
+	rootProv := &scriptedProvider{
+		id:          "test/fake-root",
+		contextSize: 1000,
+		scripts: [][]chat.MessageStreamResponse{
+			toolCallScript("call-1", agenttool.ToolNameRunBackgroundAgent,
+				`{"agent":"worker","task":"count the files"}`, 40, 10),
+			// Session context tracks the LAST call's usage (its input already
+			// spans the whole prompt), so the root settles at 100/1000 = 10%.
+			contentScript("Dispatched the worker.", 80, 20),
+		},
+	}
+	workerProv := &scriptedProvider{
+		id:          "test/fake-worker",
+		contextSize: 1000,
+		scripts: [][]chat.MessageStreamResponse{
+			contentScript("worker finished the count", 300, 150),
+		},
+	}
+
+	worker := agent.New("worker", "Count things when asked.",
+		agent.WithModel(workerProv),
+		agent.WithDescription("Background worker"),
+	)
+	root := agent.New("root", "Dispatch work to the worker in the background.",
+		agent.WithModel(rootProv),
+		agent.WithDescription("Orchestrator"),
+		agent.WithSubAgents(worker),
+		agent.WithToolSets(agenttool.New()),
+	)
+
+	rt, err := runtime.New(t.Context(), team.New(team.WithAgents(root, worker)),
+		runtime.WithCurrentAgent("root"),
+		runtime.WithSessionCompaction(false),
+		runtime.WithModelStore(stubModelStore{}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rt.Close() })
+
+	application := app.New(t.Context(), rt, session.New(session.WithToolsApproved(true)))
+
+	wd, _ := os.Getwd()
+	model := tui.New(t.Context(), nil /* no spawner: single tab */, application, wd, func() {})
+	return tuitest.New(t, model, width, height)
+}
+
+// TestBackgroundAgent_PerAgentContextInSidebar drives the full journey: the
+// worker's usage (450 of 1000 tokens) can only reach the TUI through the
+// runtime's out-of-band background-event forwarding, so the 45% appearing on
+// the worker's roster line proves the whole chain — tool call, detached
+// sub-session, OnBackgroundEvent, app event stream, sidebar accounting.
+// The root's own line independently settles at 10% (its final turn consumed
+// 100 of 1000 tokens).
+func TestBackgroundAgent_PerAgentContextInSidebar(t *testing.T) {
+	d := newBackgroundAgentTUI(t, 120, 40)
+
+	// Both agents are listed before anything runs, with no context percent.
+	d.WaitFor(tuitest.ContainsAll("root", "worker")).
+		Assert(tuitest.Absent("%"))
+
+	d.Type("Please dispatch the worker.").
+		Enter().
+		WaitFor(tuitest.Contains("Dispatched the worker.")).
+		WaitFor(tuitest.Contains("45%")).
+		WaitFor(tuitest.Contains("10%"))
+}
+
+// TestBackgroundAgent_InspectorShowsWorkerContext opens the worker's Agent
+// Inspector (right-click on its roster line) after the background task
+// completed and checks the exact per-agent context line.
+func TestBackgroundAgent_InspectorShowsWorkerContext(t *testing.T) {
+	d := newBackgroundAgentTUI(t, 120, 40)
+
+	d.Type("Please dispatch the worker.").
+		Enter().
+		WaitFor(tuitest.Contains("Dispatched the worker.")).
+		WaitFor(tuitest.Contains("45%"))
+
+	// "45%" renders only on the worker's roster line, so its coordinates are
+	// a reliable right-click target for that agent (either of the entry's two
+	// lines opens the inspector).
+	x, y := d.MustFindText("45%")
+	d.Send(tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseRight}).
+		Send(tea.MouseReleaseMsg{X: x, Y: y, Button: tea.MouseRight}).
+		WaitFor(tuitest.Contains("Context: 450 of 1.0K tokens (45%)"))
+}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -168,6 +168,16 @@ func (a *App) Start(ctx context.Context) {
 			case <-ctx.Done():
 			}
 		})
+
+		// Forward events surfaced from detached background work (token usage
+		// from background agent tasks) so the sidebar and agent inspector can
+		// account for background agents' context usage.
+		a.runtime.OnBackgroundEvent(func(event runtime.Event) {
+			select {
+			case a.events <- event:
+			case <-ctx.Done():
+			}
+		})
 	})
 }
 

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -105,6 +105,7 @@ func (m *mockRuntime) SetAgentThinkingLevel(context.Context, string, effort.Leve
 func (m *mockRuntime) AvailableModels(context.Context) []runtime.ModelChoice { return nil }
 func (m *mockRuntime) SupportsModelSwitching() bool                          { return false }
 func (m *mockRuntime) OnToolsChanged(func(runtime.Event))                    {}
+func (m *mockRuntime) OnBackgroundEvent(func(runtime.Event))                 {}
 
 // Verify mockRuntime implements runtime.Runtime
 var _ runtime.Runtime = (*mockRuntime)(nil)
@@ -170,6 +171,49 @@ func TestApp_Retry_SuppressesReEmittedUserMessage(t *testing.T) {
 	// (steered) user message is kept.
 	assert.Equal(t, []string{"steered"}, userMessages,
 		"only the post-StreamStarted user message should be forwarded")
+}
+
+// backgroundEventMockRuntime captures the handler App.Start registers via
+// OnBackgroundEvent so tests can emit background events through it.
+type backgroundEventMockRuntime struct {
+	mockRuntime
+
+	handler func(runtime.Event)
+}
+
+func (m *backgroundEventMockRuntime) OnBackgroundEvent(handler func(runtime.Event)) {
+	m.handler = handler
+}
+
+// TestApp_Start_ForwardsBackgroundEvents verifies Start wires the runtime's
+// out-of-band background-event hook into the app's event stream, so token
+// usage from background agent tasks reaches the TUI subscribers.
+func TestApp_Start_ForwardsBackgroundEvents(t *testing.T) {
+	t.Parallel()
+
+	rt := &backgroundEventMockRuntime{}
+	events := make(chan tea.Msg, 16)
+	app := &App{
+		runtime: rt,
+		session: session.New(),
+		events:  events,
+	}
+
+	app.Start(t.Context())
+	require.NotNil(t, rt.handler, "Start must register the background-event handler")
+
+	usage := runtime.NewTokenUsageEvent("bg-session", "worker", &runtime.Usage{
+		ContextLength: 150,
+		ContextLimit:  1000,
+	})
+	rt.handler(usage)
+
+	select {
+	case msg := <-events:
+		assert.Equal(t, usage, msg, "the background event must reach the app's event stream unchanged")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the forwarded background event")
+	}
 }
 
 // stubSnapshotController is a tiny SnapshotController used by the app

--- a/pkg/cli/runner_test.go
+++ b/pkg/cli/runner_test.go
@@ -107,6 +107,7 @@ func (m *mockRuntime) SetAgentThinkingLevel(context.Context, string, effort.Leve
 func (m *mockRuntime) AvailableModels(context.Context) []runtime.ModelChoice                 { return nil }
 func (m *mockRuntime) SupportsModelSwitching() bool                                          { return false }
 func (m *mockRuntime) OnToolsChanged(func(runtime.Event))                                    {}
+func (m *mockRuntime) OnBackgroundEvent(func(runtime.Event))                                 {}
 func (m *mockRuntime) RegenerateTitle(context.Context, *session.Session, chan runtime.Event) {}
 
 func (m *mockRuntime) Resume(_ context.Context, req runtime.ResumeRequest) {

--- a/pkg/leantui/update_test.go
+++ b/pkg/leantui/update_test.go
@@ -118,6 +118,7 @@ func (r *cycleThinkingRuntime) SetAgentThinkingLevel(_ context.Context, _ string
 func (r *cycleThinkingRuntime) AvailableModels(context.Context) []runtime.ModelChoice { return nil }
 func (r *cycleThinkingRuntime) SupportsModelSwitching() bool                          { return r.supports }
 func (r *cycleThinkingRuntime) OnToolsChanged(func(runtime.Event))                    {}
+func (r *cycleThinkingRuntime) OnBackgroundEvent(func(runtime.Event))                 {}
 
 var _ runtime.Runtime = (*cycleThinkingRuntime)(nil)
 

--- a/pkg/runtime/agent_delegation.go
+++ b/pkg/runtime/agent_delegation.go
@@ -367,6 +367,12 @@ func (r *LocalRuntime) runCollecting(ctx context.Context, parent *session.Sessio
 				onContent(choice.Content)
 			}
 		}
+		// Token usage is the one event a background sub-session surfaces
+		// out-of-band: it carries the sub-session id and agent name, so the
+		// UI can keep per-agent context accounting for background agents.
+		if usage, ok := event.(*TokenUsageEvent); ok {
+			r.emitBackgroundEvent(usage)
+		}
 		if errEvt, ok := event.(*ErrorEvent); ok {
 			errMsg = errEvt.Error
 			break

--- a/pkg/runtime/commands_test.go
+++ b/pkg/runtime/commands_test.go
@@ -92,6 +92,7 @@ func (m *mockRuntime) SetAgentThinkingLevel(context.Context, string, effort.Leve
 func (m *mockRuntime) AvailableModels(context.Context) []ModelChoice { return nil }
 func (m *mockRuntime) SupportsModelSwitching() bool                  { return false }
 func (m *mockRuntime) OnToolsChanged(func(Event))                    {}
+func (m *mockRuntime) OnBackgroundEvent(func(Event))                 {}
 
 func (m *mockRuntime) RegenerateTitle(context.Context, *session.Session, chan Event) {
 }

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -702,6 +702,10 @@ func (r *RemoteRuntime) TogglePause(ctx context.Context) (bool, error) {
 // than via an out-of-band callback.
 func (r *RemoteRuntime) OnToolsChanged(func(Event)) {}
 
+// OnBackgroundEvent is a no-op for remote runtimes; background agent tasks
+// run server-side and their events are not forwarded out-of-band.
+func (r *RemoteRuntime) OnBackgroundEvent(func(Event)) {}
+
 // Close is a no-op for remote runtimes.
 func (r *RemoteRuntime) Close() error {
 	return nil

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -169,6 +169,13 @@ type Runtime interface {
 	// can implement this as a no-op.
 	OnToolsChanged(handler func(Event))
 
+	// OnBackgroundEvent registers a handler invoked outside of any RunStream
+	// for events surfaced from detached background work (e.g. token usage
+	// from background agent tasks started via run_background_agent), which
+	// has no live event channel of its own. Runtimes that don't run local
+	// background work can implement this as a no-op.
+	OnBackgroundEvent(handler func(Event))
+
 	// QueueStatus returns the current depth and capacity of message queues
 	QueueStatus() QueueStatus
 
@@ -291,6 +298,13 @@ type LocalRuntime struct {
 
 	// onToolsChanged is called when an MCP toolset reports a tool list change.
 	onToolsChanged func(Event)
+
+	// onBackgroundEvent is called for events surfaced from detached
+	// background work (e.g. background agent tasks). Protected by
+	// backgroundEventMu because background tasks read it from their own
+	// goroutines.
+	backgroundEventMu sync.RWMutex
+	onBackgroundEvent func(Event)
 
 	bgAgents *agenttool.Handler
 
@@ -1435,6 +1449,28 @@ func (r *LocalRuntime) emitToolsChanged() {
 		return
 	}
 	r.onToolsChanged(ToolsetInfo(len(agentTools), false, r.currentAgentName()))
+}
+
+// OnBackgroundEvent registers a handler that receives events surfaced from
+// detached background work — today the TokenUsageEvents of background agent
+// tasks (run_background_agent), whose sub-sessions run on their own goroutine
+// with no live event channel. This lets the UI keep per-agent context
+// accounting for background agents.
+func (r *LocalRuntime) OnBackgroundEvent(handler func(Event)) {
+	r.backgroundEventMu.Lock()
+	defer r.backgroundEventMu.Unlock()
+	r.onBackgroundEvent = handler
+}
+
+// emitBackgroundEvent forwards an event from detached background work to the
+// registered handler, if any.
+func (r *LocalRuntime) emitBackgroundEvent(event Event) {
+	r.backgroundEventMu.RLock()
+	handler := r.onBackgroundEvent
+	r.backgroundEventMu.RUnlock()
+	if handler != nil {
+		handler(event)
+	}
 }
 
 // emitAgentAndTeamInfo sends the AgentInfo and TeamInfo events that drive the

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -4272,6 +4272,50 @@ func TestRunAgentPersistsSubSessionOnError(t *testing.T) {
 		"parent session must record the sub-session even when the background agent errored")
 }
 
+// TestRunAgentForwardsTokenUsageOutOfBand verifies runCollecting surfaces the
+// background sub-session's TokenUsageEvents through OnBackgroundEvent — the
+// out-of-band path that lets the TUI keep per-agent context accounting for
+// background agents — tagged with the sub-session id and the worker's name,
+// and forwards nothing else.
+func TestRunAgentForwardsTokenUsageOutOfBand(t *testing.T) {
+	t.Parallel()
+
+	workerStream := newStreamBuilder().AddContent("worker done").AddStopWithUsage(100, 50).Build()
+	parentProv := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	workerProv := &mockProvider{id: "test/mock-model", stream: workerStream}
+
+	worker := agent.New("worker", "Worker agent", agent.WithModel(workerProv))
+	root := agent.New("root", "Root agent", agent.WithModel(parentProv))
+	agent.WithSubAgents(worker)(root)
+
+	tm := team.New(team.WithAgents(root, worker))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	var forwarded []Event
+	rt.OnBackgroundEvent(func(event Event) { forwarded = append(forwarded, event) })
+
+	sess := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))
+	result := rt.RunAgent(t.Context(), agenttool.RunParams{
+		AgentName:     "worker",
+		Task:          "do something",
+		ParentSession: sess,
+	})
+	require.Empty(t, result.ErrMsg, "RunAgent should succeed")
+
+	require.NotEmpty(t, forwarded, "the background task's token usage must be forwarded out-of-band")
+	for _, event := range forwarded {
+		usage, ok := event.(*TokenUsageEvent)
+		require.Truef(t, ok, "only TokenUsageEvents may be forwarded, got %T", event)
+		assert.Equal(t, "worker", usage.AgentName, "usage is attributed to the background agent")
+		assert.NotEqual(t, sess.ID, usage.SessionID, "usage carries the sub-session id, not the parent's")
+		assert.NotEmpty(t, usage.SessionID)
+	}
+	last := forwarded[len(forwarded)-1].(*TokenUsageEvent)
+	require.NotNil(t, last.Usage)
+	assert.Equal(t, int64(150), last.Usage.ContextLength, "final snapshot carries the worker's cumulative usage")
+}
+
 // TestReasoningOnlyTurnEmitsWarning is a regression test for
 // https://github.com/docker/docker-agent/issues/3145. A thinking-mode model
 // (e.g. Qwen3 via an openai_chatcompletions provider) can stream only reasoning

--- a/pkg/tui/components/sidebar/agent_context_test.go
+++ b/pkg/tui/components/sidebar/agent_context_test.go
@@ -1,0 +1,134 @@
+package sidebar
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+)
+
+// recordAgentUsage feeds a TokenUsageEvent through the sidebar's normal entry
+// point, as the chat page does for live, sub-session, and background events.
+func recordAgentUsage(m *model, sessionID, agentName string, contextLen, contextLimit int64) {
+	m.SetTokenUsage(&runtime.TokenUsageEvent{
+		SessionID:    sessionID,
+		AgentContext: runtime.AgentContext{AgentName: agentName},
+		Usage: &runtime.Usage{
+			InputTokens:   contextLen / 2,
+			OutputTokens:  contextLen - contextLen/2,
+			ContextLength: contextLen,
+			ContextLimit:  contextLimit,
+		},
+	})
+}
+
+// TestAgentRosterShowsPerAgentContextPercent verifies line 2 of each roster
+// entry carries the agent's own context percentage, right-aligned, once that
+// agent has emitted usage — and stays bare for agents that have not run.
+func TestAgentRosterShowsPerAgentContextPercent(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus", Thinking: "high"},
+		runtime.AgentDetails{Name: "developer", Provider: "openai", Model: "gpt-5.4", Thinking: "off"},
+		runtime.AgentDetails{Name: "idle", Provider: "openai", Model: "gpt-4o", Thinking: "off"},
+	)
+
+	recordAgentUsage(m, "session-root", "root", 30_000, 100_000)
+	recordAgentUsage(m, "session-child", "developer", 42_000, 100_000)
+
+	_, rootLine2 := agentLines(m, "root")
+	assert.True(t, strings.HasSuffix(strings.TrimRight(rootLine2, " "), "30%"),
+		"root's line 2 ends with its context percent, got %q", rootLine2)
+	assert.Contains(t, rootLine2, "anthropic/opus", "model text stays on line 2")
+
+	_, devLine2 := agentLines(m, "developer")
+	assert.True(t, strings.HasSuffix(strings.TrimRight(devLine2, " "), "42%"),
+		"developer's line 2 ends with its context percent, got %q", devLine2)
+
+	_, idleLine2 := agentLines(m, "idle")
+	assert.NotContains(t, idleLine2, "%", "agents that never ran show no percent")
+}
+
+// TestAgentContextPercent_LatestSnapshotWins verifies a fresh delegation to the
+// same agent (new sub-session) replaces its displayed context usage.
+func TestAgentContextPercent_LatestSnapshotWins(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus"},
+	)
+
+	recordAgentUsage(m, "session-1", "root", 80_000, 100_000)
+	assert.Equal(t, "80%", m.agentContextPercent("root"))
+
+	recordAgentUsage(m, "session-2", "root", 10_000, 100_000)
+	assert.Equal(t, "10%", m.agentContextPercent("root"))
+}
+
+// TestAgentContextPercent_UnknownLimit verifies no percent is shown when the
+// context limit is unknown (e.g. harness-backed agents) or nothing was
+// recorded for the agent.
+func TestAgentContextPercent_UnknownLimit(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus"},
+	)
+
+	assert.Empty(t, m.agentContextPercent("root"), "no usage recorded yet")
+
+	recordAgentUsage(m, "session-1", "root", 30_000, 0)
+	assert.Empty(t, m.agentContextPercent("root"), "no percent without a context limit")
+
+	_, line2 := agentLines(m, "root")
+	assert.NotContains(t, line2, "%")
+}
+
+// TestAgentContextPercent_BackgroundAgentUsage verifies a usage event from a
+// detached background sub-session (forwarded out-of-band by the runtime, with
+// its own session id) surfaces on the background agent's roster line without
+// disturbing the parent's active-session accounting.
+func TestAgentContextPercent_BackgroundAgentUsage(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus"},
+		runtime.AgentDetails{Name: "worker", Provider: "openai", Model: "gpt-5.4"},
+	)
+
+	// Parent runs on the main session; the background worker's events carry
+	// its own sub-session id and interleave with the parent's.
+	m.rootSessionID = "session-root"
+	recordAgentUsage(m, "session-root", "root", 20_000, 100_000)
+	recordAgentUsage(m, "bg-session", "worker", 55_000, 100_000)
+
+	_, workerLine2 := agentLines(m, "worker")
+	assert.True(t, strings.HasSuffix(strings.TrimRight(workerLine2, " "), "55%"),
+		"background worker's line 2 ends with its context percent, got %q", workerLine2)
+
+	assert.Equal(t, "20%", m.contextPercent(),
+		"the main context gauge keeps tracking the active session, not the background one")
+}
+
+// TestAgentRosterLine2ReservesRoomForPercent verifies the model text yields
+// space to the percent instead of colliding with it at narrow widths.
+func TestAgentRosterLine2ReservesRoomForPercent(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 28,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "claude-sonnet-4-6"},
+	)
+	recordAgentUsage(m, "session-1", "root", 100_000, 100_000)
+
+	_, line2 := agentLines(m, "root")
+	require.NotEmpty(t, line2)
+	trimmed := strings.TrimRight(line2, " ")
+	assert.True(t, strings.HasSuffix(trimmed, " 100%"),
+		"percent stays separated from the truncated model, got %q", line2)
+	assert.Contains(t, line2, "…", "overflowing model is still left-truncated")
+	assert.Contains(t, line2, "-4-6", "informative model tail survives")
+}

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -260,6 +260,12 @@ func (m *model) SetTokenUsage(event *runtime.TokenUsageEvent) {
 	usage := *event.Usage
 	m.sessionUsage[event.SessionID] = &usage
 
+	// Record the per-agent snapshot in the shared session state so the
+	// agent roster and the agent-details dialog can show per-agent context
+	// usage. Background agent tasks reach this path too: their usage
+	// events are forwarded out-of-band by the runtime.
+	m.sessionState.SetAgentUsage(event.AgentName, usage)
+
 	// Mark session as having content once we receive token usage
 	m.sessionHasContent = true
 	m.invalidateCache()
@@ -559,9 +565,28 @@ func (m *model) activeSessionTokens() (tokens int64, found bool) {
 
 // contextPercent returns a context usage percentage string for the active session.
 func (m *model) contextPercent() string {
-	if usage, ok := m.activeSessionUsage(); ok && usage.ContextLimit > 0 {
-		percent := (float64(usage.ContextLength) / float64(usage.ContextLimit)) * 100
-		return fmt.Sprintf("%.0f%%", percent)
+	if usage, ok := m.activeSessionUsage(); ok {
+		return usageContextPercent(usage)
+	}
+	return ""
+}
+
+// usageContextPercent formats a usage snapshot's context fill as "N%", or ""
+// when the snapshot is missing or its context limit is unknown.
+func usageContextPercent(usage *runtime.Usage) string {
+	if usage == nil || usage.ContextLimit <= 0 {
+		return ""
+	}
+	percent := (float64(usage.ContextLength) / float64(usage.ContextLimit)) * 100
+	return fmt.Sprintf("%.0f%%", percent)
+}
+
+// agentContextPercent returns the latest known context usage percentage for
+// the named agent ("N%"), or "" when the agent has not run yet or its
+// context limit is unknown.
+func (m *model) agentContextPercent(agentName string) string {
+	if usage, ok := m.sessionState.AgentUsage(agentName); ok {
+		return usageContextPercent(&usage)
 	}
 	return ""
 }
@@ -1178,7 +1203,8 @@ func (m *model) queueSection(contentWidth int) string {
 // agentInfo renders the Agents panel: every agent as a two-line entry, with a
 // blank separator line between entries. Line 1 shows the agent's name (in its
 // accent color), the thinking badge right-aligned, and the "^N" switch shortcut
-// flush against the right edge; line 2 shows the indented provider/model. The
+// flush against the right edge; line 2 shows the indented provider/model with
+// the agent's latest context usage percentage right-aligned once known. The
 // current agent is marked with ▶ (or the spinner while it works); the other
 // agents pad that marker column so their names stay aligned. Descriptions are
 // deliberately omitted. Each content line is owned by its agent (agentLineOwners)
@@ -1332,15 +1358,17 @@ func padLeft(s string, width int) string {
 // renderAgentLine renders a single agent as two lines:
 //
 //	▶ name            <thinking> ^N
-//	  provider/model
+//	  provider/model         <ctx%>
 //
 // Line 1: the name is left-aligned in its accent color, the thinking badge is
 // right-aligned in a shared column, and the "^N" switch shortcut sits flush
 // against the right edge. The current agent is marked with ▶ (or the spinner
 // while it — or any agent — is working); other agents pad the marker column so
 // the names stay aligned. Line 2: the indented provider/model, left-truncated
-// so its informative tail survives. The description is omitted. Agents past the
-// 9th have no shortcut.
+// so its informative tail survives, with the agent's latest known context
+// usage percentage right-aligned once the agent has run (background agent
+// tasks included). The description is omitted. Agents past the 9th have no
+// shortcut.
 func (m *model) renderAgentLine(agent runtime.AgentDetails, index, contentWidth, nameWidth, badgeWidth int, glyphOnly, current bool) []string {
 	agentStyle := styles.AgentAccentStyleFor(agent.Name)
 
@@ -1371,8 +1399,17 @@ func (m *model) renderAgentLine(agent runtime.AgentDetails, index, contentWidth,
 	if agent.Provider != "" {
 		modelText = agent.Provider + "/" + agent.Model
 	}
-	model := toolcommon.TruncateTextLeft(modelText, max(1, contentWidth-agentMarkerWidth))
+	ctxPercent := m.agentContextPercent(agent.Name)
+	modelWidth := contentWidth - agentMarkerWidth
+	if ctxPercent != "" {
+		modelWidth -= lipgloss.Width(ctxPercent) + 1
+	}
+	model := toolcommon.TruncateTextLeft(modelText, max(1, modelWidth))
 	line2 := strings.Repeat(" ", agentMarkerWidth) + styles.MutedStyle.Render(model)
+	if ctxPercent != "" {
+		gap := max(1, contentWidth-lipgloss.Width(line2)-lipgloss.Width(ctxPercent))
+		line2 += strings.Repeat(" ", gap) + styles.MutedStyle.Render(ctxPercent)
+	}
 
 	return []string{line1, line2}
 }

--- a/pkg/tui/dialog/agent_details.go
+++ b/pkg/tui/dialog/agent_details.go
@@ -25,20 +25,23 @@ type agentDetailsDialog struct {
 
 	agent runtime.AgentDetails
 	cfg   runtime.AgentConfigInfo
+	usage *runtime.Usage
 }
 
 // NewAgentDetailsDialog creates the read-only Agent Inspector: an agent's
 // static configuration combined with live state. It shows the description, a
-// "current agent" line when live, model/fallback/thinking, the sub-agent,
-// handoff and skill lists, configured limits and enabled option flags, every
-// toolset with a status marker and its tools (live names when started,
-// otherwise the declared allow-list), and the slash commands it defines. The
-// instruction/system prompt is deliberately omitted. cfg carries the inspector
-// dataset resolved by the caller (pass the zero value to omit those sections,
-// e.g. for remote runtimes). The dialog is opened by right-clicking (or
-// Ctrl+clicking) an agent in the sidebar.
-func NewAgentDetailsDialog(a runtime.AgentDetails, cfg runtime.AgentConfigInfo) Dialog {
-	d := &agentDetailsDialog{agent: a, cfg: cfg}
+// "current agent" line when live, model/fallback/thinking, the agent's latest
+// known context usage, the sub-agent, handoff and skill lists, configured
+// limits and enabled option flags, every toolset with a status marker and its
+// tools (live names when started, otherwise the declared allow-list), and the
+// slash commands it defines. The instruction/system prompt is deliberately
+// omitted. cfg carries the inspector dataset resolved by the caller (pass the
+// zero value to omit those sections, e.g. for remote runtimes); usage carries
+// the agent's latest token-usage snapshot (pass nil when the agent has not
+// run). The dialog is opened by right-clicking (or Ctrl+clicking) an agent in
+// the sidebar.
+func NewAgentDetailsDialog(a runtime.AgentDetails, cfg runtime.AgentConfigInfo, usage *runtime.Usage) Dialog {
+	d := &agentDetailsDialog{agent: a, cfg: cfg, usage: usage}
 	d.readOnlyScrollDialog = newReadOnlyScrollDialog(
 		readOnlyScrollDialogSize{widthPercent: 70, minWidth: 50, maxWidth: 100, heightPercent: 80, heightMax: 40},
 		d.renderLines,
@@ -75,6 +78,9 @@ func (d *agentDetailsDialog) renderLines(contentWidth, _ int) []string {
 	if gv := toolcommon.ThinkingGaugeValue(d.agent.Thinking); gv != "" {
 		lines = append(lines, styles.BoldStyle.Render("Thinking:")+" "+gv)
 	}
+	if l := d.contextLine(); l != "" {
+		lines = append(lines, l)
+	}
 
 	lines = append(lines, d.inlineList(contentWidth, "Sub-agents", d.cfg.SubAgents)...)
 	lines = append(lines, d.inlineList(contentWidth, "Handoffs", d.cfg.Handoffs)...)
@@ -101,6 +107,24 @@ func (d *agentDetailsDialog) modelText() string {
 		return d.agent.Model
 	}
 	return d.agent.Provider
+}
+
+// contextLine renders the agent's latest known context usage as
+// "Context: 12.3K of 128.0K tokens (10%)", falling back to a bare token count
+// when the context limit is unknown (e.g. harness-backed agents). It returns
+// "" when no usage has been recorded yet — the agent has not run in this
+// session, as a delegated sub-agent, or as a background agent task.
+func (d *agentDetailsDialog) contextLine() string {
+	if d.usage == nil || d.usage.ContextLength <= 0 {
+		return ""
+	}
+	tokens := toolcommon.FormatTokenCount(d.usage.ContextLength)
+	if d.usage.ContextLimit <= 0 {
+		return detailField("Context", tokens+" tokens")
+	}
+	percent := float64(d.usage.ContextLength) / float64(d.usage.ContextLimit) * 100
+	return detailField("Context", fmt.Sprintf("%s of %s tokens (%.0f%%)",
+		tokens, toolcommon.FormatTokenCount(d.usage.ContextLimit), percent))
 }
 
 // inlineList renders a compact "Label (N): a, b, c" summary wrapped to the

--- a/pkg/tui/dialog/agent_details_test.go
+++ b/pkg/tui/dialog/agent_details_test.go
@@ -18,7 +18,13 @@ import (
 // body. cfg populates the inline config sections (toolsets, sub-agents,
 // handoffs, fallbacks).
 func renderAgentDetails(a runtime.AgentDetails, cfg runtime.AgentConfigInfo) string {
-	d := NewAgentDetailsDialog(a, cfg).(*agentDetailsDialog)
+	return renderAgentDetailsUsage(a, cfg, nil)
+}
+
+// renderAgentDetailsUsage is renderAgentDetails with a token-usage snapshot
+// for the context-usage line.
+func renderAgentDetailsUsage(a runtime.AgentDetails, cfg runtime.AgentConfigInfo, usage *runtime.Usage) string {
+	d := NewAgentDetailsDialog(a, cfg, usage).(*agentDetailsDialog)
 	return ansi.Strip(strings.Join(d.renderLines(80, 24), "\n"))
 }
 
@@ -104,7 +110,7 @@ func TestAgentDetailsDialog_TitleUsesAgentAccentColor(t *testing.T) {
 	t.Cleanup(func() { styles.SetAgentOrder(nil) })
 
 	titleOf := func(name string) string {
-		d := NewAgentDetailsDialog(runtime.AgentDetails{Name: name, Model: "gpt"}, runtime.AgentConfigInfo{}).(*agentDetailsDialog)
+		d := NewAgentDetailsDialog(runtime.AgentDetails{Name: name, Model: "gpt"}, runtime.AgentConfigInfo{}, nil).(*agentDetailsDialog)
 		return d.renderLines(80, 24)[0] // raw title line, with ANSI styling
 	}
 
@@ -215,6 +221,34 @@ func TestAgentDetailsDialog_LimitsOmitsUnsetValues(t *testing.T) {
 	assert.Contains(t, out, "Limits: history 40")
 	assert.NotContains(t, out, "max-iter", "unset max-iter is omitted")
 	assert.NotContains(t, out, "max-tool-calls", "unset max-tool-calls is omitted")
+}
+
+// TestAgentDetailsDialog_ContextUsage covers the per-agent context line: full
+// "tokens of limit (percent)" form when the context limit is known, bare token
+// count when it is not (e.g. harness-backed agents), and omission when the
+// agent has no recorded usage or an empty snapshot.
+func TestAgentDetailsDialog_ContextUsage(t *testing.T) {
+	t.Parallel()
+
+	agent := runtime.AgentDetails{Name: "root", Provider: "openai", Model: "gpt-5.4"}
+
+	withLimit := renderAgentDetailsUsage(agent, runtime.AgentConfigInfo{}, &runtime.Usage{
+		ContextLength: 12_800,
+		ContextLimit:  128_000,
+	})
+	assert.Contains(t, withLimit, "Context: 12.8K of 128.0K tokens (10%)")
+
+	noLimit := renderAgentDetailsUsage(agent, runtime.AgentConfigInfo{}, &runtime.Usage{
+		ContextLength: 8_200,
+	})
+	assert.Contains(t, noLimit, "Context: 8.2K tokens")
+	assert.NotContains(t, noLimit, "%)", "no percent without a context limit")
+
+	noUsage := renderAgentDetailsUsage(agent, runtime.AgentConfigInfo{}, nil)
+	assert.NotContains(t, noUsage, "Context:", "no context line when the agent has not run")
+
+	emptyUsage := renderAgentDetailsUsage(agent, runtime.AgentConfigInfo{}, &runtime.Usage{})
+	assert.NotContains(t, emptyUsage, "Context:", "no context line for an empty snapshot")
 }
 
 // TestInlineList_NarrowWidth_NoLabelDuplication verifies that when contentWidth

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -329,13 +329,19 @@ func (m *appModel) handleSwitchAgent(agentName string) (tea.Model, tea.Cmd) {
 }
 
 // handleShowAgentDetails opens the read-only agent-details dialog for the named
-// agent, looking it up in the available-agents roster.
+// agent, looking it up in the available-agents roster. The agent's latest
+// token-usage snapshot (if it has run) rides along so the dialog can show its
+// context usage.
 func (m *appModel) handleShowAgentDetails(agentName string) (tea.Model, tea.Cmd) {
 	for _, agent := range m.sessionState.AvailableAgents() {
 		if agent.Name == agentName {
 			cfg := m.application.AgentConfigInfo(m.ctx(), agentName)
+			var usage *runtime.Usage
+			if u, ok := m.sessionState.AgentUsage(agentName); ok {
+				usage = &u
+			}
 			return m, core.CmdHandler(dialog.OpenDialogMsg{
-				Model: dialog.NewAgentDetailsDialog(agent, cfg),
+				Model: dialog.NewAgentDetailsDialog(agent, cfg, usage),
 			})
 		}
 	}

--- a/pkg/tui/page/chat/queue_test.go
+++ b/pkg/tui/page/chat/queue_test.go
@@ -107,6 +107,7 @@ func (queueTestRuntime) SetAgentThinkingLevel(context.Context, string, effort.Le
 func (queueTestRuntime) AvailableModels(context.Context) []runtime.ModelChoice { return nil }
 func (queueTestRuntime) SupportsModelSwitching() bool                          { return false }
 func (queueTestRuntime) OnToolsChanged(func(runtime.Event))                    {}
+func (queueTestRuntime) OnBackgroundEvent(func(runtime.Event))                 {}
 func (queueTestRuntime) QueueStatus() runtime.QueueStatus                      { return runtime.QueueStatus{} }
 func (queueTestRuntime) TogglePause(context.Context) (bool, error)             { return false, nil }
 func (queueTestRuntime) Close() error                                          { return nil }

--- a/pkg/tui/service/sessionstate.go
+++ b/pkg/tui/service/sessionstate.go
@@ -57,6 +57,12 @@ type SessionState struct {
 	currentAgentName string
 	availableAgents  []runtime.AgentDetails
 	pauseState       PauseState
+
+	// agentUsage holds the latest token-usage snapshot per agent name,
+	// fed by TokenUsageEvents (including those of sub-sessions and
+	// background agent tasks). It backs the per-agent context display in
+	// the sidebar roster and the agent-details dialog.
+	agentUsage map[string]runtime.Usage
 }
 
 func NewSessionState(s *session.Session) *SessionState {
@@ -169,4 +175,24 @@ func (s *SessionState) GetCurrentAgent() runtime.AgentDetails {
 	}
 
 	return runtime.AgentDetails{}
+}
+
+// SetAgentUsage records the latest token-usage snapshot for the named agent.
+// Each snapshot carries cumulative totals for the agent's most recent
+// session, so the last write always reflects its current context usage.
+func (s *SessionState) SetAgentUsage(agentName string, usage runtime.Usage) {
+	if agentName == "" {
+		return
+	}
+	if s.agentUsage == nil {
+		s.agentUsage = make(map[string]runtime.Usage)
+	}
+	s.agentUsage[agentName] = usage
+}
+
+// AgentUsage returns the latest token-usage snapshot recorded for the named
+// agent, and whether one exists (an agent that has not run yet has none).
+func (s *SessionState) AgentUsage(agentName string) (runtime.Usage, bool) {
+	usage, ok := s.agentUsage[agentName]
+	return usage, ok
 }

--- a/pkg/tui/service/sessionstate_test.go
+++ b/pkg/tui/service/sessionstate_test.go
@@ -1,0 +1,34 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+)
+
+// TestSessionState_AgentUsage covers the per-agent usage snapshot store: set,
+// last-write-wins replacement, the empty-name guard, and the miss case.
+func TestSessionState_AgentUsage(t *testing.T) {
+	t.Parallel()
+
+	s := NewSessionState(nil)
+
+	_, ok := s.AgentUsage("root")
+	assert.False(t, ok, "no snapshot before any usage is recorded")
+
+	s.SetAgentUsage("root", runtime.Usage{ContextLength: 1000, ContextLimit: 10000})
+	usage, ok := s.AgentUsage("root")
+	assert.True(t, ok)
+	assert.Equal(t, int64(1000), usage.ContextLength)
+
+	s.SetAgentUsage("root", runtime.Usage{ContextLength: 2000, ContextLimit: 10000})
+	usage, ok = s.AgentUsage("root")
+	assert.True(t, ok)
+	assert.Equal(t, int64(2000), usage.ContextLength, "latest snapshot wins")
+
+	s.SetAgentUsage("", runtime.Usage{ContextLength: 3000})
+	_, ok = s.AgentUsage("")
+	assert.False(t, ok, "snapshots without an agent name are dropped")
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1229,8 +1229,13 @@ func (m *appModel) handleRoutedMsg(msg messages.RoutedMsg) (tea.Model, tea.Cmd) 
 	// Update session state for inactive sessions
 	if event, isRuntimeEvent := msg.Inner.(runtime.Event); isRuntimeEvent {
 		if sessionState, ok := m.sessionStates[msg.SessionID]; ok {
-			if agentName := event.GetAgentName(); agentName != "" {
-				sessionState.SetCurrentAgentName(agentName)
+			// Token-usage events are accounting, not agent-switch signals: a
+			// background agent task's usage can arrive while the tab is idle
+			// and must not move the current-agent marker to that agent.
+			if _, isUsage := msg.Inner.(*runtime.TokenUsageEvent); !isUsage {
+				if agentName := event.GetAgentName(); agentName != "" {
+					sessionState.SetCurrentAgentName(agentName)
+				}
 			}
 			m.applyPauseEvent(sessionState, msg.Inner)
 		}


### PR DESCRIPTION
Closes #3438

Surfaces each agent's context usage (% of its window) in the TUI, including background agents. No competitor exposes per-sub-agent context accounting.

## Issue expectations vs implementation

| Expectation | Implementation |
| --- | --- |
| Per-agent / per-sub-session context % in the sidebar agent list | Each roster entry's line 2 now carries the agent's latest known context percentage, right-aligned next to `provider/model` (model text yields room, keeps left-truncation) |
| Same in the agent-details dialog | New `Context: 12.8K of 128.0K tokens (10%)` line; bare token count when the limit is unknown (harness models); omitted until the agent has run |
| Include background agents (`pkg/tools/builtin/agent`) | `runCollecting` forwards the background sub-session's `TokenUsageEvent`s through a new out-of-band `Runtime.OnBackgroundEvent` hook; `App.Start` bridges them into the TUI event stream |

## Data flow

```
TokenUsageEvent (session id + agent name + Usage incl. ContextLimit)
 ├─ interactive stream (parent / transfer_task / run_skill) ──────► a.events
 └─ background task (runCollecting, events otherwise dropped)
      └─ emitBackgroundEvent ──► OnBackgroundEvent ──────────────► a.events   [new]

chatPage.handleTokenUsage ──► sidebar.SetTokenUsage
 ├─ sessionUsage[sessionID]          (existing: main gauge, cost totals)
 └─ SessionState.SetAgentUsage()     [new: per-agent snapshot, last write wins]
      ├─ sidebar roster line 2 ("N%")
      └─ agent-details dialog ("Context: ...")
```

## Rendering (frames captured by the e2e harness)

```
 Agents ───────────────────────────────
 ▶ root                              ^1
   test/fake-root                   10%

   worker                            ^2
   test/fake-worker                 45%
```

```
 │  Model: test/fake-worker                       │
 │  Context: 450 of 1.0K tokens (45%)             │
```

## Design notes

- Roster granularity is per agent (last snapshot wins). Concurrent background tasks of the same agent alternate its displayed %; per-session accounting stays intact underneath (cost totals, sub-session count). If per-task rows seem more appropriate, this can be extended later.
- The percentage renders as plain muted text. #3434 (warning/compacting gauge states) is not implemented yet; the shared `usageContextPercent` helper is the single place to recolor once it lands.
- Provider-reported `Usage` (ContextLength/ContextLimit) is used rather than the #3432 `ContextBreakdown`: the breakdown needs the live session object, which is not available for arbitrary sub-sessions.
- `RemoteRuntime.OnBackgroundEvent` is a documented no-op (background tasks run server-side), same convention as `OnToolsChanged`.
- Token-usage events routed to inactive tabs no longer move the current-agent marker: a background task's usage can arrive while the tab is idle and previously would have pinned the marker to the worker.
- Per-agent snapshots are in-memory; after a session restore only the current agent's % is re-seeded (by the startup TokenUsageEvent) until other agents run again.

## Testing

| Layer | Test |
| --- | --- |
| Runtime | `TestRunAgentForwardsTokenUsageOutOfBand`: runCollecting forwards only TokenUsageEvents, tagged with the sub-session id and worker name |
| App | `TestApp_Start_ForwardsBackgroundEvents`: Start registers the hook and events reach the app stream |
| Sidebar | `agent_context_test.go`: per-agent %, last-snapshot-wins, unknown limit, background usage not disturbing the main gauge, narrow-width layout |
| SessionState | set/get, empty-name guard, replacement |
| Dialog | `TestAgentDetailsDialog_ContextUsage`: full form, no-limit form, omission cases |
| e2e (real TUI, real runtime, scripted providers) | `TestBackgroundAgent_PerAgentContextInSidebar` and `TestBackgroundAgent_InspectorShowsWorkerContext`: full journey from tool call to detached sub-session to sidebar/inspector |

Full suite, `-race` on touched packages, `golangci-lint`, and the repo's custom linters all pass.
