### PR TITLE
fix: don't clobber attached runtime's cancel in RunSession/recallSession

### DIFF
--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -648,7 +648,13 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 		cancel()
 		return nil, ErrSessionBusy
 	}
-	runtimeSession.cancel = cancel
+	// Track the current stream's cancel so DeleteSession aborts it — but only
+	// for server-owned entries. Attached runtimes (done != nil) keep their
+	// attach-lifetime cancel: DELETE must cancel the attach context, not the
+	// in-flight stream, which WaitStopped waits on to end naturally.
+	if runtimeSession.done == nil {
+		runtimeSession.cancel = cancel
+	}
 
 	// Apply the model override (if any) before persisting the user
 	// messages so that an invalid ref does not leave an orphaned user
@@ -875,7 +881,11 @@ func (sm *SessionManager) recallSession(ctx context.Context, sessionID string, m
 		return err
 	}
 	rt.session = sess
-	rt.cancel = runCancel
+	// Same rule as RunSession: never clobber an attached runtime's
+	// attach-lifetime cancel with a per-stream cancel.
+	if rt.done == nil {
+		rt.cancel = runCancel
+	}
 	sm.mux.Unlock()
 
 	go func() {


### PR DESCRIPTION
`go test -race ./pkg/server/` made `TestAttachedServer_DeleteWithWaitBlocksUntilStreamStops` fail roughly 25% of runs with "DELETE returned before the stream goroutine exited". The race was introduced by commit 064a464a0 ("fix: wake idle sessions on tool recall"), which unconditionally overwrote `runtimeSession.cancel` in `SessionManager.RunSession` and `rt.cancel` in `recallSession` with the per-stream cancel. `DeleteSession` then aborted the in-flight stream instead of cancelling the attach context, so `WaitStopped` returned as soon as the aborted stream unwound — breaking the graceful-delete contract established in e73a2c074 (`DELETE /api/sessions/:id?wait=true` must block until the stream ends naturally).

The fix guards both cancel assignments with `done == nil`. The `done` channel is only set by `AttachRuntime`, so server-owned sessions continue to get the abort-on-delete behaviour from 064a464a0, while attached (TUI-owned) sessions keep their attach-lifetime cancel intact. The previously flaky test now passes 50/50 under `-race`, and a full `go test -race ./...` reports zero data races.