### PR TITLE
fix(board): surface agent startup failures instead of silently doing nothing

### DIFF
--- a/docs/features/board/index.md
+++ b/docs/features/board/index.md
@@ -34,7 +34,10 @@ Requirements: `tmux` and `git` must be installed.
   detaches and returns to the board.
 - **Everything is recoverable.** Quitting the board leaves agents running in
   tmux; restarting it reattaches to them. If an agent process dies, the board
-  relaunches it and resumes the same conversation and worktree.
+  relaunches it and resumes the same conversation and worktree. An agent that
+  keeps crashing at startup turns its card red instead of relaunching
+  forever: attach to it (`enter`) to read the error output, then move the
+  card forward to relaunch it, or delete it.
 
 ## Key bindings
 

--- a/pkg/board/app.go
+++ b/pkg/board/app.go
@@ -370,14 +370,20 @@ var ErrAgentStarting = errors.New("the agent is still starting")
 // agent's control plane answers, so the user never lands on a bare launch
 // command. An errored card is attachable regardless: its agent may have
 // died at startup, and the dead pane holds the error output the user needs
-// to read. Before attaching, the session's header row is refreshed with the
-// card's current title and project.
+// to read — unless the session is gone entirely (its recreation failed), in
+// which case a clear error beats tmux's raw "can't find session". Before
+// attaching, the session's header row is refreshed with the card's current
+// title and project.
 func (a *App) AttachCommand(cardID string) (*exec.Cmd, error) {
 	card, err := a.store.GetCard(cardID)
 	if err != nil {
 		return nil, err
 	}
-	if card.Status != StatusError && !a.controller.Ready(card) {
+	if card.Status == StatusError {
+		if exists, err := a.sessions.Exists(card.Session); err == nil && !exists {
+			return nil, errors.New("the agent's session is gone; move the card forward to relaunch it, or delete it")
+		}
+	} else if !a.controller.Ready(card) {
 		return nil, ErrAgentStarting
 	}
 	socket, err := TmuxSocketPath()

--- a/pkg/board/app.go
+++ b/pkg/board/app.go
@@ -368,14 +368,16 @@ var ErrAgentStarting = errors.New("the agent is still starting")
 // AttachCommand returns the command that attaches the caller's terminal to
 // the card's agent session. It fails with [ErrAgentStarting] until the
 // agent's control plane answers, so the user never lands on a bare launch
-// command. Before attaching, the session's header row is refreshed with the
+// command. An errored card is attachable regardless: its agent may have
+// died at startup, and the dead pane holds the error output the user needs
+// to read. Before attaching, the session's header row is refreshed with the
 // card's current title and project.
 func (a *App) AttachCommand(cardID string) (*exec.Cmd, error) {
 	card, err := a.store.GetCard(cardID)
 	if err != nil {
 		return nil, err
 	}
-	if !a.controller.Ready(card) {
+	if card.Status != StatusError && !a.controller.Ready(card) {
 		return nil, ErrAgentStarting
 	}
 	socket, err := TmuxSocketPath()

--- a/pkg/board/controller.go
+++ b/pkg/board/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sync"
@@ -21,6 +22,11 @@ type sessionClient interface {
 const (
 	// retryDelay paces reconnect and relaunch attempts.
 	retryDelay = 500 * time.Millisecond
+	// cappedRetryDelay paces the watcher of a card whose agent keeps
+	// crashing at startup (see maxLaunchFailures): the card is red and only
+	// a user action revives it, so polling every retryDelay would waste a
+	// tmux fork per tick for nothing.
+	cappedRetryDelay = 5 * time.Second
 	// snapshotTimeout bounds a single snapshot request so a wedged server
 	// cannot block a watcher forever.
 	snapshotTimeout = 10 * time.Second
@@ -29,11 +35,13 @@ const (
 	// readyProbeTimeout bounds the control-plane probe behind "attach" so
 	// the user gets quick feedback instead of hanging.
 	readyProbeTimeout = 2 * time.Second
-	// maxLaunchFailures is how many times in a row the watcher relaunches an
-	// agent that dies before its control plane ever answers. Past it, the
+	// maxLaunchFailures is how many consecutive agent deaths — before the
+	// control plane ever answers — the watcher tolerates. At the cap the
 	// agent is crashing deterministically (bad config, missing key…):
 	// relaunching again would only kill the dead pane holding the error
 	// output, so the watcher goes red and leaves the pane for inspection.
+	// A successful snapshot or a user-initiated (prompt-bearing) relaunch
+	// resets the count.
 	maxLaunchFailures = 3
 )
 
@@ -57,6 +65,11 @@ type controller struct {
 	// a first turn is imminent, so the watcher keeps them "starting" until
 	// the event stream reports it instead of flashing "ready" first.
 	expectTurn map[string]bool
+	// launchFailures counts, per card, consecutive agent deaths before the
+	// control plane ever answered. It lives on the controller — not in the
+	// watcher loop — so a user-initiated relaunch can reset it and give the
+	// agent a fresh set of attempts after the cap tripped.
+	launchFailures map[string]int
 
 	// relaunchMu serializes session relaunches. A watcher's background
 	// resume and a prompt-bearing relaunch (SendPrompt) can otherwise race:
@@ -72,13 +85,14 @@ type watcher struct {
 
 func newController(ctx context.Context, store *Store, sessions sessionManager, onChanged func()) *controller {
 	return &controller{
-		ctx:        ctx,
-		store:      store,
-		sessions:   sessions,
-		onChanged:  onChanged,
-		clientFor:  func(socket, session string) sessionClient { return newClient(socket, session) },
-		watchers:   make(map[string]*watcher),
-		expectTurn: make(map[string]bool),
+		ctx:            ctx,
+		store:          store,
+		sessions:       sessions,
+		onChanged:      onChanged,
+		clientFor:      func(socket, session string) sessionClient { return newClient(socket, session) },
+		watchers:       make(map[string]*watcher),
+		expectTurn:     make(map[string]bool),
+		launchFailures: make(map[string]int),
 	}
 }
 
@@ -128,6 +142,21 @@ func (c *controller) turnExpected(cardID string) bool {
 	return c.expectTurn[cardID]
 }
 
+// launchFailed records one more agent death before the control plane ever
+// answered, and returns the updated consecutive count.
+func (c *controller) launchFailed(cardID string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.launchFailures[cardID]++
+	return c.launchFailures[cardID]
+}
+
+func (c *controller) resetLaunchFailures(cardID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.launchFailures, cardID)
+}
+
 // Stop cancels the card's watcher and waits for it to exit. Waiting matters:
 // it guarantees the watcher cannot relaunch the session after the caller
 // goes on to tear it down (kill the tmux session, remove the worktree),
@@ -137,6 +166,7 @@ func (c *controller) Stop(cardID string) {
 	w, ok := c.watchers[cardID]
 	delete(c.watchers, cardID)
 	delete(c.expectTurn, cardID)
+	delete(c.launchFailures, cardID)
 	c.mu.Unlock()
 	if ok {
 		w.cancel()
@@ -148,10 +178,6 @@ func (c *controller) Stop(cardID string) {
 // then tail events; on a drop, reconnect; if the agent is gone, relaunch and
 // resume.
 func (c *controller) watch(ctx context.Context, cardID string) {
-	// launchFailures counts consecutive attempts where the agent died
-	// without its control plane ever answering. Reset by a successful
-	// snapshot.
-	launchFailures := 0
 	for ctx.Err() == nil {
 		card, err := c.store.GetCard(cardID)
 		if errors.Is(err, ErrCardNotFound) {
@@ -175,23 +201,21 @@ func (c *controller) watch(ctx context.Context, cardID string) {
 			// answering is crashing at startup: surface the failure instead
 			// of silently relaunching forever, and stop killing the dead
 			// pane so the user can attach and read the agent's last output.
+			delay := retryDelay
 			if alive, aerr := c.sessions.Alive(card.Session); aerr == nil && !alive {
-				launchFailures++
-				if launchFailures >= maxLaunchFailures {
+				if c.launchFailed(cardID) >= maxLaunchFailures {
 					c.setStatus(cardID, StatusError)
-				} else if rerr := c.relaunch(card, ""); rerr != nil && !errors.Is(rerr, ErrCardNotFound) {
-					// The session cannot even be recreated (tmux failure,
-					// missing worktree…): show the card as failed rather
-					// than leaving it "starting" forever.
-					c.setStatus(cardID, StatusError)
+					delay = cappedRetryDelay
+				} else {
+					c.resume(card)
 				}
 			}
-			if sleep(ctx, retryDelay) {
+			if sleep(ctx, delay) {
 				return
 			}
 			continue
 		}
-		launchFailures = 0
+		c.resetLaunchFailures(cardID)
 
 		if snap.Title != "" {
 			c.setTitle(cardID, snap.Title)
@@ -320,13 +344,21 @@ func (c *controller) watch(ctx context.Context, cardID string) {
 
 		if exited && ctx.Err() == nil {
 			// The agent process ended; resume it so the card stays usable.
-			if rerr := c.relaunch(card, ""); rerr != nil && !errors.Is(rerr, ErrCardNotFound) {
-				c.setStatus(cardID, StatusError)
-			}
+			c.resume(card)
 		}
 		if sleep(ctx, retryDelay) {
 			return
 		}
+	}
+}
+
+// resume relaunches the card's session in the background recovery paths
+// (dead pane, session_exited). A session that cannot even be recreated
+// (tmux failure, missing worktree…) is surfaced as an errored card rather
+// than left "starting" forever; a deleted card is not stamped.
+func (c *controller) resume(card *Card) {
+	if err := c.relaunch(card, ""); err != nil && !errors.Is(err, ErrCardNotFound) {
+		c.setStatus(card.ID, StatusError)
 	}
 }
 
@@ -415,9 +447,11 @@ func (c *controller) relaunch(card *Card, prompt string) error {
 	_ = os.Remove(socket)
 	// docker agent creates the worktree on the first launch; if that launch
 	// died before it did, resuming from the worktree directory would fail.
-	// Launch from the repository again so --worktree (re)creates it.
+	// Launch from the repository again so --worktree (re)creates it. Only a
+	// confirmed absence takes the fallback: recreating an existing worktree
+	// fails, so a transient stat error must not reroute the launch.
 	workDir, worktreeName, worktreeBase := card.Worktree, "", ""
-	if _, statErr := os.Stat(card.Worktree); statErr != nil {
+	if _, statErr := os.Stat(card.Worktree); card.Worktree != "" && errors.Is(statErr, fs.ErrNotExist) {
 		workDir = card.RepoPath
 		worktreeName = filepath.Base(card.Worktree)
 		worktreeBase = upstreamBase(c.ctx, card.RepoPath)
@@ -430,6 +464,11 @@ func (c *controller) relaunch(card *Card, prompt string) error {
 		// The agent is launching again: show it as starting until its
 		// control plane answers and the event stream drives the status.
 		c.setExpectTurn(card.ID, prompt != "")
+		if prompt != "" {
+			// A user asked for this relaunch: give the agent a fresh set of
+			// startup attempts even if the crash-loop cap tripped before.
+			c.resetLaunchFailures(card.ID)
+		}
 		c.setStatus(card.ID, StatusStarting)
 	}
 	return err

--- a/pkg/board/controller.go
+++ b/pkg/board/controller.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 )
@@ -28,6 +29,12 @@ const (
 	// readyProbeTimeout bounds the control-plane probe behind "attach" so
 	// the user gets quick feedback instead of hanging.
 	readyProbeTimeout = 2 * time.Second
+	// maxLaunchFailures is how many times in a row the watcher relaunches an
+	// agent that dies before its control plane ever answers. Past it, the
+	// agent is crashing deterministically (bad config, missing key…):
+	// relaunching again would only kill the dead pane holding the error
+	// output, so the watcher goes red and leaves the pane for inspection.
+	maxLaunchFailures = 3
 )
 
 // controller keeps each card in sync with its agent's control plane. One
@@ -141,6 +148,10 @@ func (c *controller) Stop(cardID string) {
 // then tail events; on a drop, reconnect; if the agent is gone, relaunch and
 // resume.
 func (c *controller) watch(ctx context.Context, cardID string) {
+	// launchFailures counts consecutive attempts where the agent died
+	// without its control plane ever answering. Reset by a successful
+	// snapshot.
+	launchFailures := 0
 	for ctx.Err() == nil {
 		card, err := c.store.GetCard(cardID)
 		if errors.Is(err, ErrCardNotFound) {
@@ -160,15 +171,27 @@ func (c *controller) watch(ctx context.Context, cardID string) {
 		if err != nil {
 			// The control plane is unreachable. If the agent's tmux pane is
 			// gone, relaunch to resume; otherwise it is still starting, so
-			// just wait and retry.
+			// just wait and retry. An agent that keeps dying before ever
+			// answering is crashing at startup: surface the failure instead
+			// of silently relaunching forever, and stop killing the dead
+			// pane so the user can attach and read the agent's last output.
 			if alive, aerr := c.sessions.Alive(card.Session); aerr == nil && !alive {
-				_ = c.relaunch(card, "")
+				launchFailures++
+				if launchFailures >= maxLaunchFailures {
+					c.setStatus(cardID, StatusError)
+				} else if rerr := c.relaunch(card, ""); rerr != nil && !errors.Is(rerr, ErrCardNotFound) {
+					// The session cannot even be recreated (tmux failure,
+					// missing worktree…): show the card as failed rather
+					// than leaving it "starting" forever.
+					c.setStatus(cardID, StatusError)
+				}
 			}
 			if sleep(ctx, retryDelay) {
 				return
 			}
 			continue
 		}
+		launchFailures = 0
 
 		if snap.Title != "" {
 			c.setTitle(cardID, snap.Title)
@@ -297,7 +320,9 @@ func (c *controller) watch(ctx context.Context, cardID string) {
 
 		if exited && ctx.Err() == nil {
 			// The agent process ended; resume it so the card stays usable.
-			_ = c.relaunch(card, "")
+			if rerr := c.relaunch(card, ""); rerr != nil && !errors.Is(rerr, ErrCardNotFound) {
+				c.setStatus(cardID, StatusError)
+			}
 		}
 		if sleep(ctx, retryDelay) {
 			return
@@ -388,9 +413,18 @@ func (c *controller) relaunch(card *Card, prompt string) error {
 	// so the resumed run can bind --listen; otherwise the new agent fails to
 	// start and the card stays stuck "starting".
 	_ = os.Remove(socket)
+	// docker agent creates the worktree on the first launch; if that launch
+	// died before it did, resuming from the worktree directory would fail.
+	// Launch from the repository again so --worktree (re)creates it.
+	workDir, worktreeName, worktreeBase := card.Worktree, "", ""
+	if _, statErr := os.Stat(card.Worktree); statErr != nil {
+		workDir = card.RepoPath
+		worktreeName = filepath.Base(card.Worktree)
+		worktreeBase = upstreamBase(c.ctx, card.RepoPath)
+	}
 	err := c.sessions.NewSession(
-		card.Session, card.Worktree, card.Agent, card.AgentSession,
-		socket, "", "", prompt,
+		card.Session, workDir, card.Agent, card.AgentSession,
+		socket, worktreeName, worktreeBase, prompt,
 	)
 	if err == nil {
 		// The agent is launching again: show it as starting until its

--- a/pkg/board/controller_test.go
+++ b/pkg/board/controller_test.go
@@ -17,6 +17,7 @@ type fakeSessions struct{}
 func (fakeSessions) NewSession(_, _, _, _, _, _, _, _ string) error { return nil }
 func (fakeSessions) KillSession(string) error                       { return nil }
 func (fakeSessions) Alive(string) (bool, error)                     { return true, nil }
+func (fakeSessions) Exists(string) (bool, error)                    { return true, nil }
 
 // fakeClient replays a scripted event stream, then blocks like a live
 // connection until the watcher is cancelled.
@@ -216,8 +217,9 @@ func (r *recordingSessions) NewSession(_, _, _, _, _, _, _, _ string) error {
 	r.newSessions++
 	return nil
 }
-func (r *recordingSessions) KillSession(string) error   { return nil }
-func (r *recordingSessions) Alive(string) (bool, error) { return r.alive, nil }
+func (r *recordingSessions) KillSession(string) error    { return nil }
+func (r *recordingSessions) Alive(string) (bool, error)  { return r.alive, nil }
+func (r *recordingSessions) Exists(string) (bool, error) { return r.alive, nil }
 
 func TestRelaunchAbortsForDeletedCard(t *testing.T) {
 	t.Parallel()
@@ -287,8 +289,9 @@ func (s *crashingSessions) NewSession(_, _, _, _, _, _, _, _ string) error {
 	s.newSessions.Add(1)
 	return s.newErr
 }
-func (s *crashingSessions) KillSession(string) error   { return nil }
-func (s *crashingSessions) Alive(string) (bool, error) { return false, nil }
+func (s *crashingSessions) KillSession(string) error    { return nil }
+func (s *crashingSessions) Alive(string) (bool, error)  { return false, nil }
+func (s *crashingSessions) Exists(string) (bool, error) { return false, nil }
 
 // watchCrashingCard spins up a watcher for a card whose agent never answers
 // and whose tmux pane is dead, simulating a startup crash.
@@ -332,6 +335,106 @@ func TestControllerFailedRelaunchGoesRed(t *testing.T) {
 	waitForStatus(t, store, StatusError)
 }
 
+// flakyClient fails its first snapshots, then behaves like a healthy agent
+// replaying the given events.
+type flakyClient struct {
+	failures atomic.Int32
+	healthy  fakeClient
+}
+
+func (f *flakyClient) Snapshot(ctx context.Context) (snapshot, error) {
+	if f.failures.Add(-1) >= 0 {
+		return snapshot{}, errors.New("connection refused")
+	}
+	return f.healthy.Snapshot(ctx)
+}
+
+func (f *flakyClient) StreamEvents(ctx context.Context, since uint64, onEvent func(event) bool) error {
+	return f.healthy.StreamEvents(ctx, since, onEvent)
+}
+
+func (f *flakyClient) Followup(ctx context.Context, key, msg string) error {
+	return f.healthy.Followup(ctx, key, msg)
+}
+
+func TestControllerCrashCapToleratesTransientFailures(t *testing.T) {
+	t.Parallel()
+
+	// The agent dies fewer times than the cap before its control plane
+	// answers: the card must recover, not go red.
+	store := testStore(t)
+	require.NoError(t, store.InsertCard(&Card{ID: "c1", Column: "dev", Status: StatusStarting, Session: "s", Worktree: t.TempDir()}))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	client := &flakyClient{healthy: fakeClient{events: []event{
+		{Type: eventUserMessage},
+		{Type: eventStreamStarted},
+		{Type: eventStreamStopped, Reason: reasonNormal},
+	}}}
+	client.failures.Store(int32(maxLaunchFailures - 1))
+
+	sessions := &crashingSessions{}
+	c := newController(ctx, store, sessions, func() {})
+	c.clientFor = func(_, _ string) sessionClient { return client }
+	card, err := store.GetCard("c1")
+	require.NoError(t, err)
+	c.Start(card)
+	t.Cleanup(func() { c.Stop("c1") })
+
+	waitForStatus(t, store, StatusWaiting)
+	// The successful snapshot reset the count: a later death gets fresh
+	// relaunch attempts instead of tripping the cap immediately.
+	assert.Equal(t, 1, c.launchFailed("c1"), "count should have been reset by the successful snapshot")
+}
+
+func TestControllerExitedResumeFailureGoesRed(t *testing.T) {
+	t.Parallel()
+
+	// The agent reports session_exited and the resume cannot recreate the
+	// session: the failure must be surfaced.
+	store := testStore(t)
+	require.NoError(t, store.InsertCard(&Card{ID: "c1", Column: "dev", Status: StatusStarting, Session: "s", Worktree: t.TempDir()}))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	sessions := &crashingSessions{newErr: errors.New("tmux: server exited")}
+	c := newController(ctx, store, sessions, func() {})
+	c.clientFor = func(_, _ string) sessionClient {
+		return &fakeClient{events: []event{{Type: eventSessionExited}}}
+	}
+	card, err := store.GetCard("c1")
+	require.NoError(t, err)
+	c.Start(card)
+	t.Cleanup(func() { c.Stop("c1") })
+
+	waitForStatus(t, store, StatusError)
+}
+
+func TestRelaunchWithPromptResetsCrashCap(t *testing.T) {
+	t.Parallel()
+
+	store := testStore(t)
+	require.NoError(t, store.InsertCard(&Card{ID: "c1", Session: "s", Worktree: t.TempDir()}))
+
+	c := newController(t.Context(), store, &crashingSessions{}, func() {})
+	for range maxLaunchFailures {
+		c.launchFailed("c1")
+	}
+	card, err := store.GetCard("c1")
+	require.NoError(t, err)
+
+	// A user-initiated (prompt-bearing) relaunch grants fresh attempts…
+	require.NoError(t, c.relaunch(card, "try again"))
+	assert.Equal(t, 1, c.launchFailed("c1"), "cap should have been reset")
+
+	// …but a background resume does not, or the cap could never trip.
+	require.NoError(t, c.relaunch(card, ""))
+	assert.Equal(t, 2, c.launchFailed("c1"))
+}
+
 // argSessions records the arguments of the last NewSession call.
 type argSessions struct {
 	workDir, worktreeName, worktreeBase string
@@ -341,8 +444,9 @@ func (s *argSessions) NewSession(_, workDir, _, _, _, worktreeName, worktreeBase
 	s.workDir, s.worktreeName, s.worktreeBase = workDir, worktreeName, worktreeBase
 	return nil
 }
-func (s *argSessions) KillSession(string) error   { return nil }
-func (s *argSessions) Alive(string) (bool, error) { return false, nil }
+func (s *argSessions) KillSession(string) error    { return nil }
+func (s *argSessions) Alive(string) (bool, error)  { return false, nil }
+func (s *argSessions) Exists(string) (bool, error) { return false, nil }
 
 func TestRelaunchRecreatesMissingWorktree(t *testing.T) {
 	t.Parallel()

--- a/pkg/board/controller_test.go
+++ b/pkg/board/controller_test.go
@@ -2,6 +2,9 @@ package board
 
 import (
 	"context"
+	"errors"
+	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -256,4 +259,126 @@ func TestControllerStopWaits(t *testing.T) {
 	// Stopping twice (or a never-watched card) is safe.
 	c.Stop("c1")
 	c.Stop("unknown")
+}
+
+// downClient simulates an agent whose control plane never comes up.
+type downClient struct{}
+
+func (downClient) Snapshot(context.Context) (snapshot, error) {
+	return snapshot{}, errors.New("connection refused")
+}
+
+func (downClient) StreamEvents(context.Context, uint64, func(event) bool) error {
+	return errors.New("connection refused")
+}
+
+func (downClient) Followup(context.Context, string, string) error {
+	return errors.New("connection refused")
+}
+
+// crashingSessions simulates an agent that dies at startup: the session is
+// never alive, and creating a new one optionally fails too.
+type crashingSessions struct {
+	newErr      error
+	newSessions atomic.Int32
+}
+
+func (s *crashingSessions) NewSession(_, _, _, _, _, _, _, _ string) error {
+	s.newSessions.Add(1)
+	return s.newErr
+}
+func (s *crashingSessions) KillSession(string) error   { return nil }
+func (s *crashingSessions) Alive(string) (bool, error) { return false, nil }
+
+// watchCrashingCard spins up a watcher for a card whose agent never answers
+// and whose tmux pane is dead, simulating a startup crash.
+func watchCrashingCard(t *testing.T, sessions *crashingSessions) *Store {
+	t.Helper()
+	store := testStore(t)
+	require.NoError(t, store.InsertCard(&Card{ID: "c1", Column: "dev", Status: StatusStarting, Session: "s", Worktree: t.TempDir()}))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	c := newController(ctx, store, sessions, func() {})
+	c.clientFor = func(_, _ string) sessionClient { return downClient{} }
+	card, err := store.GetCard("c1")
+	require.NoError(t, err)
+	c.Start(card)
+	t.Cleanup(func() { c.Stop("c1") })
+	return store
+}
+
+func TestControllerStartupCrashLoopGoesRed(t *testing.T) {
+	t.Parallel()
+
+	// The agent dies before its control plane ever answers, relaunch after
+	// relaunch: the watcher must surface the failure instead of silently
+	// relaunching forever with the card stuck "starting".
+	sessions := &crashingSessions{}
+	store := watchCrashingCard(t, sessions)
+	waitForStatus(t, store, StatusError)
+	// Relaunches stop at the cap, preserving the dead pane's error output.
+	assert.Equal(t, int32(maxLaunchFailures-1), sessions.newSessions.Load())
+}
+
+func TestControllerFailedRelaunchGoesRed(t *testing.T) {
+	t.Parallel()
+
+	// The session cannot even be recreated (e.g. tmux new-session fails):
+	// the card must go red, not stay "starting" forever.
+	sessions := &crashingSessions{newErr: errors.New("tmux: bad working directory")}
+	store := watchCrashingCard(t, sessions)
+	waitForStatus(t, store, StatusError)
+}
+
+// argSessions records the arguments of the last NewSession call.
+type argSessions struct {
+	workDir, worktreeName, worktreeBase string
+}
+
+func (s *argSessions) NewSession(_, workDir, _, _, _, worktreeName, worktreeBase, _ string) error {
+	s.workDir, s.worktreeName, s.worktreeBase = workDir, worktreeName, worktreeBase
+	return nil
+}
+func (s *argSessions) KillSession(string) error   { return nil }
+func (s *argSessions) Alive(string) (bool, error) { return false, nil }
+
+func TestRelaunchRecreatesMissingWorktree(t *testing.T) {
+	t.Parallel()
+
+	// The first launch died before docker-agent created the worktree:
+	// relaunching from the (missing) worktree directory would fail, so the
+	// relaunch goes back to the repository and recreates the worktree.
+	store := testStore(t)
+	repo := t.TempDir()
+	wt := filepath.Join(t.TempDir(), "board-abc")
+	require.NoError(t, store.InsertCard(&Card{ID: "c1", Session: "s", RepoPath: repo, Worktree: wt}))
+
+	sessions := &argSessions{}
+	c := newController(t.Context(), store, sessions, func() {})
+	card, err := store.GetCard("c1")
+	require.NoError(t, err)
+
+	require.NoError(t, c.relaunch(card, ""))
+	assert.Equal(t, repo, sessions.workDir)
+	assert.Equal(t, "board-abc", sessions.worktreeName)
+	assert.NotEmpty(t, sessions.worktreeBase)
+}
+
+func TestRelaunchResumesFromExistingWorktree(t *testing.T) {
+	t.Parallel()
+
+	store := testStore(t)
+	wt := t.TempDir()
+	require.NoError(t, store.InsertCard(&Card{ID: "c1", Session: "s", RepoPath: t.TempDir(), Worktree: wt}))
+
+	sessions := &argSessions{}
+	c := newController(t.Context(), store, sessions, func() {})
+	card, err := store.GetCard("c1")
+	require.NoError(t, err)
+
+	require.NoError(t, c.relaunch(card, ""))
+	assert.Equal(t, wt, sessions.workDir)
+	assert.Empty(t, sessions.worktreeName)
 }

--- a/pkg/board/tmux.go
+++ b/pkg/board/tmux.go
@@ -33,6 +33,10 @@ type sessionManager interface {
 	// slow to start from a session whose agent has died and must be
 	// relaunched.
 	Alive(name string) (bool, error)
+	// Exists reports whether the session exists at all, dead pane included.
+	// It tells a session holding a dead agent's output (attachable) from one
+	// that is gone entirely.
+	Exists(name string) (bool, error)
 }
 
 // tmuxSocketDir creates and validates, once per process, the per-user
@@ -315,6 +319,17 @@ func (t tmuxSessions) Alive(name string) (bool, error) {
 	}
 	first, _, _ := strings.Cut(strings.TrimSpace(out), "\n")
 	return first == "0", nil
+}
+
+// Exists reports whether the session exists, dead pane included.
+func (t tmuxSessions) Exists(name string) (bool, error) {
+	if _, err := tmuxRun(t.ctx, "has-session", "-t", "="+name); err != nil {
+		if isNoSuchSession(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 // isNoSuchSession matches tmux's errors for a missing session or a server


### PR DESCRIPTION
On the Kanban board (`docker agent board`), an agent that crashed at startup — bad ref, missing API key, `--listen` bind failure — left its card stuck in "starting" forever. Relaunch errors were silently discarded, the controller relaunched the crashing agent every 500ms (destroying the dead pane's error output each time), a first-launch failure before the worktree existed caused every subsequent relaunch to fail on a nonexistent working directory, and the user could not even attach to investigate because attach is gated on the control plane answering.

The fix caps consecutive startup deaths at three before giving up: the card transitions to an error state, the dead tmux pane is preserved so its output can be read, and polling slows to 5 s instead of 500 ms. `watch()` now surfaces relaunch failures as `StatusError` rather than dropping them. `relaunch()` falls back to launching from the repo root with `--worktree`/`--worktree-base` when the card's worktree was never created. `AttachCommand` allows attaching to an errored card even when the control plane is down, and returns a clear error when the session is gone entirely (via a new `sessionManager.Exists` check). The crash-loop counter is per-card controller state; a user-initiated relaunch (one that carries a prompt) resets it so a red card gets fresh attempts when moved forward.

No breaking changes. The new `sessionManager.Exists` method wraps `tmux has-session` and is additive.