### PR TITLE
feat(board): move cards to any column with digit keys and drag & drop

### DIFF
--- a/docs/features/board/index.md
+++ b/docs/features/board/index.md
@@ -49,11 +49,12 @@ Requirements: `tmux` and `git` must be installed.
 | `o`           | Open the card's worktree in `$DOCKER_AGENT_BOARD_EDITOR` (`code`) |
 | `s`           | Open an interactive shell in the card's worktree    |
 | `[` / `]`     | Move the card back / forward                        |
+| `1`-`9`       | Move the card to column N                           |
 | `x`           | Delete the card, its session, worktree, and branch  |
 | `p`           | Manage projects (add, edit, reorder, remove)        |
 | `e`           | Edit the selected column's prompt                   |
 | `←↓↑→` `hjkl` | Navigate                                            |
-| mouse         | Click selects, double-click attaches, wheel scrolls |
+| mouse         | Click selects, double-click attaches, drag moves, wheel scrolls |
 | `?`           | Help                                                |
 | `q`           | Quit (agents keep running)                          |
 

--- a/pkg/board/tui/dialogs.go
+++ b/pkg/board/tui/dialogs.go
@@ -704,11 +704,12 @@ func (d *helpDialog) View(width, _ int) string {
 		{keys.Editor.Help().Key, keys.Editor.Help().Desc + " ($DOCKER_AGENT_BOARD_EDITOR, default code)"},
 		{keys.Shell.Help().Key, keys.Shell.Help().Desc},
 		{"[ / ]", "move card (forward sends the column's prompt)"},
+		{keys.MoveTo.Help().Key, keys.MoveTo.Help().Desc},
 		{keys.Delete.Help().Key, "delete card, its session and worktree"},
 		{keys.Projects.Help().Key, keys.Projects.Help().Desc},
 		{keys.Prompt.Help().Key, "edit the selected column's prompt"},
 		{"←↓↑→ hjkl", "navigate (g/G first/last card)"},
-		{"mouse", "click selects · double-click attaches · wheel scrolls"},
+		{"mouse", "click selects · double-click attaches · drag moves · wheel scrolls"},
 		{keys.Quit.Help().Key, "quit (agents keep running in tmux)"},
 	}
 	// Same row styling as the main TUI's help dialog.

--- a/pkg/board/tui/tui.go
+++ b/pkg/board/tui/tui.go
@@ -136,6 +136,7 @@ type keyMap struct {
 	Diff     key.Binding
 	MoveFwd  key.Binding
 	MoveBack key.Binding
+	MoveTo   key.Binding
 	Delete   key.Binding
 	Projects key.Binding
 	Prompt   key.Binding
@@ -157,6 +158,7 @@ var keys = keyMap{
 	Diff:     key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "view diff")),
 	MoveFwd:  key.NewBinding(key.WithKeys("]", "shift+right", "L"), key.WithHelp("]", "move card forward")),
 	MoveBack: key.NewBinding(key.WithKeys("[", "shift+left", "H"), key.WithHelp("[", "move card back")),
+	MoveTo:   key.NewBinding(key.WithKeys("1", "2", "3", "4", "5", "6", "7", "8", "9"), key.WithHelp("1-9", "move card to column N")),
 	Delete:   key.NewBinding(key.WithKeys("x", "backspace", "delete"), key.WithHelp("x", "delete card")),
 	Projects: key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "manage projects")),
 	Prompt:   key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "edit column prompt")),
@@ -229,6 +231,14 @@ type model struct {
 	// lastClick* back double-click-to-attach on cards.
 	lastClickCard string
 	lastClickTime time.Time
+
+	// drag* back drag-and-drop card moves: dragCardID is the pressed card
+	// (a drag candidate), dragging turns true on the first motion event
+	// (cell-motion mode only reports motion while a button is held), and
+	// dragCol is the drop target column under the pointer (-1 when none).
+	dragCardID string
+	dragging   bool
+	dragCol    int
 }
 
 func newModel(app *board.App, refresh chan struct{}) *model {
@@ -499,6 +509,11 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleKey(msg)
 	case tea.MouseClickMsg:
 		return m.handleClick(msg)
+	case tea.MouseMotionMsg:
+		m.handleMotion(msg)
+		return m, nil
+	case tea.MouseReleaseMsg:
+		return m.handleRelease(msg)
 	case tea.MouseWheelMsg:
 		m.handleWheel(msg)
 		return m, nil
@@ -544,10 +559,13 @@ func (m *model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case key.Matches(msg, keys.MoveFwd):
-		cmd := m.moveCard(1)
+		cmd := m.moveCardTo(m.selCol + 1)
 		return m, cmd
 	case key.Matches(msg, keys.MoveBack):
-		cmd := m.moveCard(-1)
+		cmd := m.moveCardTo(m.selCol - 1)
+		return m, cmd
+	case key.Matches(msg, keys.MoveTo):
+		cmd := m.moveCardTo(int(msg.String()[0] - '1'))
 		return m, cmd
 
 	case key.Matches(msg, keys.Delete):
@@ -686,7 +704,43 @@ func (m *model) handleClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 	}
 	m.lastClickCard = card.ID
 	m.lastClickTime = time.Now()
+	// The pressed card is a drag candidate: motion before the release turns
+	// the click into a drag (see handleMotion/handleRelease).
+	m.dragCardID = card.ID
+	m.dragCol = col
 	return m, nil
+}
+
+// handleMotion tracks a pressed card being dragged. Cell-motion mode only
+// reports motion while a button is held, so any motion after a card press
+// means a drag; the column under the pointer becomes the drop target.
+func (m *model) handleMotion(msg tea.MouseMotionMsg) {
+	if m.dragCardID == "" || msg.Button != tea.MouseLeft {
+		return
+	}
+	m.dragging = true
+	if col, ok := m.columnAt(msg.X, msg.Y); ok {
+		m.dragCol = col
+	} else {
+		m.dragCol = -1
+	}
+}
+
+// handleRelease completes a drag-and-drop: dropping a card on another
+// column moves it there. A release without prior motion is a plain click,
+// already handled by handleClick.
+func (m *model) handleRelease(msg tea.MouseReleaseMsg) (tea.Model, tea.Cmd) {
+	wasDragging, dst := m.dragging, m.dragCol
+	m.dragCardID, m.dragging, m.dragCol = "", false, -1
+	if !wasDragging {
+		return m, nil
+	}
+	m.lastClickCard = "" // a completed drag must not arm double-click
+	if col, ok := m.columnAt(msg.X, msg.Y); ok {
+		dst = col
+	}
+	cmd := m.moveCardTo(dst)
+	return m, cmd
 }
 
 // handleWheel moves the selection through the column under the cursor, so
@@ -731,13 +785,10 @@ func (m *model) createCard(project board.Project, prompt string) tea.Cmd {
 	}
 }
 
-func (m *model) moveCard(direction int) tea.Cmd {
+// moveCardTo moves the selected card to the column at index dst.
+func (m *model) moveCardTo(dst int) tea.Cmd {
 	card := m.selectedCard()
-	if card == nil {
-		return nil
-	}
-	dst := m.selCol + direction
-	if dst < 0 || dst >= len(m.columns) {
+	if card == nil || dst == m.selCol || dst < 0 || dst >= len(m.columns) {
 		return nil
 	}
 	colID := m.columns[dst].ID

--- a/pkg/board/tui/tui.go
+++ b/pkg/board/tui/tui.go
@@ -6,6 +6,7 @@ import (
 	"image/color"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 	"time"
 
@@ -254,6 +255,7 @@ func newModel(app *board.App, refresh chan struct{}) *model {
 
 // openDialog installs a dialog and runs its init command.
 func (m *model) openDialog(d dialog) tea.Cmd {
+	m.resetDrag() // the dialog captures the release: the drag cannot finish
 	m.dialog = d
 	return d.Init()
 }
@@ -269,6 +271,15 @@ func (m *model) reload() {
 		m.projectColors[p.Name] = projectColorAt(i)
 	}
 	m.clampSelection()
+	// A refresh can remove the dragged card or shrink the column list;
+	// re-validate so a drop cannot act on stale state.
+	if m.dragCardID != "" {
+		if m.cardByID(m.dragCardID) == nil {
+			m.resetDrag()
+		} else if m.dragCol >= len(m.columns) {
+			m.dragCol = -1
+		}
+	}
 }
 
 // groupCards buckets cards by column, in board order. A card whose column
@@ -311,6 +322,18 @@ func (m *model) selectedCard() *board.Card {
 		return nil
 	}
 	return cards[m.selRow]
+}
+
+// cardByID finds a card anywhere on the board.
+func (m *model) cardByID(id string) *board.Card {
+	for _, cards := range m.cards {
+		for _, c := range cards {
+			if c.ID == id {
+				return c
+			}
+		}
+	}
+	return nil
 }
 
 func (m *model) Init() tea.Cmd {
@@ -522,6 +545,10 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	// A key press cancels any drag in progress (esc cancels a drag) and
+	// keeps the state clean across paths that lose the release event, like
+	// tea.ExecProcess (attach, shell) leaving mouse mode.
+	m.resetDrag()
 	switch {
 	case key.Matches(msg, keys.Quit):
 		return m, tea.Quit
@@ -712,11 +739,18 @@ func (m *model) handleClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 }
 
 // handleMotion tracks a pressed card being dragged. Cell-motion mode only
-// reports motion while a button is held, so any motion after a card press
+// reports motion while a button is held, so motion after a card press
 // means a drag; the column under the pointer becomes the drop target.
 func (m *model) handleMotion(msg tea.MouseMotionMsg) {
 	if m.dragCardID == "" || msg.Button != tea.MouseLeft {
 		return
+	}
+	// Jitter within the pressed card stays a click (double-click keeps
+	// working): the drag starts once the pointer leaves the card.
+	if !m.dragging {
+		if col, row, ok := m.cardAt(msg.X, msg.Y); ok && col == m.selCol && row == m.selRow {
+			return
+		}
 	}
 	m.dragging = true
 	if col, ok := m.columnAt(msg.X, msg.Y); ok {
@@ -730,8 +764,11 @@ func (m *model) handleMotion(msg tea.MouseMotionMsg) {
 // column moves it there. A release without prior motion is a plain click,
 // already handled by handleClick.
 func (m *model) handleRelease(msg tea.MouseReleaseMsg) (tea.Model, tea.Cmd) {
-	wasDragging, dst := m.dragging, m.dragCol
-	m.dragCardID, m.dragging, m.dragCol = "", false, -1
+	if msg.Button != tea.MouseLeft {
+		return m, nil
+	}
+	cardID, wasDragging, dst := m.dragCardID, m.dragging, m.dragCol
+	m.resetDrag()
 	if !wasDragging {
 		return m, nil
 	}
@@ -739,8 +776,17 @@ func (m *model) handleRelease(msg tea.MouseReleaseMsg) (tea.Model, tea.Cmd) {
 	if col, ok := m.columnAt(msg.X, msg.Y); ok {
 		dst = col
 	}
-	cmd := m.moveCardTo(dst)
+	cmd := m.moveCard(cardID, dst)
 	return m, cmd
+}
+
+// resetDrag abandons any drag in progress. Called whenever a drag can no
+// longer complete cleanly: a dialog opening (it captures the release), a
+// key press, or the dragged card disappearing on a refresh.
+func (m *model) resetDrag() {
+	m.dragCardID = ""
+	m.dragging = false
+	m.dragCol = -1
 }
 
 // handleWheel moves the selection through the column under the cursor, so
@@ -787,13 +833,25 @@ func (m *model) createCard(project board.Project, prompt string) tea.Cmd {
 
 // moveCardTo moves the selected card to the column at index dst.
 func (m *model) moveCardTo(dst int) tea.Cmd {
-	card := m.selectedCard()
-	if card == nil || dst == m.selCol || dst < 0 || dst >= len(m.columns) {
+	if card := m.selectedCard(); card != nil {
+		return m.moveCard(card.ID, dst)
+	}
+	return nil
+}
+
+// moveCard moves a card — by ID, so a board refresh mid-drag cannot
+// redirect the move to another card — to the column at index dst. Moving a
+// card to the column it already occupies is a no-op.
+func (m *model) moveCard(cardID string, dst int) tea.Cmd {
+	if dst < 0 || dst >= len(m.columns) {
 		return nil
 	}
 	colID := m.columns[dst].ID
+	if slices.ContainsFunc(m.cards[colID], func(c *board.Card) bool { return c.ID == cardID }) {
+		return nil
+	}
 	return func() tea.Msg {
-		if err := m.app.MoveCard(card.ID, colID); err != nil {
+		if err := m.app.MoveCard(cardID, colID); err != nil {
 			return flashMsg{text: err.Error(), isErr: true}
 		}
 		return cardMovedMsg{colIdx: dst}

--- a/pkg/board/tui/tui_test.go
+++ b/pkg/board/tui/tui_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -102,6 +103,91 @@ func TestCardAtMirrorsLayout(t *testing.T) {
 	assert.False(t, ok)
 	_, _, ok = m.cardAt(59, 5) // gap between columns
 	assert.False(t, ok)
+}
+
+// dragTestModel is a two-column board with two cards in the first column
+// and one in the second, on a 120x40 terminal (colWidth 59, cards from row 5).
+func dragTestModel() *model {
+	return &model{
+		width:   120,
+		height:  40,
+		columns: []board.Column{{ID: "dev", Name: "Dev"}, {ID: "done", Name: "Done"}},
+		cards: map[string][]*board.Card{
+			"dev":  {{ID: "a", Column: "dev"}, {ID: "b", Column: "dev"}},
+			"done": {{ID: "c", Column: "done"}},
+		},
+		scroll: map[string]int{},
+	}
+}
+
+func TestDragAndDropMovesCard(t *testing.T) {
+	t.Parallel()
+
+	m := dragTestModel()
+
+	// Pressing a card selects it and arms a drag candidate.
+	_, cmd := m.handleClick(tea.MouseClickMsg{X: 5, Y: 5, Button: tea.MouseLeft})
+	assert.Nil(t, cmd)
+	assert.Equal(t, "a", m.dragCardID)
+	assert.False(t, m.dragging)
+
+	// Motion while pressed turns the click into a drag targeting the
+	// column under the pointer.
+	m.handleMotion(tea.MouseMotionMsg{X: 65, Y: 5, Button: tea.MouseLeft})
+	assert.True(t, m.dragging)
+	assert.Equal(t, 1, m.dragCol)
+
+	// Releasing over the other column moves the card there.
+	_, cmd = m.handleRelease(tea.MouseReleaseMsg{X: 65, Y: 5, Button: tea.MouseLeft})
+	assert.NotNil(t, cmd, "drop on another column should move the card")
+	assert.False(t, m.dragging)
+	assert.Empty(t, m.dragCardID)
+	assert.Empty(t, m.lastClickCard, "a drag must not arm double-click attach")
+}
+
+func TestDragBackToOriginIsANoop(t *testing.T) {
+	t.Parallel()
+
+	m := dragTestModel()
+	_, _ = m.handleClick(tea.MouseClickMsg{X: 5, Y: 5, Button: tea.MouseLeft})
+	m.handleMotion(tea.MouseMotionMsg{X: 65, Y: 5, Button: tea.MouseLeft})
+
+	// Dropping the card back on its own column moves nothing.
+	_, cmd := m.handleRelease(tea.MouseReleaseMsg{X: 5, Y: 5, Button: tea.MouseLeft})
+	assert.Nil(t, cmd)
+	assert.False(t, m.dragging)
+}
+
+func TestReleaseWithoutMotionIsAClick(t *testing.T) {
+	t.Parallel()
+
+	m := dragTestModel()
+	_, _ = m.handleClick(tea.MouseClickMsg{X: 5, Y: 5, Button: tea.MouseLeft})
+
+	_, cmd := m.handleRelease(tea.MouseReleaseMsg{X: 5, Y: 5, Button: tea.MouseLeft})
+	assert.Nil(t, cmd)
+	assert.Equal(t, "a", m.lastClickCard, "a plain click still arms double-click attach")
+}
+
+func TestDigitKeysMoveCardToColumn(t *testing.T) {
+	t.Parallel()
+
+	m := dragTestModel()
+
+	// 2 moves the selected card (first column) to the second column.
+	_, cmd := m.handleKey(tea.KeyPressMsg{Code: '2', Text: "2"})
+	assert.NotNil(t, cmd)
+
+	// The card's own column and out-of-range columns are no-ops.
+	_, cmd = m.handleKey(tea.KeyPressMsg{Code: '1', Text: "1"})
+	assert.Nil(t, cmd)
+	_, cmd = m.handleKey(tea.KeyPressMsg{Code: '9', Text: "9"})
+	assert.Nil(t, cmd)
+
+	// No selected card: nothing to move.
+	m.cards = map[string][]*board.Card{}
+	_, cmd = m.handleKey(tea.KeyPressMsg{Code: '2', Text: "2"})
+	assert.Nil(t, cmd)
 }
 
 func TestPlusButtonAt(t *testing.T) {

--- a/pkg/board/tui/tui_test.go
+++ b/pkg/board/tui/tui_test.go
@@ -158,6 +158,68 @@ func TestDragBackToOriginIsANoop(t *testing.T) {
 	assert.False(t, m.dragging)
 }
 
+func TestDragJitterWithinCardStaysAClick(t *testing.T) {
+	t.Parallel()
+
+	m := dragTestModel()
+	_, _ = m.handleClick(tea.MouseClickMsg{X: 5, Y: 5, Button: tea.MouseLeft})
+
+	// Motion within the pressed card does not start a drag…
+	m.handleMotion(tea.MouseMotionMsg{X: 6, Y: 6, Button: tea.MouseLeft})
+	assert.False(t, m.dragging)
+
+	// …so the release is a plain click and double-click stays armed.
+	_, cmd := m.handleRelease(tea.MouseReleaseMsg{X: 6, Y: 6, Button: tea.MouseLeft})
+	assert.Nil(t, cmd)
+	assert.Equal(t, "a", m.lastClickCard)
+}
+
+func TestNonLeftReleaseDoesNotDrop(t *testing.T) {
+	t.Parallel()
+
+	m := dragTestModel()
+	_, _ = m.handleClick(tea.MouseClickMsg{X: 5, Y: 5, Button: tea.MouseLeft})
+	m.handleMotion(tea.MouseMotionMsg{X: 65, Y: 5, Button: tea.MouseLeft})
+
+	// A stray non-left release mid-drag neither drops nor cancels.
+	_, cmd := m.handleRelease(tea.MouseReleaseMsg{X: 65, Y: 5, Button: tea.MouseRight})
+	assert.Nil(t, cmd)
+	assert.True(t, m.dragging)
+}
+
+func TestDragCancelledByDialogAndKeys(t *testing.T) {
+	t.Parallel()
+
+	// A dialog opening mid-drag captures the release: the drag must not
+	// survive, or the next click would silently move a card.
+	m := dragTestModel()
+	_, _ = m.handleClick(tea.MouseClickMsg{X: 5, Y: 5, Button: tea.MouseLeft})
+	m.handleMotion(tea.MouseMotionMsg{X: 65, Y: 5, Button: tea.MouseLeft})
+	_ = m.openDialog(newHelpDialog())
+	assert.False(t, m.dragging)
+	assert.Empty(t, m.dragCardID)
+
+	// A key press cancels a drag too (esc cancels).
+	m = dragTestModel()
+	_, _ = m.handleClick(tea.MouseClickMsg{X: 5, Y: 5, Button: tea.MouseLeft})
+	m.handleMotion(tea.MouseMotionMsg{X: 65, Y: 5, Button: tea.MouseLeft})
+	_, _ = m.handleKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+	assert.False(t, m.dragging)
+}
+
+func TestMoveCardResolvesByID(t *testing.T) {
+	t.Parallel()
+
+	m := dragTestModel()
+
+	// Moving a card to the column it already occupies is a no-op, wherever
+	// the selection points (the drop path resolves the card by ID).
+	assert.Nil(t, m.moveCard("c", 1), "card c already sits in column done")
+	assert.NotNil(t, m.moveCard("c", 0))
+	assert.Nil(t, m.moveCard("a", -1))
+	assert.Nil(t, m.moveCard("a", 2))
+}
+
 func TestReleaseWithoutMotionIsAClick(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/board/tui/view.go
+++ b/pkg/board/tui/view.go
@@ -289,9 +289,13 @@ func (m *model) renderColumn(idx int, col board.Column, colWidth, boardHeight in
 		lines = append(lines, styles.MutedStyle.Render(fmt.Sprintf(" … %d more", len(cards)-end)))
 	}
 
-	// Selected column: white; others: a dimmed secondary border.
+	// Selected column: white; drag drop target: success green; others: a
+	// dimmed secondary border.
 	borderColor := darken(styles.BorderSecondary, 0.35)
-	if selected {
+	switch {
+	case m.dragging && idx == m.dragCol && idx != m.selCol:
+		borderColor = styles.Success
+	case selected:
 		borderColor = styles.White
 	}
 	return styles.BaseStyle.
@@ -407,6 +411,13 @@ func (m *model) renderStatus(status board.CardStatus, width int) string {
 }
 
 func (m *model) renderFooter() string {
+	if m.dragging {
+		if m.dragCol >= 0 && m.dragCol != m.selCol {
+			name := strings.TrimSpace(m.columns[m.dragCol].Emoji + " " + m.columns[m.dragCol].Name)
+			return styles.SuccessStyle.Render(" Release to move the card to " + toolcommon.TruncateText(sanitize(name), max(m.width-31, 1)))
+		}
+		return styles.MutedStyle.Render(" Drop the card on another column to move it")
+	}
 	if m.flash != "" {
 		style := styles.SuccessStyle
 		if m.isErr {
@@ -418,7 +429,7 @@ func (m *model) renderFooter() string {
 	// Same look as the main TUI's status bar: highlighted keys with secondary
 	// descriptions on the left, muted context on the right.
 	hints := []string{
-		"n", "new", "⏎", "attach", "d", "diff", "o", "editor", "s", "shell", "[ ]", "move",
+		"n", "new", "⏎", "attach", "d", "diff", "o", "editor", "s", "shell", "[ ] 1-9", "move",
 		"x", "delete", "p", "projects", "e", "prompt", "?", "help", "q", "quit",
 	}
 	parts := make([]string, 0, len(hints)/2)

--- a/pkg/board/tui/view.go
+++ b/pkg/board/tui/view.go
@@ -412,9 +412,10 @@ func (m *model) renderStatus(status board.CardStatus, width int) string {
 
 func (m *model) renderFooter() string {
 	if m.dragging {
-		if m.dragCol >= 0 && m.dragCol != m.selCol {
+		if m.dragCol >= 0 && m.dragCol < len(m.columns) && m.dragCol != m.selCol {
+			const hint = " Release to move the card to "
 			name := strings.TrimSpace(m.columns[m.dragCol].Emoji + " " + m.columns[m.dragCol].Name)
-			return styles.SuccessStyle.Render(" Release to move the card to " + toolcommon.TruncateText(sanitize(name), max(m.width-31, 1)))
+			return styles.SuccessStyle.Render(hint + toolcommon.TruncateText(sanitize(name), max(m.width-len(hint)-1, 1)))
 		}
 		return styles.MutedStyle.Render(" Drop the card on another column to move it")
 	}


### PR DESCRIPTION
The Kanban board previously only let you step a card one column at a time with `[` and `]`. For boards with many columns this is tedious, and there was no way to reposition a card at all without a keyboard.

This PR adds two complementary shortcuts. Pressing a digit key 1–9 moves the selected card directly to that column number (`MoveTo` binding), while `[`/`]` continue to do single-step moves. Moving a card forward still triggers the destination column's prompt via the existing `App.MoveCard` engine path, so the workflow is unchanged. For mouse users, pressing on a card and dragging it over another column highlights that column's border in green and shows a "Release to move the card to \<column\>" hint in the footer; releasing the button completes the move. Drops on the origin column or outside the board are no-ops, and motion jitter within the pressed cell is treated as a click rather than a drag.

A second commit hardens the edge cases surfaced during review: drag state is cleared whenever a dialog opens or a key is pressed, and it is re-validated on every board refresh so a swallowed mouse-release cannot leave stale state that fires on a later click. The drop resolves the target by card ID rather than position, so a refresh mid-drag cannot move the wrong card. Non-left-button releases are ignored, and `renderFooter` bounds-checks the drop-target column index before accessing it.