### PR TITLE
feat(board): edit, reorder, and confirm-delete projects

### DIFF
--- a/docs/features/board/index.md
+++ b/docs/features/board/index.md
@@ -49,7 +49,7 @@ Requirements: `tmux` and `git` must be installed.
 | `o`           | Open the card's worktree in `$BOARD_EDITOR` (`code`) |
 | `[` / `]`     | Move the card back / forward                        |
 | `x`           | Delete the card, its session, worktree, and branch  |
-| `p`           | Manage projects                                     |
+| `p`           | Manage projects (add, edit, reorder, remove)        |
 | `e`           | Edit the selected column's prompt                   |
 | `←↓↑→` `hjkl` | Navigate                                            |
 | mouse         | Click selects, double-click attaches, wheel scrolls |

--- a/pkg/board/app.go
+++ b/pkg/board/app.go
@@ -165,8 +165,8 @@ func (a *App) AddProject(p Project) error {
 		a.config.Board = &userconfig.Board{}
 	}
 	for _, existing := range a.config.Board.Projects {
-		if existing.Name == p.Name {
-			return fmt.Errorf("project %q already exists", p.Name)
+		if existing.Name == stored.Name {
+			return fmt.Errorf("project %q already exists", stored.Name)
 		}
 	}
 	a.config.Board.Projects = append(a.config.Board.Projects, stored)
@@ -174,8 +174,9 @@ func (a *App) AddProject(p Project) error {
 }
 
 // UpdateProject replaces the project named oldName with p, applying the
-// same validation as AddProject and persisting the change. Existing cards
-// keep the repo path and agent they were created with.
+// same validation as AddProject and persisting the change. Cards created
+// against the old name follow a rename; they keep the repo path and agent
+// they were created with.
 func (a *App) UpdateProject(oldName string, p Project) error {
 	stored, err := a.validateProject(p)
 	if err != nil {
@@ -192,22 +193,35 @@ func (a *App) UpdateProject(oldName string, p Project) error {
 	if idx < 0 {
 		return fmt.Errorf("unknown project %q", oldName)
 	}
-	if p.Name != oldName {
+	if stored.Name != oldName {
 		for _, existing := range projects {
-			if existing.Name == p.Name {
-				return fmt.Errorf("project %q already exists", p.Name)
+			if existing.Name == stored.Name {
+				return fmt.Errorf("project %q already exists", stored.Name)
 			}
 		}
 	}
 	projects[idx] = stored
-	return a.saveConfigLocked()
+	if err := a.saveConfigLocked(); err != nil {
+		return err
+	}
+	if stored.Name != oldName {
+		// Keep existing cards attached to their project across the rename
+		// (their accent color and header stay consistent).
+		if err := a.store.RenameProject(oldName, stored.Name); err != nil {
+			return err
+		}
+		a.onChanged()
+	}
+	return nil
 }
 
 // validateProject checks a project's name and path and returns its stored
-// form. The path is stored ~-contracted so the shared config works across
-// environments whose home differs (host vs. docker sandbox).
+// form. The name is trimmed and the path is stored ~-contracted so the
+// shared config works across environments whose home differs (host vs.
+// docker sandbox).
 func (a *App) validateProject(p Project) (userconfig.BoardProject, error) {
-	if strings.TrimSpace(p.Name) == "" {
+	name := strings.TrimSpace(p.Name)
+	if name == "" {
 		return userconfig.BoardProject{}, errors.New("project name is required")
 	}
 	path, err := normalizeProjectPath(p.Path)
@@ -217,7 +231,7 @@ func (a *App) validateProject(p Project) (userconfig.BoardProject, error) {
 	if !isGitRepo(a.ctx, path) {
 		return userconfig.BoardProject{}, fmt.Errorf("%s is not a git repository", path)
 	}
-	return userconfig.BoardProject{Name: p.Name, Path: contractHome(path), Agent: p.Agent}, nil
+	return userconfig.BoardProject{Name: name, Path: contractHome(path), Agent: strings.TrimSpace(p.Agent)}, nil
 }
 
 // normalizeProjectPath expands a leading ~ and makes the path absolute. An

--- a/pkg/board/app.go
+++ b/pkg/board/app.go
@@ -154,16 +154,9 @@ func (a *App) Projects() []Project {
 // global config file. The path is normalized to an absolute path (expanding
 // a leading ~) so cards never depend on the board's working directory.
 func (a *App) AddProject(p Project) error {
-	if strings.TrimSpace(p.Name) == "" {
-		return errors.New("project name is required")
-	}
-	path, err := normalizeProjectPath(p.Path)
+	stored, err := a.validateProject(p)
 	if err != nil {
 		return err
-	}
-	p.Path = path
-	if !isGitRepo(a.ctx, p.Path) {
-		return fmt.Errorf("%s is not a git repository", p.Path)
 	}
 
 	a.mu.Lock()
@@ -176,14 +169,55 @@ func (a *App) AddProject(p Project) error {
 			return fmt.Errorf("project %q already exists", p.Name)
 		}
 	}
-	a.config.Board.Projects = append(a.config.Board.Projects, userconfig.BoardProject{
-		Name: p.Name,
-		// Stored ~-contracted so the shared config works across
-		// environments whose home differs (host vs. docker sandbox).
-		Path:  contractHome(p.Path),
-		Agent: p.Agent,
-	})
+	a.config.Board.Projects = append(a.config.Board.Projects, stored)
 	return a.saveConfigLocked()
+}
+
+// UpdateProject replaces the project named oldName with p, applying the
+// same validation as AddProject and persisting the change. Existing cards
+// keep the repo path and agent they were created with.
+func (a *App) UpdateProject(oldName string, p Project) error {
+	stored, err := a.validateProject(p)
+	if err != nil {
+		return err
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	var projects []userconfig.BoardProject
+	if a.config.Board != nil {
+		projects = a.config.Board.Projects
+	}
+	idx := slices.IndexFunc(projects, func(bp userconfig.BoardProject) bool { return bp.Name == oldName })
+	if idx < 0 {
+		return fmt.Errorf("unknown project %q", oldName)
+	}
+	if p.Name != oldName {
+		for _, existing := range projects {
+			if existing.Name == p.Name {
+				return fmt.Errorf("project %q already exists", p.Name)
+			}
+		}
+	}
+	projects[idx] = stored
+	return a.saveConfigLocked()
+}
+
+// validateProject checks a project's name and path and returns its stored
+// form. The path is stored ~-contracted so the shared config works across
+// environments whose home differs (host vs. docker sandbox).
+func (a *App) validateProject(p Project) (userconfig.BoardProject, error) {
+	if strings.TrimSpace(p.Name) == "" {
+		return userconfig.BoardProject{}, errors.New("project name is required")
+	}
+	path, err := normalizeProjectPath(p.Path)
+	if err != nil {
+		return userconfig.BoardProject{}, err
+	}
+	if !isGitRepo(a.ctx, path) {
+		return userconfig.BoardProject{}, fmt.Errorf("%s is not a git repository", path)
+	}
+	return userconfig.BoardProject{Name: p.Name, Path: contractHome(path), Agent: p.Agent}, nil
 }
 
 // normalizeProjectPath expands a leading ~ and makes the path absolute. An
@@ -199,6 +233,31 @@ func normalizeProjectPath(path string) (string, error) {
 		return "", fmt.Errorf("resolve project path: %w", err)
 	}
 	return abs, nil
+}
+
+// MoveProject moves the named project delta positions in the list
+// (negative moves it up) and persists the new order. The destination is
+// clamped to the list, so moves past either end are safe no-ops. Project
+// order drives the accent colors and the new-card selector.
+func (a *App) MoveProject(name string, delta int) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	var projects []userconfig.BoardProject
+	if a.config.Board != nil {
+		projects = a.config.Board.Projects
+	}
+	idx := slices.IndexFunc(projects, func(p userconfig.BoardProject) bool { return p.Name == name })
+	if idx < 0 {
+		return fmt.Errorf("unknown project %q", name)
+	}
+	dst := min(max(idx+delta, 0), len(projects)-1)
+	if dst == idx {
+		return nil
+	}
+	p := projects[idx]
+	projects = slices.Delete(projects, idx, idx+1)
+	a.config.Board.Projects = slices.Insert(projects, dst, p)
+	return a.saveConfigLocked()
 }
 
 // RemoveProject deletes a project by name and persists the change. Existing

--- a/pkg/board/app_test.go
+++ b/pkg/board/app_test.go
@@ -43,16 +43,27 @@ func TestUpdateProject(t *testing.T) {
 
 	cfg, err := userconfig.Load()
 	require.NoError(t, err)
-	app := &App{ctx: t.Context(), config: cfg, columns: DefaultColumns}
+	store, err := OpenStore(filepath.Join(t.TempDir(), "cards.json"))
+	require.NoError(t, err)
+	app := &App{ctx: t.Context(), config: cfg, columns: DefaultColumns, store: store, onChanged: func() {}}
 
 	require.NoError(t, app.AddProject(Project{Name: "one", Path: repo}))
 	require.NoError(t, app.AddProject(Project{Name: "two", Path: repo2}))
+	require.NoError(t, store.InsertCard(&Card{ID: "card1", Project: "one"}))
+	require.NoError(t, store.InsertCard(&Card{ID: "card2", Project: "two"}))
 
-	// Rename, repoint, and set the agent in one update; order is preserved.
+	// Rename, repoint, and set the agent in one update; order is preserved
+	// and existing cards follow the rename.
 	require.NoError(t, app.UpdateProject("one", Project{Name: "renamed", Path: repo2, Agent: "coder"}))
 	projects := app.Projects()
 	require.Len(t, projects, 2)
 	assert.Equal(t, Project{Name: "renamed", Path: repo2, Agent: "coder"}, projects[0])
+	card, err := store.GetCard("card1")
+	require.NoError(t, err)
+	assert.Equal(t, "renamed", card.Project)
+	card, err = store.GetCard("card2")
+	require.NoError(t, err)
+	assert.Equal(t, "two", card.Project)
 
 	// Unknown project, duplicate name, and AddProject-style validation.
 	require.Error(t, app.UpdateProject("one", Project{Name: "x", Path: repo}))

--- a/pkg/board/app_test.go
+++ b/pkg/board/app_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/paths"
+	"github.com/docker/docker-agent/pkg/userconfig"
 )
 
 func TestNormalizeProjectPath(t *testing.T) {
@@ -31,4 +32,77 @@ func TestNormalizeProjectPath(t *testing.T) {
 	abs, err = normalizeProjectPath("repo")
 	require.NoError(t, err)
 	assert.True(t, filepath.IsAbs(abs))
+}
+
+func TestUpdateProject(t *testing.T) {
+	paths.SetConfigDir(t.TempDir())
+	t.Cleanup(func() { paths.SetConfigDir("") })
+
+	repo := newLocalRepo(t)
+	repo2 := newLocalRepo(t)
+
+	cfg, err := userconfig.Load()
+	require.NoError(t, err)
+	app := &App{ctx: t.Context(), config: cfg, columns: DefaultColumns}
+
+	require.NoError(t, app.AddProject(Project{Name: "one", Path: repo}))
+	require.NoError(t, app.AddProject(Project{Name: "two", Path: repo2}))
+
+	// Rename, repoint, and set the agent in one update; order is preserved.
+	require.NoError(t, app.UpdateProject("one", Project{Name: "renamed", Path: repo2, Agent: "coder"}))
+	projects := app.Projects()
+	require.Len(t, projects, 2)
+	assert.Equal(t, Project{Name: "renamed", Path: repo2, Agent: "coder"}, projects[0])
+
+	// Unknown project, duplicate name, and AddProject-style validation.
+	require.Error(t, app.UpdateProject("one", Project{Name: "x", Path: repo}))
+	require.Error(t, app.UpdateProject("renamed", Project{Name: "two", Path: repo}))
+	require.Error(t, app.UpdateProject("renamed", Project{Name: "", Path: repo}))
+	require.Error(t, app.UpdateProject("renamed", Project{Name: "renamed", Path: ""}))
+	require.Error(t, app.UpdateProject("renamed", Project{Name: "renamed", Path: t.TempDir()})) // not a git repo
+
+	// Keeping the name while changing other fields is not a duplicate.
+	require.NoError(t, app.UpdateProject("two", Project{Name: "two", Path: repo}))
+
+	// The update is persisted to the config file.
+	reloaded, err := userconfig.Load()
+	require.NoError(t, err)
+	require.Len(t, reloaded.Board.Projects, 2)
+	assert.Equal(t, "renamed", reloaded.Board.Projects[0].Name)
+	assert.Equal(t, "coder", reloaded.Board.Projects[0].Agent)
+}
+
+func TestMoveProject(t *testing.T) {
+	paths.SetConfigDir(t.TempDir())
+	t.Cleanup(func() { paths.SetConfigDir("") })
+
+	cfg, err := userconfig.Load()
+	require.NoError(t, err)
+	cfg.Board = &userconfig.Board{Projects: []userconfig.BoardProject{
+		{Name: "a", Path: "/a"}, {Name: "b", Path: "/b"}, {Name: "c", Path: "/c"},
+	}}
+	app := &App{ctx: t.Context(), config: cfg, columns: DefaultColumns}
+
+	names := func() []string {
+		var out []string
+		for _, p := range app.Projects() {
+			out = append(out, p.Name)
+		}
+		return out
+	}
+
+	require.NoError(t, app.MoveProject("c", -1))
+	assert.Equal(t, []string{"a", "c", "b"}, names())
+
+	// Moves past either end clamp to a no-op.
+	require.NoError(t, app.MoveProject("a", -1))
+	require.NoError(t, app.MoveProject("b", 5))
+	assert.Equal(t, []string{"a", "c", "b"}, names())
+
+	require.Error(t, app.MoveProject("nope", 1))
+
+	// The new order is persisted to the config file.
+	reloaded, err := userconfig.Load()
+	require.NoError(t, err)
+	assert.Equal(t, "c", reloaded.Board.Projects[1].Name)
 }

--- a/pkg/board/store.go
+++ b/pkg/board/store.go
@@ -121,6 +121,25 @@ func (s *Store) InsertCard(c *Card) error {
 	return s.save()
 }
 
+// RenameProject rewrites the project name on every card that references
+// oldName, so a project rename keeps its cards attached. Saves only when a
+// card actually changed.
+func (s *Store) RenameProject(oldName, newName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	changed := false
+	for _, c := range s.cards {
+		if c.Project == oldName {
+			c.Project = newName
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+	return s.save()
+}
+
 // UpdateCardStatus persists only the status field of a card, so background
 // watchers holding a stale snapshot of the card cannot revert concurrent
 // edits. It reports whether the status actually changed.

--- a/pkg/board/tui/dialogs.go
+++ b/pkg/board/tui/dialogs.go
@@ -273,14 +273,20 @@ func newProjectsDialog(projects []board.Project) *projectsDialog {
 	return &projectsDialog{projects: projects, confirmKeys: tuidialog.DefaultConfirmKeyMap()}
 }
 
-// setProjects refreshes the list after an add, edit or delete, leaving the
-// list view visible and keeping the cursor position (clamped).
+// setProjects refreshes the list after an add, edit or delete and returns
+// to the list view, keeping the cursor position (clamped).
 func (d *projectsDialog) setProjects(projects []board.Project) {
-	d.projects = projects
-	d.idx = min(max(d.idx, 0), max(len(projects)-1, 0))
+	d.refreshProjects(projects)
 	d.mode = projectsList
 	d.editing = ""
 	d.deleting = ""
+	d.inputs = nil
+}
+
+// refreshProjects updates the list data without leaving the current view.
+func (d *projectsDialog) refreshProjects(projects []board.Project) {
+	d.projects = projects
+	d.idx = min(max(d.idx, 0), max(len(projects)-1, 0))
 }
 
 // selectProject moves the cursor to the named project, if present.
@@ -392,13 +398,13 @@ func (d *projectsDialog) moveProject(delta int) tea.Cmd {
 }
 
 // updatePicking drives the directory picker; a picked directory pre-fills
-// the add form. When the picker was opened from an edit in progress
-// (ctrl+o), only the path field is replaced.
+// the add form. When the picker was opened from a form in progress
+// (ctrl+o), only the path field is replaced and esc returns to the form.
 func (d *projectsDialog) updatePicking(press tea.KeyPressMsg) (dialog, tea.Cmd) {
 	chosen, done, cmd := d.picker.Update(press)
 	switch {
 	case chosen != "":
-		if d.editing != "" {
+		if d.inputs != nil {
 			d.mode = projectsEditing
 			d.inputs[1].SetValue(chosen)
 			return d, nil
@@ -406,7 +412,7 @@ func (d *projectsDialog) updatePicking(press tea.KeyPressMsg) (dialog, tea.Cmd) 
 		cmd := d.startForm("", filepath.Base(chosen), chosen, "")
 		return d, cmd
 	case done:
-		if d.editing != "" {
+		if d.inputs != nil {
 			d.mode = projectsEditing
 		} else {
 			d.mode = projectsList
@@ -420,6 +426,7 @@ func (d *projectsDialog) updateEditing(press tea.KeyPressMsg) (dialog, tea.Cmd) 
 	case "esc":
 		d.mode = projectsList
 		d.editing = ""
+		d.inputs = nil
 		return d, nil
 	case "ctrl+o":
 		// Re-open the browser, starting from the path typed so far.

--- a/pkg/board/tui/dialogs.go
+++ b/pkg/board/tui/dialogs.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -244,12 +245,14 @@ type projectsMode int
 const (
 	projectsList projectsMode = iota
 	projectsPicking
-	projectsAdding
+	projectsEditing
+	projectsConfirming
 )
 
 // projectsDialog lists and edits the projects stored in the user's global
 // config file. Adding a project starts with a directory picker, then a
-// pre-filled form.
+// pre-filled form; editing opens the same form pre-filled from the
+// selected project. Removal asks for confirmation first.
 type projectsDialog struct {
 	projects []board.Project
 	idx      int
@@ -258,18 +261,33 @@ type projectsDialog struct {
 	picker *dirPicker
 	inputs []textinput.Model // name, path, agent
 	focus  int
+	// editing is the original name of the project being edited; empty when
+	// the form adds a new project.
+	editing string
+	// deleting is the name of the project awaiting delete confirmation.
+	deleting    string
+	confirmKeys tuidialog.ConfirmKeyMap
 }
 
 func newProjectsDialog(projects []board.Project) *projectsDialog {
-	return &projectsDialog{projects: projects}
+	return &projectsDialog{projects: projects, confirmKeys: tuidialog.DefaultConfirmKeyMap()}
 }
 
-// setProjects refreshes the list after an add or delete, leaving the list
-// view visible and keeping the cursor position (clamped).
+// setProjects refreshes the list after an add, edit or delete, leaving the
+// list view visible and keeping the cursor position (clamped).
 func (d *projectsDialog) setProjects(projects []board.Project) {
 	d.projects = projects
 	d.idx = min(max(d.idx, 0), max(len(projects)-1, 0))
 	d.mode = projectsList
+	d.editing = ""
+	d.deleting = ""
+}
+
+// selectProject moves the cursor to the named project, if present.
+func (d *projectsDialog) selectProject(name string) {
+	if i := slices.IndexFunc(d.projects, func(p board.Project) bool { return p.Name == name }); i >= 0 {
+		d.idx = i
+	}
 }
 
 var projectFields = []struct{ label, placeholder string }{
@@ -278,9 +296,12 @@ var projectFields = []struct{ label, placeholder string }{
 	{"Agent", "default (or any agent ref)"},
 }
 
-// startAdding opens the form, pre-filled from the picked directory.
-func (d *projectsDialog) startAdding(name, path string) tea.Cmd {
-	d.mode = projectsAdding
+// startForm opens the add/edit form. editing is the original name of the
+// project being edited, or empty when adding; name/path/agent pre-fill the
+// fields.
+func (d *projectsDialog) startForm(editing, name, path, agent string) tea.Cmd {
+	d.mode = projectsEditing
+	d.editing = editing
 	d.focus = 0
 	d.inputs = make([]textinput.Model, len(projectFields))
 	for i, f := range projectFields {
@@ -292,6 +313,7 @@ func (d *projectsDialog) startAdding(name, path string) tea.Cmd {
 	}
 	d.inputs[0].SetValue(name)
 	d.inputs[1].SetValue(path)
+	d.inputs[2].SetValue(agent)
 	d.inputs[0].Focus()
 	return textinput.Blink
 }
@@ -306,8 +328,10 @@ func (d *projectsDialog) Update(msg tea.Msg) (dialog, tea.Cmd) {
 	switch d.mode {
 	case projectsPicking:
 		return d.updatePicking(press)
-	case projectsAdding:
-		return d.updateAdding(press)
+	case projectsEditing:
+		return d.updateEditing(press)
+	case projectsConfirming:
+		return d.updateConfirming(press)
 	}
 
 	switch press.String() {
@@ -321,33 +345,81 @@ func (d *projectsDialog) Update(msg tea.Msg) (dialog, tea.Cmd) {
 		d.mode = projectsPicking
 		d.picker = newDirPicker(pickerStartDir(""))
 		return d, textinput.Blink
+	case "e", "enter":
+		if len(d.projects) > 0 {
+			p := d.projects[d.idx]
+			cmd := d.startForm(p.Name, p.Name, p.Path, p.Agent)
+			return d, cmd
+		}
+	case "shift+up", "K":
+		cmd := d.moveProject(-1)
+		return d, cmd
+	case "shift+down", "J":
+		cmd := d.moveProject(1)
+		return d, cmd
 	case "x", "d", "backspace", "delete":
 		if len(d.projects) > 0 {
-			name := d.projects[d.idx].Name
-			return d, func() tea.Msg { return deleteProjectMsg{name: name} }
+			d.mode = projectsConfirming
+			d.deleting = d.projects[d.idx].Name
 		}
 	}
 	return d, nil
 }
 
+// updateConfirming handles the delete confirmation prompt.
+func (d *projectsDialog) updateConfirming(press tea.KeyPressMsg) (dialog, tea.Cmd) {
+	switch {
+	case key.Matches(press, d.confirmKeys.Yes), press.String() == "enter":
+		name := d.deleting
+		d.mode = projectsList
+		d.deleting = ""
+		return d, func() tea.Msg { return deleteProjectMsg{name: name} }
+	case key.Matches(press, d.confirmKeys.No), press.String() == "esc", press.String() == "q":
+		d.mode = projectsList
+		d.deleting = ""
+	}
+	return d, nil
+}
+
+// moveProject asks the model to reorder the selected project by delta
+// positions; the model persists the order and moves the cursor along.
+func (d *projectsDialog) moveProject(delta int) tea.Cmd {
+	if len(d.projects) == 0 {
+		return nil
+	}
+	name := d.projects[d.idx].Name
+	return func() tea.Msg { return moveProjectMsg{name: name, delta: delta} }
+}
+
 // updatePicking drives the directory picker; a picked directory pre-fills
-// the add form.
+// the add form. When the picker was opened from an edit in progress
+// (ctrl+o), only the path field is replaced.
 func (d *projectsDialog) updatePicking(press tea.KeyPressMsg) (dialog, tea.Cmd) {
 	chosen, done, cmd := d.picker.Update(press)
 	switch {
 	case chosen != "":
-		cmd := d.startAdding(filepath.Base(chosen), chosen)
+		if d.editing != "" {
+			d.mode = projectsEditing
+			d.inputs[1].SetValue(chosen)
+			return d, nil
+		}
+		cmd := d.startForm("", filepath.Base(chosen), chosen, "")
 		return d, cmd
 	case done:
-		d.mode = projectsList
+		if d.editing != "" {
+			d.mode = projectsEditing
+		} else {
+			d.mode = projectsList
+		}
 	}
 	return d, cmd
 }
 
-func (d *projectsDialog) updateAdding(press tea.KeyPressMsg) (dialog, tea.Cmd) {
+func (d *projectsDialog) updateEditing(press tea.KeyPressMsg) (dialog, tea.Cmd) {
 	switch press.String() {
 	case "esc":
 		d.mode = projectsList
+		d.editing = ""
 		return d, nil
 	case "ctrl+o":
 		// Re-open the browser, starting from the path typed so far.
@@ -366,7 +438,8 @@ func (d *projectsDialog) updateAdding(press tea.KeyPressMsg) (dialog, tea.Cmd) {
 			Path:  strings.TrimSpace(d.inputs[1].Value()),
 			Agent: strings.TrimSpace(d.inputs[2].Value()),
 		}
-		return d, func() tea.Msg { return submitProjectMsg{project: project} }
+		oldName := d.editing
+		return d, func() tea.Msg { return submitProjectMsg{project: project, oldName: oldName} }
 	}
 	var cmd tea.Cmd
 	d.inputs[d.focus], cmd = d.inputs[d.focus].Update(press)
@@ -388,8 +461,15 @@ func (d *projectsDialog) View(width, _ int) string {
 			"",
 			helpLine(w, "↑↓", "select", "enter", "open/pick", "backspace", "up", "esc", "back"),
 		)
-	case projectsAdding:
-		return d.viewAdding(w)
+	case projectsEditing:
+		return d.viewForm(w)
+	case projectsConfirming:
+		return renderDialog("Remove project?", w,
+			styles.BaseStyle.Render(toolcommon.TruncateText(sanitize(d.deleting), w)),
+			styles.MutedStyle.Render("Removes it from the config; existing cards are unaffected."),
+			"",
+			helpLine(w, d.confirmKeys.Yes.Help().Key, "remove", d.confirmKeys.No.Help().Key+"/esc", "cancel"),
+		)
 	}
 
 	var rows []string
@@ -414,11 +494,11 @@ func (d *projectsDialog) View(width, _ int) string {
 	return renderDialog("Projects", w,
 		lipgloss.JoinVertical(lipgloss.Left, rows...),
 		"",
-		helpLine(w, "a", "add", "x", "remove", "↑↓", "select", "esc", "close"),
+		helpLine(w, "a", "add", "e", "edit", "x", "remove", "shift+↑↓", "reorder", "↑↓", "select", "esc", "close"),
 	)
 }
 
-func (d *projectsDialog) viewAdding(w int) string {
+func (d *projectsDialog) viewForm(w int) string {
 	rows := make([]string, 0, len(projectFields)*2)
 	for i, f := range projectFields {
 		label := styles.SecondaryStyle.Render(f.label)
@@ -427,7 +507,11 @@ func (d *projectsDialog) viewAdding(w int) string {
 		}
 		rows = append(rows, label, d.inputs[i].View())
 	}
-	return renderDialog("Add project", w,
+	title := "Add project"
+	if d.editing != "" {
+		title = "Edit project"
+	}
+	return renderDialog(title, w,
 		lipgloss.JoinVertical(lipgloss.Left, rows...),
 		"",
 		helpLine(w, "enter", "save", "tab", "next field", "ctrl+o", "browse", "esc", "back"),

--- a/pkg/board/tui/dialogs_test.go
+++ b/pkg/board/tui/dialogs_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -28,4 +29,62 @@ func TestProjectsDialogDeleteAsksConfirmation(t *testing.T) {
 	_, cmd = d.Update(keyPress("y"))
 	require.NotNil(t, cmd)
 	assert.Equal(t, deleteProjectMsg{name: "one"}, cmd())
+}
+
+func TestProjectsDialogEditPrefillsForm(t *testing.T) {
+	d := newProjectsDialog([]board.Project{{Name: "one", Path: "/one", Agent: "coder"}})
+
+	_, _ = d.Update(keyPress("e"))
+	require.Equal(t, projectsEditing, d.mode)
+	assert.Equal(t, "one", d.editing)
+	assert.Equal(t, "one", d.inputs[0].Value())
+	assert.Equal(t, "/one", d.inputs[1].Value())
+	assert.Equal(t, "coder", d.inputs[2].Value())
+	assert.Contains(t, d.View(80, 40), "Edit project")
+
+	// Submitting carries the original name so the model updates in place.
+	_, cmd := d.Update(keyPress("enter"))
+	require.NotNil(t, cmd)
+	assert.Equal(t, submitProjectMsg{
+		project: board.Project{Name: "one", Path: "/one", Agent: "coder"},
+		oldName: "one",
+	}, cmd())
+}
+
+func TestProjectsDialogMoveEmitsReorder(t *testing.T) {
+	d := newProjectsDialog([]board.Project{{Name: "one"}, {Name: "two"}})
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyDown, Mod: tea.ModShift})
+	require.NotNil(t, cmd)
+	assert.Equal(t, moveProjectMsg{name: "one", delta: 1}, cmd())
+
+	_, cmd = d.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift})
+	require.NotNil(t, cmd)
+	assert.Equal(t, moveProjectMsg{name: "one", delta: -1}, cmd())
+}
+
+// A form in progress must survive a ctrl+o browse round-trip: only the
+// path field may change (regression test for the add flow losing the typed
+// name and agent).
+func TestProjectsDialogBrowseKeepsFormInProgress(t *testing.T) {
+	root := pickerDirs(t)
+	d := newProjectsDialog(nil)
+	_ = d.startForm("", "myname", root, "coder")
+
+	// ctrl+o browses from the form; esc returns to it with fields intact.
+	_, _ = d.Update(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
+	require.Equal(t, projectsPicking, d.mode)
+	_, _ = d.Update(keyPress("esc"))
+	require.Equal(t, projectsEditing, d.mode)
+	assert.Equal(t, "myname", d.inputs[0].Value())
+	assert.Equal(t, "coder", d.inputs[2].Value())
+
+	// Picking a directory ("use this directory") replaces only the path.
+	_, _ = d.Update(tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl})
+	require.Equal(t, projectsPicking, d.mode)
+	_, _ = d.Update(keyPress("enter"))
+	require.Equal(t, projectsEditing, d.mode)
+	assert.Equal(t, "myname", d.inputs[0].Value())
+	assert.Equal(t, root, d.inputs[1].Value())
+	assert.Equal(t, "coder", d.inputs[2].Value())
 }

--- a/pkg/board/tui/dialogs_test.go
+++ b/pkg/board/tui/dialogs_test.go
@@ -1,0 +1,31 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/board"
+)
+
+func TestProjectsDialogDeleteAsksConfirmation(t *testing.T) {
+	d := newProjectsDialog([]board.Project{{Name: "one", Path: "/one"}, {Name: "two", Path: "/two"}})
+
+	// x opens the confirmation instead of deleting right away.
+	_, cmd := d.Update(keyPress("x"))
+	require.Nil(t, cmd)
+	assert.Equal(t, projectsConfirming, d.mode)
+	assert.Contains(t, d.View(80, 40), "Remove project?")
+
+	// esc cancels: back to the list, nothing deleted.
+	_, cmd = d.Update(keyPress("esc"))
+	require.Nil(t, cmd)
+	assert.Equal(t, projectsList, d.mode)
+
+	// x then y confirms and emits the delete for the selected project.
+	_, _ = d.Update(keyPress("x"))
+	_, cmd = d.Update(keyPress("y"))
+	require.NotNil(t, cmd)
+	assert.Equal(t, deleteProjectMsg{name: "one"}, cmd())
+}

--- a/pkg/board/tui/tui.go
+++ b/pkg/board/tui/tui.go
@@ -90,6 +90,12 @@ type (
 		project board.Project
 		oldName string
 	}
+	// projectSavedMsg means an add/update was validated and persisted; name
+	// is the saved project's name, oldName its previous name (empty on add).
+	projectSavedMsg struct {
+		name    string
+		oldName string
+	}
 	// deleteProjectMsg removes a project from the projects dialog.
 	deleteProjectMsg struct{ name string }
 	// moveProjectMsg reorders a project from the projects dialog; delta is
@@ -404,21 +410,28 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case submitProjectMsg:
-		var err error
-		action := "added to"
-		if msg.oldName == "" {
-			err = m.app.AddProject(msg.project)
-		} else {
-			err = m.app.UpdateProject(msg.oldName, msg.project)
-			action = "updated in"
-		}
-		if err != nil {
-			cmd := m.setFlash(err.Error(), true)
-			return m, cmd
-		}
+		cmd := m.saveProject(msg.project, msg.oldName)
+		return m, cmd
+
+	case projectSavedMsg:
 		m.reload()
+		// A rename keeps the new-card dialog starting on the same project.
+		if msg.oldName != "" && m.lastProject == msg.oldName {
+			m.lastProject = msg.name
+		}
 		if d, ok := m.dialog.(*projectsDialog); ok {
-			d.setProjects(m.projects)
+			if d.mode == projectsEditing {
+				d.setProjects(m.projects)
+			} else {
+				// The save is asynchronous and the user may have moved on:
+				// refresh without leaving the dialog's current view.
+				d.refreshProjects(m.projects)
+			}
+			d.selectProject(msg.name) // the cursor follows the saved project
+		}
+		action := "added to"
+		if msg.oldName != "" {
+			action = "updated in"
 		}
 		cmd := m.setFlash("Project "+action+" the global config", false)
 		return m, cmd
@@ -440,8 +453,11 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		}
 		m.reload()
+		// Refresh without leaving the dialog's current view: the message is
+		// delivered asynchronously and the user may already have opened the
+		// edit form or the delete confirmation.
 		if d, ok := m.dialog.(*projectsDialog); ok {
-			d.setProjects(m.projects)
+			d.refreshProjects(m.projects)
 			d.selectProject(msg.name) // the cursor follows the moved project
 		}
 		return m, nil
@@ -674,7 +690,8 @@ func (m *model) setFlash(text string, isErr bool) tea.Cmd {
 	return tea.Tick(4*time.Second, func(time.Time) tea.Msg { return clearFlashMsg{id: id} })
 }
 
-// --- engine commands (all engine calls that can block run in tea.Cmds) ---
+// --- engine commands (engine calls that can block — git, tmux, readiness
+// probes — run in tea.Cmds; plain config-file mutations run inline) ---
 
 func (m *model) createCard(project board.Project, prompt string) tea.Cmd {
 	return func() tea.Msg {
@@ -709,6 +726,23 @@ func (m *model) deleteCard(cardID string) tea.Cmd {
 			return flashMsg{text: err.Error(), isErr: true}
 		}
 		return flashMsg{text: "Card deleted, worktree and session cleaned up", isErr: false}
+	}
+}
+
+// saveProject adds or updates a project off the UI loop: validation spawns
+// a git subprocess and the config write hits the filesystem.
+func (m *model) saveProject(project board.Project, oldName string) tea.Cmd {
+	return func() tea.Msg {
+		var err error
+		if oldName == "" {
+			err = m.app.AddProject(project)
+		} else {
+			err = m.app.UpdateProject(oldName, project)
+		}
+		if err != nil {
+			return flashMsg{text: err.Error(), isErr: true}
+		}
+		return projectSavedMsg{name: project.Name, oldName: oldName}
 	}
 }
 

--- a/pkg/board/tui/tui.go
+++ b/pkg/board/tui/tui.go
@@ -84,10 +84,20 @@ type (
 		project board.Project
 		prompt  string
 	}
-	// submitProjectMsg adds a project from the projects dialog.
-	submitProjectMsg struct{ project board.Project }
+	// submitProjectMsg adds a project from the projects dialog, or updates
+	// the one named oldName when set.
+	submitProjectMsg struct {
+		project board.Project
+		oldName string
+	}
 	// deleteProjectMsg removes a project from the projects dialog.
 	deleteProjectMsg struct{ name string }
+	// moveProjectMsg reorders a project from the projects dialog; delta is
+	// the number of positions to move (negative moves it up).
+	moveProjectMsg struct {
+		name  string
+		delta int
+	}
 	// submitPromptMsg saves a column prompt from the prompt editor.
 	submitPromptMsg struct {
 		colID  string
@@ -394,7 +404,15 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case submitProjectMsg:
-		if err := m.app.AddProject(msg.project); err != nil {
+		var err error
+		action := "added to"
+		if msg.oldName == "" {
+			err = m.app.AddProject(msg.project)
+		} else {
+			err = m.app.UpdateProject(msg.oldName, msg.project)
+			action = "updated in"
+		}
+		if err != nil {
 			cmd := m.setFlash(err.Error(), true)
 			return m, cmd
 		}
@@ -402,7 +420,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if d, ok := m.dialog.(*projectsDialog); ok {
 			d.setProjects(m.projects)
 		}
-		cmd := m.setFlash("Project added to the global config", false)
+		cmd := m.setFlash("Project "+action+" the global config", false)
 		return m, cmd
 
 	case deleteProjectMsg:
@@ -413,6 +431,18 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.reload()
 		if d, ok := m.dialog.(*projectsDialog); ok {
 			d.setProjects(m.projects)
+		}
+		return m, nil
+
+	case moveProjectMsg:
+		if err := m.app.MoveProject(msg.name, msg.delta); err != nil {
+			cmd := m.setFlash(err.Error(), true)
+			return m, cmd
+		}
+		m.reload()
+		if d, ok := m.dialog.(*projectsDialog); ok {
+			d.setProjects(m.projects)
+			d.selectProject(msg.name) // the cursor follows the moved project
 		}
 		return m, nil
 


### PR DESCRIPTION
The board's project management was read-only after initial creation: users could add and delete projects but couldn't rename them, change their order, or confirm destructive deletes. This adds the remaining lifecycle operations and hardens several edge cases surfaced during code review.

Pressing e or enter on a project in the projects dialog now opens a pre-filled edit form. Saving calls `App.UpdateProject`, which persists the new name and propagates it to `Store.RenameProject` so existing cards stay associated with the renamed project and the new-card dialog's last-used project tracks the change. Projects can be reordered with shift+↑/↓ (or J/K) via `App.MoveProject`, clamped at list boundaries; order drives both accent-color assignment and the project selector in the new-card form. Deletion now requires confirmation using the same `ConfirmKeyMap` as card deletion — y or enter confirms, n or esc cancels — so a stray keystroke can't silently destroy a project and all its cards.

The second commit addresses findings from code review: a ctrl+o browse round-trip no longer discards a form in progress; async move/save results are gated so they can't overwrite an open form; validation (the git subprocess that checks agent names) runs off the UI goroutine; and project names and agent identifiers are trimmed consistently before storage. Tests were added at the engine level (`TestUpdateProject`, `TestMoveProject`) and at the dialog level covering confirm-delete, edit prefill, reorder event emission, and the browse round-trip regression. `docs/features/board/index.md` is updated to document the new interactions.