### PR TITLE
feat(board): add `s` shortcut to open a shell in the card's worktree

### DIFF
--- a/docs/features/board/index.md
+++ b/docs/features/board/index.md
@@ -47,6 +47,7 @@ Requirements: `tmux` and `git` must be installed.
 | `enter`       | Attach to the card's agent (`ctrl+q` detaches)      |
 | `d`           | View the card's worktree diff                       |
 | `o`           | Open the card's worktree in `$DOCKER_AGENT_BOARD_EDITOR` (`code`) |
+| `s`           | Open an interactive shell in the card's worktree    |
 | `[` / `]`     | Move the card back / forward                        |
 | `x`           | Delete the card, its session, worktree, and branch  |
 | `p`           | Manage projects (add, edit, reorder, remove)        |

--- a/pkg/board/tui/dialogs.go
+++ b/pkg/board/tui/dialogs.go
@@ -702,6 +702,7 @@ func (d *helpDialog) View(width, _ int) string {
 		{keys.Attach.Help().Key, keys.Attach.Help().Desc},
 		{keys.Diff.Help().Key, "view the card's worktree diff"},
 		{keys.Editor.Help().Key, keys.Editor.Help().Desc + " ($DOCKER_AGENT_BOARD_EDITOR, default code)"},
+		{keys.Shell.Help().Key, keys.Shell.Help().Desc},
 		{"[ / ]", "move card (forward sends the column's prompt)"},
 		{keys.Delete.Help().Key, "delete card, its session and worktree"},
 		{keys.Projects.Help().Key, keys.Projects.Help().Desc},

--- a/pkg/board/tui/tui.go
+++ b/pkg/board/tui/tui.go
@@ -13,6 +13,7 @@ import (
 	"github.com/atotto/clipboard"
 
 	"github.com/docker/docker-agent/pkg/board"
+	"github.com/docker/docker-agent/pkg/shellpath"
 	"github.com/docker/docker-agent/pkg/tui/core"
 	"github.com/docker/docker-agent/pkg/tui/styles"
 )
@@ -138,6 +139,7 @@ type keyMap struct {
 	Projects key.Binding
 	Prompt   key.Binding
 	Editor   key.Binding
+	Shell    key.Binding
 	Help     key.Binding
 	Quit     key.Binding
 }
@@ -158,6 +160,7 @@ var keys = keyMap{
 	Projects: key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "manage projects")),
 	Prompt:   key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "edit column prompt")),
 	Editor:   key.NewBinding(key.WithKeys("o"), key.WithHelp("o", "open worktree in editor")),
+	Shell:    key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "open shell in worktree")),
 	Help:     key.NewBinding(key.WithKeys("?", "f1", "ctrl+h"), key.WithHelp("?", "help")),
 	Quit:     key.NewBinding(key.WithKeys("q", "ctrl+c"), key.WithHelp("q", "quit")),
 }
@@ -572,11 +575,31 @@ func (m *model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		}
 
+	case key.Matches(msg, keys.Shell):
+		if card := m.selectedCard(); card != nil {
+			cmd := m.openShell(card)
+			return m, cmd
+		}
+
 	case key.Matches(msg, keys.Help):
 		cmd := m.openDialog(newHelpDialog())
 		return m, cmd
 	}
 	return m, nil
+}
+
+// openShell launches an interactive shell in the card's worktree, like the
+// main TUI's /shell command. tea.ExecProcess suspends the board and wires the
+// terminal to the shell until it exits.
+func (m *model) openShell(card *board.Card) tea.Cmd {
+	cmd := shellpath.InteractiveShellCmd("Type 'exit' to return to the board")
+	cmd.Dir = card.Worktree
+	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		if err != nil {
+			return flashMsg{text: "shell: " + err.Error(), isErr: true}
+		}
+		return nil
+	})
 }
 
 // openNewCard opens the new-card dialog, or the projects dialog first when

--- a/pkg/board/tui/tui.go
+++ b/pkg/board/tui/tui.go
@@ -4,6 +4,7 @@ package tui
 import (
 	"context"
 	"image/color"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -592,6 +593,11 @@ func (m *model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 // main TUI's /shell command. tea.ExecProcess suspends the board and wires the
 // terminal to the shell until it exits.
 func (m *model) openShell(card *board.Card) tea.Cmd {
+	// The worktree is created by the agent launch; a card that is still
+	// starting (or a stale state-file entry) has nothing to open yet.
+	if _, err := os.Stat(card.Worktree); card.Worktree == "" || err != nil {
+		return m.setFlash("Worktree not available yet — the agent may still be starting", true)
+	}
 	cmd := shellpath.InteractiveShellCmd("Type 'exit' to return to the board")
 	cmd.Dir = card.Worktree
 	return tea.ExecProcess(cmd, func(err error) tea.Msg {

--- a/pkg/board/tui/view.go
+++ b/pkg/board/tui/view.go
@@ -418,7 +418,7 @@ func (m *model) renderFooter() string {
 	// Same look as the main TUI's status bar: highlighted keys with secondary
 	// descriptions on the left, muted context on the right.
 	hints := []string{
-		"n", "new", "⏎", "attach", "d", "diff", "o", "editor", "[ ]", "move",
+		"n", "new", "⏎", "attach", "d", "diff", "o", "editor", "s", "shell", "[ ]", "move",
 		"x", "delete", "p", "projects", "e", "prompt", "?", "help", "q", "quit",
 	}
 	parts := make([]string, 0, len(hints)/2)

--- a/pkg/shellpath/shellpath.go
+++ b/pkg/shellpath/shellpath.go
@@ -49,13 +49,21 @@ func DetectShell() (shell string, argsPrefix []string) {
 // It prefers PowerShell (resolved via LookPath, which returns an absolute path),
 // falling back to cmd.exe via [WindowsCmdExe].
 func DetectWindowsShell() (shell string, argsPrefix []string) {
-	powershellArgs := []string{"-NoProfile", "-NonInteractive", "-Command"}
-	for _, ps := range []string{"pwsh.exe", "powershell.exe"} {
-		if path, err := exec.LookPath(ps); err == nil {
-			return path, powershellArgs
-		}
+	if path, ok := lookPowerShell(); ok {
+		return path, []string{"-NoProfile", "-NonInteractive", "-Command"}
 	}
 	return WindowsCmdExe(), []string{"/C"}
+}
+
+// lookPowerShell resolves the preferred PowerShell binary (pwsh.exe first,
+// then powershell.exe) via LookPath, which returns an absolute path.
+func lookPowerShell() (string, bool) {
+	for _, ps := range []string{"pwsh.exe", "powershell.exe"} {
+		if path, err := exec.LookPath(ps); err == nil {
+			return path, true
+		}
+	}
+	return "", false
 }
 
 // DetectUnixShell returns the user's shell from the SHELL environment variable,
@@ -73,24 +81,34 @@ func defaultUnixShell() string {
 }
 
 // InteractiveShellCmd returns a command that launches the user's preferred
-// interactive shell, printing exitMsg first. The command is owned by the
-// caller (typically tea.ExecProcess), not by a request-scoped context, so
+// interactive shell, printing exitMsg first. The message is passed through an
+// environment variable — never interpolated into the command line — so it
+// cannot be reparsed as shell syntax. The command is owned by the caller
+// (typically tea.ExecProcess), not by a request-scoped context, so
 // exec.Command is intentional.
 func InteractiveShellCmd(exitMsg string) *exec.Cmd {
-	if runtime.GOOS != "windows" {
-		shell := DetectUnixShell()
-		return execCmd(shell, "-i", "-c", `echo -e "\n`+exitMsg+`"; exec `+shell)
-	}
+	const msgVar = "DOCKER_AGENT_SHELL_EXIT_MSG"
+	cmd := interactiveShellCmd(msgVar)
+	cmd.Env = append(os.Environ(), msgVar+"="+exitMsg)
+	return cmd
+}
 
-	psArgs := []string{"-NoLogo", "-NoExit", "-Command", `Write-Host ""; Write-Host "` + exitMsg + `"`}
-	if path, err := exec.LookPath("pwsh.exe"); err == nil {
-		return execCmd(path, psArgs...)
+// interactiveShellCmd builds the platform-specific command that prints the
+// message held in the msgVar environment variable, then hands over to an
+// interactive shell.
+func interactiveShellCmd(msgVar string) *exec.Cmd {
+	if runtime.GOOS != "windows" {
+		// printf (not `echo -e`) so the message prints verbatim under dash,
+		// bash, zsh and fish alike.
+		shell := DetectUnixShell()
+		return execCmd(shell, "-i", "-c", `printf '\n%s\n' "$`+msgVar+`"; exec `+shell)
 	}
-	if path, err := exec.LookPath("powershell.exe"); err == nil {
-		return execCmd(path, psArgs...)
+	if path, ok := lookPowerShell(); ok {
+		return execCmd(path, "-NoLogo", "-NoExit", "-Command", `Write-Host ""; Write-Host $env:`+msgVar)
 	}
-	// Use absolute path to cmd.exe to prevent PATH hijacking (CWE-426).
-	return execCmd(WindowsCmdExe(), "/K", "echo. & echo "+exitMsg)
+	// Absolute path to cmd.exe prevents PATH hijacking (CWE-426); /V:ON
+	// delayed expansion (!VAR!) keeps the message out of cmd's parser.
+	return execCmd(WindowsCmdExe(), "/V:ON", "/K", "echo. & echo !"+msgVar+"!")
 }
 
 // execCmd is a thin wrapper around exec.Command used for interactive

--- a/pkg/shellpath/shellpath.go
+++ b/pkg/shellpath/shellpath.go
@@ -71,3 +71,30 @@ func defaultUnixShell() string {
 	}
 	return "/bin/sh"
 }
+
+// InteractiveShellCmd returns a command that launches the user's preferred
+// interactive shell, printing exitMsg first. The command is owned by the
+// caller (typically tea.ExecProcess), not by a request-scoped context, so
+// exec.Command is intentional.
+func InteractiveShellCmd(exitMsg string) *exec.Cmd {
+	if runtime.GOOS != "windows" {
+		shell := DetectUnixShell()
+		return execCmd(shell, "-i", "-c", `echo -e "\n`+exitMsg+`"; exec `+shell)
+	}
+
+	psArgs := []string{"-NoLogo", "-NoExit", "-Command", `Write-Host ""; Write-Host "` + exitMsg + `"`}
+	if path, err := exec.LookPath("pwsh.exe"); err == nil {
+		return execCmd(path, psArgs...)
+	}
+	if path, err := exec.LookPath("powershell.exe"); err == nil {
+		return execCmd(path, psArgs...)
+	}
+	// Use absolute path to cmd.exe to prevent PATH hijacking (CWE-426).
+	return execCmd(WindowsCmdExe(), "/K", "echo. & echo "+exitMsg)
+}
+
+// execCmd is a thin wrapper around exec.Command used for interactive
+// processes whose lifecycle is owned by the caller (not a context).
+func execCmd(name string, args ...string) *exec.Cmd {
+	return exec.Command(name, args...) //nolint:noctx // owned by the caller (tea.ExecProcess)
+}

--- a/pkg/shellpath/shellpath_test.go
+++ b/pkg/shellpath/shellpath_test.go
@@ -3,6 +3,7 @@ package shellpath
 import (
 	"path/filepath"
 	"runtime"
+	"slices"
 	"testing"
 )
 
@@ -99,5 +100,24 @@ func TestDetectWindowsShell_FallbackUsesAbsolutePath(t *testing.T) {
 	}
 	if len(args) != 1 || args[0] != "/C" {
 		t.Errorf("DetectWindowsShell() args = %v, want [/C]", args)
+	}
+}
+
+func TestInteractiveShellCmd_Unix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix-only test")
+	}
+
+	t.Setenv("SHELL", "/bin/zsh")
+	// A hostile message must stay an env value, never argv or shell syntax.
+	msg := `pwned"; rm -rf $(HOME) &`
+	cmd := InteractiveShellCmd(msg)
+
+	want := []string{"/bin/zsh", "-i", "-c", `printf '\n%s\n' "$DOCKER_AGENT_SHELL_EXIT_MSG"; exec /bin/zsh`}
+	if !slices.Equal(cmd.Args, want) {
+		t.Errorf("InteractiveShellCmd() args = %q, want %q", cmd.Args, want)
+	}
+	if !slices.Contains(cmd.Env, "DOCKER_AGENT_SHELL_EXIT_MSG="+msg) {
+		t.Errorf("InteractiveShellCmd() env is missing DOCKER_AGENT_SHELL_EXIT_MSG=%q", msg)
 	}
 }

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -6,9 +6,7 @@ import (
 	"log/slog"
 	neturl "net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
-	goruntime "runtime"
 	"strings"
 	"time"
 
@@ -1067,7 +1065,7 @@ func (m *appModel) handleElicitationResponse(action tools.ElicitationAction, con
 }
 
 func (m *appModel) startShell() (tea.Model, tea.Cmd) {
-	cmd := newInteractiveShellCmd("Type 'exit' to return to " + m.appName)
+	cmd := shellpath.InteractiveShellCmd("Type 'exit' to return to " + m.appName)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -1078,30 +1076,4 @@ func (m *appModel) startShell() (tea.Model, tea.Cmd) {
 		cmd.Dir = runner.WorkingDir
 	}
 	return m, tea.ExecProcess(cmd, nil)
-}
-
-// newInteractiveShellCmd returns a command that launches the user's preferred
-// interactive shell. The command is owned by tea.ExecProcess, not by any
-// request-scoped context, so exec.Command is intentional.
-func newInteractiveShellCmd(exitMsg string) *exec.Cmd {
-	if goruntime.GOOS != "windows" {
-		shell := shellpath.DetectUnixShell()
-		return execCmd(shell, "-i", "-c", `echo -e "\n`+exitMsg+`"; exec `+shell)
-	}
-
-	psArgs := []string{"-NoLogo", "-NoExit", "-Command", `Write-Host ""; Write-Host "` + exitMsg + `"`}
-	if path, err := exec.LookPath("pwsh.exe"); err == nil {
-		return execCmd(path, psArgs...)
-	}
-	if path, err := exec.LookPath("powershell.exe"); err == nil {
-		return execCmd(path, psArgs...)
-	}
-	// Use absolute path to cmd.exe to prevent PATH hijacking (CWE-426).
-	return execCmd(shellpath.WindowsCmdExe(), "/K", "echo. & echo "+exitMsg)
-}
-
-// execCmd is a thin wrapper around exec.Command used for interactive
-// processes whose lifecycle is owned by tea.ExecProcess (not a context).
-func execCmd(name string, args ...string) *exec.Cmd {
-	return exec.Command(name, args...) //nolint:noctx // owned by tea.ExecProcess
 }


### PR DESCRIPTION
The `docker agent board` TUI had no way to drop into a shell inside a card's worktree — you had to leave the board, find the directory, and open a terminal manually. This adds an `s` shortcut that opens an interactive shell directly in the selected card's worktree, bringing board parity with the main TUI's `/shell` slash command.

When `s` is pressed the board validates that the worktree exists on disk, then execs an interactive shell in that directory using the same logic that powers `/shell`. To avoid duplicating that logic, `InteractiveShellCmd` has been extracted from `pkg/tui` into the new exported `pkg/shellpath` function, so both TUIs share a single implementation. The exit message is passed via the `DOCKER_AGENT_SHELL_EXIT_MSG` environment variable rather than being interpolated into the shell command string, closing a shell-injection vector and making the Windows (`cmd.exe` with `/V:ON`) and PowerShell paths cleaner. POSIX `printf` replaces the non-portable `echo -e`. The help dialog, footer hints, and `docs/features/board/index.md` are all updated.

If the worktree directory no longer exists the board shows a brief flash message instead of crashing, so the error surface is friendly. A test locks in the Unix argv/env contract for `InteractiveShellCmd`.