### PR TITLE
feat(cli): add docker agent doctor for model and credential diagnosis

### DIFF
--- a/cmd/root/doctor.go
+++ b/cmd/root/doctor.go
@@ -1,0 +1,477 @@
+package root
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"slices"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/docker/cli/cli"
+	"github.com/spf13/cobra"
+
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/model/provider/dmr"
+	"github.com/docker/docker-agent/pkg/telemetry"
+	"github.com/docker/docker-agent/pkg/userconfig"
+)
+
+const dmrDocsURL = "https://docs.docker.com/ai/model-runner/get-started/"
+
+const (
+	dmrStatusReachable    = "reachable"
+	dmrStatusNotInstalled = "not-installed"
+	dmrStatusUnreachable  = "unreachable"
+)
+
+// doctorReport is the machine-readable form of the diagnosis. Secret values
+// are never included, only where each one was found.
+type doctorReport struct {
+	Providers     []doctorProviderStatus `json:"providers"`
+	DMR           doctorDMRStatus        `json:"dmr"`
+	ModelsGateway string                 `json:"models_gateway,omitempty"`
+	AutoModel     doctorAutoModel        `json:"auto_model"`
+	AgentFile     *doctorAgentFileStatus `json:"agent_file,omitempty"`
+	Issues        []string               `json:"issues,omitempty"`
+}
+
+type doctorProviderStatus struct {
+	Provider string   `json:"provider"`
+	EnvVars  []string `json:"env_vars"`
+	Found    bool     `json:"found"`
+	EnvVar   string   `json:"env_var,omitempty"`
+	Source   string   `json:"source,omitempty"`
+}
+
+type doctorDMRStatus struct {
+	Status string   `json:"status"`
+	Error  string   `json:"error,omitempty"`
+	Models []string `json:"models,omitempty"`
+}
+
+type doctorAutoModel struct {
+	Provider         string `json:"provider"`
+	Model            string `json:"model"`
+	FromDefaultModel bool   `json:"from_default_model,omitempty"`
+	Usable           bool   `json:"usable"`
+	Note             string `json:"note,omitempty"`
+}
+
+type doctorAgentFileStatus struct {
+	Ref            string                 `json:"ref"`
+	Requirements   []doctorEnvRequirement `json:"requirements,omitempty"`
+	ToolCheckError string                 `json:"tool_check_error,omitempty"`
+}
+
+type doctorEnvRequirement struct {
+	EnvVar     string `json:"env_var"`
+	RequiredBy string `json:"required_by"`
+	Found      bool   `json:"found"`
+	Source     string `json:"source,omitempty"`
+}
+
+type doctorFlags struct {
+	jsonOutput bool
+	runConfig  config.RuntimeConfig
+
+	// Test seams: sourcesForTests replaces the env-file + default secret-source
+	// chain, dmrLister replaces dmr.ListModels, and loadUserConfig replaces
+	// userconfig.Load so tests never exec `pass`/`security`/`docker model` or
+	// read the developer's real configuration.
+	sourcesForTests []environment.Source
+	dmrLister       config.DMRModelLister
+	loadUserConfig  userConfigLoader
+}
+
+type doctorCmdOption func(*doctorFlags)
+
+func newDoctorCmd(opts ...doctorCmdOption) *cobra.Command {
+	var flags doctorFlags
+	for _, opt := range opts {
+		opt(&flags)
+	}
+
+	cmd := &cobra.Command{
+		Use:   "doctor [agent-file]|[registry-ref]",
+		Short: "Diagnose model and credential setup",
+		Long: `Diagnose the model and credential setup.
+
+Reports, without ever printing secret values:
+  - which model providers have credentials and where each credential comes from
+  - whether Docker Model Runner is reachable and which models are pulled
+  - which model the 'auto' selection would pick
+  - with an agent file: the environment variables it requires and their status
+
+Exits with a non-zero status when an issue would prevent an agent from running.`,
+		Example: `  docker-agent doctor
+  docker-agent doctor ./agent.yaml
+  docker-agent doctor --json`,
+		Args:         cobra.MaximumNArgs(1),
+		GroupID:      "core",
+		SilenceUsage: true,
+		ValidArgsFunction: func(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) == 0 {
+				return completeAlias(toComplete)
+			}
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: flags.runDoctorCommand,
+	}
+
+	cmd.Flags().BoolVar(&flags.jsonOutput, "json", false, "Output in JSON format")
+	cmd.Flags().StringSliceVar(&flags.runConfig.EnvFiles, "env-from-file", nil, "Set environment variables from file")
+
+	loadUserConfig := flags.loadUserConfig
+	if loadUserConfig == nil {
+		loadUserConfig = userconfig.Load
+	}
+	addGatewayFlags(cmd, &flags.runConfig, loadUserConfig)
+
+	return cmd
+}
+
+func (f *doctorFlags) runDoctorCommand(cmd *cobra.Command, args []string) (commandErr error) {
+	ctx := cmd.Context()
+	telemetry.TrackCommand(ctx, "doctor", args)
+	defer func() { // do not inline this defer so that commandErr is not resolved early
+		telemetry.TrackCommandError(ctx, "doctor", args, commandErr)
+	}()
+
+	var agentRef string
+	if len(args) == 1 {
+		agentRef = args[0]
+	}
+
+	report, err := f.buildReport(ctx, agentRef)
+	if err != nil {
+		return err
+	}
+
+	w := cmd.OutOrStdout()
+	if f.jsonOutput {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			return err
+		}
+	} else {
+		printDoctorReport(w, report)
+	}
+
+	// A non-zero exit code makes the diagnosis scriptable (e.g. in CI).
+	if n := len(report.Issues); n > 0 {
+		return cli.StatusError{StatusCode: 1, Status: fmt.Sprintf("%d issue(s) found", n)}
+	}
+
+	return nil
+}
+
+func (f *doctorFlags) buildReport(ctx context.Context, agentRef string) (*doctorReport, error) {
+	sources, err := f.secretSources()
+	if err != nil {
+		return nil, err
+	}
+
+	// Every lookup in the report goes through the same labeled source chain so
+	// the provider table, the auto-selection result, and the agent-file checks
+	// can never disagree with each other.
+	providers := make([]environment.Provider, 0, len(sources))
+	for _, source := range sources {
+		providers = append(providers, source.Provider)
+	}
+	env := environment.NewMultiProvider(providers...)
+
+	report := &doctorReport{ModelsGateway: f.runConfig.ModelsGateway}
+
+	credFound := map[string]bool{}
+	primaryEnvVar := map[string]string{}
+	for _, p := range config.CloudProviderEnvVars() {
+		status := doctorProviderStatus{Provider: p.Provider, EnvVars: p.EnvVars}
+		for _, name := range p.EnvVars {
+			if source, ok := findSource(ctx, sources, name); ok {
+				status.Found, status.EnvVar, status.Source = true, name, source
+				break
+			}
+		}
+		credFound[p.Provider] = status.Found
+		if len(p.EnvVars) > 0 {
+			primaryEnvVar[p.Provider] = p.EnvVars[0]
+		}
+		report.Providers = append(report.Providers, status)
+	}
+
+	dmrModels, dmrErr := f.listDMRModels(ctx)
+	switch {
+	case dmrErr == nil:
+		report.DMR = doctorDMRStatus{Status: dmrStatusReachable, Models: dmrModels}
+	case errors.Is(dmrErr, dmr.ErrNotInstalled):
+		report.DMR = doctorDMRStatus{Status: dmrStatusNotInstalled}
+	default:
+		report.DMR = doctorDMRStatus{Status: dmrStatusUnreachable, Error: dmrErr.Error()}
+	}
+
+	// Reuse the discovery results above instead of querying DMR a second time.
+	lister := func(context.Context) ([]string, error) { return dmrModels, dmrErr }
+	auto := config.AutoModelConfig(ctx, f.runConfig.ModelsGateway, env, f.runConfig.DefaultModel, lister)
+
+	// Mirrors the condition under which AutoModelConfig short-circuits to the
+	// configured default model.
+	fromDefault := f.runConfig.DefaultModel != nil && f.runConfig.DefaultModel.Provider != "" && f.runConfig.DefaultModel.Model != ""
+
+	autoStatus := doctorAutoModel{
+		Provider:         auto.Provider,
+		Model:            auto.Model,
+		FromDefaultModel: fromDefault,
+		Usable:           true,
+	}
+
+	switch {
+	case f.runConfig.ModelsGateway != "":
+		autoStatus.Note = "credentials are supplied by the models gateway"
+		// Mirrors the run-time preflight: the Docker AI Gateway authenticates
+		// with the Docker Desktop JWT, not per-provider API keys.
+		if environment.IsTrustedDockerURL(f.runConfig.ModelsGateway) {
+			if _, ok := findSource(ctx, sources, environment.DockerDesktopTokenEnv); !ok {
+				autoStatus.Usable = false
+				report.Issues = append(report.Issues,
+					"the models gateway requires Docker Desktop sign-in and no DOCKER_TOKEN was found; sign in to Docker Desktop (check with `docker agent debug auth`)")
+			}
+		}
+
+	case auto.Provider == "dmr":
+		dmrDown := report.DMR.Status != dmrStatusReachable
+		switch {
+		case dmrDown && fromDefault:
+			autoStatus.Usable = false
+			report.Issues = append(report.Issues, fmt.Sprintf(
+				"the configured default model %s/%s needs Docker Model Runner, which is %s; install or start it (%s)",
+				auto.Provider, auto.Model, describeDMRStatus(report.DMR.Status), dmrDocsURL))
+		case dmrDown:
+			autoStatus.Usable = false
+			report.Issues = append(report.Issues, fmt.Sprintf(
+				"no usable model: no provider credential was found and Docker Model Runner is %s; set an API key for one of the providers above (%s) or install Docker Model Runner (%s)",
+				describeDMRStatus(report.DMR.Status), environment.SecretsDocsURL, dmrDocsURL))
+		case !slices.Contains(dmrModels, auto.Model):
+			autoStatus.Note = fmt.Sprintf("not pulled yet; run `docker model pull %s` or let the first run pull it", auto.Model)
+		}
+
+	default:
+		// Only reachable through a configured default model: bare auto
+		// selection never picks a cloud provider without credentials.
+		if found, known := credFound[auto.Provider]; known && !found {
+			autoStatus.Usable = false
+			report.Issues = append(report.Issues, fmt.Sprintf(
+				"the configured default model %s/%s has no credential for provider %s; set %s (%s)",
+				auto.Provider, auto.Model, auto.Provider, primaryEnvVar[auto.Provider], environment.SecretsDocsURL))
+		}
+	}
+	report.AutoModel = autoStatus
+
+	if agentRef != "" {
+		if err := f.checkAgentFile(ctx, agentRef, env, sources, report); err != nil {
+			return nil, err
+		}
+	}
+
+	return report, nil
+}
+
+// checkAgentFile reports the environment variables the agent configuration
+// requires (models and tools), whether each one is set, and from which source.
+func (f *doctorFlags) checkAgentFile(ctx context.Context, ref string, env environment.Provider, sources []environment.Source, report *doctorReport) error {
+	agentSource, err := config.Resolve(ref, env)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := config.Load(ctx, agentSource)
+	if err != nil {
+		return err
+	}
+
+	status := &doctorAgentFileStatus{Ref: ref}
+
+	// first_available selectors resolve to the first candidate with
+	// credentials; when none has any, surface it as an issue and keep
+	// reporting the rest of the file's requirements. Only the error's first
+	// line is kept: the full message repeats the secret-sources guidance.
+	if err := config.ResolveFirstAvailableModels(ctx, cfg, f.runConfig.ModelsGateway, env); err != nil {
+		firstLine, _, _ := strings.Cut(err.Error(), "\n")
+		report.Issues = append(report.Issues, fmt.Sprintf("%s: %s", ref, firstLine))
+	}
+
+	requiredBy := map[string][]string{}
+	for _, name := range config.RequiredModelEnvVars(ctx, cfg, f.runConfig.ModelsGateway, env) {
+		requiredBy[name] = append(requiredBy[name], "models")
+	}
+	toolVars, toolErr := config.GatherEnvVarsForTools(ctx, cfg)
+	if toolErr != nil {
+		status.ToolCheckError = toolErr.Error()
+	}
+	for _, name := range toolVars {
+		requiredBy[name] = append(requiredBy[name], "tools")
+	}
+
+	var missing []string
+	for _, name := range slices.Sorted(maps.Keys(requiredBy)) {
+		requirement := doctorEnvRequirement{EnvVar: name, RequiredBy: strings.Join(requiredBy[name], ", ")}
+		if source, ok := findSource(ctx, sources, name); ok {
+			requirement.Found = true
+			requirement.Source = source
+		} else {
+			missing = append(missing, name)
+		}
+		status.Requirements = append(status.Requirements, requirement)
+	}
+	if len(missing) > 0 {
+		report.Issues = append(report.Issues, fmt.Sprintf(
+			"%s requires environment variables that are not set: %s (see %s)",
+			ref, strings.Join(missing, ", "), environment.SecretsDocsURL))
+	}
+
+	report.AgentFile = status
+	return nil
+}
+
+// secretSources returns the labeled secret sources in the same precedence
+// order as the run-time env provider chain: --env-from-file first, then the
+// default chain. EnvFiles were already made absolute and validated by the
+// gateway-flags pre-run.
+func (f *doctorFlags) secretSources() ([]environment.Source, error) {
+	if f.sourcesForTests != nil {
+		return f.sourcesForTests, nil
+	}
+
+	var sources []environment.Source
+	if len(f.runConfig.EnvFiles) > 0 {
+		envFiles, err := environment.NewEnvFilesProvider(f.runConfig.EnvFiles)
+		if err != nil {
+			return nil, fmt.Errorf("--env-from-file: %w", err)
+		}
+		sources = append(sources, environment.Source{Name: "env-file", Provider: envFiles})
+	}
+
+	return append(sources, environment.DefaultSources()...), nil
+}
+
+func (f *doctorFlags) listDMRModels(ctx context.Context) ([]string, error) {
+	if f.dmrLister != nil {
+		return f.dmrLister(ctx)
+	}
+	return dmr.ListModels(ctx)
+}
+
+// findSource returns the name of the first secret source that supplies a
+// non-empty value for the variable. Empty values are skipped so a source that
+// merely defines the variable (e.g. an env file with `KEY=`) is not reported
+// as supplying a credential.
+func findSource(ctx context.Context, sources []environment.Source, name string) (string, bool) {
+	for _, source := range sources {
+		if value, ok := source.Provider.Get(ctx, name); ok && value != "" {
+			return source.Name, true
+		}
+	}
+	return "", false
+}
+
+func describeDMRStatus(status string) string {
+	if status == dmrStatusUnreachable {
+		return "unreachable"
+	}
+	return "not installed"
+}
+
+func printDoctorReport(w io.Writer, report *doctorReport) {
+	fmt.Fprintln(w, "Model provider credentials")
+	tw := tabwriter.NewWriter(w, 0, 2, 3, ' ', 0)
+	fmt.Fprintln(tw, "  PROVIDER\tSTATUS\tCREDENTIAL\tSOURCE")
+	for _, p := range report.Providers {
+		if p.Found {
+			fmt.Fprintf(tw, "  %s\tfound\t%s\t%s\n", p.Provider, p.EnvVar, p.Source)
+		} else {
+			fmt.Fprintf(tw, "  %s\tnot set\t%s\t-\n", p.Provider, credentialCandidates(p.EnvVars))
+		}
+	}
+	tw.Flush()
+
+	fmt.Fprintln(w, "\nDocker Model Runner")
+	switch report.DMR.Status {
+	case dmrStatusReachable:
+		if len(report.DMR.Models) == 0 {
+			fmt.Fprintln(w, "  Status: reachable, no models pulled (run `docker model pull ai/qwen3` to get one)")
+		} else {
+			fmt.Fprintf(w, "  Status: reachable, %d model(s) pulled:\n", len(report.DMR.Models))
+			for _, m := range report.DMR.Models {
+				fmt.Fprintf(w, "    - %s\n", m)
+			}
+		}
+	case dmrStatusNotInstalled:
+		fmt.Fprintf(w, "  Status: not installed (%s)\n", dmrDocsURL)
+	default:
+		fmt.Fprintf(w, "  Status: unreachable: %s\n", report.DMR.Error)
+		fmt.Fprintf(w, "  Install or start Docker Model Runner: %s\n", dmrDocsURL)
+	}
+
+	if report.ModelsGateway != "" {
+		fmt.Fprintf(w, "\nModels gateway\n  %s\n", report.ModelsGateway)
+	}
+
+	fmt.Fprintln(w, "\nModel auto-selection")
+	line := fmt.Sprintf("  auto -> %s/%s", report.AutoModel.Provider, report.AutoModel.Model)
+	if report.AutoModel.FromDefaultModel {
+		line += " (configured default model)"
+	}
+	fmt.Fprintln(w, line)
+	if report.AutoModel.Note != "" {
+		fmt.Fprintf(w, "  Note: %s\n", report.AutoModel.Note)
+	}
+
+	if af := report.AgentFile; af != nil {
+		fmt.Fprintf(w, "\nAgent requirements: %s\n", af.Ref)
+		if len(af.Requirements) == 0 {
+			fmt.Fprintln(w, "  No environment variables required.")
+		} else {
+			tw := tabwriter.NewWriter(w, 0, 2, 3, ' ', 0)
+			fmt.Fprintln(tw, "  ENV VAR\tREQUIRED BY\tSTATUS\tSOURCE")
+			for _, r := range af.Requirements {
+				if r.Found {
+					fmt.Fprintf(tw, "  %s\t%s\tfound\t%s\n", r.EnvVar, r.RequiredBy, r.Source)
+				} else {
+					fmt.Fprintf(tw, "  %s\t%s\tnot set\t-\n", r.EnvVar, r.RequiredBy)
+				}
+			}
+			tw.Flush()
+		}
+		if af.ToolCheckError != "" {
+			fmt.Fprintf(w, "  Warning: %s\n", af.ToolCheckError)
+		}
+	}
+
+	if len(report.Issues) == 0 {
+		fmt.Fprintln(w, "\nNo issues found.")
+		return
+	}
+	fmt.Fprintln(w, "\nIssues")
+	for _, issue := range report.Issues {
+		fmt.Fprintf(w, "  - %s\n", issue)
+	}
+}
+
+// credentialCandidates renders the env vars that could supply a missing
+// credential: the primary variable plus a count of the alternatives, keeping
+// the table narrow for providers with several detection variables.
+func credentialCandidates(envVars []string) string {
+	switch len(envVars) {
+	case 0:
+		return "-"
+	case 1:
+		return envVars[0]
+	default:
+		return fmt.Sprintf("%s (+%d more)", envVars[0], len(envVars)-1)
+	}
+}

--- a/cmd/root/doctor_test.go
+++ b/cmd/root/doctor_test.go
@@ -1,0 +1,322 @@
+package root
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/cli/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/model/provider/dmr"
+	"github.com/docker/docker-agent/pkg/userconfig"
+)
+
+// withDoctorTestEnv wires a hermetic doctor command: a map-backed secret
+// source chain, a stubbed DMR lister, and an empty user config, so tests
+// never exec `pass`/`security`/`docker model` and never read the developer's
+// real configuration.
+func withDoctorTestEnv(env map[string]string, dmrModels []string, dmrErr error) doctorCmdOption {
+	return func(f *doctorFlags) {
+		mapProvider := environment.NewMapEnvProvider(env)
+		f.runConfig.EnvProviderForTests = mapProvider
+		f.sourcesForTests = []environment.Source{{Name: "environment", Provider: mapProvider}}
+		f.dmrLister = func(context.Context) ([]string, error) { return dmrModels, dmrErr }
+		f.loadUserConfig = func() (*userconfig.Config, error) { return &userconfig.Config{}, nil }
+	}
+}
+
+func executeDoctor(t *testing.T, args []string, opts ...doctorCmdOption) (string, error) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	cmd := newDoctorCmd(opts...)
+	cmd.SilenceErrors = true
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+func TestDoctorCommand_ReportsCredentialSource(t *testing.T) {
+	t.Parallel()
+
+	output, err := executeDoctor(t, nil, withDoctorTestEnv(
+		map[string]string{"ANTHROPIC_API_KEY": "sk-secret-value"},
+		[]string{"ai/qwen3:latest"}, nil))
+
+	require.NoError(t, err)
+	assert.Regexp(t, `anthropic\s+found\s+ANTHROPIC_API_KEY\s+environment`, output)
+	assert.Regexp(t, `openai\s+not set\s+OPENAI_API_KEY\s+-`, output)
+	assert.Contains(t, output, "auto -> anthropic/claude-sonnet-4-6")
+	assert.Contains(t, output, "No issues found.")
+	assert.NotContains(t, output, "sk-secret-value", "secret values must never be printed")
+}
+
+func TestDoctorCommand_SourcePrecedenceMatchesProviderChain(t *testing.T) {
+	t.Parallel()
+
+	fileProvider := environment.NewMapEnvProvider(map[string]string{"OPENAI_API_KEY": "from-file"})
+	osProvider := environment.NewMapEnvProvider(map[string]string{"OPENAI_API_KEY": "from-env"})
+
+	output, err := executeDoctor(t, nil, func(f *doctorFlags) {
+		f.runConfig.EnvProviderForTests = environment.NewMultiProvider(fileProvider, osProvider)
+		f.sourcesForTests = []environment.Source{
+			{Name: "env-file", Provider: fileProvider},
+			{Name: "environment", Provider: osProvider},
+		}
+		f.dmrLister = func(context.Context) ([]string, error) { return nil, nil }
+		f.loadUserConfig = func() (*userconfig.Config, error) { return &userconfig.Config{}, nil }
+	})
+
+	require.NoError(t, err)
+	assert.Regexp(t, `openai\s+found\s+OPENAI_API_KEY\s+env-file`, output)
+}
+
+func TestDoctorCommand_EmptyValueIsNotACredential(t *testing.T) {
+	t.Parallel()
+
+	output, err := executeDoctor(t, nil, withDoctorTestEnv(
+		map[string]string{"OPENAI_API_KEY": "", "MISTRAL_API_KEY": "key"},
+		[]string{"ai/qwen3:latest"}, nil))
+
+	require.NoError(t, err)
+	assert.Regexp(t, `openai\s+not set`, output)
+	assert.Regexp(t, `mistral\s+found\s+MISTRAL_API_KEY\s+environment`, output)
+}
+
+func TestDoctorCommand_NoUsableModel(t *testing.T) {
+	t.Parallel()
+
+	output, err := executeDoctor(t, nil, withDoctorTestEnv(nil, nil, dmr.ErrNotInstalled))
+
+	require.Error(t, err)
+	statusErr, ok := errors.AsType[cli.StatusError](err)
+	require.True(t, ok, "expected a cli.StatusError, got %T", err)
+	assert.Equal(t, 1, statusErr.StatusCode)
+
+	assert.Contains(t, output, "Status: not installed")
+	assert.Contains(t, output, "Issues")
+	assert.Contains(t, output, "no usable model")
+	assert.Contains(t, output, environment.SecretsDocsURL)
+	assert.Contains(t, output, dmrDocsURL)
+}
+
+func TestDoctorCommand_DMRUnreachable(t *testing.T) {
+	t.Parallel()
+
+	output, err := executeDoctor(t, nil, withDoctorTestEnv(nil, nil, errors.New("connection refused")))
+
+	require.Error(t, err)
+	assert.Contains(t, output, "Status: unreachable: connection refused")
+	assert.Contains(t, output, "no usable model")
+}
+
+func TestDoctorCommand_DMRModelNotPulled(t *testing.T) {
+	t.Parallel()
+
+	// DMR reachable with no models pulled: the run would offer a pull, so it
+	// is a note on the selection, not an issue.
+	output, err := executeDoctor(t, nil, withDoctorTestEnv(nil, nil, nil))
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "auto -> dmr/ai/qwen3:latest")
+	assert.Contains(t, output, "docker model pull ai/qwen3:latest")
+	assert.Contains(t, output, "No issues found.")
+}
+
+func TestDoctorCommand_DMRPrefersLocalModel(t *testing.T) {
+	t.Parallel()
+
+	output, err := executeDoctor(t, nil, withDoctorTestEnv(nil, []string{"ai/smollm2"}, nil))
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "auto -> dmr/ai/smollm2")
+	assert.Contains(t, output, "- ai/smollm2")
+	assert.Contains(t, output, "No issues found.")
+}
+
+func TestDoctorCommand_DefaultModelWithoutCredential(t *testing.T) {
+	t.Parallel()
+
+	output, err := executeDoctor(t, nil, func(f *doctorFlags) {
+		mapProvider := environment.NewMapEnvProvider(nil)
+		f.runConfig.EnvProviderForTests = mapProvider
+		f.sourcesForTests = []environment.Source{{Name: "environment", Provider: mapProvider}}
+		f.dmrLister = func(context.Context) ([]string, error) { return []string{"ai/qwen3:latest"}, nil }
+		f.loadUserConfig = func() (*userconfig.Config, error) {
+			return &userconfig.Config{
+				DefaultModel: &latest.FlexibleModelConfig{
+					ModelConfig: latest.ModelConfig{Provider: "openai", Model: "gpt-5"},
+				},
+			}, nil
+		}
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, output, "auto -> openai/gpt-5 (configured default model)")
+	assert.Contains(t, output, "no credential for provider openai")
+	assert.Contains(t, output, "OPENAI_API_KEY")
+}
+
+func TestDoctorCommand_ModelsGateway(t *testing.T) {
+	t.Parallel()
+
+	output, err := executeDoctor(t, []string{"--models-gateway", "https://gateway.example.com"},
+		withDoctorTestEnv(nil, nil, dmr.ErrNotInstalled))
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "https://gateway.example.com")
+	assert.Contains(t, output, "credentials are supplied by the models gateway")
+	assert.Contains(t, output, "No issues found.")
+}
+
+func TestDoctorCommand_DockerGatewayNeedsSignIn(t *testing.T) {
+	t.Parallel()
+
+	output, err := executeDoctor(t, []string{"--models-gateway", "https://api.docker.com/gateway"},
+		withDoctorTestEnv(nil, nil, dmr.ErrNotInstalled))
+
+	require.Error(t, err)
+	assert.Contains(t, output, "requires Docker Desktop sign-in")
+
+	output, err = executeDoctor(t, []string{"--models-gateway", "https://api.docker.com/gateway"},
+		withDoctorTestEnv(map[string]string{"DOCKER_TOKEN": "jwt"}, nil, dmr.ErrNotInstalled))
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "No issues found.")
+}
+
+func TestDoctorCommand_JSON(t *testing.T) {
+	t.Parallel()
+
+	output, err := executeDoctor(t, []string{"--json"}, withDoctorTestEnv(
+		map[string]string{"OPENAI_API_KEY": "sk-json-secret"},
+		[]string{"ai/qwen3:latest"}, nil))
+
+	require.NoError(t, err)
+	assert.NotContains(t, output, "sk-json-secret", "secret values must never be printed")
+
+	var report doctorReport
+	require.NoError(t, json.Unmarshal([]byte(output), &report))
+
+	assert.Equal(t, dmrStatusReachable, report.DMR.Status)
+	assert.Equal(t, []string{"ai/qwen3:latest"}, report.DMR.Models)
+	assert.Equal(t, "openai", report.AutoModel.Provider)
+	assert.Equal(t, "gpt-5", report.AutoModel.Model)
+	assert.True(t, report.AutoModel.Usable)
+	assert.Empty(t, report.Issues)
+
+	byProvider := map[string]doctorProviderStatus{}
+	for _, p := range report.Providers {
+		byProvider[p.Provider] = p
+	}
+	assert.True(t, byProvider["openai"].Found)
+	assert.Equal(t, "OPENAI_API_KEY", byProvider["openai"].EnvVar)
+	assert.Equal(t, "environment", byProvider["openai"].Source)
+	assert.False(t, byProvider["anthropic"].Found)
+}
+
+func writeDoctorAgentFile(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "agent.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+agents:
+  root:
+    model: openai/gpt-5
+    instruction: test agent
+`), 0o600))
+	return path
+}
+
+func TestDoctorCommand_AgentFileMissingVars(t *testing.T) {
+	t.Parallel()
+
+	path := writeDoctorAgentFile(t)
+
+	output, err := executeDoctor(t, []string{path}, withDoctorTestEnv(
+		map[string]string{"ANTHROPIC_API_KEY": "key"},
+		[]string{"ai/qwen3:latest"}, nil))
+
+	require.Error(t, err)
+	statusErr, ok := errors.AsType[cli.StatusError](err)
+	require.True(t, ok, "expected a cli.StatusError, got %T", err)
+	assert.Equal(t, 1, statusErr.StatusCode)
+
+	assert.Contains(t, output, "Agent requirements: "+path)
+	assert.Regexp(t, `OPENAI_API_KEY\s+models\s+not set\s+-`, output)
+	assert.Contains(t, output, "requires environment variables that are not set: OPENAI_API_KEY")
+}
+
+func TestDoctorCommand_AgentFileVarsSatisfied(t *testing.T) {
+	t.Parallel()
+
+	path := writeDoctorAgentFile(t)
+
+	output, err := executeDoctor(t, []string{path}, withDoctorTestEnv(
+		map[string]string{"OPENAI_API_KEY": "key"},
+		[]string{"ai/qwen3:latest"}, nil))
+
+	require.NoError(t, err)
+	assert.Regexp(t, `OPENAI_API_KEY\s+models\s+found\s+environment`, output)
+	assert.Contains(t, output, "No issues found.")
+}
+
+func TestDoctorCommand_AgentFileBehindGateway(t *testing.T) {
+	t.Parallel()
+
+	// A models gateway supplies model credentials, so the file's model env
+	// vars are not required (mirrors the run-time preflight).
+	path := writeDoctorAgentFile(t)
+
+	output, err := executeDoctor(t, []string{"--models-gateway", "https://gateway.example.com", path},
+		withDoctorTestEnv(nil, []string{"ai/qwen3:latest"}, nil))
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "No environment variables required.")
+	assert.Contains(t, output, "No issues found.")
+}
+
+func TestDoctorCommand_AgentFileNotFound(t *testing.T) {
+	t.Parallel()
+
+	_, err := executeDoctor(t, []string{filepath.Join(t.TempDir(), "missing.yaml")},
+		withDoctorTestEnv(nil, []string{"ai/qwen3:latest"}, nil))
+
+	require.Error(t, err)
+}
+
+func TestCredentialCandidates(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "-", credentialCandidates(nil))
+	assert.Equal(t, "OPENAI_API_KEY", credentialCandidates([]string{"OPENAI_API_KEY"}))
+	assert.Equal(t, "GOOGLE_API_KEY (+2 more)", credentialCandidates([]string{"GOOGLE_API_KEY", "GEMINI_API_KEY", "GOOGLE_GENAI_USE_VERTEXAI"}))
+}
+
+func TestFindSource_SkipsSourcesWithoutValue(t *testing.T) {
+	t.Parallel()
+
+	sources := []environment.Source{
+		{Name: "empty", Provider: environment.NewMapEnvProvider(map[string]string{"KEY": ""})},
+		{Name: "none", Provider: environment.NewNoEnvProvider()},
+		{Name: "filled", Provider: environment.NewMapEnvProvider(map[string]string{"KEY": "value"})},
+	}
+
+	source, found := findSource(t.Context(), sources, "KEY")
+	require.True(t, found)
+	assert.Equal(t, "filled", source)
+
+	_, found = findSource(t.Context(), sources, "OTHER")
+	assert.False(t, found)
+}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -165,6 +165,7 @@ We collect anonymous usage data to help improve docker agent. To disable:
 		newEvalCmd(),
 		newShareCmd(),
 		newModelsCmd(),
+		newDoctorCmd(),
 		newDebugCmd(),
 		newAliasCmd(),
 		newSandboxCmd(),

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -199,6 +199,29 @@ $ docker agent models --provider openai
 $ docker agent models --format json | jq
 ```
 
+### `docker agent doctor`
+
+Diagnose the model and credential setup. Reports which model providers have credentials and where each credential comes from (shell environment, env file, pass, keychain, …), whether Docker Model Runner is reachable and which models are pulled, and which model the `auto` selection would pick. Secret values are never printed. Exits with a non-zero status when an issue would prevent an agent from running, which makes it usable in scripts and CI.
+
+```bash
+$ docker agent doctor [agent-file|registry-ref] [flags]
+```
+
+With an agent file, also lists the environment variables that file requires (model credentials and tool secrets such as `GITHUB_PERSONAL_ACCESS_TOKEN`), whether each one is set, and from which source.
+
+| Flag                     | Default | Description                                                    |
+| ------------------------ | ------- | -------------------------------------------------------------- |
+| `--json`                 | `false` | Output the full report in JSON format (for scripting).         |
+| `--env-from-file <file>` | (none)  | Also check variables supplied by an env file.                  |
+| `--models-gateway <url>` | (none)  | Diagnose against a models gateway (credentials come from it).  |
+
+```bash
+# Examples
+$ docker agent doctor                        # credential, DMR, and auto-selection state
+$ docker agent doctor ./agent.yaml           # also check that file's requirements
+$ docker agent doctor --json | jq .issues
+```
+
 ### `docker agent serve api`
 
 Start the HTTP API server for programmatic access. The argument can be a single agent file, a registry reference, or a directory — when given a directory, every `.yaml`/`.yml`/`.hcl` file in it is exposed as a separate entry under `/api/agents`.

--- a/pkg/config/auto.go
+++ b/pkg/config/auto.go
@@ -74,6 +74,25 @@ var cloudProviders = []providerConfig{
 	{"opencode-go", []string{"OPENCODE_API_KEY"}, "OPENCODE_API_KEY", "OPENCODE_API_KEY"},
 }
 
+// ProviderEnvVars associates a cloud provider known to auto-selection with
+// the environment variables that can supply its credentials.
+type ProviderEnvVars struct {
+	Provider string
+	EnvVars  []string
+}
+
+// CloudProviderEnvVars returns, in auto-selection priority order, every cloud
+// provider with the environment variables that can hold its credentials.
+// Diagnostic commands (e.g. `docker agent doctor`) use it to report credential
+// state without duplicating the provider table.
+func CloudProviderEnvVars() []ProviderEnvVars {
+	out := make([]ProviderEnvVars, 0, len(cloudProviders))
+	for _, p := range cloudProviders {
+		out = append(out, ProviderEnvVars{Provider: p.name, EnvVars: slices.Clone(p.envVars)})
+	}
+	return out
+}
+
 // AutoModelFallbackError is returned when auto model selection fails because
 // no model could be initialized (no API keys configured and no usable Docker
 // Model Runner model, e.g. DMR not installed or the pull was declined).

--- a/pkg/config/auto_test.go
+++ b/pkg/config/auto_test.go
@@ -1090,3 +1090,21 @@ func TestProviderAPIKeyEnvVars(t *testing.T) {
 	// Broad, general-purpose tokens must not be forwarded as model credentials.
 	assert.NotContains(t, vars, "GITHUB_TOKEN")
 }
+
+func TestCloudProviderEnvVars(t *testing.T) {
+	t.Parallel()
+
+	providers := CloudProviderEnvVars()
+
+	// Must mirror the auto-selection table: same providers, same priority
+	// order, same detection variables.
+	assert.Len(t, providers, len(cloudProviders))
+	for i, p := range providers {
+		assert.Equal(t, cloudProviders[i].name, p.Provider)
+		assert.Equal(t, cloudProviders[i].envVars, p.EnvVars)
+	}
+
+	// Mutating the returned slices must not corrupt the package table.
+	providers[0].EnvVars[0] = "MUTATED"
+	assert.NotEqual(t, "MUTATED", cloudProviders[0].envVars[0])
+}

--- a/pkg/config/gather.go
+++ b/pkg/config/gather.go
@@ -65,6 +65,15 @@ func GatherEnvVarsForModels(ctx context.Context, cfg *latest.Config, env environ
 	return gatherEnvVarsForModels(ctx, cfg, env, false)
 }
 
+// RequiredModelEnvVars returns the env vars the config's models need under
+// the given gateway configuration, mirroring the run-time preflight check:
+// every model credential when no models gateway is set, and only those of
+// models that bypass the gateway otherwise (the gateway supplies credentials
+// for routed models).
+func RequiredModelEnvVars(ctx context.Context, cfg *latest.Config, modelsGateway string, env environment.Provider) []string {
+	return gatherEnvVarsForModels(ctx, cfg, env, modelsGateway != "")
+}
+
 // gatherEnvVarsForModels collects the env vars required by model-backed agents.
 // When bypassOnly is true, only the leaf models that effectively dial their
 // provider directly (bypassing the models gateway) are inspected — used to

--- a/pkg/environment/default.go
+++ b/pkg/environment/default.go
@@ -5,16 +5,24 @@ import (
 	"github.com/docker/docker-agent/pkg/userconfig"
 )
 
-// NewDefaultProvider creates a provider chain with OS env, run secrets,
-// credential helper (if configured), Docker Desktop, pass, and keychain providers.
-// The whole chain is wrapped so that values shaped like "op://..." are resolved
-// as 1Password secret references through the `op` CLI.
+// Source is a labeled secret source in the default provider chain. The name
+// identifies where a value comes from (e.g. "environment", "keychain") so
+// diagnostic commands like `docker agent doctor` can report it.
+type Source struct {
+	Name     string
+	Provider Provider
+}
+
+// DefaultSources returns the ordered, labeled secret sources that make up the
+// default provider chain: OS env, run secrets, credential helper (if
+// configured), Docker Desktop, pass, and keychain. Lookup precedence is the
+// slice order.
 //
 // When running inside a Docker sandbox (detected via SANDBOX_VM_ID), a
 // [SandboxTokenProvider] is prepended so that DOCKER_TOKEN is read from the
 // JSON file written by the host-side token writer.
-func NewDefaultProvider() Provider {
-	var providers []Provider
+func DefaultSources() []Source {
+	var sources []Source
 
 	// Inside a sandbox the Docker Desktop backend API is unreachable and
 	// any DOCKER_TOKEN env var is a stale one-shot value.
@@ -22,32 +30,50 @@ func NewDefaultProvider() Provider {
 	// The host writes the token file into the config directory (mounted read-only
 	// into the sandbox), so we must read from GetConfigDir — not GetDataDir.
 	if InSandbox() {
-		providers = append(providers,
-			NewSandboxTokenProvider(SandboxTokensFilePath(paths.GetConfigDir())),
-		)
+		sources = append(sources, Source{
+			Name:     "sandbox-tokens",
+			Provider: NewSandboxTokenProvider(SandboxTokensFilePath(paths.GetConfigDir())),
+		})
 	}
 
-	providers = append(providers,
-		NewOsEnvProvider(),
-		NewRunSecretsProvider(),
+	sources = append(sources,
+		Source{Name: "environment", Provider: NewOsEnvProvider()},
+		Source{Name: "run-secrets", Provider: NewRunSecretsProvider()},
 	)
 
 	// Add credential helper provider if configured
 	if cfg, err := userconfig.Load(); err == nil && cfg.CredentialHelper != nil && cfg.CredentialHelper.Command != "" {
-		providers = append(providers, NewCredentialHelperProvider(cfg.CredentialHelper.Command, cfg.CredentialHelper.Args...))
+		sources = append(sources, Source{
+			Name:     "credential-helper",
+			Provider: NewCredentialHelperProvider(cfg.CredentialHelper.Command, cfg.CredentialHelper.Args...),
+		})
 	}
 
 	// Docker Desktop provider comes after credential helper
-	providers = append(providers, NewDockerDesktopProvider())
+	sources = append(sources, Source{Name: "docker-desktop", Provider: NewDockerDesktopProvider()})
 
 	// Append pass provider at the end if available
 	if passProvider, err := NewPassProvider(); err == nil {
-		providers = append(providers, passProvider)
+		sources = append(sources, Source{Name: "pass", Provider: passProvider})
 	}
 
 	// Append keychain provider if available
 	if keychainProvider, err := NewKeychainProvider(); err == nil {
-		providers = append(providers, keychainProvider)
+		sources = append(sources, Source{Name: "keychain", Provider: keychainProvider})
+	}
+
+	return sources
+}
+
+// NewDefaultProvider creates a provider chain from [DefaultSources].
+// The whole chain is wrapped so that values shaped like "op://..." are resolved
+// as 1Password secret references through the `op` CLI.
+func NewDefaultProvider() Provider {
+	sources := DefaultSources()
+
+	providers := make([]Provider, 0, len(sources))
+	for _, source := range sources {
+		providers = append(providers, source.Provider)
 	}
 
 	// Resolve any "op://" secret references through the 1Password CLI,

--- a/pkg/environment/default_test.go
+++ b/pkg/environment/default_test.go
@@ -1,0 +1,44 @@
+package environment
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultSources(t *testing.T) {
+	// Not parallel: DefaultSources reads the real user config and probes the
+	// local system for optional binaries (pass, security), which is cheap but
+	// environment-dependent.
+	sources := DefaultSources()
+
+	names := make([]string, 0, len(sources))
+	for _, source := range sources {
+		require.NotNil(t, source.Provider, "source %q has a nil provider", source.Name)
+		names = append(names, source.Name)
+	}
+
+	// Names must be unique so diagnostic output can identify each source.
+	sorted := slices.Sorted(slices.Values(names))
+	assert.Len(t, slices.Compact(sorted), len(names))
+
+	// The core sources are always present and keep their precedence order.
+	envIdx := slices.Index(names, "environment")
+	secretsIdx := slices.Index(names, "run-secrets")
+	desktopIdx := slices.Index(names, "docker-desktop")
+	require.GreaterOrEqual(t, envIdx, 0)
+	require.Greater(t, secretsIdx, envIdx)
+	require.Greater(t, desktopIdx, secretsIdx)
+}
+
+func TestNewDefaultProvider_UsesDefaultSources(t *testing.T) {
+	t.Setenv("SOME_DOCKER_AGENT_TEST_ONLY_VAR", "value")
+
+	provider := NewDefaultProvider()
+
+	value, found := provider.Get(t.Context(), "SOME_DOCKER_AGENT_TEST_ONLY_VAR")
+	require.True(t, found)
+	assert.Equal(t, "value", value)
+}


### PR DESCRIPTION
Phase 2 of #3442: a diagnosis command that answers "is this machine ready to run an agent, and if not, why?". Complements Phase 1 (#3452), which made run-time failures actionable.

## What it does

```
docker agent doctor [agent-file] [--json] [--env-from-file <file>] [--models-gateway <url>]
```

| Section | Content |
| --- | --- |
| Model provider credentials | provider, status, credential env var, source (environment, env-file, run-secrets, credential-helper, docker-desktop, pass, keychain) |
| Docker Model Runner | reachable + pulled models, not installed, or unreachable + error |
| Model auto-selection | the model `auto` would pick, whether it is usable, notes (configured default model, gateway, "not pulled yet") |
| Agent requirements (optional arg) | env vars required by the given file (model credentials + tool secrets), each with status and source |
| Issues | actionable problems, each naming the exact command or docs URL; non-zero exit code when present |

Secret values are never printed, only the source that supplies them. `--json` emits the full report for scripting; the non-zero exit code makes it usable as a CI preflight.

## Issue expectations vs implementation

| Phase 2 expectation | Status |
| --- | --- |
| provider / credential found / source (env, env-file, helper, Desktop, pass, keychain) | yes |
| DMR installed/reachable + pulled models | yes, via `dmr.ListModels` (queried once, result reused for auto-selection) |
| the model `auto` would select | yes, via `config.AutoModelConfig` on the same source chain |
| optional `doctor agent.yaml`: models + toolset env (e.g. `GITHUB_PERSONAL_ACCESS_TOKEN`) | yes; resolves `first_available`, honours the models gateway like the run-time preflight |
| values always redacted; `--json` for scripting | yes, asserted by tests |

## Sample output

```
$ docker agent doctor golang_developer.yaml

Model provider credentials
  PROVIDER    STATUS    CREDENTIAL                 SOURCE
  anthropic   found     ANTHROPIC_API_KEY          environment
  openai      not set   OPENAI_API_KEY             -
  google      not set   GOOGLE_API_KEY (+2 more)   -
  ...

Docker Model Runner
  Status: reachable, 1 model(s) pulled:
    - ai/qwen3:latest

Model auto-selection
  auto -> anthropic/claude-sonnet-4-6

Agent requirements: golang_developer.yaml
  ENV VAR             REQUIRED BY   STATUS    SOURCE
  ANTHROPIC_API_KEY   models        found     environment
  OPENAI_API_KEY      models        not set   -

Issues
  - golang_developer.yaml requires environment variables that are not set: OPENAI_API_KEY (see https://docs.docker.com/ai/docker-agent/guides/secrets/)
Error: 1 issue(s) found

$ echo $?
1
```

## Implementation notes

- `cmd/root/doctor.go`: the command (telemetry, agent-ref completion, `cli.StatusError{StatusCode: 1}` when issues exist)
- `pkg/environment/default.go`: `DefaultSources()` exposes the labeled secret-source chain and `NewDefaultProvider()` now consumes it, so the doctor and the runtime can never diverge; no behavior change
- `pkg/config/auto.go`: `CloudProviderEnvVars()` exposes the auto-selection provider table without duplicating it
- `pkg/config/gather.go`: `RequiredModelEnvVars()` mirrors the gateway-aware model-credential preflight used by the run path
- Checks beyond the issue text: Docker AI Gateway configured but no Docker Desktop sign-in, configured default model whose provider has no credential
- Every lookup (provider table, auto-selection, agent-file checks) goes through the same labeled source chain, so the report sections cannot disagree

## Validation

| Check | Result |
| --- | --- |
| `go build ./...` | ok |
| `go test ./cmd/... ./pkg/environment ./pkg/config` | ok (`TestURLSource_Read_RejectsLocalAddresses` already fails on `main` in sandboxed networks, unrelated) |
| `golangci-lint run` on touched packages | 0 issues |
| `go run ./lint .` | no offenses |

## Open question

The issue leaves command naming open (`doctor` vs `debug env` vs `models --verbose`); `doctor` matches the flow in the issue's proposed behavior. If `debug env` seems more appropriate, it can always be changed.
