### PR TITLE
fix(board): clarify dirty-worktree removal prompt with explicit consequences

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -674,7 +674,9 @@ func promptRemoveDirtyWorktree(ctx context.Context, out *cli.Printer, wt *worktr
 	}
 
 	out.Println("\nThe git worktree " + wt.Dir + " (branch " + wt.Branch + ") still has " + strings.Join(held, ", ") + ".")
-	out.Println("Remove it and discard this work? Keeping preserves the directory and branch so you can return later. (y/N):")
+	out.Println("Delete this worktree and discard the work? (y/N)")
+	out.Println("  y: delete the directory and its work")
+	out.Println("  N: keep the directory and branch so you can return later")
 
 	response, err := input.ReadLine(ctx, os.Stdin)
 	if err != nil {

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -674,9 +674,9 @@ func promptRemoveDirtyWorktree(ctx context.Context, out *cli.Printer, wt *worktr
 	}
 
 	out.Println("\nThe git worktree " + wt.Dir + " (branch " + wt.Branch + ") still has " + strings.Join(held, ", ") + ".")
-	out.Println("Delete this worktree and discard the work? (y/N)")
-	out.Println("  y: delete the directory and its work")
-	out.Println("  N: keep the directory and branch so you can return later")
+	out.Println("  y: delete the worktree, its branch, and all of this work")
+	out.Println("  N: keep them so you can return later")
+	out.Print("Delete this worktree and discard the work? (y/N) ")
 
 	response, err := input.ReadLine(ctx, os.Stdin)
 	if err != nil {


### PR DESCRIPTION
When a card's worktree has uncommitted changes or unpushed commits and the user
tries to close the card, docker-agent asks whether to delete it. The old prompt
crammed the question and the explanation into a single line, making it unclear
what "y" and "N" would actually do. Users had to parse a single run-on sentence
to understand that "y" meant permanent deletion.

The prompt now prints the two options on separate indented lines before asking
the question, so the consequences of each choice are unambiguous at a glance.
The question itself is moved to the last line using `Print` instead of
`Println`, which leaves the cursor right after the `(y/N)` marker — consistent
with how every other interactive prompt in the CLI behaves.

No behavioural change; the logic that reads and acts on the response is
untouched.