### PR TITLE
chore(board): rename $BOARD_EDITOR to $DOCKER_AGENT_BOARD_EDITOR

### DIFF
--- a/docs/features/board/index.md
+++ b/docs/features/board/index.md
@@ -46,7 +46,7 @@ Requirements: `tmux` and `git` must be installed.
 | `n`           | Create a card (project + prompt)                    |
 | `enter`       | Attach to the card's agent (`ctrl+q` detaches)      |
 | `d`           | View the card's worktree diff                       |
-| `o`           | Open the card's worktree in `$BOARD_EDITOR` (`code`) |
+| `o`           | Open the card's worktree in `$DOCKER_AGENT_BOARD_EDITOR` (`code`) |
 | `[` / `]`     | Move the card back / forward                        |
 | `x`           | Delete the card, its session, worktree, and branch  |
 | `p`           | Manage projects                                     |

--- a/pkg/board/app.go
+++ b/pkg/board/app.go
@@ -349,14 +349,14 @@ func (a *App) Diff(cardID string) (string, error) {
 }
 
 // OpenEditor opens the card's worktree in the user's GUI editor: the
-// command named by $BOARD_EDITOR, defaulting to VS Code's `code`. The
+// command named by $DOCKER_AGENT_BOARD_EDITOR, defaulting to VS Code's `code`. The
 // editor is started detached and reaped in the background.
 func (a *App) OpenEditor(cardID string) error {
 	card, err := a.store.GetCard(cardID)
 	if err != nil {
 		return err
 	}
-	editor := cmp.Or(os.Getenv("BOARD_EDITOR"), "code")
+	editor := cmp.Or(os.Getenv("DOCKER_AGENT_BOARD_EDITOR"), "code")
 	cmd := exec.CommandContext(a.ctx, editor, card.Worktree)
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("open editor (%s): %w", editor, err)

--- a/pkg/board/app.go
+++ b/pkg/board/app.go
@@ -356,7 +356,8 @@ func (a *App) OpenEditor(cardID string) error {
 	if err != nil {
 		return err
 	}
-	editor := cmp.Or(os.Getenv("DOCKER_AGENT_BOARD_EDITOR"), "code")
+	// BOARD_EDITOR is the legacy name, kept as a fallback for one release.
+	editor := cmp.Or(os.Getenv("DOCKER_AGENT_BOARD_EDITOR"), os.Getenv("BOARD_EDITOR"), "code")
 	cmd := exec.CommandContext(a.ctx, editor, card.Worktree)
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("open editor (%s): %w", editor, err)

--- a/pkg/board/tmux.go
+++ b/pkg/board/tmux.go
@@ -251,7 +251,7 @@ func setSessionHeader(ctx context.Context, name, title, project, worktree string
 	wt := shQuote(worktree)
 	diffCmd := "git -C " + wt + " diff --color=always \"$(git -C " + wt + " merge-base HEAD " +
 		shQuote(upstreamBase(ctx, worktree)) + " || echo HEAD)\" | less -R"
-	editorCmd := "${DOCKER_AGENT_BOARD_EDITOR:-code} " + wt
+	editorCmd := "${DOCKER_AGENT_BOARD_EDITOR:-${BOARD_EDITOR:-code}} " + wt
 
 	right := "#[range=user|diff] diff #[norange]·#[range=user|editor] editor #[norange]·" +
 		"#[range=right] #[bold]ctrl+q#[nobold] board #[norange]"

--- a/pkg/board/tmux.go
+++ b/pkg/board/tmux.go
@@ -251,7 +251,7 @@ func setSessionHeader(ctx context.Context, name, title, project, worktree string
 	wt := shQuote(worktree)
 	diffCmd := "git -C " + wt + " diff --color=always \"$(git -C " + wt + " merge-base HEAD " +
 		shQuote(upstreamBase(ctx, worktree)) + " || echo HEAD)\" | less -R"
-	editorCmd := "${BOARD_EDITOR:-code} " + wt
+	editorCmd := "${DOCKER_AGENT_BOARD_EDITOR:-code} " + wt
 
 	right := "#[range=user|diff] diff #[norange]·#[range=user|editor] editor #[norange]·" +
 		"#[range=right] #[bold]ctrl+q#[nobold] board #[norange]"

--- a/pkg/board/tui/dialogs.go
+++ b/pkg/board/tui/dialogs.go
@@ -610,7 +610,7 @@ func (d *helpDialog) View(width, _ int) string {
 		{keys.New.Help().Key, "create a card (launches an agent in a worktree)"},
 		{keys.Attach.Help().Key, keys.Attach.Help().Desc},
 		{keys.Diff.Help().Key, "view the card's worktree diff"},
-		{keys.Editor.Help().Key, keys.Editor.Help().Desc + " ($BOARD_EDITOR, default code)"},
+		{keys.Editor.Help().Key, keys.Editor.Help().Desc + " ($DOCKER_AGENT_BOARD_EDITOR, default code)"},
 		{"[ / ]", "move card (forward sends the column's prompt)"},
 		{keys.Delete.Help().Key, "delete card, its session and worktree"},
 		{keys.Projects.Help().Key, keys.Projects.Help().Desc},


### PR DESCRIPTION
The board feature lets users configure a preferred editor via an environment variable, but the original name `BOARD_EDITOR` is too generic and doesn't follow the `DOCKER_AGENT_` prefix convention used by the project's other env vars.

This renames the variable to `DOCKER_AGENT_BOARD_EDITOR` across the codebase and documentation. To avoid silently breaking existing setups, the old `BOARD_EDITOR` name is kept as a fallback for one release — both in the Go env lookup and in the tmux shell expansion (`${DOCKER_AGENT_BOARD_EDITOR:-${BOARD_EDITOR:-code}}`), matching the pattern already used for other renamed env vars in this project.

Users relying on `BOARD_EDITOR` will continue to see their editor launched without any change; they can migrate to `DOCKER_AGENT_BOARD_EDITOR` at their own pace before the fallback is removed.