### PR TITLE
fix(board): run agent control-plane sockets outside the data dir so cards start in docker sandboxes

### DIFF
--- a/pkg/board/app.go
+++ b/pkg/board/app.go
@@ -450,9 +450,9 @@ var ErrAgentStarting = errors.New("the agent is still starting")
 // command. An errored card is attachable regardless: its agent may have
 // died at startup, and the dead pane holds the error output the user needs
 // to read — unless the session is gone entirely (its recreation failed), in
-// which case a clear error beats tmux's raw "can't find session". Before
-// attaching, the session's header row is refreshed with the card's current
-// title and project.
+// which case the recorded relaunch failure, when known, beats tmux's raw
+// "can't find session". Before attaching, the session's header row is
+// refreshed with the card's current title and project.
 func (a *App) AttachCommand(cardID string) (*exec.Cmd, error) {
 	card, err := a.store.GetCard(cardID)
 	if err != nil {
@@ -460,6 +460,9 @@ func (a *App) AttachCommand(cardID string) (*exec.Cmd, error) {
 	}
 	if card.Status == StatusError {
 		if exists, err := a.sessions.Exists(card.Session); err == nil && !exists {
+			if lerr := a.controller.LaunchError(cardID); lerr != nil {
+				return nil, fmt.Errorf("the agent could not be relaunched (%w); move the card forward to retry, or delete it", lerr)
+			}
 			return nil, errors.New("the agent's session is gone; move the card forward to relaunch it, or delete it")
 		}
 	} else if !a.controller.Ready(card) {

--- a/pkg/board/app_test.go
+++ b/pkg/board/app_test.go
@@ -1,6 +1,7 @@
 package board
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -116,4 +117,24 @@ func TestMoveProject(t *testing.T) {
 	reloaded, err := userconfig.Load()
 	require.NoError(t, err)
 	assert.Equal(t, "c", reloaded.Board.Projects[1].Name)
+}
+
+func TestAttachCommandExplainsFailedRelaunch(t *testing.T) {
+	t.Parallel()
+
+	store := testStore(t)
+	require.NoError(t, store.InsertCard(&Card{ID: "c1", Status: StatusError, Session: "s", Worktree: t.TempDir()}))
+
+	// The session cannot be recreated: there is no pane holding the error,
+	// so attach must report why the relaunch failed instead of a bare
+	// "session is gone".
+	sessions := &crashingSessions{newErr: errors.New("tmux: bad working directory")}
+	c := newController(t.Context(), store, sessions, func() {})
+	card, err := store.GetCard("c1")
+	require.NoError(t, err)
+	c.resume(card)
+
+	app := &App{ctx: t.Context(), store: store, sessions: sessions, controller: c, onChanged: func() {}}
+	_, err = app.AttachCommand("c1")
+	assert.ErrorContains(t, err, "bad working directory")
 }

--- a/pkg/board/controller.go
+++ b/pkg/board/controller.go
@@ -70,6 +70,10 @@ type controller struct {
 	// watcher loop — so a user-initiated relaunch can reset it and give the
 	// agent a fresh set of attempts after the cap tripped.
 	launchFailures map[string]int
+	// launchErrors keeps, per card, the last failed relaunch's error. When a
+	// session cannot even be recreated there is no dead pane to attach to and
+	// read, so this is the only record of why the card went red.
+	launchErrors map[string]error
 
 	// relaunchMu serializes session relaunches. A watcher's background
 	// resume and a prompt-bearing relaunch (SendPrompt) can otherwise race:
@@ -93,6 +97,7 @@ func newController(ctx context.Context, store *Store, sessions sessionManager, o
 		watchers:       make(map[string]*watcher),
 		expectTurn:     make(map[string]bool),
 		launchFailures: make(map[string]int),
+		launchErrors:   make(map[string]error),
 	}
 }
 
@@ -157,6 +162,24 @@ func (c *controller) resetLaunchFailures(cardID string) {
 	delete(c.launchFailures, cardID)
 }
 
+func (c *controller) setLaunchError(cardID string, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err == nil {
+		delete(c.launchErrors, cardID)
+	} else {
+		c.launchErrors[cardID] = err
+	}
+}
+
+// LaunchError returns the last failed relaunch's error for the card, or nil.
+// It explains why an errored card may have no session left to attach to.
+func (c *controller) LaunchError(cardID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.launchErrors[cardID]
+}
+
 // Stop cancels the card's watcher and waits for it to exit. Waiting matters:
 // it guarantees the watcher cannot relaunch the session after the caller
 // goes on to tear it down (kill the tmux session, remove the worktree),
@@ -167,6 +190,7 @@ func (c *controller) Stop(cardID string) {
 	delete(c.watchers, cardID)
 	delete(c.expectTurn, cardID)
 	delete(c.launchFailures, cardID)
+	delete(c.launchErrors, cardID)
 	c.mu.Unlock()
 	if ok {
 		w.cancel()
@@ -460,6 +484,7 @@ func (c *controller) relaunch(card *Card, prompt string) error {
 		card.Session, workDir, card.Agent, card.AgentSession,
 		socket, worktreeName, worktreeBase, prompt,
 	)
+	c.setLaunchError(card.ID, err)
 	if err == nil {
 		// The agent is launching again: show it as starting until its
 		// control plane answers and the event stream drives the status.

--- a/pkg/board/controller.go
+++ b/pkg/board/controller.go
@@ -183,19 +183,28 @@ func (c *controller) LaunchError(cardID string) error {
 // Stop cancels the card's watcher and waits for it to exit. Waiting matters:
 // it guarantees the watcher cannot relaunch the session after the caller
 // goes on to tear it down (kill the tmux session, remove the worktree),
-// which would otherwise leave an orphaned session.
+// which would otherwise leave an orphaned session. The card's controller
+// state is dropped only after the wait, so a watcher mid-relaunch cannot
+// re-add entries behind the cleanup.
 func (c *controller) Stop(cardID string) {
 	c.mu.Lock()
 	w, ok := c.watchers[cardID]
 	delete(c.watchers, cardID)
-	delete(c.expectTurn, cardID)
-	delete(c.launchFailures, cardID)
-	delete(c.launchErrors, cardID)
 	c.mu.Unlock()
 	if ok {
 		w.cancel()
 		<-w.done
 	}
+	c.forget(cardID)
+}
+
+// forget drops all per-card controller state.
+func (c *controller) forget(cardID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.expectTurn, cardID)
+	delete(c.launchFailures, cardID)
+	delete(c.launchErrors, cardID)
 }
 
 // watch keeps one card mirrored to its control plane: snapshot to resync,
@@ -502,11 +511,15 @@ func (c *controller) relaunch(card *Card, prompt string) error {
 // Teardown kills the card's tmux session under the relaunch lock, so an
 // in-flight relaunch cannot recreate a session the caller is tearing down.
 // The caller must have removed the card from the store first: that is what
-// makes a later relaunch abort instead of resurrecting the session.
+// makes a later relaunch abort instead of resurrecting the session. The
+// card's controller state is dropped again here: a SendPrompt relaunch runs
+// outside the watcher (so Stop does not wait for it) and may have re-added
+// entries; holding the lock guarantees it has finished.
 func (c *controller) Teardown(card *Card) {
 	c.relaunchMu.Lock()
 	defer c.relaunchMu.Unlock()
 	_ = c.sessions.KillSession(card.Session)
+	c.forget(card.ID)
 }
 
 // sleep waits for d or until ctx is done, reporting whether ctx was done.

--- a/pkg/board/controller_test.go
+++ b/pkg/board/controller_test.go
@@ -491,3 +491,22 @@ func TestRelaunchResumesFromExistingWorktree(t *testing.T) {
 	assert.Equal(t, wt, sessions.workDir)
 	assert.Empty(t, sessions.worktreeName)
 }
+
+func TestTeardownForgetsControllerState(t *testing.T) {
+	t.Parallel()
+
+	// A SendPrompt relaunch runs outside the watcher, so Stop cannot wait
+	// for it: Teardown must drop the per-card state it may have re-added.
+	store := testStore(t)
+	require.NoError(t, store.InsertCard(&Card{ID: "c1", Session: "s", Worktree: t.TempDir()}))
+
+	c := newController(t.Context(), store, &crashingSessions{newErr: errors.New("boom")}, func() {})
+	card, err := store.GetCard("c1")
+	require.NoError(t, err)
+	c.resume(card)
+	require.Error(t, c.LaunchError("c1"))
+
+	c.Teardown(card)
+	require.NoError(t, c.LaunchError("c1"))
+	assert.Equal(t, 1, c.launchFailed("c1"), "failure count should have been dropped")
+}

--- a/pkg/board/controller_test.go
+++ b/pkg/board/controller_test.go
@@ -295,7 +295,7 @@ func (s *crashingSessions) Exists(string) (bool, error) { return false, nil }
 
 // watchCrashingCard spins up a watcher for a card whose agent never answers
 // and whose tmux pane is dead, simulating a startup crash.
-func watchCrashingCard(t *testing.T, sessions *crashingSessions) *Store {
+func watchCrashingCard(t *testing.T, sessions *crashingSessions) (*Store, *controller) {
 	t.Helper()
 	store := testStore(t)
 	require.NoError(t, store.InsertCard(&Card{ID: "c1", Column: "dev", Status: StatusStarting, Session: "s", Worktree: t.TempDir()}))
@@ -309,7 +309,7 @@ func watchCrashingCard(t *testing.T, sessions *crashingSessions) *Store {
 	require.NoError(t, err)
 	c.Start(card)
 	t.Cleanup(func() { c.Stop("c1") })
-	return store
+	return store, c
 }
 
 func TestControllerStartupCrashLoopGoesRed(t *testing.T) {
@@ -319,20 +319,25 @@ func TestControllerStartupCrashLoopGoesRed(t *testing.T) {
 	// relaunch: the watcher must surface the failure instead of silently
 	// relaunching forever with the card stuck "starting".
 	sessions := &crashingSessions{}
-	store := watchCrashingCard(t, sessions)
+	store, c := watchCrashingCard(t, sessions)
 	waitForStatus(t, store, StatusError)
 	// Relaunches stop at the cap, preserving the dead pane's error output.
 	assert.Equal(t, int32(maxLaunchFailures-1), sessions.newSessions.Load())
+	// The relaunches themselves worked: the dead pane is the record, not a
+	// launch error.
+	assert.NoError(t, c.LaunchError("c1"))
 }
 
 func TestControllerFailedRelaunchGoesRed(t *testing.T) {
 	t.Parallel()
 
 	// The session cannot even be recreated (e.g. tmux new-session fails):
-	// the card must go red, not stay "starting" forever.
+	// the card must go red, not stay "starting" forever, and the failure
+	// must be recorded — there is no pane left to read it from.
 	sessions := &crashingSessions{newErr: errors.New("tmux: bad working directory")}
-	store := watchCrashingCard(t, sessions)
+	store, c := watchCrashingCard(t, sessions)
 	waitForStatus(t, store, StatusError)
+	assert.ErrorContains(t, c.LaunchError("c1"), "bad working directory")
 }
 
 // flakyClient fails its first snapshots, then behaves like a healthy agent

--- a/pkg/board/model.go
+++ b/pkg/board/model.go
@@ -8,6 +8,7 @@ package board
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -108,10 +109,19 @@ func newSessionName() string {
 
 // socketPath returns the unix socket a card's agent control plane listens
 // on. It is derived from the (unique) docker-agent session id, so it is
-// stable across board restarts and needs no extra storage. Kept short to
-// stay under the ~104-byte unix sun_path limit.
+// stable across board restarts and needs no extra storage. The socket lives
+// in the board's per-user socket dir (see socketDir) — not under the data
+// dir, whose bind mount into a docker sandbox cannot host unix sockets: the
+// agent would die at startup failing to bind --listen. Kept short to stay
+// under the ~104-byte unix sun_path limit.
 func socketPath(agentSession string) string {
-	return filepath.Join(paths.GetDataDir(), "run", "board-"+agentSession+".sock")
+	dir, err := socketDir()
+	if err != nil {
+		// The board cannot run at all when the socket dir is unusable (its
+		// tmux socket lives there too); keep the path deterministic anyway.
+		dir = os.TempDir()
+	}
+	return filepath.Join(dir, agentSession+".sock")
 }
 
 // worktreeDir returns the directory docker-agent creates for a worktree of

--- a/pkg/board/model_test.go
+++ b/pkg/board/model_test.go
@@ -1,13 +1,31 @@
 package board
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/paths"
 	"github.com/docker/docker-agent/pkg/userconfig"
 )
+
+// The data dir (~/.cagent) may be bind-mounted into a docker sandbox, where
+// unix sockets cannot be bound: an agent whose --listen socket lived there
+// would die at startup. Control-plane sockets must live in the board's
+// local, per-user socket dir instead.
+func TestSocketPathOutsideDataDir(t *testing.T) {
+	t.Parallel()
+
+	sock := socketPath("abc123")
+	assert.False(t, strings.HasPrefix(sock, paths.GetDataDir()+string(filepath.Separator)))
+
+	dir, err := socketDir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "abc123.sock"), sock)
+}
 
 func TestPlaceholderTitle(t *testing.T) {
 	t.Parallel()

--- a/pkg/board/tmux.go
+++ b/pkg/board/tmux.go
@@ -49,14 +49,14 @@ type sessionManager interface {
 var socketDir = sync.OnceValues(func() (string, error) {
 	dir := filepath.Join(os.TempDir(), "cagent-board-"+strconv.Itoa(os.Getuid()))
 	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return "", fmt.Errorf("create tmux socket dir: %w", err)
+		return "", fmt.Errorf("create board socket dir: %w", err)
 	}
 	info, err := os.Lstat(dir)
 	if err != nil {
 		return "", err
 	}
 	if !info.IsDir() {
-		return "", fmt.Errorf("tmux socket dir %s is not a directory", dir)
+		return "", fmt.Errorf("board socket dir %s is not a directory", dir)
 	}
 	if err := checkOwner(dir, info); err != nil {
 		return "", err
@@ -66,7 +66,7 @@ var socketDir = sync.OnceValues(func() (string, error) {
 	// else's directory.
 	if info.Mode().Perm() != 0o700 {
 		if err := os.Chmod(dir, 0o700); err != nil { //nolint:gosec // 0700 is the tightest usable mode for a directory
-			return "", fmt.Errorf("tighten tmux socket dir permissions: %w", err)
+			return "", fmt.Errorf("tighten board socket dir permissions: %w", err)
 		}
 	}
 	return dir, nil

--- a/pkg/board/tmux.go
+++ b/pkg/board/tmux.go
@@ -39,11 +39,14 @@ type sessionManager interface {
 	Exists(name string) (bool, error)
 }
 
-// tmuxSocketDir creates and validates, once per process, the per-user
-// directory holding the board's private tmux socket. The checks fail
+// socketDir creates and validates, once per process, the per-user
+// directory holding the board's unix sockets: its private tmux socket and
+// each card's agent control-plane socket. It lives under the system temp
+// dir — never under the data dir: ~/.cagent may be bind-mounted into a
+// docker sandbox, where unix sockets cannot be bound. The checks fail
 // closed: a pre-existing path owned by another user, or not a real
-// directory, must never be used for the socket.
-var tmuxSocketDir = sync.OnceValues(func() (string, error) {
+// directory, must never be used for the sockets.
+var socketDir = sync.OnceValues(func() (string, error) {
 	dir := filepath.Join(os.TempDir(), "cagent-board-"+strconv.Itoa(os.Getuid()))
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", fmt.Errorf("create tmux socket dir: %w", err)
@@ -79,7 +82,7 @@ var tmuxSocketDir = sync.OnceValues(func() (string, error) {
 // per-user 0700 directory so other local users cannot pre-create or reach
 // it. The directory is created and validated before tmux binds the socket.
 func TmuxSocketPath() (string, error) {
-	dir, err := tmuxSocketDir()
+	dir, err := socketDir()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/board/tmux_unix.go
+++ b/pkg/board/tmux_unix.go
@@ -8,8 +8,8 @@ import (
 	"syscall"
 )
 
-// checkOwner verifies that the tmux socket directory belongs to the current
-// user, so the board never binds its private tmux server inside a directory
+// checkOwner verifies that the board's socket directory belongs to the
+// current user, so the board never binds its sockets inside a directory
 // another local user pre-created.
 func checkOwner(dir string, info os.FileInfo) error {
 	stat, ok := info.Sys().(*syscall.Stat_t)
@@ -17,7 +17,7 @@ func checkOwner(dir string, info os.FileInfo) error {
 		return nil
 	}
 	if int(stat.Uid) != os.Getuid() {
-		return fmt.Errorf("tmux socket dir %s is not owned by the current user", dir)
+		return fmt.Errorf("board socket dir %s is not owned by the current user", dir)
 	}
 	return nil
 }


### PR DESCRIPTION
When the board runs inside a Docker sandbox that bind-mounts `~/.cagent` from the host, unix sockets cannot be bound on that shared mount. Every per-card `--listen` socket lived under `~/.cagent/run`, so every agent died at startup and cards never left "starting". The fix moves those sockets into the board's per-user socket dir under the system temp dir, alongside the private tmux socket, which is always sandbox-local.

Two smaller companion fixes land in the same batch. When a card's session could not even be recreated on relaunch, `resume()` was silently dropping the error: the card went red with no pane to attach to and `attach` only said "the agent's session is gone". The controller now records the last relaunch failure per card and `AttachCommand` surfaces it. The other fix tightens the teardown path: per-card controller state is now stopped before waiting for the watcher, forgotten after the wait, and forgotten again under the relaunch lock in `Teardown`, closing a race window where a concurrent relaunch could re-insert state for a card being deleted.

All three fixes are covered by new regression tests (`TestSocketPathOutsideDataDir`, `TestControllerFailedRelaunchGoesRed`, `TestAttachCommandExplainsFailedRelaunch`, `TestTeardownForgetsControllerState`), and `task test` / `task lint` are clean. One migration caveat: cards whose agents are still alive on the old `~/.cagent/run` socket stay unreachable until that agent exits, then self-heal on relaunch.