### PR TITLE
feat(tui): opt-in "auto" theme that follows the terminal light/dark background

### DIFF
--- a/cmd/root/completion.go
+++ b/cmd/root/completion.go
@@ -102,6 +102,7 @@ func completeTheme(_ *cobra.Command, _ []string, toComplete string) ([]string, c
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
+	refs = append([]string{styles.AutoThemeRef}, refs...)
 
 	var candidates []string
 	for _, ref := range refs {

--- a/cmd/root/completion_test.go
+++ b/cmd/root/completion_test.go
@@ -333,13 +333,19 @@ func TestCompleteTheme(t *testing.T) {
 		{
 			name:       "empty prefix lists default and built-ins",
 			toComplete: "",
-			wantSome:   []string{"default", "nord", "dracula"},
+			wantSome:   []string{"auto", "default", "nord", "dracula"},
+		},
+		{
+			name:       "auto sentinel completes",
+			toComplete: "au",
+			wantSome:   []string{"auto"},
+			wantNone:   []string{"default", "nord"},
 		},
 		{
 			name:       "prefix filters to matching themes",
 			toComplete: "gruvbox",
 			wantSome:   []string{"gruvbox-dark", "gruvbox-light"},
-			wantNone:   []string{"default", "nord"},
+			wantNone:   []string{"auto", "default", "nord"},
 		},
 		{
 			name:       "non-matching prefix yields no themes",

--- a/cmd/root/new.go
+++ b/cmd/root/new.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/docker/docker-agent/pkg/telemetry"
 	"github.com/docker/docker-agent/pkg/tui"
 	tuiinput "github.com/docker/docker-agent/pkg/tui/input"
+	"github.com/docker/docker-agent/pkg/tui/styles"
 )
 
 type newFlags struct {
@@ -87,6 +89,10 @@ func (f *newFlags) runNewCommand(cmd *cobra.Command, args []string) (commandErr 
 
 	sess := session.New(sessOpts...)
 
+	// The agent builder shares the run TUI, so honour the user's configured
+	// theme (including "auto") the same way `docker-agent run` does.
+	applyTheme("")
+
 	return runTUI(ctx, rt, sess, nil, nil, nil, appOpts...)
 }
 
@@ -138,5 +144,18 @@ func runTUIWrapped(ctx context.Context, rt runtime.Runtime, sess *session.Sessio
 	}
 
 	_, err := p.Run()
+	resetLightDarkReports()
 	return err
+}
+
+// resetLightDarkReports clears DEC mode 2031 after the TUI program exits
+// while the auto theme is active, covering exits that bypass the model's own
+// quit path (context cancellation, forced shutdown). A duplicate reset is
+// harmless and invisible, and nothing is written when the auto theme was
+// never enabled.
+func resetLightDarkReports() {
+	if !styles.AutoThemeEnabled() {
+		return
+	}
+	_, _ = os.Stdout.WriteString(ansi.ResetModeLightDark)
 }

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel"
@@ -169,7 +170,7 @@ func addRunOrExecFlags(cmd *cobra.Command, flags *runExecFlags) {
 	cmd.PersistentFlags().StringVar(&flags.appName, "app-name", "", "Application name shown in the TUI in place of \"docker agent\"")
 	cmd.PersistentFlags().StringSliceVar(&flags.disabledCommands, "disable-commands", nil, "Comma-separated list of slash commands to hide and disable in the TUI (e.g. /cost,/eval,/model)")
 	cmd.PersistentFlags().BoolVar(&flags.sidebar, "sidebar", true, "Show the sidebar in the TUI (set --sidebar=false to hide it)")
-	cmd.PersistentFlags().StringVar(&flags.theme, "theme", "", "Preselect a TUI theme by name (overrides the theme from user config; ignored outside the interactive TUI)")
+	cmd.PersistentFlags().StringVar(&flags.theme, "theme", "", "Preselect a TUI theme by name, or \"auto\" to match the terminal's light/dark background (overrides the theme from user config; ignored outside the interactive TUI)")
 	_ = cmd.RegisterFlagCompletionFunc("theme", completeTheme)
 	cmd.PersistentFlags().BoolVar(&flags.sandbox, "sandbox", false, "Run the agent inside a Docker sandbox (requires Docker Desktop with sandbox support)")
 	cmd.PersistentFlags().StringVar(&flags.sandboxTemplate, "template", "docker/sandbox-templates:docker-agent", "Template image for the sandbox (passed to docker sandbox create -t)")
@@ -1129,10 +1130,15 @@ func stopToolSets(ctx context.Context, t toolStopper) {
 
 // validateTheme reports whether ref names a loadable theme. It is used to
 // fail fast on an explicit --theme value, listing the available themes so the
-// user can correct a typo.
+// user can correct a typo. The "auto" sentinel is accepted as-is: it resolves
+// to a concrete theme at apply time.
 func validateTheme(ref string) error {
+	if ref == styles.AutoThemeRef {
+		return nil
+	}
 	if _, err := styles.LoadTheme(ref); err != nil {
 		if refs, listErr := styles.ListThemeRefs(); listErr == nil && len(refs) > 0 {
+			refs = append([]string{styles.AutoThemeRef}, refs...)
 			return fmt.Errorf("unknown theme %q; available themes: %s", ref, strings.Join(refs, ", "))
 		}
 		return fmt.Errorf("unknown theme %q: %w", ref, err)
@@ -1141,7 +1147,10 @@ func validateTheme(ref string) error {
 }
 
 // applyTheme applies the theme, resolving it from the --theme flag, then the
-// user config, then the built-in default.
+// user config, then the built-in default. The "auto" sentinel resolves to the
+// configured light/dark theme pair based on the terminal background, queried
+// synchronously (OSC 11) before the TUI starts so the first frame already has
+// the right polarity.
 func applyTheme(themeOverride string) {
 	// Resolve theme from --theme flag > user config > built-in default
 	themeRef := styles.DefaultThemeRef
@@ -1152,6 +1161,14 @@ func applyTheme(themeOverride string) {
 		themeRef = themeOverride
 	}
 
+	if themeRef == styles.AutoThemeRef {
+		styles.SetAutoThemeEnabled(true)
+		styles.SetTerminalDark(detectDarkTerminalBackground())
+		themeRef = styles.ResolveThemeRef(themeRef)
+	} else {
+		styles.SetAutoThemeEnabled(false)
+	}
+
 	theme, err := styles.LoadTheme(themeRef)
 	if err != nil {
 		slog.Warn("Failed to load theme, using default", "theme", themeRef, "error", err)
@@ -1160,4 +1177,23 @@ func applyTheme(themeOverride string) {
 
 	styles.ApplyTheme(theme)
 	slog.Debug("Applied theme", "theme_ref", themeRef, "theme_name", theme.Name)
+}
+
+// detectDarkTerminalBackground reports whether the terminal background is
+// dark, falling back to dark when it cannot tell (non-TTY, pipes, CI, or a
+// terminal that never answers). The query is TTY-gated so non-interactive
+// runs emit no escape sequences at all; lipgloss bounds the wait internally
+// and terminates early on the DA1 fallback answer that virtually every
+// terminal sends.
+func detectDarkTerminalBackground() bool {
+	return terminalHasDarkBackground(os.Stdin, os.Stdout)
+}
+
+// terminalHasDarkBackground implements detectDarkTerminalBackground against
+// explicit files so tests can drive the OSC 11 round-trip with a pty pair.
+func terminalHasDarkBackground(in, out *os.File) bool {
+	if !isatty.IsTerminal(in.Fd()) || !isatty.IsTerminal(out.Fd()) {
+		return true
+	}
+	return lipgloss.HasDarkBackground(in, out)
 }

--- a/cmd/root/run_theme_detect_test.go
+++ b/cmd/root/run_theme_detect_test.go
@@ -1,0 +1,91 @@
+//go:build !windows
+
+package root
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTerminal answers the OSC 11 background query on the master side of a
+// pty pair with the given color response, followed by a DA1 answer (the
+// fallback query lipgloss uses to terminate the read early). An empty
+// response simulates a terminal that never answers.
+func fakeTerminal(t *testing.T, ptmx *os.File, response string) {
+	t.Helper()
+	go func() {
+		var seen []byte
+		buf := make([]byte, 256)
+		for {
+			n, err := ptmx.Read(buf)
+			if err != nil {
+				return
+			}
+			seen = append(seen, buf[:n]...)
+			if response != "" && bytes.Contains(seen, []byte("]11;?")) {
+				_, _ = ptmx.WriteString(response)
+				return
+			}
+		}
+	}()
+}
+
+// TestTerminalHasDarkBackground exercises the real OSC 11 round-trip through
+// a pty pair: raw-mode query on the slave side, fake terminal answering on
+// the master side.
+func TestTerminalHasDarkBackground(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-tty falls back to dark without querying", func(t *testing.T) {
+		t.Parallel()
+		devNull, err := os.Open(os.DevNull)
+		require.NoError(t, err)
+		defer devNull.Close()
+
+		start := time.Now()
+		assert.True(t, terminalHasDarkBackground(devNull, devNull))
+		assert.Less(t, time.Since(start), time.Second, "non-tty detection must not wait on a query")
+	})
+
+	t.Run("light background answer is detected", func(t *testing.T) {
+		t.Parallel()
+		ptmx, tty, err := pty.Open()
+		require.NoError(t, err)
+		defer ptmx.Close()
+		defer tty.Close()
+
+		fakeTerminal(t, ptmx, "\x1b]11;rgb:fafa/fafa/fafa\x1b\\\x1b[?62;22c")
+		assert.False(t, terminalHasDarkBackground(tty, tty), "near-white background must be detected as light")
+	})
+
+	t.Run("dark background answer is detected", func(t *testing.T) {
+		t.Parallel()
+		ptmx, tty, err := pty.Open()
+		require.NoError(t, err)
+		defer ptmx.Close()
+		defer tty.Close()
+
+		fakeTerminal(t, ptmx, "\x1b]11;rgb:1c1c/1c1c/2222\x1b\\\x1b[?62;22c")
+		assert.True(t, terminalHasDarkBackground(tty, tty))
+	})
+
+	t.Run("terminal that never answers falls back to dark without hanging", func(t *testing.T) {
+		t.Parallel()
+		ptmx, tty, err := pty.Open()
+		require.NoError(t, err)
+		defer ptmx.Close()
+		defer tty.Close()
+
+		fakeTerminal(t, ptmx, "")
+
+		start := time.Now()
+		assert.True(t, terminalHasDarkBackground(tty, tty))
+		assert.Less(t, time.Since(start), 10*time.Second, "detection must be bounded by the query timeout")
+	})
+}

--- a/cmd/root/run_theme_test.go
+++ b/cmd/root/run_theme_test.go
@@ -23,12 +23,18 @@ func TestValidateTheme(t *testing.T) {
 		require.NoError(t, validateTheme(styles.DefaultThemeRef))
 	})
 
+	t.Run("accepts auto sentinel", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, validateTheme(styles.AutoThemeRef))
+	})
+
 	t.Run("rejects unknown theme with helpful message", func(t *testing.T) {
 		t.Parallel()
 		err := validateTheme("does-not-exist")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does-not-exist")
 		assert.Contains(t, err.Error(), "available themes")
+		assert.Contains(t, err.Error(), styles.AutoThemeRef)
 	})
 
 	t.Run("rejects path traversal", func(t *testing.T) {
@@ -44,9 +50,13 @@ func TestApplyThemePrecedence(t *testing.T) {
 	dir := t.TempDir()
 	paths.SetConfigDir(dir)
 	paths.SetDataDir(dir)
+	prevDark := styles.TerminalIsDark()
+	prevEnabled := styles.AutoThemeEnabled()
 	t.Cleanup(func() {
 		paths.SetConfigDir("")
 		paths.SetDataDir("")
+		styles.SetTerminalDark(prevDark)
+		styles.SetAutoThemeEnabled(prevEnabled)
 	})
 
 	t.Run("override takes precedence and is applied", func(t *testing.T) {
@@ -64,5 +74,21 @@ func TestApplyThemePrecedence(t *testing.T) {
 	t.Run("empty override applies default when no user config theme", func(t *testing.T) {
 		applyTheme("")
 		assert.Equal(t, styles.DefaultThemeRef, styles.CurrentTheme().Ref)
+	})
+
+	t.Run("auto falls back to dark default without a terminal", func(t *testing.T) {
+		// Tests run without a TTY, so detection must skip the query and
+		// resolve auto to the dark half of the pair.
+		applyTheme("auto")
+		assert.Equal(t, styles.DefaultThemeRef, styles.CurrentTheme().Ref)
+		assert.True(t, styles.AutoThemeEnabled())
+		assert.True(t, styles.TerminalIsDark())
+	})
+
+	t.Run("concrete override disables a previously enabled auto theme", func(t *testing.T) {
+		applyTheme("auto")
+		applyTheme("nord")
+		assert.Equal(t, "nord", styles.CurrentTheme().Ref)
+		assert.False(t, styles.AutoThemeEnabled())
 	})
 }

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -42,7 +42,7 @@ $ docker agent run [config] [message...] [flags]
 | `--app-name <name>`                     | Override the application name label shown in the TUI (status bar, window title, "/exit" notifications).                                   |
 | `--sidebar`                             | Control sidebar visibility. Set to `--sidebar=false` to hide the sidebar and disable the Ctrl+B toggle (default: `true`).                 |
 | `--disable-commands <list>`             | Hide and disable specific slash commands in the TUI. Accepts a comma-separated list of command names (leading slash optional, case-insensitive). E.g. `--disable-commands="/cost,/eval,/model"`. |
-| `--theme <name>`                        | Preselect a TUI theme by name (overrides the theme from user config; ignored outside the interactive TUI)                                 |
+| `--theme <name>`                        | Preselect a TUI theme by name, or `auto` to follow the terminal's light/dark background (overrides the theme from user config; ignored outside the interactive TUI) |
 | `--on-event <type>=<cmd>`               | Run a shell command when an event of the given type fires (`*=<cmd>` matches any event). Repeatable.                                      |
 | `--json`                                | Output results as newline-delimited JSON (use with `--exec`)                                                                              |
 | `--hide-tool-calls`                     | Hide tool calls in the output                                                                                                             |

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -330,7 +330,20 @@ Customize the TUI appearance with built-in or custom themes:
 
 ### Built-in Themes
 
-`default`, `catppuccin-latte`, `catppuccin-mocha`, `dracula`, `gruvbox-dark`, `gruvbox-light`, `nord`, `one-dark`, `solarized-dark`, `tokyo-night`
+`default`, `default-light`, `catppuccin-latte`, `catppuccin-mocha`, `dracula`, `gruvbox-dark`, `gruvbox-light`, `nord`, `one-dark`, `solarized-dark`, `tokyo-night`
+
+### Auto Theme (match the terminal)
+
+The special theme `auto` follows the terminal's light/dark background instead of naming a fixed theme. Select **Auto (match terminal)** in the `/theme` picker, pass `--theme auto`, or set it in your user config:
+
+```yaml
+settings:
+  theme: auto
+  theme_dark: default # optional, theme used on dark backgrounds (default: default)
+  theme_light: default-light # optional, theme used on light backgrounds (default: default-light)
+```
+
+At startup the terminal background is queried (OSC 11) to pick the dark or light theme of the pair; non-interactive runs (pipes, CI) fall back to the dark theme. In terminals that report appearance changes (DEC mode 2031 — Ghostty, kitty, contour, …), flipping the OS or terminal appearance while docker-agent is running switches the theme live. Terminals without that mode re-sync when the window regains focus.
 
 ### Custom Themes
 
@@ -383,7 +396,7 @@ settings:
   theme: my-theme # References ~/.cagent/themes/my-theme.yaml
 ```
 
-**At launch:** Pass `--theme <name>` to `docker agent run` to preselect a theme for that session. This overrides `settings.theme` in your config but is not saved. Invalid theme names print an error at startup listing the available options. Has no effect in `--exec` mode.
+**At launch:** Pass `--theme <name>` to `docker agent run` to preselect a theme for that session. This overrides `settings.theme` in your config but is not saved. Invalid theme names print an error at startup listing the available options. Has no effect in `--exec` mode. `--theme auto` enables the [auto theme](#auto-theme-match-the-terminal) for the session.
 
 **At runtime:** Use the `/theme` command to open the theme picker and select from available themes. Your selection is saved globally in `~/.config/cagent/config.yaml` under `settings.theme` and persists across sessions.
 

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/clipperhouse/displaywidth v0.11.0
 	github.com/clipperhouse/uax29/v2 v2.7.0
 	github.com/coder/acp-go-sdk v0.13.5
+	github.com/creack/pty v1.1.24
 	github.com/docker/aijson v0.1.0
 	github.com/docker/cli v29.6.1+incompatible
 	github.com/docker/go-units v0.5.0
@@ -131,7 +132,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
-	github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7 // indirect
+	github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7
 	github.com/charmbracelet/x/exp/slice v0.0.0-20251113172435-cef867b85f6a // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -14,6 +14,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/atotto/clipboard"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/docker/docker-agent/pkg/app"
 	"github.com/docker/docker-agent/pkg/browser"
@@ -669,8 +670,17 @@ func (m *appModel) handleOpenThemePicker() (tea.Model, tea.Cmd) {
 	}
 	currentTheme := styles.CurrentTheme()
 	currentRef := currentTheme.Ref
+	autoEnabled := styles.AutoThemeEnabled()
 
-	var choices []dialog.ThemeChoice
+	// The auto entry resolves to the configured light/dark pair at apply
+	// time. While it is active, the resolved concrete theme is not marked
+	// current so only one entry carries the badge.
+	choices := []dialog.ThemeChoice{{
+		Ref:       styles.AutoThemeRef,
+		Name:      styles.AutoThemeDisplayName,
+		IsCurrent: autoEnabled,
+		IsBuiltin: true,
+	}}
 	for _, ref := range themeRefs {
 		theme, loadErr := styles.LoadTheme(ref)
 		if loadErr != nil {
@@ -683,7 +693,7 @@ func (m *appModel) handleOpenThemePicker() (tea.Model, tea.Cmd) {
 		choices = append(choices, dialog.ThemeChoice{
 			Ref:       ref,
 			Name:      name,
-			IsCurrent: ref == currentRef,
+			IsCurrent: !autoEnabled && ref == currentRef,
 			IsDefault: ref == styles.DefaultThemeRef,
 			IsBuiltin: styles.IsBuiltinTheme(ref),
 		})
@@ -694,26 +704,47 @@ func (m *appModel) handleOpenThemePicker() (tea.Model, tea.Cmd) {
 }
 
 func (m *appModel) handleChangeTheme(themeRef string) (tea.Model, tea.Cmd) {
-	if styles.GetPersistedThemeRef() == themeRef {
+	selectingAuto := themeRef == styles.AutoThemeRef
+	if styles.GetPersistedThemeRef() == themeRef && styles.AutoThemeEnabled() == selectingAuto {
 		return m, nil
 	}
-	theme, err := styles.LoadTheme(themeRef)
+	theme, err := styles.LoadTheme(styles.ResolveThemeRef(themeRef))
 	if err != nil {
 		return m, notification.ErrorCmd(fmt.Sprintf("Failed to load theme: %v", err))
 	}
+	wasAuto := styles.AutoThemeEnabled()
+	styles.SetAutoThemeEnabled(selectingAuto)
 	styles.ApplyTheme(theme)
 	m.invalidateCachesForThemeChange()
 
 	if err := styles.SaveThemeToUserConfig(themeRef); err != nil {
 		slog.Warn("Failed to save theme to user config", "theme", themeRef, "error", err)
 	}
-	return m, tea.Sequence(
-		notification.SuccessCmd("Theme changed to "+theme.Name),
+
+	displayName := theme.Name
+	if selectingAuto {
+		displayName = styles.AutoThemeDisplayName
+	}
+	cmds := []tea.Cmd{
+		notification.SuccessCmd("Theme changed to " + displayName),
 		core.CmdHandler(messages.ThemeChangedMsg{}),
-	)
+	}
+	// Keep terminal color-scheme reporting (DEC mode 2031) in sync with the
+	// auto selection: enable it and re-query the polarity when auto is picked
+	// mid-session, reset it when a concrete theme replaces auto.
+	switch {
+	case selectingAuto && !m.lightDarkModeSet:
+		m.lightDarkModeSet = true
+		cmds = append(cmds, tea.Raw(ansi.SetModeLightDark), tea.RequestBackgroundColor)
+	case !selectingAuto && wasAuto && m.lightDarkModeSet:
+		m.lightDarkModeSet = false
+		cmds = append(cmds, tea.Raw(ansi.ResetModeLightDark))
+	}
+	return m, tea.Sequence(cmds...)
 }
 
 func (m *appModel) handleThemePreview(themeRef string) (tea.Model, tea.Cmd) {
+	themeRef = styles.ResolveThemeRef(themeRef)
 	if current := styles.CurrentTheme(); current != nil && current.Ref == themeRef {
 		return m, nil
 	}
@@ -757,6 +788,28 @@ func (m *appModel) handleThemeFileChanged(themeRef string) (tea.Model, tea.Cmd) 
 		notification.SuccessCmd("Theme hot-reloaded"),
 		core.CmdHandler(messages.ThemeChangedMsg{}),
 	)
+}
+
+// handleColorSchemeChange reacts to a terminal light/dark report (a DEC mode
+// 2031 event or an OSC 11 response). The polarity is always recorded so a
+// later switch to the auto theme starts from the freshest value; the theme
+// itself only changes while the auto theme is active.
+func (m *appModel) handleColorSchemeChange(dark bool) (tea.Model, tea.Cmd) {
+	styles.SetTerminalDark(dark)
+	if !styles.AutoThemeEnabled() {
+		return m, nil
+	}
+	resolved := styles.ResolveThemeRef(styles.AutoThemeRef)
+	if current := styles.CurrentTheme(); current != nil && current.Ref == resolved {
+		return m, nil
+	}
+	theme, err := styles.LoadTheme(resolved)
+	if err != nil {
+		slog.Warn("Failed to load auto theme for terminal background change", "theme", resolved, "error", err)
+		return m, nil
+	}
+	styles.ApplyTheme(theme)
+	return m, core.CmdHandler(messages.ThemeChangedMsg{})
 }
 
 // --- Miscellaneous ---

--- a/pkg/tui/styles/auto_theme.go
+++ b/pkg/tui/styles/auto_theme.go
@@ -1,0 +1,73 @@
+package styles
+
+import (
+	"sync/atomic"
+
+	"github.com/docker/docker-agent/pkg/userconfig"
+)
+
+// AutoThemeRef is the sentinel theme reference that makes the theme follow
+// the terminal's light/dark background. It is never loaded directly: callers
+// resolve it to a concrete theme with ResolveThemeRef first.
+const AutoThemeRef = "auto"
+
+// DefaultLightThemeRef is the built-in light counterpart of the default
+// theme, applied when the auto theme detects a light terminal background and
+// no settings.theme_light is configured.
+const DefaultLightThemeRef = "default-light"
+
+// AutoThemeDisplayName is the label shown for the auto theme in the picker
+// and in notifications.
+const AutoThemeDisplayName = "Auto (match terminal)"
+
+// terminalIsLight holds the detected terminal background polarity. The zero
+// value (false) means dark, so an undetected terminal keeps today's dark
+// default.
+var terminalIsLight atomic.Bool
+
+// SetTerminalDark records the detected terminal background polarity.
+func SetTerminalDark(dark bool) {
+	terminalIsLight.Store(!dark)
+}
+
+// TerminalIsDark reports the last detected terminal background polarity.
+// Defaults to dark when no detection ever ran.
+func TerminalIsDark() bool {
+	return !terminalIsLight.Load()
+}
+
+// autoThemeEnabled tracks whether the auto theme is the active selection
+// (via settings.theme, --theme auto, or the picker). The TUI consults it to
+// enable terminal color-scheme reporting and to react to polarity changes.
+var autoThemeEnabled atomic.Bool
+
+// SetAutoThemeEnabled records whether the auto theme is the active selection.
+func SetAutoThemeEnabled(enabled bool) {
+	autoThemeEnabled.Store(enabled)
+}
+
+// AutoThemeEnabled reports whether the auto theme is the active selection.
+func AutoThemeEnabled() bool {
+	return autoThemeEnabled.Load()
+}
+
+// ResolveThemeRef maps the AutoThemeRef sentinel to the concrete theme for
+// the current terminal polarity: settings.theme_dark (default "default") on
+// a dark background, settings.theme_light (default "default-light") on a
+// light one. Any other ref passes through unchanged.
+func ResolveThemeRef(ref string) string {
+	if ref != AutoThemeRef {
+		return ref
+	}
+	settings := userconfig.Get()
+	if TerminalIsDark() {
+		if settings.ThemeDark != "" {
+			return settings.ThemeDark
+		}
+		return DefaultThemeRef
+	}
+	if settings.ThemeLight != "" {
+		return settings.ThemeLight
+	}
+	return DefaultLightThemeRef
+}

--- a/pkg/tui/styles/auto_theme_test.go
+++ b/pkg/tui/styles/auto_theme_test.go
@@ -1,0 +1,161 @@
+package styles
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/paths"
+)
+
+// isolateUserConfig points the user config at an empty temp dir and restores
+// the previous polarity/enabled state afterwards, so tests can mutate the
+// package-level auto-theme state without leaking into each other.
+func isolateUserConfig(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	paths.SetConfigDir(dir)
+	prevDark := TerminalIsDark()
+	prevEnabled := AutoThemeEnabled()
+	t.Cleanup(func() {
+		paths.SetConfigDir("")
+		SetTerminalDark(prevDark)
+		SetAutoThemeEnabled(prevEnabled)
+	})
+	return dir
+}
+
+func TestTerminalPolarityDefaultsToDark(t *testing.T) {
+	isolateUserConfig(t)
+
+	SetTerminalDark(true)
+	assert.True(t, TerminalIsDark())
+
+	SetTerminalDark(false)
+	assert.False(t, TerminalIsDark())
+}
+
+func TestAutoThemeEnabledRoundTrip(t *testing.T) {
+	isolateUserConfig(t)
+
+	SetAutoThemeEnabled(true)
+	assert.True(t, AutoThemeEnabled())
+
+	SetAutoThemeEnabled(false)
+	assert.False(t, AutoThemeEnabled())
+}
+
+func TestResolveThemeRefPassesThroughConcreteRefs(t *testing.T) {
+	isolateUserConfig(t)
+
+	assert.Equal(t, "nord", ResolveThemeRef("nord"))
+	assert.Equal(t, DefaultThemeRef, ResolveThemeRef(DefaultThemeRef))
+	assert.Empty(t, ResolveThemeRef(""))
+}
+
+func TestResolveThemeRefAutoDefaults(t *testing.T) {
+	isolateUserConfig(t)
+
+	SetTerminalDark(true)
+	assert.Equal(t, DefaultThemeRef, ResolveThemeRef(AutoThemeRef))
+
+	SetTerminalDark(false)
+	assert.Equal(t, DefaultLightThemeRef, ResolveThemeRef(AutoThemeRef))
+}
+
+func TestResolveThemeRefAutoHonorsConfiguredPair(t *testing.T) {
+	dir := isolateUserConfig(t)
+	cfg := "settings:\n  theme: auto\n  theme_dark: tokyo-night\n  theme_light: gruvbox-light\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(cfg), 0o600))
+
+	SetTerminalDark(true)
+	assert.Equal(t, "tokyo-night", ResolveThemeRef(AutoThemeRef))
+
+	SetTerminalDark(false)
+	assert.Equal(t, "gruvbox-light", ResolveThemeRef(AutoThemeRef))
+}
+
+func TestDefaultLightThemeLoads(t *testing.T) {
+	t.Parallel()
+
+	theme, err := LoadTheme(DefaultLightThemeRef)
+	require.NoError(t, err)
+	assert.Equal(t, "Default Light", theme.Name)
+	assert.True(t, IsBuiltinTheme(DefaultLightThemeRef))
+
+	refs, err := ListThemeRefs()
+	require.NoError(t, err)
+	assert.Contains(t, refs, DefaultLightThemeRef)
+}
+
+func TestUserThemeNamedAutoListsUnderUserPrefix(t *testing.T) {
+	dir := t.TempDir()
+	paths.SetDataDir(dir)
+	t.Cleanup(func() { paths.SetDataDir("") })
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "themes"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "themes", "auto.yaml"), []byte("name: Not The Sentinel\n"), 0o600))
+
+	refs, err := ListThemeRefs()
+	require.NoError(t, err)
+	assert.Contains(t, refs, UserThemePrefix+AutoThemeRef, "a user theme named auto must not shadow the sentinel")
+	assert.NotContains(t, refs, AutoThemeRef)
+}
+
+// TestDefaultLightThemeContrast checks the readability of the bundled light
+// theme: every foreground role must clear a WCAG-ish contrast ratio against
+// the background it is rendered on.
+func TestDefaultLightThemeContrast(t *testing.T) {
+	t.Parallel()
+
+	theme, err := LoadTheme(DefaultLightThemeRef)
+	require.NoError(t, err)
+	c := theme.Colors
+
+	// Sanity check: this is a light theme.
+	bgLum, ok := relativeLuminanceHex(c.Background)
+	require.True(t, ok)
+	assert.Greater(t, bgLum, 0.5, "default-light background should be light")
+
+	checks := []struct {
+		name     string
+		fg, bg   string
+		minRatio float64
+	}{
+		{"text_bright on background", c.TextBright, c.Background, 7},
+		{"text_primary on background", c.TextPrimary, c.Background, 7},
+		{"text_secondary on background", c.TextSecondary, c.Background, 4.5},
+		{"text_muted on background", c.TextMuted, c.Background, 4.5},
+		{"accent on background", c.Accent, c.Background, 4.5},
+		{"accent_muted on background", c.AccentMuted, c.Background, 4.5},
+		{"success on background", c.Success, c.Background, 4.5},
+		{"error on background", c.Error, c.Background, 4.5},
+		{"warning on background", c.Warning, c.Background, 4.5},
+		{"info on background", c.Info, c.Background, 4.5},
+		{"highlight on background", c.Highlight, c.Background, 4.5},
+		{"error_strong on background", c.ErrorStrong, c.Background, 4.5},
+		{"text_primary on background_alt", c.TextPrimary, c.BackgroundAlt, 4.5},
+		{"text_primary on selected", c.TextPrimary, c.Selected, 4.5},
+		{"selected_fg on brand", c.SelectedFg, c.Brand, 4.5},
+		{"tab_active_fg on tab_active_bg", c.TabActiveFg, c.TabActiveBg, 4.5},
+		{"tab_inactive_fg on tab_bg", c.TabInactiveFg, c.TabBg, 4.5},
+		{"placeholder on background", c.Placeholder, c.Background, 4.5},
+		{"badge_accent on background", c.BadgeAccent, c.Background, 4.5},
+		{"badge_info on background", c.BadgeInfo, c.Background, 4.5},
+		{"badge_success on background", c.BadgeSuccess, c.Background, 4.5},
+		{"success on diff_add_bg", c.Success, c.DiffAddBg, 4.5},
+		{"error on diff_remove_bg", c.Error, c.DiffRemoveBg, 4.5},
+		{"markdown heading on background", theme.Markdown.Heading, c.Background, 4.5},
+		{"markdown link on background", theme.Markdown.Link, c.Background, 4.5},
+	}
+
+	for _, check := range checks {
+		ratio, ok := contrastRatioHex(check.fg, check.bg)
+		require.True(t, ok, "%s: invalid colors %q on %q", check.name, check.fg, check.bg)
+		assert.GreaterOrEqual(t, ratio, check.minRatio,
+			"%s: contrast of %s on %s is %.2f, want >= %.2f", check.name, check.fg, check.bg, ratio, check.minRatio)
+	}
+}

--- a/pkg/tui/styles/theme.go
+++ b/pkg/tui/styles/theme.go
@@ -372,6 +372,11 @@ func (r *themeRegistry) ListThemeRefs() ([]string, error) {
 	refs := []string{DefaultThemeRef}
 	builtinSet[DefaultThemeRef] = true
 
+	// Reserve the auto sentinel: a user theme named "auto" must not shadow
+	// it, so such a theme lists under the "user:" prefix instead. The
+	// sentinel itself is not listed; pickers add their own entry for it.
+	builtinSet[AutoThemeRef] = true
+
 	// Add built-in themes from embedded files (default.yaml will be skipped since already added)
 	builtinRefs, err := r.listBuiltinThemeRefs()
 	if err != nil {

--- a/pkg/tui/styles/themes/default-light.yaml
+++ b/pkg/tui/styles/themes/default-light.yaml
@@ -1,0 +1,100 @@
+version: 1
+name: "Default Light"
+colors:
+  # Text colors
+  text_bright: "#0F1420"
+  text_primary: "#33374C"
+  text_secondary: "#5A607D"
+  text_muted: "#5A607D"
+  text_faint: "#A6ABBF"
+
+  # Accent colors
+  accent: "#2E59D9"
+  accent_muted: "#5A6AA8"
+
+  # Background colors
+  background: "#FAFAFA"
+  background_alt: "#EAECF2"
+
+  # Border colors
+  border_secondary: "#8A91B4"
+
+  # Status colors
+  success: "#4F6B33"
+  error: "#B02A3C"
+  warning: "#8C6D1F"
+  info: "#0F7490"
+  highlight: "#3F7A28"
+
+  # Brand colors
+  brand: "#1D63ED"
+  brand_bg: "#D9E4FB"
+
+  # Error colors
+  error_strong: "#A83220"
+  error_dark: "#F6D9D5"
+
+  # Spinner colors
+  spinner_dim: "#7C90DC"
+  spinner_bright: "#4A66C4"
+  spinner_brightest: "#1F3FAE"
+
+  # Diff colors
+  diff_add_bg: "#D8EAD3"
+  diff_remove_bg: "#F5DBDB"
+
+  # UI element colors
+  line_number: "#9A9EB6"
+  separator: "#C9CCDA"
+  selected: "#C7D4F2"
+  selected_fg: "#FFFFFF"
+  suggestion_ghost: "#767D99"
+  tab_bg: "#F1F2F6"
+  tab_active_bg: "#DFE3EE"
+  tab_active_fg: "#0F1420"
+  tab_inactive_fg: "#61677F"
+  tab_border: "#2E59D9"
+
+  placeholder: "#5A607D"
+
+  # Badge colors
+  badge_accent: "#7B3FBF"
+  badge_info: "#0F7490"
+  badge_success: "#4F6B33"
+
+  # Agent colors (hue values 0-360 for dynamic palette generation)
+  agent_hues: [220, 280, 170, 30, 330, 140, 200, 260, 50, 0, 185, 20, 235, 295, 155, 340]
+
+chroma:
+  # Syntax highlighting colors (GitHub-light-inspired)
+  error_fg: "#B31D28"
+  error_bg: "#F6D9D5"
+  success: "#1A7F37"
+  comment: "#7C8393"
+  comment_preproc: "#B35A00"
+  keyword: "#0550AE"
+  keyword_reserved: "#A626A4"
+  keyword_namespace: "#CF222E"
+  keyword_type: "#6F42C1"
+  operator: "#B3305C"
+  punctuation: "#3B4152"
+  name_builtin: "#953800"
+  name_tag: "#116329"
+  name_attribute: "#0550AE"
+  name_decorator: "#B08800"
+  literal_number: "#0A7B83"
+  literal_string: "#0A3069"
+  literal_string_escape: "#116329"
+  generic_deleted: "#CF222E"
+  generic_subheading: "#6E7781"
+  background: "#EFF1F5"
+
+markdown:
+  heading: "#2E59D9"
+  link: "#1D63ED"
+  strong: "#1A1F33"
+  code: "#33374C"
+  code_bg: "#EAECF2"
+  blockquote: "#5A607D"
+  list: "#33374C"
+  hr: "#8A91B4"

--- a/pkg/tui/theme_auto_test.go
+++ b/pkg/tui/theme_auto_test.go
@@ -1,0 +1,189 @@
+package tui
+
+import (
+	"image/color"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/paths"
+	"github.com/docker/docker-agent/pkg/tui/messages"
+	"github.com/docker/docker-agent/pkg/tui/styles"
+)
+
+// setupAutoThemeTest isolates the user config in a temp dir and restores the
+// process-global theme state afterwards. Tests using it must not be parallel:
+// they mutate the applied theme and the auto-theme flags shared by the styles
+// package.
+func setupAutoThemeTest(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	paths.SetConfigDir(dir)
+	paths.SetDataDir(dir)
+	prevDark := styles.TerminalIsDark()
+	prevEnabled := styles.AutoThemeEnabled()
+	t.Cleanup(func() {
+		paths.SetConfigDir("")
+		paths.SetDataDir("")
+		styles.SetTerminalDark(prevDark)
+		styles.SetAutoThemeEnabled(prevEnabled)
+		styles.ApplyTheme(styles.DefaultTheme())
+	})
+}
+
+func rawMsgs(msgs []tea.Msg) []string {
+	var raws []string
+	for _, msg := range msgs {
+		if raw, ok := msg.(tea.RawMsg); ok {
+			raws = append(raws, raw.Msg.(string))
+		}
+	}
+	return raws
+}
+
+func TestAutoThemeInitCmd(t *testing.T) {
+	setupAutoThemeTest(t)
+	m, _ := newTestModel(t)
+
+	styles.SetAutoThemeEnabled(false)
+	assert.Nil(t, m.autoThemeInitCmd(), "no sequence should be emitted when auto theme is off")
+	assert.False(t, m.lightDarkModeSet)
+
+	styles.SetAutoThemeEnabled(true)
+	msgs := collectMsgs(m.autoThemeInitCmd())
+	assert.Contains(t, rawMsgs(msgs), ansi.SetModeLightDark)
+	assert.True(t, m.lightDarkModeSet)
+}
+
+func TestQuitCmdResetsLightDarkMode(t *testing.T) {
+	setupAutoThemeTest(t)
+	m, _ := newTestModel(t)
+
+	msgs := collectMsgs(m.quitCmd())
+	assert.True(t, hasMsg[tea.QuitMsg](msgs))
+	assert.Empty(t, rawMsgs(msgs), "no mode reset expected when 2031 was never set")
+
+	m.lightDarkModeSet = true
+	msgs = collectMsgs(m.quitCmd())
+	assert.True(t, hasMsg[tea.QuitMsg](msgs))
+	assert.Contains(t, rawMsgs(msgs), ansi.ResetModeLightDark)
+	assert.False(t, m.lightDarkModeSet)
+}
+
+func TestColorSchemeEventSwitchesAutoTheme(t *testing.T) {
+	setupAutoThemeTest(t)
+	m, _ := newTestModel(t)
+
+	styles.SetAutoThemeEnabled(true)
+	styles.SetTerminalDark(true)
+	styles.ApplyTheme(styles.DefaultTheme())
+
+	_, cmd := m.Update(uv.LightColorSchemeEvent{})
+	assert.False(t, styles.TerminalIsDark())
+	assert.Equal(t, styles.DefaultLightThemeRef, styles.CurrentTheme().Ref)
+	assert.True(t, hasMsg[messages.ThemeChangedMsg](collectMsgs(cmd)))
+
+	_, cmd = m.Update(uv.DarkColorSchemeEvent{})
+	assert.True(t, styles.TerminalIsDark())
+	assert.Equal(t, styles.DefaultThemeRef, styles.CurrentTheme().Ref)
+	assert.True(t, hasMsg[messages.ThemeChangedMsg](collectMsgs(cmd)))
+
+	// Same polarity again: no redundant theme application.
+	_, cmd = m.Update(uv.DarkColorSchemeEvent{})
+	assert.False(t, hasMsg[messages.ThemeChangedMsg](collectMsgs(cmd)))
+}
+
+func TestColorSchemeEventIgnoredWithoutAutoTheme(t *testing.T) {
+	setupAutoThemeTest(t)
+	m, _ := newTestModel(t)
+
+	styles.SetAutoThemeEnabled(false)
+	styles.SetTerminalDark(true)
+	styles.ApplyTheme(styles.DefaultTheme())
+
+	_, cmd := m.Update(uv.LightColorSchemeEvent{})
+	assert.Equal(t, styles.DefaultThemeRef, styles.CurrentTheme().Ref, "theme must not change when auto is off")
+	assert.False(t, hasMsg[messages.ThemeChangedMsg](collectMsgs(cmd)))
+	assert.False(t, styles.TerminalIsDark(), "polarity should still be recorded")
+}
+
+func TestBackgroundColorMsgDrivesAutoTheme(t *testing.T) {
+	setupAutoThemeTest(t)
+	m, _ := newTestModel(t)
+
+	styles.SetAutoThemeEnabled(true)
+	styles.SetTerminalDark(true)
+	styles.ApplyTheme(styles.DefaultTheme())
+
+	_, _ = m.Update(tea.BackgroundColorMsg{Color: color.White})
+	assert.Equal(t, styles.DefaultLightThemeRef, styles.CurrentTheme().Ref)
+
+	_, _ = m.Update(tea.BackgroundColorMsg{Color: color.Black})
+	assert.Equal(t, styles.DefaultThemeRef, styles.CurrentTheme().Ref)
+}
+
+func TestHandleChangeThemeAutoSelection(t *testing.T) {
+	setupAutoThemeTest(t)
+	m, _ := newTestModel(t)
+
+	styles.SetAutoThemeEnabled(false)
+	styles.SetTerminalDark(false)
+	styles.ApplyTheme(styles.DefaultTheme())
+
+	_, cmd := m.handleChangeTheme(styles.AutoThemeRef)
+	require.NotNil(t, cmd)
+
+	assert.True(t, styles.AutoThemeEnabled())
+	assert.Equal(t, styles.DefaultLightThemeRef, styles.CurrentTheme().Ref)
+	assert.Equal(t, styles.AutoThemeRef, styles.GetPersistedThemeRef())
+	assert.True(t, m.lightDarkModeSet)
+	assert.Contains(t, rawMsgs(collectMsgs(cmd)), ansi.SetModeLightDark)
+}
+
+func TestHandleChangeThemeAwayFromAutoResetsMode(t *testing.T) {
+	setupAutoThemeTest(t)
+	m, _ := newTestModel(t)
+
+	styles.SetAutoThemeEnabled(true)
+	styles.SetTerminalDark(true)
+	styles.ApplyTheme(styles.DefaultTheme())
+	m.lightDarkModeSet = true
+
+	_, cmd := m.handleChangeTheme("nord")
+	require.NotNil(t, cmd)
+
+	assert.False(t, styles.AutoThemeEnabled())
+	assert.Equal(t, "nord", styles.CurrentTheme().Ref)
+	assert.Equal(t, "nord", styles.GetPersistedThemeRef())
+	assert.False(t, m.lightDarkModeSet)
+	assert.Contains(t, rawMsgs(collectMsgs(cmd)), ansi.ResetModeLightDark)
+}
+
+func TestHandleChangeThemeAutoNoOpWhenAlreadyActive(t *testing.T) {
+	setupAutoThemeTest(t)
+	m, _ := newTestModel(t)
+
+	styles.SetAutoThemeEnabled(true)
+	styles.SetTerminalDark(true)
+	require.NoError(t, styles.SaveThemeToUserConfig(styles.AutoThemeRef))
+
+	_, cmd := m.handleChangeTheme(styles.AutoThemeRef)
+	assert.Nil(t, cmd, "re-selecting the active auto theme should be a no-op")
+}
+
+func TestHandleThemePreviewResolvesAuto(t *testing.T) {
+	setupAutoThemeTest(t)
+	m, _ := newTestModel(t)
+
+	styles.SetAutoThemeEnabled(false)
+	styles.SetTerminalDark(false)
+	styles.ApplyTheme(styles.DefaultTheme())
+
+	_, _ = m.handleThemePreview(styles.AutoThemeRef)
+	assert.Equal(t, styles.DefaultLightThemeRef, styles.CurrentTheme().Ref)
+	assert.False(t, styles.AutoThemeEnabled(), "previewing auto must not enable it")
+}

--- a/pkg/tui/theme_auto_wire_test.go
+++ b/pkg/tui/theme_auto_wire_test.go
@@ -1,0 +1,43 @@
+package tui
+
+import (
+	"testing"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tui/styles"
+)
+
+// TestColorSchemeWireFormat drives the auto theme from the raw DEC mode 2031
+// report bytes a terminal emits (CSI ? 997 ; 1|2 n), going through the same
+// ultraviolet decoder bubbletea's input loop uses. This pins the full chain:
+// wire bytes -> decoder event -> appModel.Update -> theme switch.
+func TestColorSchemeWireFormat(t *testing.T) {
+	setupAutoThemeTest(t)
+	m, _ := newTestModel(t)
+
+	styles.SetAutoThemeEnabled(true)
+	styles.SetTerminalDark(true)
+	styles.ApplyTheme(styles.DefaultTheme())
+
+	decode := func(seq string) uv.Event {
+		t.Helper()
+		var decoder uv.EventDecoder
+		n, event := decoder.Decode([]byte(seq))
+		require.Equal(t, len(seq), n, "decoder must consume the full sequence %q", seq)
+		require.NotNil(t, event)
+		return event
+	}
+
+	lightEvent := decode("\x1b[?997;2n")
+	require.IsType(t, uv.LightColorSchemeEvent{}, lightEvent)
+	_, _ = m.Update(lightEvent)
+	assert.Equal(t, styles.DefaultLightThemeRef, styles.CurrentTheme().Ref)
+
+	darkEvent := decode("\x1b[?997;1n")
+	require.IsType(t, uv.DarkColorSchemeEvent{}, darkEvent)
+	_, _ = m.Update(darkEvent)
+	assert.Equal(t, styles.DefaultThemeRef, styles.CurrentTheme().Ref)
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -17,6 +17,8 @@ import (
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/docker/docker-agent/pkg/app"
 	"github.com/docker/docker-agent/pkg/audio/transcribe"
@@ -172,6 +174,11 @@ type appModel struct {
 	// keep flowing at startup even before any focus event arrives — some
 	// terminals never send FocusMsg.
 	tickPaused bool
+
+	// lightDarkModeSet is true while DEC mode 2031 (terminal color-scheme
+	// reports) is enabled. Set when the auto theme turns the mode on, so the
+	// quit path knows to reset it and leave no stray reports in the shell.
+	lightDarkModeSet bool
 
 	// pendingRestores maps runtime tab IDs (supervisor routing keys) to
 	// persisted session-store IDs. When a tab with a pending restore is first
@@ -604,7 +611,30 @@ func (m *appModel) contextShutdownCmd() tea.Cmd {
 
 // Init initializes the model.
 func (m *appModel) Init() tea.Cmd {
-	return tea.Batch(m.init(), m.tourStartupCmd())
+	return tea.Batch(m.init(), m.tourStartupCmd(), m.autoThemeInitCmd())
+}
+
+// autoThemeInitCmd enables DEC mode 2031 (terminal color-scheme reports) so
+// terminals that support it push light/dark changes live while the auto
+// theme is active. Terminals without the mode ignore the sequence. When the
+// auto theme is off nothing is emitted, keeping default runs byte-identical.
+func (m *appModel) autoThemeInitCmd() tea.Cmd {
+	if !styles.AutoThemeEnabled() {
+		return nil
+	}
+	m.lightDarkModeSet = true
+	return tea.Raw(ansi.SetModeLightDark)
+}
+
+// quitCmd returns tea.Quit, first resetting DEC mode 2031 when the auto
+// theme enabled it, so the terminal stops sending color-scheme reports
+// after exit.
+func (m *appModel) quitCmd() tea.Cmd {
+	if !m.lightDarkModeSet {
+		return tea.Quit
+	}
+	m.lightDarkModeSet = false
+	return tea.Sequence(tea.Raw(ansi.ResetModeLightDark), tea.Quit)
 }
 
 // tourStartupCmd applies the configured startup tour mode: start the tour
@@ -830,6 +860,12 @@ func (m *appModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, animation.StartTick())
 			}
 		}
+		if styles.AutoThemeEnabled() {
+			// Terminals without mode 2031 can still flip their appearance
+			// while we're in the background; re-query on focus so the auto
+			// theme catches up.
+			cmds = append(cmds, tea.RequestBackgroundColor)
+		}
 		if m.dockerDesktop && m.program != nil {
 			// Docker Desktop: the terminal may have lost all mode state (alt
 			// screen, mouse tracking, keyboard enhancements, background
@@ -842,6 +878,17 @@ func (m *appModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			})
 		}
 		return m, tea.Batch(cmds...)
+
+	case tea.BackgroundColorMsg:
+		return m.handleColorSchemeChange(msg.IsDark())
+
+	// DEC mode 2031 color-scheme reports. bubbletea passes these ultraviolet
+	// events through untyped, so they are matched here directly.
+	case uv.DarkColorSchemeEvent:
+		return m.handleColorSchemeChange(true)
+
+	case uv.LightColorSchemeEvent:
+		return m.handleColorSchemeChange(false)
 
 	case tea.KeyboardEnhancementsMsg:
 		m.keyboardEnhancements = &msg
@@ -887,7 +934,8 @@ func (m *appModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case dialog.ExitConfirmedMsg:
 		m.cleanupAll()
-		return m, tea.Quit
+		quit := m.quitCmd()
+		return m, quit
 
 	case dialog.RuntimeResumeMsg:
 		m.application.Resume(msg.Request)
@@ -973,11 +1021,13 @@ func (m *appModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.handleCloseTab(m.supervisor.ActiveID())
 		}
 		m.cleanupAll()
-		return m, tea.Quit
+		quit := m.quitCmd()
+		return m, quit
 
 	case messages.ExitAfterFirstResponseMsg:
 		m.cleanupAll()
-		return m, tea.Quit
+		quit := m.quitCmd()
+		return m, quit
 
 	// --- SendMsg from editor ---
 

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -52,7 +52,15 @@ type Settings struct {
 	SplitDiffView *bool `yaml:"split_diff_view,omitempty"`
 	// Theme is the default theme reference (e.g., "dark", "light")
 	// Theme files are loaded from ~/.cagent/themes/<theme>.yaml
+	// The special value "auto" follows the terminal's light/dark background,
+	// resolving to ThemeDark or ThemeLight.
 	Theme string `yaml:"theme,omitempty"`
+	// ThemeDark is the theme applied when Theme is "auto" and the terminal
+	// background is dark. Defaults to "default".
+	ThemeDark string `yaml:"theme_dark,omitempty"`
+	// ThemeLight is the theme applied when Theme is "auto" and the terminal
+	// background is light. Defaults to "default-light".
+	ThemeLight string `yaml:"theme_light,omitempty"`
 	// YOLO enables auto-approve mode for all tool calls globally
 	YOLO bool `yaml:"YOLO,omitempty"`
 	// Lean makes the simplified TUI with minimal chrome the default UI.


### PR DESCRIPTION
Closes #3500

Adds an explicit, opt-in `auto` theme that follows the terminal's light/dark background, at startup and live. Default behavior is unchanged: without `auto`, no terminal queries are emitted and escape sequences are byte-identical to today.

## Behavior

| Situation | Result |
|---|---|
| `settings.theme: auto`, `--theme auto`, or "Auto (match terminal)" in `/theme` | background queried at startup (OSC 11), theme follows the detected polarity |
| Dark background | `settings.theme_dark` (default `default`) |
| Light background | `settings.theme_light` (default: new bundled `default-light`) |
| Non-TTY / terminal that never answers | dark fallback, bounded wait, no hang |
| Appearance flip while running (DEC mode 2031 terminals) | theme switches live; terminals without 2031 re-sync on focus |
| Exit | mode 2031 reset (in-TUI quit path plus a post-Run safety net) |

## Implementation (issue plan mapping)

| Issue step | Change |
|---|---|
| 1. sentinel + polarity + resolver | `pkg/tui/styles/auto_theme.go`: `AutoThemeRef`, `SetTerminalDark`/`TerminalIsDark` (dark default), `SetAutoThemeEnabled`/`AutoThemeEnabled`, `ResolveThemeRef` |
| 2. `default-light` theme + contrast test | `pkg/tui/styles/themes/default-light.yaml`, WCAG checks built on `colorutil.go` helpers |
| 3. `theme_dark`/`theme_light` | new `Settings` fields in `pkg/userconfig` |
| 4. startup detection + validation/completion | `applyTheme()` resolves `auto` via a TTY-gated `lipgloss.HasDarkBackground`; `validateTheme` and `completeTheme` accept `auto`; `docker-agent new` now applies the configured theme like `run` and `board` |
| 5. live switching + mode reset | `appModel.Init` emits `tea.Raw(ansi.SetModeLightDark)` when auto is active; `uv.DarkColorSchemeEvent`/`uv.LightColorSchemeEvent` and `tea.BackgroundColorMsg` apply the pair through the existing `styles.ApplyTheme` + `ThemeChangedMsg` invalidation path; `tea.RequestBackgroundColor` re-issued on `tea.FocusMsg`; mode reset on quit and after `Program.Run` returns |
| 6. picker entry + persistence | "Auto (match terminal)" entry with an exclusive current badge, persists `settings.theme: auto`, enables/resets mode 2031 when toggled mid-session |
| 7. tests | see below |
| 8. docs | `docs/features/tui/index.md` (new "Auto Theme" section), `docs/features/cli/index.md` (`--theme` row) |

## Acceptance criteria

| Criterion | Status |
|---|---|
| Unchanged config: behavior and emitted sequences byte-identical | yes (queries, mode set/reset and focus re-queries are all gated on `auto`) |
| `theme: auto` picks light/dark at launch | yes (synchronous OSC 11 pre-TUI, correct first frame) |
| Live switching on appearance flip | yes (mode 2031 events, focus re-query for terminals without the mode) |
| `--theme auto` accepted, validated, shell-completed; picker offers Auto and persists it | yes |
| Non-TTY/tmux: dark fallback, no hang; mode 2031 reset on exit | yes |
| build, test, lint clean; docs updated | yes (three pre-existing failures are unrelated network-bound SSRF tests: `pkg/config`, `pkg/httpclient`, `pkg/teamloader`) |

## Testing

| Layer | Coverage |
|---|---|
| Resolver, polarity, enabled state, configured pair | unit tests (`pkg/tui/styles`) |
| `default-light` readability | WCAG contrast test over the foreground/background role pairs |
| OSC 11 round-trip | pty-based test: a fake terminal answers light, dark, or nothing; raw mode, response parsing and bounded timeout verified |
| DEC 2031 wire format | raw `CSI ?997;1\|2 n` bytes through the real ultraviolet decoder into `appModel.Update` |
| Picker choices, change/preview/no-op, mode toggling, quit reset, init | unit tests (`pkg/tui`) |
| Flag validation, precedence, completion | unit tests (`cmd/root`) |

Manual verification in a graphical terminal (Ghostty or kitty: launch on light and dark, flip the OS appearance while running, check for stray `?997` reports after exit) remains recommended.

## Notes

- A user theme literally named `auto` no longer shadows the sentinel; it lists and loads as `user:auto`.
- `docker-agent new` previously ignored `settings.theme`; it now applies it, aligning with `run` and `board` as the issue assumes.
- Live 2031 handling inside the standalone lean TUI event loop stays a follow-up, per the issue.
- `github.com/creack/pty` (already in the dependency graph via docker/cli) becomes a direct, test-only dependency; `github.com/charmbracelet/ultraviolet` moves from indirect to direct.
