### PR TITLE
docs: sync documentation with recent main merges

### DIFF
--- a/docs/features/a2a/index.md
+++ b/docs/features/a2a/index.md
@@ -38,6 +38,7 @@ $ docker agent serve a2a agentcatalog/pirate
 | --------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------- |
 | `-l, --listen <addr>`             | `127.0.0.1:8082` | Address to listen on.                                                                                                |
 | `-a, --agent <name>`              | (first agent)    | Name of the agent to expose when the config contains multiple agents. Defaults to the team's first agent.            |
+| `-s, --session-db <path>`         | `<data-dir>/session.db` | Path to the SQLite session database.                                                                          |
 | `--working-dir <path>`            | current dir      | Working directory the agent runs in.                                                                                 |
 | `--env-from-file <file>`          | (none)           | Load additional environment variables from a `.env` file (repeatable).                                               |
 | `--models-gateway <url>`          | (none)           | Route all provider traffic through a models gateway URL.                                                             |

--- a/docs/features/board/index.md
+++ b/docs/features/board/index.md
@@ -25,6 +25,11 @@ Requirements: `tmux` and `git` must be installed.
   a dedicated tmux session, working in a fresh git worktree branched from the
   project's upstream default branch. The card's title, running/idle status,
   and failures are mirrored live from the agent's control plane.
+- **Startup phases.** While an agent is coming up its card moves through three
+  intermediate statuses before reaching **running**: `starting` (tmux session
+  created, process booting, no worktree yet) → `loading` (worktree present;
+  agent loading config, models, and tools) → `attaching` (control-plane socket
+  bound; board waiting for the first snapshot).
 - **Columns are a pipeline.** The default pipeline is
   Dev → Review → Push → Done. Moving a card forward (`]`)
   sends the destination column's prompt to the card's agent; moving it back

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -77,6 +77,7 @@ Type `/` during a session to see available commands, or press <kbd>Ctrl</kbd>+<k
 | `/sessions`        | Browse and load past sessions                                                        |
 | `/model`           | Change the model for the current agent                                               |
 | `/effort`          | Set the current model's reasoning-effort level (`/effort <none\|minimal\|low\|medium\|high\|xhigh\|max>`, or `/effort` alone to pick from the supported levels; reasoning models only) |
+| `/custom`          | Customize the TUI layout: sidebar position and visible sidebar sections              |
 | `/theme`           | Change the color theme                                                               |
 | `/yolo`            | Toggle automatic tool call approval                                                  |
 | `/title`           | Set or regenerate session title                                                      |


### PR DESCRIPTION
Covers doc gaps from PRs merged to `main` in the past 36 hours.

**Source PRs covered:**

- **#3509** `feat(tui): add /custom command to customize layout` — added `/custom` layout dialog and section, but the slash commands reference table was missing the entry. Added it.
- **#3516** `feat(board): show intermediate startup statuses on cards` — introduced `starting → loading → attaching` card startup progression with no docs update. Documented the three phases in `docs/features/board/index.md`.
- **#3503** `fix(cli): resolve session DB default against the data dir` — updated `cli/index.md` and `acp/index.md` but left `docs/features/a2a/index.md` missing the `--session-db` flag in its Flags table. Added the row.

**Reviewed and already up to date:**

#3517, #3513, #3514 (board: shell shortcut, project editing, env var rename — board docs already reflect these), #3504 (auto theme — TUI and CLI docs already updated), #3505 (theme watcher — no doc change needed per PR), #3507 (dep bumps — no docs), #3506, #3497 (changelogs), #3518, #3515, #3510, #3508, #3491 (bug fixes, internal — no user-facing change), #3499, #3498, #3496, #3489, #3502, #3494 (each updated their own docs).