### PR TITLE
fix(tui): rewire theme watcher lost in tab-view rewrite

### DIFF
--- a/e2e/tui/testdata/cassettes/TestTheme_HotReload.yaml
+++ b/e2e/tui/testdata/cassettes/TestTheme_HotReload.yaml
@@ -1,0 +1,3 @@
+---
+version: 2
+interactions: []

--- a/e2e/tui/theme_test.go
+++ b/e2e/tui/theme_test.go
@@ -1,0 +1,54 @@
+package tui_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tui/messages"
+	"github.com/docker/docker-agent/pkg/tui/styles"
+	"github.com/docker/docker-agent/pkg/tui/tuitest"
+)
+
+// TestTheme_HotReload is the regression net for the theme watcher wiring
+// (issue #3501): editing the active custom theme file while the TUI runs
+// must hot-reload it without a restart. It drives the full loop — switch to
+// a user theme, edit its file on disk, and wait for the watcher to emit
+// ThemeFileChangedMsg, which surfaces as the "Theme hot-reloaded"
+// notification. No LLM call is made, so the cassette is empty.
+func TestTheme_HotReload(t *testing.T) {
+	// The theme registry is process-global; restore the default so other
+	// tests never see this test's theme. Registered before newTUI so that
+	// (LIFO) it runs only after the program stopped rendering.
+	t.Cleanup(func() { styles.ApplyThemeRef(styles.DefaultThemeRef) })
+	d := newTUI(t, "testdata/basic.yaml", 120, 40)
+
+	// isolateState (inside newTUI) redirected the data dir to a temp dir, so
+	// this writes the user theme where the running TUI expects it.
+	themesDir := styles.ThemesDir()
+	require.NoError(t, os.MkdirAll(themesDir, 0o755))
+	themePath := filepath.Join(themesDir, "hotreload.yaml")
+	require.NoError(t, os.WriteFile(themePath, []byte("version: 1\nname: Hot Reload Before\n"), 0o644))
+
+	// Switching themes re-targets the watcher onto the new theme's file.
+	d.Send(messages.ChangeThemeMsg{ThemeRef: "user:hotreload"}).
+		WaitFor(tuitest.Contains("Theme changed to Hot Reload Before"))
+
+	// The watcher arms asynchronously (ThemeChangedMsg is sequenced after the
+	// notification above) and debounces events for 500ms, so a single write
+	// could slip in before fsnotify is attached. Re-edit the file on every
+	// poll — like a user tweaking colors — until the reload lands. The 700ms
+	// interval exceeds the debounce so rewrites cannot starve the timer.
+	require.Eventually(t, func() bool {
+		require.NoError(t, os.WriteFile(themePath, []byte("version: 1\nname: Hot Reload After\n"), 0o644))
+		return strings.Contains(d.Frame(), "Theme hot-reloaded")
+	}, 15*time.Second, 700*time.Millisecond, "editing the theme file should hot-reload it")
+
+	require.Eventually(t, func() bool {
+		return styles.CurrentTheme().Name == "Hot Reload After"
+	}, 3*time.Second, 50*time.Millisecond, "styles.CurrentTheme() should pick up the edited theme")
+}

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -740,6 +740,9 @@ func (m *appModel) invalidateCachesForThemeChange() {
 
 func (m *appModel) applyThemeChanged() (tea.Model, tea.Cmd) {
 	m.invalidateCachesForThemeChange()
+	// Re-target the file watcher: theme changes (picker selection, preview,
+	// hot reload) can move the active theme to a different backing file.
+	m.watchCurrentTheme()
 	return m, tea.Batch(
 		m.updateDialogCmd(messages.ThemeChangedMsg{}),
 		m.updateChatCmd(messages.ThemeChangedMsg{}),

--- a/pkg/tui/theme_watcher_wiring_test.go
+++ b/pkg/tui/theme_watcher_wiring_test.go
@@ -1,0 +1,63 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/tui/components/statusbar"
+	"github.com/docker/docker-agent/pkg/tui/styles"
+)
+
+// fakeThemeWatcher records Watch/Stop calls so the wiring between the model
+// lifecycle and the theme watcher can be asserted without touching the
+// filesystem.
+type fakeThemeWatcher struct {
+	watched []string
+	stopped bool
+}
+
+func (f *fakeThemeWatcher) Watch(themeRef string) error {
+	f.watched = append(f.watched, themeRef)
+	return nil
+}
+
+func (f *fakeThemeWatcher) Stop() { f.stopped = true }
+
+func TestWatchCurrentTheme_TargetsAppliedTheme(t *testing.T) {
+	m, _ := newTestModel(t)
+	fw := &fakeThemeWatcher{}
+	m.themeWatcher = fw
+
+	m.watchCurrentTheme()
+
+	assert.Equal(t, []string{styles.CurrentTheme().Ref}, fw.watched)
+}
+
+func TestWatchCurrentTheme_NoWatcherIsNoop(t *testing.T) {
+	m, _ := newTestModel(t)
+
+	assert.NotPanics(t, func() { m.watchCurrentTheme() })
+}
+
+func TestApplyThemeChanged_RetargetsWatcher(t *testing.T) {
+	m, _ := newTestModel(t)
+	m.statusBar = statusbar.New(m)
+	fw := &fakeThemeWatcher{}
+	m.themeWatcher = fw
+
+	_, _ = m.applyThemeChanged()
+
+	assert.Equal(t, []string{styles.CurrentTheme().Ref}, fw.watched,
+		"theme changes must re-target the watcher onto the active theme")
+}
+
+func TestCleanupManagedResources_StopsThemeWatcher(t *testing.T) {
+	m, _ := newTestModel(t)
+	fw := &fakeThemeWatcher{}
+	m.themeWatcher = fw
+
+	m.cleanupManagedResources()
+
+	assert.True(t, fw.stopped, "TUI shutdown must stop the theme watcher")
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -152,6 +152,13 @@ type appModel struct {
 	// perform a full terminal release/restore cycle on focus events.
 	program *tea.Program
 
+	// themeWatcher hot-reloads the active custom theme: it watches the
+	// current theme's backing file and reports edits as ThemeFileChangedMsg.
+	// Created in SetProgram (the callback needs the program to inject
+	// messages into the event loop) and re-targeted after every theme
+	// change via watchCurrentTheme.
+	themeWatcher themeFileWatcher
+
 	// dockerDesktop is true when running inside Docker Desktop's terminal
 	// (TERM_PROGRAM=docker_desktop). Focus reporting and the terminal
 	// release/restore cycle on tab switch are only enabled in this
@@ -234,6 +241,13 @@ type appModel struct {
 	// disabledCommands holds slash commands to hide and disable.
 	// Normalized to start with "/".
 	disabledCommands map[string]bool
+}
+
+// themeFileWatcher is the subset of *styles.ThemeWatcher the model drives.
+// It is an interface so tests can record Watch/Stop calls.
+type themeFileWatcher interface {
+	Watch(themeRef string) error
+	Stop()
 }
 
 // Transcriber is the speech-to-text interface used by the TUI. It is an
@@ -493,9 +507,35 @@ func (m *appModel) Resolve(v any) any {
 }
 
 // SetProgram sets the tea.Program for the supervisor to send routed messages.
+// It also starts the theme file watcher, whose callback needs the program to
+// inject hot-reload messages into the event loop.
 func (m *appModel) SetProgram(p *tea.Program) {
 	m.program = p
 	m.supervisor.SetProgram(p)
+
+	if m.themeWatcher != nil {
+		m.themeWatcher.Stop()
+	}
+	m.themeWatcher = styles.NewThemeWatcher(func(themeRef string) {
+		p.Send(messages.ThemeFileChangedMsg{ThemeRef: themeRef})
+	})
+	m.watchCurrentTheme()
+}
+
+// watchCurrentTheme points the theme watcher at the currently applied theme
+// so edits to its backing file hot-reload it. The watcher no-ops for themes
+// without a user theme file (e.g. built-ins).
+func (m *appModel) watchCurrentTheme() {
+	if m.themeWatcher == nil {
+		return
+	}
+	theme := styles.CurrentTheme()
+	if theme.Ref == "" {
+		return
+	}
+	if err := m.themeWatcher.Watch(theme.Ref); err != nil {
+		slog.Warn("Failed to watch theme file", "theme", theme.Ref, "error", err)
+	}
 }
 
 // reapplyKeyboardEnhancements forwards the cached keyboard enhancements message
@@ -2716,6 +2756,9 @@ func (m *appModel) shutdownTimeoutOrDefault() time.Duration {
 // exit) and the context watcher (external cancellation).
 func (m *appModel) cleanupManagedResources() {
 	m.cleanupOnce.Do(func() {
+		if m.themeWatcher != nil {
+			m.themeWatcher.Stop()
+		}
 		if m.tuiStore != nil {
 			_ = m.tuiStore.Close()
 		}


### PR DESCRIPTION
Fixes #3501

Editing `~/.cagent/themes/*.yaml` while the TUI runs did nothing until restart, despite the docs promising auto-reload on save.

## Root cause

The tab-view rewrite (0069cadf7) rewrote `pkg/tui/tui.go` and kept only the `ThemeFileChangedMsg` handler: nothing constructed `styles.ThemeWatcher` or emitted the message anymore (`NewThemeWatcher` had no non-test caller). Confirmed by reproduction: an e2e test editing the active theme file times out waiting for the hot-reload on main, and passes with this change.

## Fix

```
runTUIWrapped / tuitest
  SetProgram(p)
    creates ThemeWatcher, callback: p.Send(ThemeFileChangedMsg)
    watchCurrentTheme()                          initial Watch

ChangeThemeMsg        > handleChangeTheme        > ThemeChangedMsg \
ThemePreviewMsg / ThemeCancelPreviewMsg ..........................> applyThemeChanged()
ThemeFileChangedMsg   > handleThemeFileChanged   > ThemeChangedMsg /   watchCurrentTheme() re-Watch

cleanupManagedResources()
  themeWatcher.Stop()                            both exit paths, once-guarded
```

| Issue acceptance criterion | Handled by | Status |
| --- | --- | --- |
| Editing the active custom theme updates the running TUI within ~1s (debounce), incl. atomic-save editors | `SetProgram` wiring; atomic saves already handled by the watcher (directory watching, rename/basename matching) | yes, e2e `TestTheme_HotReload` |
| Switching themes re-targets the watcher | re-Watch in `applyThemeChanged`, the single funnel for picker selection, preview, cancel and hot reload | yes, unit test |
| Exiting the TUI stops the watcher (no goroutine/fd leak) | `Stop()` in `cleanupManagedResources`, reached from both normal exit and external cancellation | yes, unit test |
| Regression test so the next TUI refactor cannot silently drop the wiring | `e2e/tui/theme_test.go` (red/green verified against main) plus `pkg/tui/theme_watcher_wiring_test.go` | yes |

## Notes

- `themeWatcher` sits behind a small `themeFileWatcher` interface so unit tests can record `Watch`/`Stop` calls.
- Nil watcher (embedders or tests that never call `SetProgram`) is a no-op; built-in-only refs already no-op inside the watcher.
- `p.Send` after program termination is a documented no-op in bubbletea v2, so a late debounce callback cannot block or crash.
- The e2e test re-edits the file on each poll: the watcher arms asynchronously (`ThemeChangedMsg` is sequenced after the change notification), so a single write could race fsnotify attachment. The 700ms poll interval exceeds the 500ms debounce so rewrites cannot starve the timer.
- `docs/features/tui/index.md` needs no change: its hot-reload claim is accurate again.

## Validation

- `go build ./...`
- `go test -race ./e2e/tui/ ./pkg/tui/ ./pkg/tui/styles/ ./cmd/root/`
- `golangci-lint run pkg/tui/... e2e/tui/...` reports 0 issues
