### PR TITLE
docs: update CLI reference and troubleshooting for board and actionable errors

### DIFF
--- a/docs/community/troubleshooting/index.md
+++ b/docs/community/troubleshooting/index.md
@@ -47,6 +47,66 @@ agents:
       cooldown: 1m # how long to stick with fallback after 429
 ```
 
+## Missing credentials or model errors
+
+When docker-agent can't find a usable model at startup, it fails fast with an actionable error. The message names the exact next step. `docker agent doctor` is the fastest way to see the full picture — which providers have credentials, whether Docker Model Runner is reachable, and which model `auto` would pick.
+
+### Required environment variables not set
+
+An agent (or a tool it uses) depends on environment variables that aren't configured:
+
+```text
+The following environment variables must be set:
+ - ANTHROPIC_API_KEY
+
+Provide them using any of these sources:
+ - Shell environment:  export ANTHROPIC_API_KEY=<value>
+ - Env file:           docker agent run --env-from-file <file> ...
+ - pass:               pass insert ANTHROPIC_API_KEY
+ - macOS Keychain:     security add-generic-password -a "$USER" -s ANTHROPIC_API_KEY -w
+
+See https://docs.docker.com/ai/docker-agent/guides/secrets/ for details.
+```
+
+Set the variable through any of the listed [secret sources](../../guides/secrets/index.md). When the missing variable is a model-provider API key, the error also suggests running a local model instead (`docker agent run --model dmr/ai/qwen3 ...`), which needs no API key.
+
+### No model available (`auto` selection failed)
+
+The `auto` model selector found no configured cloud provider and no usable Docker Model Runner model:
+
+```text
+No model is currently available.
+
+To fix this, you can:
+  - Pull a Docker Model Runner model, e.g. `docker model pull ai/qwen3`
+  - Install Docker Model Runner: https://docs.docker.com/ai/model-runner/get-started/
+  - Configure an API key for a cloud provider:
+    - anthropic: ANTHROPIC_API_KEY
+    - openai: OPENAI_API_KEY
+    ...
+```
+
+Either configure a cloud provider API key (see [API keys not set](#api-keys-not-set) below) or pull a local model. Run `docker agent doctor` to see which providers have credentials and whether Docker Model Runner is reachable.
+
+### Docker Model Runner model not pulled
+
+A `dmr/...` model was requested but isn't available locally:
+
+```text
+model ai/qwen3 is not pulled in Docker Model Runner
+
+To resolve this, you can:
+  - Pull it first: docker model pull ai/qwen3
+  - Or choose a model that is already available (see `docker model ls`).
+```
+
+If instead you see `cannot query Docker Model Runner at <url>`, Docker Model Runner isn't installed or running — see the [Model Runner get-started guide](https://docs.docker.com/ai/model-runner/get-started/).
+
+> [!TIP]
+> **Diagnose before you run**
+>
+> Run `docker agent doctor` (or `docker agent doctor ./agent.yaml` to include a file's requirements) to check all three issues in one shot. It exits non-zero when something would block a run, making it useful as a CI preflight. See the [CLI reference](../../features/cli/index.md#docker-agent-doctor).
+
 ## Debug Mode
 
 The first step for any issue is enabling debug logging. This provides detailed information about what docker-agent is doing internally.

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -364,6 +364,18 @@ $ curl http://127.0.0.1:8083/v1/chat/completions \
 
 See [Chat Server](../chat-server/index.md) for the full feature reference.
 
+### `docker agent board`
+
+Launch a full-screen Kanban TUI for orchestrating multiple agents at once. Each card runs an agent in its own tmux session on an isolated git worktree; moving a card forward through the pipeline (Dev → Review → Push → Done) delivers the destination column's prompt to that card's agent. Projects and column prompts are stored in the global config file (`~/.config/cagent/config.yaml`) and can be managed from the TUI.
+
+```bash
+$ docker agent board
+```
+
+Takes no arguments or flags. Requires `tmux` and `git` to be installed.
+
+See [Kanban Board](../board/index.md) for key bindings, configuration, and workflow details.
+
 ### `docker agent share push` / `docker agent share pull`
 
 Share agents via OCI registries.


### PR DESCRIPTION
## Summary

Catches two documentation gaps from PRs merged in the last 36 hours.

### Changes

- **`docker agent board` CLI reference** (`docs/features/cli/index.md`): PR #3451 shipped a full feature page for the new Kanban board but omitted the command from the master CLI reference. This commit adds the `docker agent board` section with its usage, requirements, and a link to the feature page.

- **Actionable model/credential errors** (`docs/community/troubleshooting/index.md`): PR #3452 introduced clear, actionable error messages when model credentials are missing or Docker Model Runner is unreachable. No documentation was written at the time. This commit adds a troubleshooting section covering those three scenarios with example error text and a `docker agent doctor` diagnosis tip.

### Source PRs

- https://github.com/docker/docker-agent/pull/3451
- https://github.com/docker/docker-agent/pull/3452

### Reviewer notes

Two low-severity/low-confidence style findings were raised and deliberately left as-is:
- **Placement of `docker agent board`**: reviewer suggested grouping it with other top-level commands (before `serve`). Placed after `serve chat` per the explicit task spec.
- **Windows caveat**: `docker agent board` doesn't work on Windows (no tmux). The feature page at `docs/features/board/index.md` notes only "Requires `tmux` and `git`"; the CLI reference mirrors that same level of detail for consistency.