### PR TITLE
feat(board): fade dragged card immediately and fix stale drag state

### DIFF
--- a/pkg/board/tui/tui.go
+++ b/pkg/board/tui/tui.go
@@ -413,6 +413,9 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case attachReadyMsg:
+		// tea.ExecProcess leaves mouse mode: a drag in flight loses its
+		// release and must not leak into the gestures after detach.
+		m.resetDrag()
 		return m, tea.ExecProcess(msg.cmd, func(err error) tea.Msg { return attachDoneMsg{err: err} })
 
 	case attachFailedMsg:
@@ -715,6 +718,7 @@ func (m *model) handleClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 	col, row, ok := m.cardAt(msg.X, msg.Y)
 	if !ok {
 		m.lastClickCard = ""
+		m.resetDrag() // a lost release must not leak into this gesture
 		return m, nil
 	}
 	m.selCol, m.selRow = col, row
@@ -732,7 +736,9 @@ func (m *model) handleClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 	m.lastClickCard = card.ID
 	m.lastClickTime = time.Now()
 	// The pressed card is a drag candidate: motion before the release turns
-	// the click into a drag (see handleMotion/handleRelease).
+	// the click into a drag (see handleMotion/handleRelease). Rearming also
+	// clears any drag whose release was lost (e.g. to tea.ExecProcess).
+	m.resetDrag()
 	m.dragCardID = card.ID
 	m.dragCol = col
 	return m, nil
@@ -774,7 +780,7 @@ func (m *model) handleRelease(msg tea.MouseReleaseMsg) (tea.Model, tea.Cmd) {
 	m.lastClickCard = "" // a completed drag must not arm double-click
 	if col, ok := m.columnAt(msg.X, msg.Y); ok {
 		dst = col
-	}
+	} // else: keep the last motion's target — the release landed in a gutter
 	cmd := m.moveCard(cardID, dst)
 	return m, cmd
 }
@@ -790,8 +796,13 @@ func (m *model) resetDrag() {
 
 // handleWheel moves the selection through the column under the cursor, so
 // scrolling anywhere on a column walks its cards (the scroll window follows
-// the selection). Wheel events outside the columns area are ignored.
+// the selection). Wheel events outside the columns area, or during a drag
+// (they would move the selection and scroll the card under the pointer),
+// are ignored.
 func (m *model) handleWheel(msg tea.MouseWheelMsg) {
+	if m.dragCardID != "" {
+		return
+	}
 	col, ok := m.columnAt(msg.X, msg.Y)
 	if !ok {
 		return

--- a/pkg/board/tui/tui.go
+++ b/pkg/board/tui/tui.go
@@ -739,18 +739,13 @@ func (m *model) handleClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 }
 
 // handleMotion tracks a pressed card being dragged. Cell-motion mode only
-// reports motion while a button is held, so motion after a card press
-// means a drag; the column under the pointer becomes the drop target.
+// reports motion while a button is held, so any motion after a card press
+// starts the drag — the card fades immediately — and the column under the
+// pointer becomes the drop target. Jitter is sorted out on release: a drop
+// back on the pressed card stays a plain click (see handleRelease).
 func (m *model) handleMotion(msg tea.MouseMotionMsg) {
 	if m.dragCardID == "" || msg.Button != tea.MouseLeft {
 		return
-	}
-	// Jitter within the pressed card stays a click (double-click keeps
-	// working): the drag starts once the pointer leaves the card.
-	if !m.dragging {
-		if col, row, ok := m.cardAt(msg.X, msg.Y); ok && col == m.selCol && row == m.selRow {
-			return
-		}
 	}
 	m.dragging = true
 	if col, ok := m.columnAt(msg.X, msg.Y); ok {
@@ -761,8 +756,9 @@ func (m *model) handleMotion(msg tea.MouseMotionMsg) {
 }
 
 // handleRelease completes a drag-and-drop: dropping a card on another
-// column moves it there. A release without prior motion is a plain click,
-// already handled by handleClick.
+// column moves it there. A release without prior motion, or back on the
+// pressed card itself, is a plain click — jitter while pressed must not
+// break double-click-to-attach.
 func (m *model) handleRelease(msg tea.MouseReleaseMsg) (tea.Model, tea.Cmd) {
 	if msg.Button != tea.MouseLeft {
 		return m, nil
@@ -771,6 +767,9 @@ func (m *model) handleRelease(msg tea.MouseReleaseMsg) (tea.Model, tea.Cmd) {
 	m.resetDrag()
 	if !wasDragging {
 		return m, nil
+	}
+	if col, row, ok := m.cardAt(msg.X, msg.Y); ok && m.cards[m.columns[col].ID][row].ID == cardID {
+		return m, nil // dropped where it was picked up: a click
 	}
 	m.lastClickCard = "" // a completed drag must not arm double-click
 	if col, ok := m.columnAt(msg.X, msg.Y); ok {

--- a/pkg/board/tui/tui_test.go
+++ b/pkg/board/tui/tui_test.go
@@ -228,6 +228,48 @@ func TestDragCancelledByDialogAndKeys(t *testing.T) {
 	assert.False(t, m.dragging)
 }
 
+func TestStaleDragDoesNotLeakIntoNextGesture(t *testing.T) {
+	t.Parallel()
+
+	// A drag whose release was lost (tea.ExecProcess leaves mouse mode)
+	// must not turn the next click into a card move.
+	m := dragTestModel()
+	_, _ = m.handleClick(tea.MouseClickMsg{X: 5, Y: 5, Button: tea.MouseLeft})
+	m.handleMotion(tea.MouseMotionMsg{X: 65, Y: 5, Button: tea.MouseLeft})
+
+	// Next gesture: click on empty column space…
+	_, cmd := m.handleClick(tea.MouseClickMsg{X: 65, Y: 5 + 2*cardHeight, Button: tea.MouseLeft})
+	assert.Nil(t, cmd)
+	assert.False(t, m.dragging)
+	_, cmd = m.handleRelease(tea.MouseReleaseMsg{X: 65, Y: 5 + 2*cardHeight, Button: tea.MouseLeft})
+	assert.Nil(t, cmd, "a stale drag must not move a card on a plain click")
+
+	// …or on another card: the press rearms a clean candidate.
+	m = dragTestModel()
+	_, _ = m.handleClick(tea.MouseClickMsg{X: 5, Y: 5, Button: tea.MouseLeft})
+	m.handleMotion(tea.MouseMotionMsg{X: 65, Y: 5, Button: tea.MouseLeft})
+	_, _ = m.handleClick(tea.MouseClickMsg{X: 65, Y: 5, Button: tea.MouseLeft})
+	assert.False(t, m.dragging)
+	assert.Equal(t, "c", m.dragCardID)
+	_, cmd = m.handleRelease(tea.MouseReleaseMsg{X: 65, Y: 5, Button: tea.MouseLeft})
+	assert.Nil(t, cmd)
+}
+
+func TestWheelIgnoredWhileCardPressed(t *testing.T) {
+	t.Parallel()
+
+	m := dragTestModel()
+	_, _ = m.handleClick(tea.MouseClickMsg{X: 5, Y: 5, Button: tea.MouseLeft})
+	m.handleMotion(tea.MouseMotionMsg{X: 65, Y: 5, Button: tea.MouseLeft})
+
+	// A wheel event mid-drag must not move the selection: the drop-target
+	// highlight keys off selCol and the scroll would shift cards under the
+	// pointer.
+	m.handleWheel(tea.MouseWheelMsg{X: 65, Y: 5, Button: tea.MouseWheelDown})
+	assert.Equal(t, 0, m.selCol)
+	assert.Equal(t, 0, m.selRow)
+}
+
 func TestMoveCardResolvesByID(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/board/tui/tui_test.go
+++ b/pkg/board/tui/tui_test.go
@@ -145,6 +145,24 @@ func TestDragAndDropMovesCard(t *testing.T) {
 	assert.Empty(t, m.lastClickCard, "a drag must not arm double-click attach")
 }
 
+func TestDraggedCardRendersFaded(t *testing.T) {
+	t.Parallel()
+
+	m := dragTestModel()
+	card := m.cards["dev"][0]
+
+	idle := m.renderCard(card, 30, true)
+	m.dragCardID, m.dragging = card.ID, true
+	assert.NotEqual(t, idle, m.renderCard(card, 30, true),
+		"the dragged card must be visually distinct")
+
+	// Other cards keep their normal look while a drag is in progress.
+	other := m.cards["dev"][1]
+	during := m.renderCard(other, 30, false)
+	m.resetDrag()
+	assert.Equal(t, during, m.renderCard(other, 30, false))
+}
+
 func TestDragBackToOriginIsANoop(t *testing.T) {
 	t.Parallel()
 
@@ -164,13 +182,16 @@ func TestDragJitterWithinCardStaysAClick(t *testing.T) {
 	m := dragTestModel()
 	_, _ = m.handleClick(tea.MouseClickMsg{X: 5, Y: 5, Button: tea.MouseLeft})
 
-	// Motion within the pressed card does not start a drag…
+	// Motion within the pressed card starts the drag right away, so the
+	// pickup is visible without waiting for the pointer to leave the card…
 	m.handleMotion(tea.MouseMotionMsg{X: 6, Y: 6, Button: tea.MouseLeft})
-	assert.False(t, m.dragging)
+	assert.True(t, m.dragging)
 
-	// …so the release is a plain click and double-click stays armed.
+	// …but releasing back on the same card is a plain click and
+	// double-click stays armed.
 	_, cmd := m.handleRelease(tea.MouseReleaseMsg{X: 6, Y: 6, Button: tea.MouseLeft})
 	assert.Nil(t, cmd)
+	assert.False(t, m.dragging)
 	assert.Equal(t, "a", m.lastClickCard)
 }
 

--- a/pkg/board/tui/view.go
+++ b/pkg/board/tui/view.go
@@ -306,10 +306,26 @@ func (m *model) renderColumn(idx int, col board.Column, colWidth, boardHeight in
 		Render(strings.Join(lines, "\n"))
 }
 
+// dragFade is how much a dragged card's colors blend toward the
+// background: enough to clearly read as "in flight", still legible.
+const dragFade = 0.55
+
+// blend interpolates c1 toward c2 by the given fraction (0..1).
+func blend(c1, c2 color.Color, f float64) color.Color {
+	r1, g1, b1 := styles.ColorToRGB(c1)
+	r2, g2, b2 := styles.ColorToRGB(c2)
+	return styles.RGBToColor(r1+(r2-r1)*f, g1+(g2-g1)*f, b1+(b2-b1)*f)
+}
+
 // darken scales a color towards black by the given fraction (0..1).
 func darken(c color.Color, f float64) color.Color {
-	r, g, b := styles.ColorToRGB(c)
-	return styles.RGBToColor(r*(1-f), g*(1-f), b*(1-f))
+	return blend(c, lipgloss.Color("#000000"), f)
+}
+
+// fade blends a color toward the theme background, approximating the
+// transparency of a dragged card on terminals that cannot alpha-blend.
+func fade(c color.Color) color.Color {
+	return blend(c, styles.Background, dragFade)
 }
 
 // columnHeaderColor interpolates a column's rule color from the theme's
@@ -359,6 +375,15 @@ func (m *model) renderCard(card *board.Card, colInnerWidth int, selected bool) s
 		borderColor = styles.BorderPrimary
 	}
 
+	// The card being dragged fades toward the background — a visible
+	// "picked up" state while the pointer carries it to another column.
+	dragged := m.dragging && card.ID == m.dragCardID
+	if dragged {
+		titleStyle = titleStyle.Foreground(fade(titleStyle.GetForeground()))
+		accent = fade(accent)
+		borderColor = fade(borderColor)
+	}
+
 	title1, title2 := splitTitle(sanitize(card.Title), textWidth)
 	project := styles.BaseStyle.Foreground(accent).Render(toolcommon.TruncateText(sanitize("◆ "+card.Project), textWidth))
 
@@ -366,7 +391,7 @@ func (m *model) renderCard(card *board.Card, colInnerWidth int, selected bool) s
 		titleStyle.Render(title1),
 		titleStyle.Render(title2),
 		project,
-		m.renderStatus(card.Status, textWidth),
+		m.renderStatus(card.Status, textWidth, dragged),
 	}, "\n")
 
 	return styles.BaseStyle.
@@ -412,8 +437,12 @@ func statusColor(status board.CardStatus) color.Color {
 	}
 }
 
-func (m *model) renderStatus(status board.CardStatus, width int) string {
-	style := styles.BaseStyle.Foreground(statusColor(status))
+func (m *model) renderStatus(status board.CardStatus, width int, faded bool) string {
+	fg := statusColor(status)
+	if faded {
+		fg = fade(fg)
+	}
+	style := styles.BaseStyle.Foreground(fg)
 	spinner := spinnerFrames[m.frame%len(spinnerFrames)]
 	switch status {
 	case board.StatusStarting, board.StatusLoading, board.StatusAttaching:


### PR DESCRIPTION
When dragging a card on the board, there was no visual feedback during the drag itself — the card looked identical whether it was being moved or stationary, making it hard to tell that a drag was in progress. Additionally, the drag only started after the pointer had moved outside the card's bounds, which felt sluggish and meant a fast move could pick up the wrong card.

The card now begins fading toward the theme background on the first mouse motion while the button is pressed, not when the pointer crosses a boundary. New helpers in `pkg/board/tui/view.go` blend the card's title, project badge, status line, and border color toward the background, giving a clear "lifted" appearance. The click-vs-drag decision moved to release time: releasing the button over the card that was originally pressed counts as a plain click (so double-click-to-attach still works), while releasing anywhere else finalizes the move.

A follow-up fix resets drag state that was lost when `tea.ExecProcess` (the attach flow) consumed the mouse-release event, preventing a later plain click from silently moving a card. Wheel events are also ignored while a card is held down to avoid accidental column scrolls mid-drag.