### PR TITLE
feat(tui): add /custom command to customize layout

### DIFF
--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -319,6 +319,26 @@ Invalid entries are ignored with a warning (visible with `--debug`) so a bad con
 
 Press <kbd>Ctrl</kbd>+<kbd>R</kbd> to enter incremental history search mode. Start typing to filter through your previous inputs. Press <kbd>Enter</kbd> to select a match, or <kbd>Escape</kbd> to cancel.
 
+## Layout Customization
+
+Run `/custom` to open the layout dialog. It shows a live schematic preview of the resulting layout and applies every change immediately to the UI behind the dialog:
+
+- **Sidebar position**: `Right` (default), `Left`, `Top`, or `Bottom`. Left/right keep the full vertical sidebar next to the chat; top/bottom render it as a compact horizontal band above or below the chat (session title, working directory, usage, plus a one-line summary of the current agent, tools, and todos).
+- **Sidebar sections**: toggle the visibility of the **Token usage**, **Agents**, **Tools**, and **Todos** sections. The session block (title and working directory) is always shown.
+
+Press <kbd>Enter</kbd> to apply and persist, or <kbd>Escape</kbd> to cancel and restore the previous layout. The settings are saved globally in `~/.config/cagent/config.yaml`:
+
+```yaml
+# ~/.config/cagent/config.yaml
+settings:
+  layout:
+    sidebar_position: left # right (default), left, top, bottom
+    hide_usage: true
+    hide_agents: false
+    hide_tools: false
+    hide_todos: false
+```
+
 ## Theming
 
 Customize the TUI appearance with built-in or custom themes:

--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -386,6 +386,17 @@ func builtInSessionCommands() []Item {
 func builtInSettingsCommands() []Item {
 	return []Item{
 		{
+			ID:           "settings.customize",
+			Label:        "Customize Layout",
+			SlashCommand: "/custom",
+			Description:  "Customize the layout: sidebar position and visible sections",
+			Category:     "Settings",
+			Immediate:    true,
+			Execute: func(string) tea.Cmd {
+				return core.CmdHandler(messages.OpenCustomizeDialogMsg{})
+			},
+		},
+		{
 			ID:           "settings.split-diff",
 			Label:        "Split Diff",
 			SlashCommand: "/split-diff",

--- a/pkg/tui/commands/commands_test.go
+++ b/pkg/tui/commands/commands_test.go
@@ -98,6 +98,15 @@ func TestParseSlashCommand_OtherCommands(t *testing.T) {
 		assert.True(t, ok)
 	})
 
+	t.Run("custom command", func(t *testing.T) {
+		t.Parallel()
+		cmd := parser.Parse("/custom")
+		require.NotNil(t, cmd)
+		msg := cmd()
+		_, ok := msg.(messages.OpenCustomizeDialogMsg)
+		assert.True(t, ok)
+	})
+
 	t.Run("undo command", func(t *testing.T) {
 		t.Parallel()
 		cmd := parser.Parse("/undo")

--- a/pkg/tui/components/sidebar/collapsed_view.go
+++ b/pkg/tui/components/sidebar/collapsed_view.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-
-	"github.com/docker/docker-agent/pkg/tui/styles"
 )
 
 // CollapsedViewModel holds the computed layout decisions for collapsed mode.
@@ -17,6 +15,9 @@ type CollapsedViewModel struct {
 	WorkingIndicator string
 	WorkingDir       string
 	UsageSummary     string
+	// InfoLine is the compact agents/tools/todos summary shown when the
+	// sidebar renders as a horizontal band.
+	InfoLine string
 
 	// Layout decisions computed from the data
 	TitleAndIndicatorOnOneLine bool
@@ -36,6 +37,10 @@ func (vm CollapsedViewModel) LineCount() int {
 		if vm.UsageSummary != "" {
 			lines += linesNeeded(lipgloss.Width(vm.UsageSummary), vm.ContentWidth)
 		}
+	}
+
+	if vm.InfoLine != "" {
+		lines += linesNeeded(lipgloss.Width(vm.InfoLine), vm.ContentWidth)
 	}
 
 	return lines
@@ -77,15 +82,20 @@ func RenderCollapsedView(vm CollapsedViewModel) string {
 		lines = append(lines, vm.TitleWithStar, vm.WorkingIndicator)
 	}
 
-	// Working directory + usage line(s)
+	// Working directory + usage line(s). WorkingDir arrives pre-styled
+	// (accent block + primary text) to match the vertical Session tab.
 	if vm.WdAndUsageOnOneLine {
 		gap := vm.ContentWidth - lipgloss.Width(vm.WorkingDir) - lipgloss.Width(vm.UsageSummary)
-		lines = append(lines, fmt.Sprintf("%s%*s%s", styles.MutedStyle.Render(vm.WorkingDir), gap, "", vm.UsageSummary))
+		lines = append(lines, fmt.Sprintf("%s%*s%s", vm.WorkingDir, gap, "", vm.UsageSummary))
 	} else {
-		lines = append(lines, styles.MutedStyle.Render(vm.WorkingDir))
+		lines = append(lines, vm.WorkingDir)
 		if vm.UsageSummary != "" {
 			lines = append(lines, vm.UsageSummary)
 		}
+	}
+
+	if vm.InfoLine != "" {
+		lines = append(lines, vm.InfoLine)
 	}
 
 	return strings.Join(lines, "\n")

--- a/pkg/tui/components/sidebar/section_visibility_test.go
+++ b/pkg/tui/components/sidebar/section_visibility_test.go
@@ -1,0 +1,172 @@
+package sidebar
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/builtin/todo"
+)
+
+// newVisibilityTestSidebar builds a sidebar with data in every optional
+// section so hiding each one is observable.
+func newVisibilityTestSidebar(tb testing.TB) *testSidebar {
+	tb.Helper()
+	s := newTestSidebar(tb)
+	s.sessionState.SetCurrentAgentName("root")
+	s.SetTeamInfo([]runtime.AgentDetails{{Name: "root", Provider: "openai", Model: "gpt-4"}})
+	s.SetToolsetInfo(12, false)
+	s.recordUsageTokens("session-1", "root", 500, 500)
+	return s
+}
+
+func renderedSections(s *testSidebar) string {
+	return ansi.Strip(strings.Join(s.renderSections(40), "\n"))
+}
+
+func TestRenderSections_AllVisibleByDefault(t *testing.T) {
+	t.Parallel()
+
+	s := newVisibilityTestSidebar(t)
+	out := renderedSections(s)
+
+	assert.Contains(t, out, "Token Usage")
+	assert.Contains(t, out, "Agent")
+	assert.Contains(t, out, "Tools")
+	assert.Contains(t, out, "12 tools available")
+}
+
+func TestRenderSections_HideUsage(t *testing.T) {
+	t.Parallel()
+
+	s := newVisibilityTestSidebar(t)
+	s.SetSectionVisibility(SectionVisibility{HideUsage: true})
+	out := renderedSections(s)
+
+	assert.NotContains(t, out, "Token Usage")
+	assert.Contains(t, out, "Tools", "other sections stay visible")
+}
+
+func TestRenderSections_HideTools(t *testing.T) {
+	t.Parallel()
+
+	s := newVisibilityTestSidebar(t)
+	s.SetSectionVisibility(SectionVisibility{HideTools: true})
+	out := renderedSections(s)
+
+	assert.NotContains(t, out, "12 tools available")
+	assert.Contains(t, out, "Token Usage")
+}
+
+func TestRenderSections_HideAgentsClearsClickZones(t *testing.T) {
+	t.Parallel()
+
+	s := newVisibilityTestSidebar(t)
+
+	s.renderSections(40)
+	assert.NotEmpty(t, s.agentClickZones, "visible agents register click zones")
+
+	s.SetSectionVisibility(SectionVisibility{HideAgents: true})
+	out := renderedSections(s)
+
+	assert.NotContains(t, out, "openai/gpt-4")
+	assert.Empty(t, s.agentClickZones, "hidden agents must not keep stale click zones")
+}
+
+func TestCollapsedViewModel_HideUsage(t *testing.T) {
+	t.Parallel()
+
+	s := newVisibilityTestSidebar(t)
+
+	vm := s.computeCollapsedViewModel(60)
+	assert.NotEmpty(t, vm.UsageSummary)
+
+	s.SetSectionVisibility(SectionVisibility{HideUsage: true})
+	vm = s.computeCollapsedViewModel(60)
+	assert.Empty(t, vm.UsageSummary, "collapsed band omits usage when hidden")
+}
+
+func TestCollapsedInfoLine_ShowsAgentsToolsTodos(t *testing.T) {
+	t.Parallel()
+
+	s := newVisibilityTestSidebar(t)
+	require.NoError(t, s.SetTodos(&tools.ToolCallResult{Meta: []todo.Todo{
+		{Description: "first", Status: "completed"},
+		{Description: "second", Status: "pending"},
+	}}))
+
+	info := ansi.Strip(s.collapsedInfoLine())
+	assert.Contains(t, info, "▶ root")
+	assert.Contains(t, info, "12 tools")
+	assert.Contains(t, info, "1/2 todos")
+
+	vm := s.computeCollapsedViewModel(60)
+	assert.NotEmpty(t, vm.InfoLine, "band view model carries the info line")
+}
+
+func TestCollapsedInfoLine_HonorsVisibility(t *testing.T) {
+	t.Parallel()
+
+	s := newVisibilityTestSidebar(t)
+	require.NoError(t, s.SetTodos(&tools.ToolCallResult{Meta: []todo.Todo{
+		{Description: "first", Status: "pending"},
+	}}))
+
+	s.SetSectionVisibility(SectionVisibility{HideAgents: true, HideTodos: true})
+	info := ansi.Strip(s.collapsedInfoLine())
+	assert.NotContains(t, info, "▶ root")
+	assert.NotContains(t, info, "todos")
+	assert.Contains(t, info, "12 tools", "tools stay visible")
+
+	s.SetSectionVisibility(SectionVisibility{HideAgents: true, HideTools: true, HideTodos: true})
+	assert.Empty(t, s.collapsedInfoLine(), "hiding every section removes the line")
+}
+
+func TestCollapsedLineCount_GrowsWithInfoLine(t *testing.T) {
+	t.Parallel()
+
+	s := newVisibilityTestSidebar(t)
+
+	withInfo := s.computeCollapsedViewModel(60).LineCount()
+	s.SetSectionVisibility(SectionVisibility{HideAgents: true, HideTools: true, HideTodos: true})
+	withoutInfo := s.computeCollapsedViewModel(60).LineCount()
+
+	assert.Equal(t, withoutInfo+1, withInfo, "the info line adds one band line")
+}
+
+func TestSetSectionVisibility_NoopWhenUnchanged(t *testing.T) {
+	t.Parallel()
+
+	s := newTestSidebar(t)
+	s.renderSections(40)
+	s.cacheDirty = false
+
+	s.SetSectionVisibility(SectionVisibility{})
+	assert.False(t, s.cacheDirty, "identical visibility must not invalidate the cache")
+
+	s.SetSectionVisibility(SectionVisibility{HideTodos: true})
+	assert.True(t, s.cacheDirty)
+}
+
+func TestSetMirroredPadding_SwapsEdgePadding(t *testing.T) {
+	t.Parallel()
+
+	s := newTestSidebar(t)
+	defaults := DefaultLayoutConfig()
+
+	s.SetMirroredPadding(true)
+	assert.Equal(t, defaults.PaddingRight, s.layoutCfg.PaddingLeft, "left padding moves to the chat side")
+	assert.Equal(t, defaults.PaddingLeft, s.layoutCfg.PaddingRight)
+
+	s.cacheDirty = false
+	s.SetMirroredPadding(true)
+	assert.False(t, s.cacheDirty, "reapplying the same padding must not invalidate the cache")
+
+	s.SetMirroredPadding(false)
+	assert.Equal(t, defaults, s.layoutCfg)
+}

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -40,6 +40,15 @@ const (
 	ModeCollapsed
 )
 
+// SectionVisibility controls which optional sidebar sections are rendered.
+// The zero value shows everything.
+type SectionVisibility struct {
+	HideUsage  bool
+	HideAgents bool
+	HideTools  bool
+	HideTodos  bool
+}
+
 // Model represents a sidebar component
 type Model interface {
 	layout.Model
@@ -49,6 +58,9 @@ type Model interface {
 	SetTokenUsage(event *runtime.TokenUsageEvent)
 	SetTodos(result *tools.ToolCallResult) error
 	SetMode(mode Mode)
+	// SetMirroredPadding swaps the horizontal edge padding so the sidebar hugs
+	// the terminal edge when rendered on the left of the chat.
+	SetMirroredPadding(mirrored bool)
 	SetAgentInfo(agentName, model, description string) tea.Cmd
 	SetTeamInfo(availableAgents []runtime.AgentDetails)
 	SetAgentSwitching(switching bool)
@@ -56,6 +68,8 @@ type Model interface {
 	SetSkillsInfo(availableSkills int)
 	SetSessionStarred(starred bool)
 	SetQueuedMessages(messages ...string)
+	// SetSectionVisibility controls which optional sidebar sections are rendered.
+	SetSectionVisibility(v SectionVisibility)
 	GetSize() (width, height int)
 	LoadFromSession(sess *session.Session)
 	// ResetStreamTracking clears the active-stream stack so a new top-level run
@@ -148,7 +162,8 @@ type model struct {
 	preferredWidth     int      // user's preferred width (persisted across collapse/expand)
 	editingTitle       bool     // true when inline title editing is active
 	titleInput         textinput.Model
-	lastTitleClickTime time.Time // for double-click detection on title
+	lastTitleClickTime time.Time         // for double-click detection on title
+	sectionVisibility  SectionVisibility // which optional sections are rendered
 
 	ctx func() context.Context
 
@@ -341,6 +356,15 @@ func (m *model) SetSessionStarred(starred bool) {
 // SetQueuedMessages sets the list of queued message previews to display
 func (m *model) SetQueuedMessages(queuedMessages ...string) {
 	m.queuedMessages = queuedMessages
+	m.invalidateCache()
+}
+
+// SetSectionVisibility controls which optional sidebar sections are rendered.
+func (m *model) SetSectionVisibility(v SectionVisibility) {
+	if m.sectionVisibility == v {
+		return
+	}
+	m.sectionVisibility = v
 	m.invalidateCache()
 }
 
@@ -625,6 +649,15 @@ func (m *model) workingDirWithBranch() string {
 	return result
 }
 
+// workingDirLine renders the working directory with the sidebar's accent
+// block, shared by the vertical Session tab and the collapsed band.
+func (m *model) workingDirLine() string {
+	if m.workingDirectory == "" {
+		return ""
+	}
+	return styles.TabAccentStyle.Render("█") + styles.TabPrimaryStyle.Render(" "+m.workingDirWithBranch())
+}
+
 // Update handles messages and updates the component state.
 func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	switch msg := msg.(type) {
@@ -877,9 +910,12 @@ func (m *model) computeCollapsedViewModel(contentWidth int) CollapsedViewModel {
 	vm := CollapsedViewModel{
 		TitleWithStar:    titleWithStar,
 		WorkingIndicator: m.workingIndicatorCollapsed(),
-		WorkingDir:       m.workingDirWithBranch(),
-		UsageSummary:     m.tokenUsageSummary(),
+		WorkingDir:       m.workingDirLine(),
+		InfoLine:         m.collapsedInfoLine(),
 		ContentWidth:     contentWidth,
+	}
+	if !m.sectionVisibility.HideUsage {
+		vm.UsageSummary = m.tokenUsageSummary()
 	}
 
 	titleWidth := lipgloss.Width(vm.TitleWithStar)
@@ -903,6 +939,95 @@ func (m *model) computeCollapsedViewModel(contentWidth int) CollapsedViewModel {
 func (m *model) CollapsedHeight(outerWidth int) int {
 	contentWidth := max(outerWidth-m.layoutCfg.PaddingLeft-m.layoutCfg.PaddingRight, 1)
 	return m.computeCollapsedViewModel(contentWidth).LineCount()
+}
+
+// collapsedInfoLine returns a one-line summary of the agents, tools, and
+// todos sections for the collapsed band, honoring section visibility.
+func (m *model) collapsedInfoLine() string {
+	var parts []string
+	appendPart := func(part string) {
+		if part != "" {
+			parts = append(parts, part)
+		}
+	}
+
+	if !m.sectionVisibility.HideAgents {
+		appendPart(m.agentSummaryCollapsed())
+	}
+	if !m.sectionVisibility.HideTools {
+		appendPart(m.toolsSummaryCollapsed())
+	}
+	if !m.sectionVisibility.HideTodos {
+		appendPart(m.todosSummaryCollapsed())
+	}
+
+	return strings.Join(parts, styles.MutedStyle.Render(" · "))
+}
+
+// agentSummaryCollapsed renders the current agent (in its accent color) with
+// its model and the number of other agents in the team.
+func (m *model) agentSummaryCollapsed() string {
+	name := m.sessionState.CurrentAgentName()
+	if name == "" {
+		return ""
+	}
+
+	summary := styles.AgentAccentStyleFor(name).Render("▶ " + name)
+	if m.agentModel != "" {
+		summary += styles.MutedStyle.Render(" " + m.agentModel)
+	}
+	if n := len(m.availableAgents); n > 1 {
+		summary += styles.MutedStyle.Render(fmt.Sprintf(" +%d", n-1))
+	}
+	return summary
+}
+
+// toolsSummaryCollapsed renders the tools/skills counts with the sidebar's
+// accent block, or the loading spinner while the toolset is starting.
+func (m *model) toolsSummaryCollapsed() string {
+	if m.toolsLoading {
+		return m.spinner.View() + styles.TabPrimaryStyle.Render(" loading tools…")
+	}
+
+	var parts []string
+	if m.availableTools > 0 {
+		label := "tools"
+		if m.availableTools == 1 {
+			label = "tool"
+		}
+		parts = append(parts, fmt.Sprintf("%d %s", m.availableTools, label))
+	}
+	if m.availableSkills > 0 {
+		label := "skills"
+		if m.availableSkills == 1 {
+			label = "skill"
+		}
+		parts = append(parts, fmt.Sprintf("%d %s", m.availableSkills, label))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return styles.TabAccentStyle.Render("█") + styles.TabPrimaryStyle.Render(" "+strings.Join(parts, ", "))
+}
+
+// todosSummaryCollapsed renders the completed/total todo counts with the
+// same status icons as the vertical TO-DO tab.
+func (m *model) todosSummaryCollapsed() string {
+	completed, total := m.todoComp.Counts()
+	if total == 0 {
+		return ""
+	}
+
+	var icon string
+	switch completed {
+	case total:
+		icon = styles.CompletedStyle.Render("✓")
+	case 0:
+		icon = styles.ToBeDoneStyle.Render("◯")
+	default:
+		icon = styles.InProgressStyle.Render("◔")
+	}
+	return icon + styles.TabPrimaryStyle.Render(fmt.Sprintf(" %d/%d todos", completed, total))
 }
 
 func (m *model) collapsedView() string {
@@ -978,18 +1103,28 @@ func (m *model) renderSections(contentWidth int) []string {
 	}
 
 	appendSection(m.sessionInfo(contentWidth))
-	appendSection(m.tokenUsage(contentWidth))
+	if !m.sectionVisibility.HideUsage {
+		appendSection(m.tokenUsage(contentWidth))
+	}
 	appendSection(m.queueSection(contentWidth))
 
 	// Track where agent entries start so we can detect clicks on agent names
 	agentSectionStart := len(lines)
-	appendSection(m.agentInfo(contentWidth))
+	if m.sectionVisibility.HideAgents {
+		m.agentLineOwners = nil
+	} else {
+		appendSection(m.agentInfo(contentWidth))
+	}
 	m.buildAgentClickZones(agentSectionStart)
 
-	appendSection(m.toolsetInfo(contentWidth))
+	if !m.sectionVisibility.HideTools {
+		appendSection(m.toolsetInfo(contentWidth))
+	}
 
-	m.todoComp.SetSize(contentWidth)
-	appendSection(strings.TrimSuffix(m.todoComp.Render(), "\n"))
+	if !m.sectionVisibility.HideTodos {
+		m.todoComp.SetSize(contentWidth)
+		appendSection(strings.TrimSuffix(m.todoComp.Render(), "\n"))
+	}
 
 	return lines
 }
@@ -1105,6 +1240,13 @@ func (m *model) computeUsageStats() usageStats {
 }
 
 func (m *model) tokenUsage(contentWidth int) string {
+	return m.renderTab("Token Usage", m.tokenUsageLine(), contentWidth)
+}
+
+// tokenUsageLine renders the usage line shared by the vertical Token Usage
+// tab and the collapsed band: token glyph, count, context %, cost, and the
+// sub-session count, all with the same styling.
+func (m *model) tokenUsageLine() string {
 	s := m.computeUsageStats()
 
 	line := styles.MutedStyle.Render(styles.TokenGlyph+" ") + toolcommon.FormatTokenCount(s.tokens)
@@ -1116,31 +1258,16 @@ func (m *model) tokenUsage(contentWidth int) string {
 		line += " " + styles.MutedStyle.Render(fmt.Sprintf("(%d sub-sessions)", s.sessionCount-1))
 	}
 
-	return m.renderTab("Token Usage", line, contentWidth)
+	return line
 }
 
-// tokenUsageSummary returns a single-line summary for horizontal layout.
+// tokenUsageSummary returns the usage line for the collapsed band, empty
+// until any usage has been recorded.
 func (m *model) tokenUsageSummary() string {
 	if len(m.sessionUsage) == 0 {
 		return ""
 	}
-
-	s := m.computeUsageStats()
-
-	parts := []string{"Tokens: " + toolcommon.FormatTokenCount(s.tokens)}
-	if s.sessionCount > 1 {
-		if s.contextPct != "" {
-			parts = append(parts, "Context: "+s.contextPct)
-		}
-		parts = append(parts, "Cost: "+toolcommon.FormatCostUSD(s.totalCost), fmt.Sprintf("%d sub-sessions", s.sessionCount-1))
-	} else {
-		parts = append(parts, "Cost: "+toolcommon.FormatCostUSD(s.totalCost))
-		if s.contextPct != "" {
-			parts = append(parts, "Context: "+s.contextPct)
-		}
-	}
-
-	return strings.Join(parts, " | ")
+	return m.tokenUsageLine()
 }
 
 func (m *model) sessionInfo(contentWidth int) string {
@@ -1164,7 +1291,7 @@ func (m *model) sessionInfo(contentWidth int) string {
 	}
 
 	if m.workingDirectory != "" {
-		lines = append(lines, styles.TabAccentStyle.Render("█")+styles.TabPrimaryStyle.Render(" "+m.workingDirWithBranch()))
+		lines = append(lines, m.workingDirLine())
 	}
 
 	return m.renderTab("Session", strings.Join(lines, "\n"), contentWidth)
@@ -1548,6 +1675,23 @@ func (m *model) GetSize() (width, height int) {
 
 func (m *model) SetMode(mode Mode) {
 	m.mode = mode
+	m.invalidateCache()
+}
+
+// SetMirroredPadding swaps the horizontal edge padding so the content hugs
+// the terminal edge when the sidebar is rendered on the left of the chat,
+// with the breathing room moved to the chat side.
+func (m *model) SetMirroredPadding(mirrored bool) {
+	cfg := DefaultLayoutConfig()
+	if mirrored {
+		cfg.PaddingLeft, cfg.PaddingRight = cfg.PaddingRight, cfg.PaddingLeft
+	}
+	if m.layoutCfg == cfg {
+		return
+	}
+	m.layoutCfg = cfg
+	m.updateScrollviewPosition()
+	m.updateTitleInputWidth()
 	m.invalidateCache()
 }
 

--- a/pkg/tui/components/sidebar/token_usage_test.go
+++ b/pkg/tui/components/sidebar/token_usage_test.go
@@ -146,11 +146,12 @@ func TestTokenUsageSummary_SingleSession(t *testing.T) {
 		},
 	})
 
-	summary := m.tokenUsageSummary()
-	// Single session: shows total tokens, cost, and context
-	assert.Contains(t, summary, "Tokens: 8.0K")
-	assert.Contains(t, summary, "Cost: $0.05")
-	assert.Contains(t, summary, "Context: 8%")
+	summary := ansi.Strip(m.tokenUsageSummary())
+	// Single session: shows total tokens, context, and cost in the same
+	// compact format as the vertical Token Usage tab
+	assert.Contains(t, summary, "8.0K")
+	assert.Contains(t, summary, "$0.05")
+	assert.Contains(t, summary, "(8%)")
 	assert.NotContains(t, summary, "sub-sessions")
 }
 
@@ -189,18 +190,18 @@ func TestTokenUsageSummary_MultipleSessions_ShowsActiveSessionTokens(t *testing.
 
 	// While the sub-agent runs, show its tokens and context, with the
 	// aggregated cost and sub-session count.
-	summary := m.tokenUsageSummary()
-	assert.Contains(t, summary, "Tokens: 10.0K")
-	assert.Contains(t, summary, "Cost: $0.15")
-	assert.Contains(t, summary, "Context: 5%")
-	assert.Contains(t, summary, "1 sub-sessions")
+	summary := ansi.Strip(m.tokenUsageSummary())
+	assert.Contains(t, summary, "10.0K")
+	assert.Contains(t, summary, "$0.15")
+	assert.Contains(t, summary, "(5%)")
+	assert.Contains(t, summary, "(1 sub-sessions)")
 
 	// Once it returns, the parent's tokens and context are shown again.
 	m.stopStream()
-	summary = m.tokenUsageSummary()
-	assert.Contains(t, summary, "Tokens: 30.0K")
-	assert.Contains(t, summary, "Cost: $0.15")
-	assert.Contains(t, summary, "Context: 30%")
+	summary = ansi.Strip(m.tokenUsageSummary())
+	assert.Contains(t, summary, "30.0K")
+	assert.Contains(t, summary, "$0.15")
+	assert.Contains(t, summary, "(30%)")
 }
 
 func TestTokenUsageSummary_Empty(t *testing.T) {

--- a/pkg/tui/components/tool/todotool/sidebar.go
+++ b/pkg/tui/components/tool/todotool/sidebar.go
@@ -63,6 +63,16 @@ func (c *SidebarComponent) InvalidateCache() {
 	c.renderCache = nil
 }
 
+// Counts returns how many todos are completed and the total count.
+func (c *SidebarComponent) Counts() (completed, total int) {
+	for _, t := range c.todos {
+		if t.Status == "completed" {
+			completed++
+		}
+	}
+	return completed, len(c.todos)
+}
+
 func (c *SidebarComponent) Render() string {
 	if len(c.todos) == 0 {
 		return ""

--- a/pkg/tui/dialog/customize.go
+++ b/pkg/tui/dialog/customize.go
@@ -1,0 +1,391 @@
+package dialog
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/docker/docker-agent/pkg/tui/components/toolcommon"
+	"github.com/docker/docker-agent/pkg/tui/core"
+	"github.com/docker/docker-agent/pkg/tui/core/layout"
+	"github.com/docker/docker-agent/pkg/tui/messages"
+	"github.com/docker/docker-agent/pkg/tui/styles"
+)
+
+const (
+	customizeWidthPercent = 50
+	customizeMinWidth     = 52
+	customizeMaxWidth     = 60
+
+	// previewMaxWidth is the widest the layout preview schematic can get.
+	previewMaxWidth = 44
+	// previewMinWidth keeps the schematic legible on tiny terminals.
+	previewMinWidth = 24
+)
+
+// customizeRows enumerates the selectable rows of the customize dialog.
+const (
+	rowPosition = iota
+	rowUsage
+	rowAgents
+	rowTools
+	rowTodos
+	rowCount
+)
+
+// sidebarPositions is the ←/→ cycle order of the position selector.
+var sidebarPositions = []messages.SidebarPosition{
+	messages.SidebarRight,
+	messages.SidebarLeft,
+	messages.SidebarTop,
+	messages.SidebarBottom,
+}
+
+// positionLabels maps positions to their display labels.
+var positionLabels = map[messages.SidebarPosition]string{
+	messages.SidebarRight:  "Right",
+	messages.SidebarLeft:   "Left",
+	messages.SidebarTop:    "Top",
+	messages.SidebarBottom: "Bottom",
+}
+
+// customizeDialog lets the user customize the TUI layout: sidebar position
+// and which sidebar sections are visible. Changes are previewed live (both in
+// the schematic and in the UI behind the dialog); Enter persists them, Esc
+// restores the original layout.
+type customizeDialog struct {
+	BaseDialog
+
+	original messages.LayoutSettings
+	current  messages.LayoutSettings
+	selected int
+}
+
+// NewCustomizeDialog creates the layout customization dialog seeded with the
+// currently active settings.
+func NewCustomizeDialog(current messages.LayoutSettings) Dialog {
+	current.SidebarPosition = messages.ParseSidebarPosition(string(current.SidebarPosition))
+	return &customizeDialog{
+		original: current,
+		current:  current,
+	}
+}
+
+func (d *customizeDialog) Init() tea.Cmd { return nil }
+
+func (d *customizeDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		cmd := d.SetSize(msg.Width, msg.Height)
+		return d, cmd
+
+	case tea.KeyPressMsg:
+		if cmd := HandleQuit(msg); cmd != nil {
+			return d, cmd
+		}
+		cmd := d.handleKey(msg)
+		return d, cmd
+	}
+	return d, nil
+}
+
+func (d *customizeDialog) handleKey(msg tea.KeyPressMsg) tea.Cmd {
+	switch msg.String() {
+	case "esc", "q":
+		return d.cancel()
+	case "up", "k", "ctrl+k":
+		if d.selected > 0 {
+			d.selected--
+		}
+	case "down", "j", "ctrl+j":
+		if d.selected < rowCount-1 {
+			d.selected++
+		}
+	case "shift+tab":
+		d.selected = (d.selected - 1 + rowCount) % rowCount
+	case "tab":
+		d.selected = (d.selected + 1) % rowCount
+	case "home", "g":
+		d.selected = 0
+	case "end", "G":
+		d.selected = rowCount - 1
+	case "left", "h":
+		return d.changeValue(-1)
+	case "right", "l", "space":
+		return d.changeValue(+1)
+	case "enter":
+		return d.apply()
+	}
+	return nil
+}
+
+// changeValue cycles the selected row's value by delta and emits a live preview.
+func (d *customizeDialog) changeValue(delta int) tea.Cmd {
+	switch d.selected {
+	case rowPosition:
+		d.current.SidebarPosition = cyclePosition(d.current.SidebarPosition, delta)
+	case rowUsage:
+		d.current.HideUsage = !d.current.HideUsage
+	case rowAgents:
+		d.current.HideAgents = !d.current.HideAgents
+	case rowTools:
+		d.current.HideTools = !d.current.HideTools
+	case rowTodos:
+		d.current.HideTodos = !d.current.HideTodos
+	default:
+		return nil
+	}
+	return core.CmdHandler(messages.PreviewLayoutMsg{Layout: d.current})
+}
+
+// cyclePosition returns the position delta steps away in the cycle order.
+func cyclePosition(current messages.SidebarPosition, delta int) messages.SidebarPosition {
+	idx := 0
+	for i, p := range sidebarPositions {
+		if p == current {
+			idx = i
+			break
+		}
+	}
+	idx = (idx + delta + len(sidebarPositions)) % len(sidebarPositions)
+	return sidebarPositions[idx]
+}
+
+// apply closes the dialog and commits the current settings.
+func (d *customizeDialog) apply() tea.Cmd {
+	if d.current == d.original {
+		return closeDialogCmd()
+	}
+	return tea.Sequence(
+		closeDialogCmd(),
+		core.CmdHandler(messages.ApplyLayoutMsg{Layout: d.current}),
+	)
+}
+
+// cancel closes the dialog and restores the original settings.
+func (d *customizeDialog) cancel() tea.Cmd {
+	if d.current == d.original {
+		return closeDialogCmd()
+	}
+	return tea.Sequence(
+		closeDialogCmd(),
+		core.CmdHandler(messages.CancelLayoutPreviewMsg{Original: d.original}),
+	)
+}
+
+func (d *customizeDialog) Position() (row, col int) {
+	return d.CenterDialog(d.View())
+}
+
+func (d *customizeDialog) View() string {
+	width := d.ComputeDialogWidth(customizeWidthPercent, customizeMinWidth, customizeMaxWidth)
+	inner := d.ContentWidth(width, 2)
+
+	preview := lipgloss.NewStyle().
+		Width(inner).
+		Align(lipgloss.Center).
+		Render(renderLayoutPreview(d.current, inner))
+
+	content := NewContent(inner).
+		AddTitle("Customize Layout").
+		AddSeparator().
+		AddSpace().
+		AddContent(preview).
+		AddSpace().
+		AddContent(d.renderPositionRow(inner)).
+		AddSpace().
+		AddContent(styles.MutedStyle.Render("Sidebar sections")).
+		AddContent(d.renderToggleRow(rowUsage, "Token usage", d.current.HideUsage)).
+		AddContent(d.renderToggleRow(rowAgents, "Agents", d.current.HideAgents)).
+		AddContent(d.renderToggleRow(rowTools, "Tools", d.current.HideTools)).
+		AddContent(d.renderToggleRow(rowTodos, "Todos", d.current.HideTodos)).
+		AddSpace().
+		AddHelpKeys("↑/↓", "navigate", "←/→", "change", "enter", "apply", "esc", "cancel").
+		Build()
+
+	return styles.DialogStyle.Width(width).Render(content)
+}
+
+// renderPositionRow renders the sidebar-position selector row.
+func (d *customizeDialog) renderPositionRow(width int) string {
+	label := "Sidebar position"
+	value := "‹ " + positionLabels[d.current.SidebarPosition] + " ›"
+
+	labelStyle := styles.PaletteUnselectedActionStyle
+	valueStyle := styles.SecondaryStyle
+	prefix := "  "
+	if d.selected == rowPosition {
+		labelStyle = styles.PaletteSelectedActionStyle
+		valueStyle = styles.HighlightWhiteStyle
+		prefix = styles.HighlightWhiteStyle.Render("› ")
+	}
+
+	left := prefix + labelStyle.Render(label)
+	gap := max(1, width-lipgloss.Width(left)-lipgloss.Width(value))
+	return left + strings.Repeat(" ", gap) + valueStyle.Render(value)
+}
+
+// renderToggleRow renders a checkbox row for one sidebar section.
+func (d *customizeDialog) renderToggleRow(row int, label string, hidden bool) string {
+	check := "[x]"
+	if hidden {
+		check = "[ ]"
+	}
+
+	labelStyle := styles.PaletteUnselectedActionStyle
+	checkStyle := styles.SecondaryStyle
+	prefix := "  "
+	if d.selected == row {
+		labelStyle = styles.PaletteSelectedActionStyle
+		checkStyle = styles.HighlightWhiteStyle
+		prefix = styles.HighlightWhiteStyle.Render("› ")
+	}
+	if !hidden {
+		checkStyle = checkStyle.Foreground(styles.Success)
+	}
+
+	return prefix + checkStyle.Render(check) + " " + labelStyle.Render(label)
+}
+
+// visibleSectionLabels returns the sidebar section labels that are visible
+// under the given settings. The session block is always shown.
+func visibleSectionLabels(s messages.LayoutSettings) []string {
+	labels := []string{"session"}
+	if !s.HideUsage {
+		labels = append(labels, "usage")
+	}
+	if !s.HideAgents {
+		labels = append(labels, "agents")
+	}
+	if !s.HideTools {
+		labels = append(labels, "tools")
+	}
+	if !s.HideTodos {
+		labels = append(labels, "todos")
+	}
+	return labels
+}
+
+// renderLayoutPreview draws a small schematic of the resulting layout: the
+// chat box, the input box, and the sidebar (side column or horizontal band)
+// listing only the visible sections. maxWidth caps the schematic width.
+func renderLayoutPreview(s messages.LayoutSettings, maxWidth int) string {
+	width := max(previewMinWidth, min(previewMaxWidth, maxWidth))
+	switch messages.ParseSidebarPosition(string(s.SidebarPosition)) {
+	case messages.SidebarLeft:
+		return renderSidePreview(s, width, true)
+	case messages.SidebarTop:
+		return renderBandPreview(s, width, false)
+	case messages.SidebarBottom:
+		return renderBandPreview(s, width, true)
+	default:
+		return renderSidePreview(s, width, false)
+	}
+}
+
+// borderStyle renders preview borders.
+var previewBorder = func(text string) string { return styles.FadingStyle.Render(text) }
+
+// previewLabelCell renders a label padded to width inside a preview box cell.
+func previewLabelCell(label string, width int, style lipgloss.Style) string {
+	label = toolcommon.TruncateText(label, max(0, width-1))
+	cell := " " + style.Render(label)
+	return cell + strings.Repeat(" ", max(0, width-lipgloss.Width(cell)))
+}
+
+// previewCenteredCell renders a label centered within width.
+func previewCenteredCell(label string, width int, style lipgloss.Style) string {
+	return lipgloss.PlaceHorizontal(width, lipgloss.Center, style.Render(label))
+}
+
+// renderSidePreview draws the vertical layout with the sidebar on the left or right.
+func renderSidePreview(s messages.LayoutSettings, width int, onLeft bool) string {
+	inner := width - 2
+	sideW := max(9, inner/3)
+	chatW := inner - sideW - 1
+	const contentRows = 5
+
+	labels := visibleSectionLabels(s)
+	sectionStyle := styles.TabAccentStyle
+
+	var lines []string
+	hbarChat := strings.Repeat("─", chatW)
+	hbarSide := strings.Repeat("─", sideW)
+	hbarFull := strings.Repeat("─", inner)
+
+	if onLeft {
+		lines = append(lines, previewBorder("╭"+hbarSide+"┬"+hbarChat+"╮"))
+	} else {
+		lines = append(lines, previewBorder("╭"+hbarChat+"┬"+hbarSide+"╮"))
+	}
+
+	for i := range contentRows {
+		var side, chat string
+		if i < len(labels) {
+			side = previewLabelCell(labels[i], sideW, sectionStyle)
+		} else {
+			side = strings.Repeat(" ", sideW)
+		}
+		if i == contentRows/2 {
+			chat = previewCenteredCell("chat", chatW, styles.SecondaryStyle)
+		} else {
+			chat = strings.Repeat(" ", chatW)
+		}
+
+		v := previewBorder("│")
+		if onLeft {
+			lines = append(lines, v+side+v+chat+v)
+		} else {
+			lines = append(lines, v+chat+v+side+v)
+		}
+	}
+
+	if onLeft {
+		lines = append(lines, previewBorder("├"+hbarSide+"┴"+hbarChat+"┤"))
+	} else {
+		lines = append(lines, previewBorder("├"+hbarChat+"┴"+hbarSide+"┤"))
+	}
+	lines = append(lines,
+		previewBorder("│")+previewLabelCell("input", inner, styles.SecondaryStyle)+previewBorder("│"),
+		previewBorder("╰"+hbarFull+"╯"),
+	)
+
+	return strings.Join(lines, "\n")
+}
+
+// renderBandPreview draws the layout with the sidebar as a horizontal band
+// above (bottom=false) or below (bottom=true) the chat.
+func renderBandPreview(s messages.LayoutSettings, width int, bottom bool) string {
+	inner := width - 2
+	const chatRows = 3
+
+	band := previewLabelCell(strings.Join(visibleSectionLabels(s), " · "), inner, styles.TabAccentStyle)
+	hbarFull := strings.Repeat("─", inner)
+	v := previewBorder("│")
+
+	chatLines := make([]string, 0, chatRows)
+	for i := range chatRows {
+		if i == chatRows/2 {
+			chatLines = append(chatLines, v+previewCenteredCell("chat", inner, styles.SecondaryStyle)+v)
+		} else {
+			chatLines = append(chatLines, v+strings.Repeat(" ", inner)+v)
+		}
+	}
+
+	lines := []string{previewBorder("╭" + hbarFull + "╮")}
+	if bottom {
+		lines = append(lines, chatLines...)
+		lines = append(lines, previewBorder("├"+hbarFull+"┤"), v+band+v)
+	} else {
+		lines = append(lines, v+band+v, previewBorder("├"+hbarFull+"┤"))
+		lines = append(lines, chatLines...)
+	}
+	lines = append(lines,
+		previewBorder("├"+hbarFull+"┤"),
+		v+previewLabelCell("input", inner, styles.SecondaryStyle)+v,
+		previewBorder("╰"+hbarFull+"╯"),
+	)
+
+	return strings.Join(lines, "\n")
+}

--- a/pkg/tui/dialog/customize_test.go
+++ b/pkg/tui/dialog/customize_test.go
@@ -1,0 +1,198 @@
+package dialog
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tui/messages"
+)
+
+func newTestCustomizeDialog(t *testing.T, current messages.LayoutSettings) *customizeDialog {
+	t.Helper()
+	d, ok := NewCustomizeDialog(current).(*customizeDialog)
+	require.True(t, ok)
+	d.Init()
+	d.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
+	return d
+}
+
+func TestCustomizeDialogNormalizesPosition(t *testing.T) {
+	t.Parallel()
+
+	d := newTestCustomizeDialog(t, messages.LayoutSettings{})
+	assert.Equal(t, messages.SidebarRight, d.current.SidebarPosition)
+}
+
+func TestCustomizeDialogNavigation(t *testing.T) {
+	t.Parallel()
+
+	d := newTestCustomizeDialog(t, messages.LayoutSettings{})
+	down := tea.KeyPressMsg{Code: tea.KeyDown}
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+
+	require.Equal(t, rowPosition, d.selected)
+
+	d.Update(down)
+	require.Equal(t, rowUsage, d.selected)
+
+	for range 10 {
+		d.Update(down)
+	}
+	require.Equal(t, rowTodos, d.selected, "down must stop at the last row")
+
+	d.Update(up)
+	require.Equal(t, rowTools, d.selected)
+}
+
+func TestCustomizeDialogCyclesPositionAndPreviews(t *testing.T) {
+	t.Parallel()
+
+	d := newTestCustomizeDialog(t, messages.LayoutSettings{})
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	require.NotNil(t, cmd)
+	msgs := collectMsgs(cmd)
+	require.Len(t, msgs, 1)
+	preview, ok := msgs[0].(messages.PreviewLayoutMsg)
+	require.True(t, ok, "changing a value must emit a live preview")
+	assert.Equal(t, messages.SidebarLeft, preview.Layout.SidebarPosition)
+
+	d.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	assert.Equal(t, messages.SidebarTop, d.current.SidebarPosition)
+
+	// Cycling backwards from the start wraps around.
+	d.current.SidebarPosition = messages.SidebarRight
+	d.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
+	assert.Equal(t, messages.SidebarBottom, d.current.SidebarPosition)
+}
+
+func TestCustomizeDialogTogglesSection(t *testing.T) {
+	t.Parallel()
+
+	d := newTestCustomizeDialog(t, messages.LayoutSettings{})
+	d.selected = rowUsage
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+	msgs := collectMsgs(cmd)
+	require.Len(t, msgs, 1)
+	preview, ok := msgs[0].(messages.PreviewLayoutMsg)
+	require.True(t, ok)
+	assert.True(t, preview.Layout.HideUsage, "space must hide the usage section")
+
+	d.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+	assert.False(t, d.current.HideUsage, "space must toggle back")
+}
+
+func TestCustomizeDialogApplyEmitsApplyLayout(t *testing.T) {
+	t.Parallel()
+
+	d := newTestCustomizeDialog(t, messages.LayoutSettings{})
+	d.selected = rowTools
+	d.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	msgs := collectMsgs(cmd)
+	require.Len(t, msgs, 2, "apply must close the dialog and emit the layout")
+	_, ok := msgs[0].(CloseDialogMsg)
+	require.True(t, ok)
+	applied, ok := msgs[1].(messages.ApplyLayoutMsg)
+	require.True(t, ok)
+	assert.True(t, applied.Layout.HideTools)
+}
+
+func TestCustomizeDialogApplyWithoutChangesOnlyCloses(t *testing.T) {
+	t.Parallel()
+
+	d := newTestCustomizeDialog(t, messages.LayoutSettings{})
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	msgs := collectMsgs(cmd)
+	require.Len(t, msgs, 1)
+	_, ok := msgs[0].(CloseDialogMsg)
+	assert.True(t, ok, "no changes: apply just closes")
+}
+
+func TestCustomizeDialogEscapeRestoresOriginal(t *testing.T) {
+	t.Parallel()
+
+	original := messages.LayoutSettings{SidebarPosition: messages.SidebarLeft}
+	d := newTestCustomizeDialog(t, original)
+	d.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	msgs := collectMsgs(cmd)
+	require.Len(t, msgs, 2)
+	_, ok := msgs[0].(CloseDialogMsg)
+	require.True(t, ok)
+	cancel, ok := msgs[1].(messages.CancelLayoutPreviewMsg)
+	require.True(t, ok, "esc after a change must restore the original layout")
+	assert.Equal(t, original, cancel.Original)
+}
+
+func TestCustomizeDialogEscapeWithoutChangesOnlyCloses(t *testing.T) {
+	t.Parallel()
+
+	d := newTestCustomizeDialog(t, messages.LayoutSettings{})
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	msgs := collectMsgs(cmd)
+	require.Len(t, msgs, 1)
+	_, ok := msgs[0].(CloseDialogMsg)
+	assert.True(t, ok)
+}
+
+func TestCustomizeDialogViewShowsRows(t *testing.T) {
+	t.Parallel()
+
+	d := newTestCustomizeDialog(t, messages.LayoutSettings{})
+	view := ansi.Strip(d.View())
+
+	assert.Contains(t, view, "Customize Layout")
+	assert.Contains(t, view, "Sidebar position")
+	assert.Contains(t, view, "Right")
+	assert.Contains(t, view, "Token usage")
+	assert.Contains(t, view, "Agents")
+	assert.Contains(t, view, "Tools")
+	assert.Contains(t, view, "Todos")
+}
+
+func TestRenderLayoutPreviewReflectsSections(t *testing.T) {
+	t.Parallel()
+
+	full := ansi.Strip(renderLayoutPreview(messages.LayoutSettings{}, previewMaxWidth))
+	assert.Contains(t, full, "chat")
+	assert.Contains(t, full, "input")
+	assert.Contains(t, full, "session")
+	assert.Contains(t, full, "usage")
+	assert.Contains(t, full, "todos")
+
+	trimmed := ansi.Strip(renderLayoutPreview(messages.LayoutSettings{
+		HideUsage: true,
+		HideTodos: true,
+	}, previewMaxWidth))
+	assert.NotContains(t, trimmed, "usage")
+	assert.NotContains(t, trimmed, "todos")
+	assert.Contains(t, trimmed, "agents")
+}
+
+func TestRenderLayoutPreviewPositions(t *testing.T) {
+	t.Parallel()
+
+	for _, position := range sidebarPositions {
+		preview := ansi.Strip(renderLayoutPreview(messages.LayoutSettings{SidebarPosition: position}, previewMaxWidth))
+		assert.Contains(t, preview, "chat", "position %s", position)
+		assert.Contains(t, preview, "session", "position %s", position)
+	}
+
+	// Band layouts list the sections on a single line.
+	band := ansi.Strip(renderLayoutPreview(messages.LayoutSettings{SidebarPosition: messages.SidebarTop}, previewMaxWidth))
+	assert.Contains(t, band, "session · usage · agents · tools · todos")
+
+	// Narrow widths truncate the band list instead of overflowing.
+	narrow := ansi.Strip(renderLayoutPreview(messages.LayoutSettings{SidebarPosition: messages.SidebarTop}, previewMinWidth))
+	assert.Contains(t, narrow, "session")
+}

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -793,6 +793,85 @@ func (m *appModel) handleThemeFileChanged(themeRef string) (tea.Model, tea.Cmd) 
 	)
 }
 
+// --- Layout customization ---
+
+// handleOpenCustomizeDialog opens the /custom layout dialog.
+func (m *appModel) handleOpenCustomizeDialog() (tea.Model, tea.Cmd) {
+	if m.hideSidebar {
+		return m, notification.InfoCmd("Sidebar is disabled; there is no layout to customize")
+	}
+	return m, core.CmdHandler(dialog.OpenDialogMsg{
+		Model: dialog.NewCustomizeDialog(m.layoutSettings),
+	})
+}
+
+// applyLayoutSettings applies the given layout to every chat page (all tabs
+// share the same layout) and optionally persists it to the user config.
+func (m *appModel) applyLayoutSettings(settings messages.LayoutSettings, persist bool) (tea.Model, tea.Cmd) {
+	settings.SidebarPosition = messages.ParseSidebarPosition(string(settings.SidebarPosition))
+	m.layoutSettings = settings
+
+	var cmds []tea.Cmd
+	for _, page := range m.chatPages {
+		if cmd := page.SetLayoutSettings(settings); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	cmds = append(cmds, m.resizeAll())
+
+	if persist {
+		if err := saveLayoutToUserConfig(settings); err != nil {
+			slog.Warn("Failed to save layout to user config", "error", err)
+			cmds = append(cmds, notification.WarningCmd("Layout applied but could not be saved"))
+		} else {
+			cmds = append(cmds, notification.SuccessCmd("Layout updated"))
+		}
+	}
+
+	return m, tea.Batch(cmds...)
+}
+
+// layoutSettingsFromConfig converts persisted layout settings to their runtime form.
+func layoutSettingsFromConfig(l userconfig.LayoutSettings) messages.LayoutSettings {
+	return messages.LayoutSettings{
+		SidebarPosition: messages.ParseSidebarPosition(l.SidebarPosition),
+		HideUsage:       l.HideUsage,
+		HideAgents:      l.HideAgents,
+		HideTools:       l.HideTools,
+		HideTodos:       l.HideTodos,
+	}
+}
+
+// saveLayoutToUserConfig persists layout settings to the user config file.
+// Default settings clear the layout entry to keep the config file minimal.
+func saveLayoutToUserConfig(s messages.LayoutSettings) error {
+	cfg, err := userconfig.Load()
+	if err != nil {
+		return err
+	}
+	if cfg.Settings == nil {
+		cfg.Settings = &userconfig.Settings{}
+	}
+
+	if s == (messages.LayoutSettings{SidebarPosition: messages.SidebarRight}) {
+		cfg.Settings.Layout = nil
+		return cfg.Save()
+	}
+
+	position := string(s.SidebarPosition)
+	if s.SidebarPosition == messages.SidebarRight {
+		position = ""
+	}
+	cfg.Settings.Layout = &userconfig.LayoutSettings{
+		SidebarPosition: position,
+		HideUsage:       s.HideUsage,
+		HideAgents:      s.HideAgents,
+		HideTools:       s.HideTools,
+		HideTodos:       s.HideTodos,
+	}
+	return cfg.Save()
+}
+
 // handleColorSchemeChange reacts to a terminal light/dark report (a DEC mode
 // 2031 event or an OSC 11 response). The polarity is always recorded so a
 // later switch to the auto theme starts from the freshest value; the theme

--- a/pkg/tui/layout_settings_test.go
+++ b/pkg/tui/layout_settings_test.go
@@ -1,0 +1,92 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/paths"
+	"github.com/docker/docker-agent/pkg/tui/messages"
+	"github.com/docker/docker-agent/pkg/userconfig"
+)
+
+// setupLayoutConfigTest isolates the user config in a temp dir. Tests using
+// it must not be parallel: the config dir override is process-global.
+func setupLayoutConfigTest(t *testing.T) {
+	t.Helper()
+	paths.SetConfigDir(t.TempDir())
+	t.Cleanup(func() { paths.SetConfigDir("") })
+}
+
+func TestLayoutSettingsFromConfig(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		messages.LayoutSettings{SidebarPosition: messages.SidebarRight},
+		layoutSettingsFromConfig(userconfig.LayoutSettings{}),
+		"empty config falls back to the default position")
+
+	assert.Equal(t,
+		messages.LayoutSettings{SidebarPosition: messages.SidebarRight},
+		layoutSettingsFromConfig(userconfig.LayoutSettings{SidebarPosition: "bogus"}),
+		"unknown positions fall back to the default")
+
+	got := layoutSettingsFromConfig(userconfig.LayoutSettings{
+		SidebarPosition: "bottom",
+		HideUsage:       true,
+		HideAgents:      true,
+		HideTools:       true,
+		HideTodos:       true,
+	})
+	assert.Equal(t, messages.LayoutSettings{
+		SidebarPosition: messages.SidebarBottom,
+		HideUsage:       true,
+		HideAgents:      true,
+		HideTools:       true,
+		HideTodos:       true,
+	}, got)
+}
+
+func TestSaveLayoutToUserConfig_RoundTrip(t *testing.T) {
+	setupLayoutConfigTest(t)
+
+	saved := messages.LayoutSettings{
+		SidebarPosition: messages.SidebarLeft,
+		HideTools:       true,
+	}
+	require.NoError(t, saveLayoutToUserConfig(saved))
+
+	assert.Equal(t, saved, layoutSettingsFromConfig(userconfig.Get().GetLayout()))
+}
+
+func TestSaveLayoutToUserConfig_DefaultsClearEntry(t *testing.T) {
+	setupLayoutConfigTest(t)
+
+	require.NoError(t, saveLayoutToUserConfig(messages.LayoutSettings{
+		SidebarPosition: messages.SidebarTop,
+	}))
+	require.NoError(t, saveLayoutToUserConfig(messages.LayoutSettings{
+		SidebarPosition: messages.SidebarRight,
+	}))
+
+	cfg, err := userconfig.Load()
+	require.NoError(t, err)
+	assert.Nil(t, cfg.GetSettings().Layout, "default layout clears the config entry")
+}
+
+func TestSaveLayoutToUserConfig_OmitsDefaultPosition(t *testing.T) {
+	setupLayoutConfigTest(t)
+
+	require.NoError(t, saveLayoutToUserConfig(messages.LayoutSettings{
+		SidebarPosition: messages.SidebarRight,
+		HideUsage:       true,
+	}))
+
+	cfg, err := userconfig.Load()
+	require.NoError(t, err)
+	layout := cfg.GetSettings().Layout
+	require.NotNil(t, layout)
+	assert.Empty(t, layout.SidebarPosition, "the default position is not written out")
+	assert.True(t, layout.HideUsage)
+}

--- a/pkg/tui/messages/layout.go
+++ b/pkg/tui/messages/layout.go
@@ -1,0 +1,60 @@
+package messages
+
+// SidebarPosition identifies where the session info sidebar is placed
+// relative to the chat area.
+type SidebarPosition string
+
+const (
+	// SidebarRight is the default vertical sidebar on the right side.
+	SidebarRight SidebarPosition = "right"
+	// SidebarLeft is a vertical sidebar on the left side.
+	SidebarLeft SidebarPosition = "left"
+	// SidebarTop is a compact horizontal band above the chat.
+	SidebarTop SidebarPosition = "top"
+	// SidebarBottom is a compact horizontal band below the chat.
+	SidebarBottom SidebarPosition = "bottom"
+)
+
+// ParseSidebarPosition normalizes a raw position string, falling back to
+// SidebarRight for empty or unknown values so persisted configs can never
+// break the layout.
+func ParseSidebarPosition(raw string) SidebarPosition {
+	switch SidebarPosition(raw) {
+	case SidebarLeft, SidebarTop, SidebarBottom:
+		return SidebarPosition(raw)
+	default:
+		return SidebarRight
+	}
+}
+
+// LayoutSettings describes the user-customizable TUI layout: where the
+// sidebar sits and which of its optional sections are rendered. The zero
+// value is the default layout (sidebar on the right, everything visible).
+type LayoutSettings struct {
+	SidebarPosition SidebarPosition
+	HideUsage       bool
+	HideAgents      bool
+	HideTools       bool
+	HideTodos       bool
+}
+
+// Layout customization messages.
+type (
+	// OpenCustomizeDialogMsg opens the layout customization dialog.
+	OpenCustomizeDialogMsg struct{}
+
+	// PreviewLayoutMsg applies layout settings live without persisting them.
+	PreviewLayoutMsg struct {
+		Layout LayoutSettings
+	}
+
+	// ApplyLayoutMsg applies layout settings and persists them to the user config.
+	ApplyLayoutMsg struct {
+		Layout LayoutSettings
+	}
+
+	// CancelLayoutPreviewMsg restores the layout that was active before a preview.
+	CancelLayoutPreviewMsg struct {
+		Original LayoutSettings
+	}
+)

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -40,11 +40,11 @@ const (
 type sidebarLayoutMode int
 
 const (
-	// sidebarVertical: wide window, sidebar on right side
+	// sidebarVertical: wide window, sidebar beside the chat (left or right)
 	sidebarVertical sidebarLayoutMode = iota
 	// sidebarCollapsed: wide window but user collapsed sidebar, shown at top with toggle
 	sidebarCollapsed
-	// sidebarCollapsedNarrow: narrow window, shown at top without toggle
+	// sidebarCollapsedNarrow: narrow window or forced band position, shown without toggle
 	sidebarCollapsedNarrow
 )
 
@@ -52,13 +52,16 @@ const (
 // Computing this once per update avoids repeating calculations across View, SetSize, and input handlers.
 type sidebarLayout struct {
 	mode          sidebarLayoutMode
-	innerWidth    int // window width minus app padding
-	chatWidth     int // width available for chat/messages
-	sidebarWidth  int // actual sidebar width (varies by mode)
-	sidebarStartX int // X coordinate where sidebar content starts (relative to innerWidth)
-	handleX       int // X coordinate of resize handle column (only valid in vertical mode)
-	chatHeight    int // height available for chat area
-	sidebarHeight int // height of sidebar
+	sidebarOnLeft bool // vertical mode: sidebar sits left of the chat
+	bandAtBottom  bool // collapsed modes: band sits below the chat instead of above
+	innerWidth    int  // window width minus app padding
+	chatWidth     int  // width available for chat/messages
+	chatStartX    int  // X coordinate where the chat area starts (relative to innerWidth)
+	sidebarWidth  int  // actual sidebar width (varies by mode)
+	sidebarStartX int  // X coordinate where sidebar content starts (relative to innerWidth)
+	handleX       int  // X coordinate of resize handle column (only valid in vertical mode)
+	chatHeight    int  // height available for chat area
+	sidebarHeight int  // height of sidebar
 }
 
 // isOnHandle returns true if adjustedX (already adjusted for app padding) is on the resize handle.
@@ -71,7 +74,37 @@ func (l sidebarLayout) isInSidebar(adjustedX int) bool {
 	if l.mode != sidebarVertical {
 		return false
 	}
+	if l.sidebarOnLeft {
+		return adjustedX < l.handleX
+	}
 	return adjustedX >= l.sidebarStartX
+}
+
+// bandY returns the Y coordinate where the collapsed band starts.
+func (l sidebarLayout) bandY() int {
+	if l.bandAtBottom {
+		return l.chatHeight
+	}
+	return 0
+}
+
+// isInBand returns true if y falls within the collapsed sidebar band.
+func (l sidebarLayout) isInBand(y int) bool {
+	if l.mode == sidebarVertical {
+		return false
+	}
+	return y >= l.bandY() && y < l.bandY()+l.sidebarHeight
+}
+
+// bandContentY converts a screen Y coordinate to a Y coordinate relative to
+// the band content. A bottom band renders its divider on the first line, so
+// the content starts one line lower.
+func (l sidebarLayout) bandContentY(y int) int {
+	contentY := y - l.bandY()
+	if l.bandAtBottom {
+		contentY--
+	}
+	return contentY
 }
 
 // showToggle returns true if a toggle glyph should be shown.
@@ -114,6 +147,9 @@ type Page interface {
 	GetSidebarSettings() SidebarSettings
 	// SetSidebarSettings applies sidebar display settings
 	SetSidebarSettings(settings SidebarSettings)
+	// SetLayoutSettings applies layout customization (sidebar position and
+	// section visibility) and relayouts the page.
+	SetLayoutSettings(settings msgtypes.LayoutSettings) tea.Cmd
 }
 
 // queuedMessage represents a message waiting to be sent to the agent
@@ -136,9 +172,10 @@ type chatPage struct {
 	sessionState *service.SessionState
 
 	// State
-	working     bool
-	leanMode    bool
-	hideSidebar bool
+	working        bool
+	leanMode       bool
+	hideSidebar    bool
+	layoutSettings msgtypes.LayoutSettings
 
 	msgCancel       context.CancelFunc
 	streamCancelled bool
@@ -195,27 +232,38 @@ func (p *chatPage) computeSidebarLayout() sidebarLayout {
 		}
 	}
 
+	position := p.layoutSettings.SidebarPosition
+	sideBySide := position == msgtypes.SidebarLeft || position == "" || position == msgtypes.SidebarRight
+
 	var mode sidebarLayoutMode
 	switch {
-	case p.width >= minWindowWidth && !p.sidebar.IsCollapsed():
+	case sideBySide && p.width >= minWindowWidth && !p.sidebar.IsCollapsed():
 		mode = sidebarVertical
-	case p.width >= minWindowWidth:
+	case sideBySide && p.width >= minWindowWidth:
 		mode = sidebarCollapsed
 	default:
 		mode = sidebarCollapsedNarrow
 	}
 
 	l := sidebarLayout{
-		mode:       mode,
-		innerWidth: innerWidth,
+		mode:          mode,
+		innerWidth:    innerWidth,
+		sidebarOnLeft: position == msgtypes.SidebarLeft,
+		bandAtBottom:  position == msgtypes.SidebarBottom,
 	}
 
 	switch mode {
 	case sidebarVertical:
 		l.sidebarWidth = p.sidebar.ClampWidth(p.sidebar.GetPreferredWidth(), innerWidth)
 		l.chatWidth = max(1, innerWidth-l.sidebarWidth)
-		l.handleX = l.chatWidth
-		l.sidebarStartX = l.chatWidth + toggleColumnWidth
+		if l.sidebarOnLeft {
+			l.sidebarStartX = 0
+			l.handleX = l.sidebarWidth - toggleColumnWidth
+			l.chatStartX = l.sidebarWidth
+		} else {
+			l.handleX = l.chatWidth
+			l.sidebarStartX = l.chatWidth + toggleColumnWidth
+		}
 		l.chatHeight = max(1, p.height)
 		l.sidebarHeight = l.chatHeight
 
@@ -307,6 +355,25 @@ func WithHideSidebar() PageOption {
 func WithCommandParser(p *commands.Parser) PageOption {
 	return func(cp *chatPage) {
 		cp.commandParser = p
+	}
+}
+
+// WithLayoutSettings applies initial layout customization (sidebar position
+// and section visibility).
+func WithLayoutSettings(settings msgtypes.LayoutSettings) PageOption {
+	return func(p *chatPage) {
+		p.layoutSettings = settings
+		p.sidebar.SetSectionVisibility(sectionVisibility(settings))
+	}
+}
+
+// sectionVisibility maps layout settings to the sidebar's visibility config.
+func sectionVisibility(settings msgtypes.LayoutSettings) sidebar.SectionVisibility {
+	return sidebar.SectionVisibility{
+		HideUsage:  settings.HideUsage,
+		HideAgents: settings.HideAgents,
+		HideTools:  settings.HideTools,
+		HideTodos:  settings.HideTodos,
 	}
 }
 
@@ -468,7 +535,8 @@ func (p *chatPage) pendingSpinnerContext() (sender, label string) {
 	return child, p.agentStack[n-2] + " → " + child
 }
 
-// renderCollapsedSidebar renders the sidebar in collapsed mode (at top of screen).
+// renderCollapsedSidebar renders the sidebar in collapsed/band mode.
+// A top band carries its divider on the last line; a bottom band on the first.
 func (p *chatPage) renderCollapsedSidebar(sl sidebarLayout) string {
 	// Guard against unset/invalid layout (can happen before WindowSizeMsg is received).
 	width := max(0, sl.innerWidth)
@@ -488,11 +556,16 @@ func (p *chatPage) renderCollapsedSidebar(sl sidebarLayout) string {
 		sidebarLines[0] = padded + toggleGlyph
 	}
 
-	// Replace the last line with a subtle divider
 	divider := styles.FadingStyle.Render(strings.Repeat("─", width))
-	if len(sidebarLines) >= height {
+	switch {
+	case sl.bandAtBottom:
+		sidebarLines = append([]string{divider}, sidebarLines...)
+		if len(sidebarLines) > height {
+			sidebarLines = sidebarLines[:height]
+		}
+	case len(sidebarLines) >= height:
 		sidebarLines[height-1] = divider
-	} else {
+	default:
 		sidebarLines = append(sidebarLines, divider)
 	}
 
@@ -528,7 +601,11 @@ func (p *chatPage) View() string {
 			Align(lipgloss.Left, lipgloss.Top).
 			Render(p.sidebar.View())
 
-		bodyContent = lipgloss.JoinHorizontal(lipgloss.Left, chatView, toggleCol, sidebarView)
+		if sl.sidebarOnLeft {
+			bodyContent = lipgloss.JoinHorizontal(lipgloss.Left, sidebarView, toggleCol, chatView)
+		} else {
+			bodyContent = lipgloss.JoinHorizontal(lipgloss.Left, chatView, toggleCol, sidebarView)
+		}
 
 	case sidebarCollapsed, sidebarCollapsedNarrow:
 		switch {
@@ -549,7 +626,11 @@ func (p *chatPage) View() string {
 				Height(sl.chatHeight).
 				Width(sl.innerWidth).
 				Render(messagesView)
-			bodyContent = lipgloss.JoinVertical(lipgloss.Top, sidebarRendered, chatView)
+			if sl.bandAtBottom {
+				bodyContent = lipgloss.JoinVertical(lipgloss.Top, chatView, sidebarRendered)
+			} else {
+				bodyContent = lipgloss.JoinVertical(lipgloss.Top, sidebarRendered, chatView)
+			}
 		}
 	}
 
@@ -561,23 +642,23 @@ func (p *chatPage) View() string {
 }
 
 // renderSidebarHandle renders the sidebar toggle/resize handle.
-// When collapsed: shows just « at top.
-// When expanded: shows » at top, rest is empty space (draggable for resize).
+// The glyph points toward the edge the sidebar collapses to and flips when
+// the sidebar sits on the left.
 func (p *chatPage) renderSidebarHandle(height int) string {
 	lines := make([]string, height)
 
+	expandGlyph, collapseGlyph := "«", "»"
+	if p.layoutSettings.SidebarPosition == msgtypes.SidebarLeft {
+		expandGlyph, collapseGlyph = "»", "«"
+	}
+
+	glyph := collapseGlyph
 	if p.sidebar.IsCollapsed() {
-		// Collapsed: just the toggle glyph, no vertical line
-		lines[0] = styles.MutedStyle.Render("«")
-		for i := 1; i < height; i++ {
-			lines[i] = " "
-		}
-	} else {
-		// Expanded: just the toggle at top, rest is empty space (still draggable)
-		lines[0] = styles.MutedStyle.Render("»")
-		for i := 1; i < height; i++ {
-			lines[i] = " "
-		}
+		glyph = expandGlyph
+	}
+	lines[0] = styles.MutedStyle.Render(glyph)
+	for i := 1; i < height; i++ {
+		lines[i] = " "
 	}
 
 	return strings.Join(lines, "\n")
@@ -595,17 +676,23 @@ func (p *chatPage) SetSize(width, height int) tea.Cmd {
 	switch sl.mode {
 	case sidebarVertical:
 		p.sidebar.SetMode(sidebar.ModeVertical)
+		p.sidebar.SetMirroredPadding(sl.sidebarOnLeft)
 		cmds = append(cmds,
 			p.sidebar.SetSize(sl.sidebarWidth-toggleColumnWidth, sl.chatHeight),
 			p.sidebar.SetPosition(styles.AppPadding+sl.sidebarStartX, 0),
-			p.messages.SetPosition(styles.AppPadding, 0),
+			p.messages.SetPosition(styles.AppPadding+sl.chatStartX, 0),
 		)
 	case sidebarCollapsed, sidebarCollapsedNarrow:
 		p.sidebar.SetMode(sidebar.ModeCollapsed)
+		p.sidebar.SetMirroredPadding(false)
+		messagesY := sl.sidebarHeight
+		if sl.bandAtBottom {
+			messagesY = 0
+		}
 		cmds = append(cmds,
 			p.sidebar.SetSize(sl.sidebarWidth, sl.sidebarHeight),
-			p.sidebar.SetPosition(styles.AppPadding, 0),
-			p.messages.SetPosition(styles.AppPadding, sl.sidebarHeight),
+			p.sidebar.SetPosition(styles.AppPadding, sl.bandY()),
+			p.messages.SetPosition(styles.AppPadding, messagesY),
 		)
 	}
 
@@ -1012,6 +1099,16 @@ func (p *chatPage) SetSidebarSettings(settings SidebarSettings) {
 	p.sidebar.SetPreferredWidth(settings.PreferredWidth)
 }
 
+// SetLayoutSettings applies layout customization and relayouts the page.
+func (p *chatPage) SetLayoutSettings(settings msgtypes.LayoutSettings) tea.Cmd {
+	p.layoutSettings = settings
+	p.sidebar.SetSectionVisibility(sectionVisibility(settings))
+	if p.width <= 0 || p.height <= 0 {
+		return nil
+	}
+	return p.SetSize(p.width, p.height)
+}
+
 // handleSidebarClickType checks what was clicked in the sidebar area.
 // Returns the click type and, for ClickAgent, the agent name.
 func (p *chatPage) handleSidebarClickType(x, y int) (sidebar.ClickResult, string) {
@@ -1020,7 +1117,7 @@ func (p *chatPage) handleSidebarClickType(x, y int) (sidebar.ClickResult, string
 
 	switch sl.mode {
 	case sidebarCollapsedNarrow, sidebarCollapsed:
-		return p.sidebar.HandleClickType(adjustedX, y)
+		return p.sidebar.HandleClickType(adjustedX, sl.bandContentY(y))
 	case sidebarVertical:
 		if sl.isInSidebar(adjustedX) {
 			return p.sidebar.HandleClickType(adjustedX-sl.sidebarStartX, y)

--- a/pkg/tui/page/chat/hittest.go
+++ b/pkg/tui/page/chat/hittest.go
@@ -58,8 +58,8 @@ func (h *HitTest) At(x, y int) MouseTarget {
 		return h.sidebarClickTarget(x, y)
 	}
 
-	// Check if in collapsed sidebar area (top of screen)
-	if sl.mode != sidebarVertical && y < sl.sidebarHeight {
+	// Check if in collapsed sidebar band (above or below the chat)
+	if sl.isInBand(y) {
 		return h.sidebarClickTarget(x, y)
 	}
 
@@ -80,8 +80,8 @@ func (h *HitTest) isOnSidebarToggleGlyph(x, y int) bool {
 		return y == 0 && h.isOnSidebarResizeHandle(x, y)
 	}
 
-	// Collapsed horizontal: toggle is at right edge of first line
-	if y != 0 {
+	// Collapsed horizontal: toggle is at right edge of the band's first content line
+	if sl.bandContentY(y) != 0 {
 		return false
 	}
 	adjustedX := x - styles.AppPadding

--- a/pkg/tui/page/chat/input_handlers.go
+++ b/pkg/tui/page/chat/input_handlers.go
@@ -291,6 +291,10 @@ func (p *chatPage) wheelTarget(x, _ int) wheelTarget {
 func (p *chatPage) handleSidebarResize(x int) tea.Cmd {
 	innerWidth := p.width - appPaddingHorizontal
 	delta := p.sidebarDragStartX - x
+	// A left-side sidebar grows when the handle is dragged right.
+	if p.layoutSettings.SidebarPosition == msgtypes.SidebarLeft {
+		delta = -delta
+	}
 	newWidth := p.sidebarDragStartWidth + delta
 
 	// Auto-collapse if dragged below minimum

--- a/pkg/tui/page/chat/layout_position_test.go
+++ b/pkg/tui/page/chat/layout_position_test.go
@@ -1,0 +1,209 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tui/components/messages"
+	"github.com/docker/docker-agent/pkg/tui/components/sidebar"
+	msgtypes "github.com/docker/docker-agent/pkg/tui/messages"
+	"github.com/docker/docker-agent/pkg/tui/service"
+)
+
+// newLayoutTestPage builds a chatPage large enough for the vertical sidebar
+// layout, with the given sidebar position applied.
+func newLayoutTestPage(t *testing.T, position msgtypes.SidebarPosition) *chatPage {
+	t.Helper()
+	sessionState := &service.SessionState{}
+	p := &chatPage{
+		sidebar:      sidebar.New(t.Context(), sessionState),
+		messages:     messages.New(sessionState),
+		sessionState: sessionState,
+		width:        160,
+		height:       40,
+	}
+	p.layoutSettings = msgtypes.LayoutSettings{SidebarPosition: position}
+	return p
+}
+
+func TestComputeSidebarLayout_RightDefault(t *testing.T) {
+	t.Parallel()
+
+	p := newLayoutTestPage(t, msgtypes.SidebarRight)
+	sl := p.computeSidebarLayout()
+
+	require.Equal(t, sidebarVertical, sl.mode)
+	assert.False(t, sl.sidebarOnLeft)
+	assert.Equal(t, 0, sl.chatStartX, "chat starts at the left edge")
+	assert.Equal(t, sl.chatWidth, sl.handleX, "handle sits right after the chat")
+	assert.Equal(t, sl.chatWidth+toggleColumnWidth, sl.sidebarStartX)
+	assert.True(t, sl.isInSidebar(sl.sidebarStartX+1))
+	assert.False(t, sl.isInSidebar(2))
+}
+
+func TestComputeSidebarLayout_ZeroValueDefaultsToRight(t *testing.T) {
+	t.Parallel()
+
+	p := newLayoutTestPage(t, "")
+	sl := p.computeSidebarLayout()
+
+	require.Equal(t, sidebarVertical, sl.mode)
+	assert.False(t, sl.sidebarOnLeft)
+}
+
+func TestComputeSidebarLayout_Left(t *testing.T) {
+	t.Parallel()
+
+	p := newLayoutTestPage(t, msgtypes.SidebarLeft)
+	sl := p.computeSidebarLayout()
+
+	require.Equal(t, sidebarVertical, sl.mode)
+	assert.True(t, sl.sidebarOnLeft)
+	assert.Equal(t, 0, sl.sidebarStartX, "sidebar starts at the left edge")
+	assert.Equal(t, sl.sidebarWidth-toggleColumnWidth, sl.handleX)
+	assert.Equal(t, sl.sidebarWidth, sl.chatStartX, "chat starts after the sidebar")
+	assert.Equal(t, sl.innerWidth, sl.sidebarWidth+sl.chatWidth)
+
+	assert.True(t, sl.isInSidebar(0))
+	assert.True(t, sl.isInSidebar(sl.handleX-1))
+	assert.False(t, sl.isInSidebar(sl.handleX), "the handle column is not sidebar content")
+	assert.False(t, sl.isInSidebar(sl.chatStartX+5))
+	assert.True(t, sl.isOnHandle(sl.handleX))
+}
+
+func TestComputeSidebarLayout_Top(t *testing.T) {
+	t.Parallel()
+
+	p := newLayoutTestPage(t, msgtypes.SidebarTop)
+	sl := p.computeSidebarLayout()
+
+	require.Equal(t, sidebarCollapsedNarrow, sl.mode, "top position always uses the band layout")
+	assert.False(t, sl.bandAtBottom)
+	assert.Equal(t, 0, sl.bandY())
+	assert.Equal(t, sl.innerWidth, sl.chatWidth)
+	assert.Equal(t, p.height-sl.sidebarHeight, sl.chatHeight)
+	assert.True(t, sl.isInBand(0))
+	assert.False(t, sl.isInBand(sl.sidebarHeight))
+	assert.Equal(t, 1, sl.bandContentY(1), "top band content starts at its first line")
+}
+
+func TestComputeSidebarLayout_Bottom(t *testing.T) {
+	t.Parallel()
+
+	p := newLayoutTestPage(t, msgtypes.SidebarBottom)
+	sl := p.computeSidebarLayout()
+
+	require.Equal(t, sidebarCollapsedNarrow, sl.mode, "bottom position always uses the band layout")
+	assert.True(t, sl.bandAtBottom)
+	assert.Equal(t, sl.chatHeight, sl.bandY())
+	assert.False(t, sl.isInBand(0), "chat rows are not in the band")
+	assert.True(t, sl.isInBand(sl.chatHeight))
+	assert.True(t, sl.isInBand(sl.chatHeight+sl.sidebarHeight-1))
+	assert.False(t, sl.isInBand(sl.chatHeight+sl.sidebarHeight))
+	assert.Equal(t, 0, sl.bandContentY(sl.chatHeight+1),
+		"bottom band renders its divider first, so content starts one line lower")
+}
+
+func TestComputeSidebarLayout_NarrowWindowKeepsConfiguredBandEdge(t *testing.T) {
+	t.Parallel()
+
+	right := newLayoutTestPage(t, msgtypes.SidebarRight)
+	right.width = 80
+	sl := right.computeSidebarLayout()
+	require.Equal(t, sidebarCollapsedNarrow, sl.mode)
+	assert.False(t, sl.bandAtBottom, "narrow side-by-side layouts collapse to a top band")
+
+	bottom := newLayoutTestPage(t, msgtypes.SidebarBottom)
+	bottom.width = 80
+	sl = bottom.computeSidebarLayout()
+	require.Equal(t, sidebarCollapsedNarrow, sl.mode)
+	assert.True(t, sl.bandAtBottom, "bottom position keeps its band at the bottom when narrow")
+}
+
+func TestComputeSidebarLayout_LeftCollapsesToTopBand(t *testing.T) {
+	t.Parallel()
+
+	p := newLayoutTestPage(t, msgtypes.SidebarLeft)
+	p.sidebar.SetCollapsed(true)
+	sl := p.computeSidebarLayout()
+
+	require.Equal(t, sidebarCollapsed, sl.mode)
+	assert.False(t, sl.bandAtBottom)
+	assert.True(t, sl.showToggle())
+}
+
+func TestSetLayoutSettingsForwardsVisibilityToSidebar(t *testing.T) {
+	t.Parallel()
+
+	p := newLayoutTestPage(t, msgtypes.SidebarRight)
+	p.SetLayoutSettings(msgtypes.LayoutSettings{
+		SidebarPosition: msgtypes.SidebarLeft,
+		HideUsage:       true,
+	})
+
+	assert.Equal(t, msgtypes.SidebarLeft, p.layoutSettings.SidebarPosition)
+
+	sl := p.computeSidebarLayout()
+	assert.True(t, sl.sidebarOnLeft)
+}
+
+func TestSetLayoutSettingsBeforeSizingReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	sessionState := &service.SessionState{}
+	p := &chatPage{
+		sidebar:      sidebar.New(t.Context(), sessionState),
+		messages:     messages.New(sessionState),
+		sessionState: sessionState,
+	}
+
+	cmd := p.SetLayoutSettings(msgtypes.LayoutSettings{SidebarPosition: msgtypes.SidebarTop})
+	assert.Nil(t, cmd, "no relayout before the first WindowSizeMsg")
+	assert.Equal(t, msgtypes.SidebarTop, p.layoutSettings.SidebarPosition)
+}
+
+// sidebarTitleLine returns the index of the first rendered line containing the
+// sidebar's default session title, or -1 when absent.
+func sidebarTitleLine(view string) int {
+	for i, line := range strings.Split(ansi.Strip(view), "\n") {
+		if strings.Contains(line, "New session") {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestViewRendersEveryPosition(t *testing.T) {
+	t.Parallel()
+
+	for _, position := range []msgtypes.SidebarPosition{
+		msgtypes.SidebarRight, msgtypes.SidebarLeft, msgtypes.SidebarTop, msgtypes.SidebarBottom,
+	} {
+		p := newLayoutTestPage(t, position)
+		p.SetSize(160, 40)
+		view := p.View()
+		assert.Equal(t, 40, lipgloss.Height(view), "position %s", position)
+		assert.GreaterOrEqual(t, sidebarTitleLine(view), 0, "position %s renders the sidebar", position)
+	}
+}
+
+func TestViewPlacesBandAtConfiguredEdge(t *testing.T) {
+	t.Parallel()
+
+	top := newLayoutTestPage(t, msgtypes.SidebarTop)
+	top.SetSize(160, 40)
+	topIdx := sidebarTitleLine(top.View())
+	require.GreaterOrEqual(t, topIdx, 0)
+	assert.Less(t, topIdx, top.computeSidebarLayout().sidebarHeight, "top band renders above the chat")
+
+	bottom := newLayoutTestPage(t, msgtypes.SidebarBottom)
+	bottom.SetSize(160, 40)
+	bottomIdx := sidebarTitleLine(bottom.View())
+	require.GreaterOrEqual(t, bottomIdx, 0)
+	assert.GreaterOrEqual(t, bottomIdx, bottom.computeSidebarLayout().chatHeight, "bottom band renders below the chat")
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -239,6 +239,10 @@ type appModel struct {
 	// hideSidebar hides the sidebar and disables the ctrl+b toggle.
 	hideSidebar bool
 
+	// layoutSettings is the active TUI layout customization (sidebar position
+	// and section visibility). Shared by every tab and managed via /custom.
+	layoutSettings messages.LayoutSettings
+
 	// buildCommandCategories is a function that returns the list of command categories.
 	buildCommandCategories func(context.Context, tea.Model) []commands.Category
 
@@ -412,8 +416,8 @@ func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initi
 	sv := supervisor.New(spawner)
 
 	// Initialize tab bar with configurable title length from user settings
-	tabTitleMaxLen := userconfig.Get().GetTabTitleMaxLength()
-	tb := tabbar.New(tabTitleMaxLen)
+	userSettings := userconfig.Get()
+	tb := tabbar.New(userSettings.GetTabTitleMaxLength())
 
 	// Initialize tab store
 	var ts *tuistate.Store
@@ -458,6 +462,7 @@ func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initi
 		workingSpinner:                spinner.New(spinner.ModeSpinnerOnly, styles.SpinnerDotsHighlightStyle),
 		focusedPanel:                  PanelEditor,
 		editorLines:                   3,
+		layoutSettings:                layoutSettingsFromConfig(userSettings.GetLayout()),
 		keyboardEnhancementsSupported: termfeatures.SupportsModifiedEnter(os.Getenv),
 		dockerDesktop:                 os.Getenv("TERM_PROGRAM") == "docker_desktop",
 		appName:                       "docker agent",
@@ -584,6 +589,7 @@ func (m *appModel) commandCategories() []commands.Category {
 func (m *appModel) chatPageOpts() []chat.PageOption {
 	opts := []chat.PageOption{
 		chat.WithCommandParser(commands.NewParser(m.commandCategories()...)),
+		chat.WithLayoutSettings(m.layoutSettings),
 	}
 
 	if m.leanMode {
@@ -759,7 +765,7 @@ func (m *appModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.(type) {
 		case messages.SpawnSessionMsg, messages.SwitchTabMsg,
 			messages.CloseTabMsg, messages.ReorderTabMsg,
-			messages.ToggleSidebarMsg:
+			messages.ToggleSidebarMsg, messages.OpenCustomizeDialogMsg:
 			return m, nil
 		}
 	}
@@ -1227,6 +1233,20 @@ func (m *appModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case messages.ThemeFileChangedMsg:
 		return m.handleThemeFileChanged(msg.ThemeRef)
+
+	// --- Layout customization ---
+
+	case messages.OpenCustomizeDialogMsg:
+		return m.handleOpenCustomizeDialog()
+
+	case messages.PreviewLayoutMsg:
+		return m.applyLayoutSettings(msg.Layout, false)
+
+	case messages.ApplyLayoutMsg:
+		return m.applyLayoutSettings(msg.Layout, true)
+
+	case messages.CancelLayoutPreviewMsg:
+		return m.applyLayoutSettings(msg.Original, false)
 
 	// --- Speech-to-text ---
 

--- a/pkg/tui/tui_exit_test.go
+++ b/pkg/tui/tui_exit_test.go
@@ -47,8 +47,11 @@ func (m *mockChatPage) FocusMessageAt(int, int) tea.Cmd          { return nil }
 func (m *mockChatPage) BlurMessages()                            {}
 func (m *mockChatPage) GetSidebarSettings() chat.SidebarSettings { return chat.SidebarSettings{} }
 func (m *mockChatPage) SetSidebarSettings(chat.SidebarSettings)  {}
-func (m *mockChatPage) Bindings() []key.Binding                  { return nil }
-func (m *mockChatPage) Help() help.KeyMap                        { return nil }
+func (m *mockChatPage) SetLayoutSettings(messages.LayoutSettings) tea.Cmd {
+	return nil
+}
+func (m *mockChatPage) Bindings() []key.Binding { return nil }
+func (m *mockChatPage) Help() help.KeyMap       { return nil }
 
 // mockEditor implements editor.Editor for testing.
 type mockEditor struct {

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -91,6 +91,33 @@ type Settings struct {
 	// "ctrl+q", "f2"). Unknown actions, malformed keys, and conflicts are
 	// ignored with a logged warning so a bad entry never breaks the TUI.
 	Keybindings []Keybinding `yaml:"keybindings,omitempty"`
+	// Layout customizes the TUI chat layout (sidebar position and which
+	// sidebar sections are visible). Managed via the /custom command.
+	Layout *LayoutSettings `yaml:"layout,omitempty"`
+}
+
+// LayoutSettings customizes the TUI chat layout. The zero value is the
+// default layout: sidebar on the right with every section visible.
+type LayoutSettings struct {
+	// SidebarPosition places the session info sidebar: "right" (default),
+	// "left", "top", or "bottom".
+	SidebarPosition string `yaml:"sidebar_position,omitempty"`
+	// HideUsage hides the token usage section in the sidebar.
+	HideUsage bool `yaml:"hide_usage,omitempty"`
+	// HideAgents hides the agents section in the sidebar.
+	HideAgents bool `yaml:"hide_agents,omitempty"`
+	// HideTools hides the tools section in the sidebar.
+	HideTools bool `yaml:"hide_tools,omitempty"`
+	// HideTodos hides the todo list section in the sidebar.
+	HideTodos bool `yaml:"hide_todos,omitempty"`
+}
+
+// GetLayout returns the layout settings, falling back to defaults when unset.
+func (s *Settings) GetLayout() LayoutSettings {
+	if s == nil || s.Layout == nil {
+		return LayoutSettings{}
+	}
+	return *s.Layout
 }
 
 // Keybinding maps a single TUI action to the key combinations that trigger it.

--- a/pkg/userconfig/userconfig_test.go
+++ b/pkg/userconfig/userconfig_test.go
@@ -171,6 +171,43 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	assert.Equal(t, config.Aliases["myagent"].Path, loaded.Aliases["myagent"].Path)
 }
 
+func TestSettings_LayoutRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+
+	config := &Config{
+		Settings: &Settings{
+			Layout: &LayoutSettings{
+				SidebarPosition: "left",
+				HideUsage:       true,
+				HideTodos:       true,
+			},
+		},
+	}
+
+	require.NoError(t, config.saveTo(configFile))
+
+	loaded, err := loadFrom(configFile, "")
+	require.NoError(t, err)
+
+	layout := loaded.GetSettings().GetLayout()
+	assert.Equal(t, "left", layout.SidebarPosition)
+	assert.True(t, layout.HideUsage)
+	assert.False(t, layout.HideAgents)
+	assert.False(t, layout.HideTools)
+	assert.True(t, layout.HideTodos)
+}
+
+func TestSettings_GetLayoutDefaults(t *testing.T) {
+	t.Parallel()
+
+	var nilSettings *Settings
+	assert.Equal(t, LayoutSettings{}, nilSettings.GetLayout())
+	assert.Equal(t, LayoutSettings{}, (&Settings{}).GetLayout())
+}
+
 func TestConfig_MigrateFromLegacy(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

New `/custom` slash command (also in the command palette as "Customize Layout") opening a dialog to customize the chat layout: sidebar position and which sidebar sections are visible. Every change is previewed live (schematic inside the dialog plus immediate application to the UI behind it) and persisted in the user config.

## Dialog preview

```text
╭──────────────────────────────────────────────────────────╮
│                     Customize Layout                     │
│  ──────────────────────────────────────────────────────  │
│                                                          │
│       ╭───────────────────────────┬──────────────╮       │
│       │                           │ session      │       │
│       │                           │ usage        │       │
│       │           chat            │ agents       │       │
│       │                           │ tools        │       │
│       │                           │ todos        │       │
│       ├───────────────────────────┴──────────────┤       │
│       │ input                                    │       │
│       ╰──────────────────────────────────────────╯       │
│                                                          │
│  › Sidebar position                           ‹ Right ›  │
│                                                          │
│  Sidebar sections                                        │
│    [x] Token usage                                       │
│    [x] Agents                                            │
│    [x] Tools                                             │
│    [x] Todos                                             │
│                                                          │
│    ↑/↓ navigate  ←/→ change  enter apply  esc cancel     │
╰──────────────────────────────────────────────────────────╯
```

The schematic adapts to the selection: the sidebar box moves (left/right column, top/bottom band) and hidden sections disappear from it.

## Features

| Feature | Detail |
|---|---|
| Sidebar position | `Right` (default), `Left` (vertical, mirrored), `Top` / `Bottom` (compact horizontal band) |
| Section toggles | Token usage, Agents, Tools, Todos (session block always visible, in the band too) |
| Live preview | Schematic in the dialog plus immediate application to all tabs behind it |
| Persistence | `settings.layout` in `~/.config/cagent/config.yaml`, loaded at startup, defaults omitted |
| Keys | `↑/↓` navigate, `←/→`/`space` change, `enter` apply and persist, `esc` cancel and restore |

## Message flow

```text
/custom → OpenCustomizeDialogMsg → customizeDialog
   value change → PreviewLayoutMsg       → applied to every tab (no save)
   enter        → ApplyLayoutMsg         → applied + saved to user config
   esc          → CancelLayoutPreviewMsg → original layout restored
```

## Band rendering (top/bottom)

The band reuses the vertical sidebar's visual language (accent blocks, usage glyph, agent accent colors, todo status icons), in the same section order, via shared render helpers (`workingDirLine`, `tokenUsageLine`):

```text
 ☆ New session
 █ ~/path (branch)                            ◉ 12.5K (6%) $0.07
 ▶ root anthropic/claude-sonnet-4-5 +1 · █ 12 tools, 2 skills · ◔ 1/3 todos
 ────────────────────────────────────────────────────────────────
```

## Left position

The sidebar's internal edge padding is mirrored so it sits flush against the terminal edge, keeping the layout symmetric with the default right position:

```text
right: [pad][ chat ][»][pad][ sidebar ][pad]
left:  [pad][ sidebar ][pad][«][ chat ][pad]
```

## Implementation notes

- `pkg/tui/messages/layout.go`: `LayoutSettings` type plus open/preview/apply/cancel messages
- `pkg/tui/dialog/customize.go`: dialog with adaptive schematic preview
- `pkg/tui/page/chat`: position-aware geometry, rendering, hit testing, and drag-resize direction
- `pkg/tui/components/sidebar`: `SectionVisibility` (vertical sections and collapsed band), `SetMirroredPadding`, band info line (agents, tools, todos)
- `pkg/userconfig`: `settings.layout` schema and defaults
- Lean mode drops the command (no overlay support); `--sidebar=false` shows a notification

## Testing

- 38 new tests: dialog navigation/preview/apply/cancel, per-position geometry, band edge placement, section visibility (vertical and band), band summaries, mirrored padding, userconfig round trip, `/custom` parsing
- `go build`, `golangci-lint`, and `go run ./lint .` pass; remaining test failures are network-dependent tests (pkg/config, pkg/httpclient, pkg/teamloader) that also fail on `main` in the sandbox
