### PR TITLE
fix(cli): resolve session DB default against the data dir

### DIFF
--- a/cmd/root/a2a.go
+++ b/cmd/root/a2a.go
@@ -1,14 +1,11 @@
 package root
 
 import (
-	"path/filepath"
-
 	"github.com/spf13/cobra"
 
 	"github.com/docker/docker-agent/pkg/a2a"
 	"github.com/docker/docker-agent/pkg/cli"
 	"github.com/docker/docker-agent/pkg/config"
-	"github.com/docker/docker-agent/pkg/paths"
 	"github.com/docker/docker-agent/pkg/telemetry"
 )
 
@@ -34,7 +31,7 @@ func newA2ACmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringVarP(&flags.agentName, "agent", "a", "", "Name of the agent to run (defaults to the team's first agent)")
 	cmd.PersistentFlags().StringVarP(&flags.listenAddr, "listen", "l", "127.0.0.1:8082", "Address to listen on")
-	cmd.PersistentFlags().StringVarP(&flags.sessionDB, "session-db", "s", filepath.Join(paths.GetHomeDir(), ".cagent", "session.db"), "Path to the session database")
+	cmd.PersistentFlags().StringVarP(&flags.sessionDB, "session-db", "s", "", "Path to the session database (default: <data-dir>/session.db)")
 	addRuntimeConfigFlags(cmd, &flags.runConfig)
 
 	return cmd
@@ -57,5 +54,5 @@ func (f *a2aFlags) runA2ACommand(cmd *cobra.Command, args []string) (commandErr 
 	defer cleanup()
 
 	out.Println("Listening on", ln.Addr().String())
-	return a2a.Run(ctx, agentFilename, f.agentName, f.sessionDB, &f.runConfig, ln)
+	return a2a.Run(ctx, agentFilename, f.agentName, sessionDBPath(f.sessionDB), &f.runConfig, ln)
 }

--- a/cmd/root/acp.go
+++ b/cmd/root/acp.go
@@ -1,14 +1,11 @@
 package root
 
 import (
-	"path/filepath"
-
 	"github.com/spf13/cobra"
 
 	"github.com/docker/docker-agent/pkg/acp"
 	"github.com/docker/docker-agent/pkg/config"
 	pathx "github.com/docker/docker-agent/pkg/path"
-	"github.com/docker/docker-agent/pkg/paths"
 	"github.com/docker/docker-agent/pkg/telemetry"
 )
 
@@ -31,7 +28,7 @@ func newACPCmd() *cobra.Command {
 		RunE: flags.runACPCommand,
 	}
 
-	cmd.Flags().StringVarP(&flags.sessionDB, "session-db", "s", filepath.Join(paths.GetHomeDir(), ".cagent", "session.db"), "Path to the session database")
+	cmd.Flags().StringVarP(&flags.sessionDB, "session-db", "s", "", "Path to the session database (default: <data-dir>/session.db)")
 	addRuntimeConfigFlags(cmd, &flags.runConfig)
 
 	return cmd
@@ -47,7 +44,7 @@ func (f *acpFlags) runACPCommand(cmd *cobra.Command, args []string) (commandErr 
 	agentFilename := args[0]
 
 	// Expand tilde in session database path
-	sessionDB, err := pathx.ExpandHomeDir(f.sessionDB)
+	sessionDB, err := pathx.ExpandHomeDir(sessionDBPath(f.sessionDB))
 	if err != nil {
 		return err
 	}

--- a/cmd/root/flags.go
+++ b/cmd/root/flags.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/paths"
 	"github.com/docker/docker-agent/pkg/server"
 	"github.com/docker/docker-agent/pkg/userconfig"
 )
@@ -42,6 +43,18 @@ func addRuntimeConfigFlags(cmd *cobra.Command, runConfig *config.RuntimeConfig) 
 			"itself (PKCE + DCR + token exchange) and expects clients to return `{code, state}` "+
 			"via ResumeElicitation. When empty, the client is expected to perform the OAuth "+
 			"flow and return an access token (legacy behavior).")
+}
+
+// sessionDBPath resolves the session database path from the --session-db
+// flag. The default is resolved lazily, at command run time, because the
+// data dir must reflect a --data-dir override applied by the root
+// PersistentPreRunE; a default baked in at flag registration would always
+// point at ~/.cagent regardless of --data-dir.
+func sessionDBPath(flagValue string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	return filepath.Join(paths.GetDataDir(), "session.db")
 }
 
 func setupWorkingDirectory(workingDir string) error {

--- a/cmd/root/payload.go
+++ b/cmd/root/payload.go
@@ -22,7 +22,7 @@ func (f *runExecFlags) createSessionRequest(workingDir string) runtime.CreateSes
 		AgentName:         f.agentName,
 		ToolsApproved:     f.autoApprove,
 		HideToolResults:   f.hideToolResults,
-		SessionDB:         f.sessionDB,
+		SessionDB:         sessionDBPath(f.sessionDB),
 		ResumeSessionID:   f.sessionID,
 		SnapshotsEnabled:  f.snapshotsEnabled,
 		GlobalPermissions: f.globalPermissions,

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -25,7 +24,6 @@ import (
 	"github.com/docker/docker-agent/pkg/hooks/builtins"
 	"github.com/docker/docker-agent/pkg/input"
 	"github.com/docker/docker-agent/pkg/leantui"
-	"github.com/docker/docker-agent/pkg/paths"
 	"github.com/docker/docker-agent/pkg/permissions"
 	"github.com/docker/docker-agent/pkg/profiling"
 	"github.com/docker/docker-agent/pkg/runtime"
@@ -146,7 +144,7 @@ func addRunOrExecFlags(cmd *cobra.Command, flags *runExecFlags) {
 	cmd.PersistentFlags().StringArrayVar(&flags.modelOverrides, "model", nil, "Override agent model: [agent=]provider/model (repeatable)")
 	cmd.PersistentFlags().BoolVar(&flags.dryRun, "dry-run", false, "Initialize the agent without executing anything")
 	cmd.PersistentFlags().StringVar(&flags.remoteAddress, "remote", "", "Use remote runtime with specified address")
-	cmd.PersistentFlags().StringVarP(&flags.sessionDB, "session-db", "s", filepath.Join(paths.GetHomeDir(), ".cagent", "session.db"), "Path to the session database")
+	cmd.PersistentFlags().StringVarP(&flags.sessionDB, "session-db", "s", "", "Path to the session database (default: <data-dir>/session.db)")
 	cmd.PersistentFlags().StringVar(&flags.sessionID, "session", "", "Continue from a previous session by ID or relative offset (e.g., -1 for last session). An explicit ID that does not exist yet is created with that ID.")
 	cmd.PersistentFlags().StringVar(&flags.fakeResponses, "fake", "", "Replay AI responses from cassette file (for testing)")
 	cmd.PersistentFlags().IntVar(&flags.fakeStreamDelay, "fake-stream", 0, "Simulate streaming with delay in ms between chunks (default 15ms if no value given)")

--- a/cmd/root/session_db_test.go
+++ b/cmd/root/session_db_test.go
@@ -1,0 +1,32 @@
+package root
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/paths"
+)
+
+// Regression test: the --session-db default used to be computed at flag
+// registration time as ~/.cagent/session.db, before the root
+// PersistentPreRunE applied --data-dir. Sessions were then always read from
+// the home dir, making past sessions stored under a custom data dir
+// invisible. The default must resolve lazily against the effective data dir.
+func TestSessionDBPath_FollowsDataDir(t *testing.T) {
+	// Not parallel: mutates the process-wide data-dir override.
+	dataDir := t.TempDir()
+	paths.SetDataDir(dataDir)
+	t.Cleanup(func() { paths.SetDataDir("") })
+
+	assert.Equal(t, filepath.Join(dataDir, "session.db"), sessionDBPath(""))
+}
+
+func TestSessionDBPath_ExplicitFlagWins(t *testing.T) {
+	// Not parallel: mutates the process-wide data-dir override.
+	paths.SetDataDir(t.TempDir())
+	t.Cleanup(func() { paths.SetDataDir("") })
+
+	assert.Equal(t, "/explicit/db.sqlite", sessionDBPath("/explicit/db.sqlite"))
+}

--- a/cmd/root/session_db_test.go
+++ b/cmd/root/session_db_test.go
@@ -30,3 +30,16 @@ func TestSessionDBPath_ExplicitFlagWins(t *testing.T) {
 
 	assert.Equal(t, "/explicit/db.sqlite", sessionDBPath("/explicit/db.sqlite"))
 }
+
+// Guards the wiring, not just the helper: createSessionRequest must resolve
+// the default through sessionDBPath so the backend never opens an empty path.
+func TestCreateSessionRequest_ResolvesSessionDBAgainstDataDir(t *testing.T) {
+	// Not parallel: mutates the process-wide data-dir override.
+	dataDir := t.TempDir()
+	paths.SetDataDir(dataDir)
+	t.Cleanup(func() { paths.SetDataDir("") })
+
+	f := &runExecFlags{}
+	req := f.createSessionRequest("")
+	assert.Equal(t, filepath.Join(dataDir, "session.db"), req.SessionDB)
+}

--- a/docs/features/acp/index.md
+++ b/docs/features/acp/index.md
@@ -70,7 +70,7 @@ docker agent serve acp <agent-file>|<registry-ref> [flags]
 
 | Flag                              | Default                | Description                                                                                                          |
 | --------------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `-s, --session-db <path>`         | `~/.cagent/session.db` | Path to the SQLite session database.                                                                                 |
+| `-s, --session-db <path>`         | `<data-dir>/session.db` | Path to the SQLite session database.                                                                                 |
 | `--working-dir <path>`            | current dir            | Working directory the agent runs in.                                                                                 |
 | `--env-from-file <file>`          | (none)                 | Load additional environment variables from a `.env` file (repeatable).                                               |
 | `--models-gateway <url>`          | (none)                 | Route all provider traffic through a models gateway URL.                                                             |

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -31,7 +31,7 @@ $ docker agent run [config] [message...] [flags]
 | `--yolo`                                | Auto-approve all tool calls                                                                                                               |
 | `--model <ref>`                         | Override model(s). Use `provider/model` for all agents, or `agent=provider/model` for specific agents. Comma-separate multiple overrides. |
 | `--session <id>`                        | Resume a previous session. Supports relative refs (`-1` = last, `-2` = second to last). An explicit ID that does not exist yet is created with that ID, so a supervisor can own the session ID upfront and reuse it across runs. |
-| `-s, --session-db <path>`               | Path to the SQLite session database (default: `~/.cagent/session.db`)                                                                     |
+| `-s, --session-db <path>`               | Path to the SQLite session database (default: `<data-dir>/session.db`, i.e. `~/.cagent/session.db`)                                       |
 | `--session-read-only`                   | Open the TUI in read-only mode: conversation history is displayed but no new messages can be sent to the LLM. Cannot be used with `--exec`. |
 | `--prompt-file <path>`                  | Include file contents as additional system context (repeatable)                                                                           |
 | `--attach <path>`                       | Attach an image file to the initial message                                                                                               |
@@ -315,7 +315,7 @@ $ docker agent serve acp <config> [flags]
 
 | Flag                      | Default                     | Description                                       |
 | ------------------------- | --------------------------- | ------------------------------------------------- |
-| `-s, --session-db <path>` | `~/.cagent/session.db`      | Path to the SQLite session database.              |
+| `-s, --session-db <path>` | `<data-dir>/session.db`     | Path to the SQLite session database.              |
 
 All [runtime configuration flags](#runtime-configuration-flags) are also accepted.
 
@@ -559,7 +559,7 @@ These flags are available on every `docker agent` command:
 | `-o, --otel`              | Enable OpenTelemetry observability: traces, metrics, and logs. Requires `OTEL_EXPORTER_OTLP_ENDPOINT` to export to a collector. |
 | `--cache-dir <path>`      | Override the cache directory (default: `~/Library/Caches/cagent` on macOS)             |
 | `--config-dir <path>`     | Override the config directory (default: `~/.config/cagent`). Also reads `DOCKER_AGENT_CONFIG_DIR` (legacy `CAGENT_CONFIG_DIR`) env var. |
-| `--data-dir <path>`       | Override the data directory (default: `~/.cagent`)                                     |
+| `--data-dir <path>`       | Override the data directory (default: `~/.cagent`; holds `session.db`, worktrees, plans, …)            |
 | `--help`                  | Show help for any command                                                              |
 
 ### OpenTelemetry environment variables

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -31,7 +31,7 @@ $ docker agent run [config] [message...] [flags]
 | `--yolo`                                | Auto-approve all tool calls                                                                                                               |
 | `--model <ref>`                         | Override model(s). Use `provider/model` for all agents, or `agent=provider/model` for specific agents. Comma-separate multiple overrides. |
 | `--session <id>`                        | Resume a previous session. Supports relative refs (`-1` = last, `-2` = second to last). An explicit ID that does not exist yet is created with that ID, so a supervisor can own the session ID upfront and reuse it across runs. |
-| `-s, --session-db <path>`               | Path to the SQLite session database (default: `<data-dir>/session.db`, i.e. `~/.cagent/session.db`)                                       |
+| `-s, --session-db <path>`               | Path to the SQLite session database (default: `<data-dir>/session.db`, so `~/.cagent/session.db` unless `--data-dir` is set)              |
 | `--session-read-only`                   | Open the TUI in read-only mode: conversation history is displayed but no new messages can be sent to the LLM. Cannot be used with `--exec`. |
 | `--prompt-file <path>`                  | Include file contents as additional system context (repeatable)                                                                           |
 | `--attach <path>`                       | Attach an image file to the initial message                                                                                               |
@@ -295,6 +295,7 @@ $ docker agent serve a2a <config> [flags]
 | ---------------------- | ------------------ | ------------------------------------------------------------------------------------------ |
 | `-a, --agent <name>`   | (team default)     | Name of the agent to run. Defaults to the team's first agent if not specified.             |
 | `-l, --listen <addr>`  | `127.0.0.1:8082`   | Address to listen on.                                                                       |
+| `-s, --session-db <path>` | `<data-dir>/session.db` | Path to the SQLite session database.                                                 |
 
 All [runtime configuration flags](#runtime-configuration-flags) are also accepted.
 


### PR DESCRIPTION
The `--session-db` default for `run`, `serve a2a`, and `serve acp` was computed at flag-registration time as `~/.cagent/session.db` (using `paths.GetHomeDir()`), before the root `PersistentPreRunE` applied the `--data-dir` override via `paths.SetDataDir`. As a result, `--data-dir` never relocated the session database: sessions were always read from and written to `~/.cagent/session.db`, making past sessions stored under a custom data dir invisible.

The flag default is now empty. A new `sessionDBPath()` helper in `cmd/root/flags.go` lazily resolves it to `<data-dir>/session.db` at command run time, after any directory overrides have been applied. An explicit `--session-db` value still wins and `~` expansion is preserved. `serve api` keeps its separate CWD-relative `session.db` default, unchanged.

New regression tests in `cmd/root/session_db_test.go` cover helper resolution, explicit-flag precedence, and wiring through `createSessionRequest`. Docs in `docs/features/cli/index.md` and `docs/features/acp/index.md` are updated to reflect the corrected defaults and the previously missing `--session-db` row in the `serve a2a` table.