### PR TITLE
fix(userconfig): harden global config file management

### DIFF
--- a/cmd/root/alias.go
+++ b/cmd/root/alias.go
@@ -138,11 +138,6 @@ func runAliasAddCommand(cmd *cobra.Command, args []string, flags *aliasAddFlags)
 	name := args[0]
 	agentPath := args[1]
 
-	cfg, err := userconfig.Load()
-	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
-	}
-
 	absAgentPath, err := pathx.ExpandHomeDir(agentPath)
 	if err != nil {
 		return err
@@ -166,13 +161,10 @@ func runAliasAddCommand(cmd *cobra.Command, args []string, flags *aliasAddFlags)
 	}
 
 	// Store the alias
-	if err := cfg.SetAlias(name, alias); err != nil {
+	if err := userconfig.Update(func(cfg *userconfig.Config) error {
+		return cfg.SetAlias(name, alias)
+	}); err != nil {
 		return err
-	}
-
-	// Save to file
-	if err := cfg.Save(); err != nil {
-		return fmt.Errorf("failed to save config: %w", err)
 	}
 
 	out.Printf("Alias '%s' created successfully\n", name)
@@ -293,17 +285,13 @@ func runAliasRemoveCommand(cmd *cobra.Command, args []string) (commandErr error)
 	out := cli.NewPrinter(cmd.OutOrStdout())
 	name := args[0]
 
-	cfg, err := userconfig.Load()
-	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
-	}
-
-	if !cfg.DeleteAlias(name) {
-		return fmt.Errorf("alias '%s' not found", name)
-	}
-
-	if err := cfg.Save(); err != nil {
-		return fmt.Errorf("failed to save config: %w", err)
+	if err := userconfig.Update(func(cfg *userconfig.Config) error {
+		if !cfg.DeleteAlias(name) {
+			return fmt.Errorf("alias '%s' not found", name)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	out.Printf("Alias '%s' removed successfully\n", name)

--- a/cmd/root/doctor.go
+++ b/cmd/root/doctor.go
@@ -30,15 +30,31 @@ const (
 	dmrStatusUnreachable  = "unreachable"
 )
 
+const (
+	userConfigStatusOK      = "ok"
+	userConfigStatusInvalid = "invalid"
+)
+
 // doctorReport is the machine-readable form of the diagnosis. Secret values
 // are never included, only where each one was found.
 type doctorReport struct {
+	UserConfig    doctorUserConfigStatus `json:"user_config"`
 	Providers     []doctorProviderStatus `json:"providers"`
 	DMR           doctorDMRStatus        `json:"dmr"`
 	ModelsGateway string                 `json:"models_gateway,omitempty"`
 	AutoModel     doctorAutoModel        `json:"auto_model"`
 	AgentFile     *doctorAgentFileStatus `json:"agent_file,omitempty"`
 	Issues        []string               `json:"issues,omitempty"`
+}
+
+// doctorUserConfigStatus reports whether the user-level config file can be
+// loaded: an unreadable file is silently ignored at run time (settings and
+// aliases fall back to defaults), which is exactly the kind of surprise the
+// doctor exists to surface.
+type doctorUserConfigStatus struct {
+	Path   string `json:"path"`
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
 }
 
 type doctorProviderStatus struct {
@@ -130,6 +146,7 @@ Exits with a non-zero status when an issue would prevent an agent from running.`
 	loadUserConfig := flags.loadUserConfig
 	if loadUserConfig == nil {
 		loadUserConfig = userconfig.Load
+		flags.loadUserConfig = loadUserConfig
 	}
 	addGatewayFlags(cmd, &flags.runConfig, loadUserConfig)
 
@@ -188,6 +205,15 @@ func (f *doctorFlags) buildReport(ctx context.Context, agentRef string) (*doctor
 	env := environment.NewMultiProvider(providers...)
 
 	report := &doctorReport{ModelsGateway: f.runConfig.ModelsGateway}
+
+	report.UserConfig = doctorUserConfigStatus{Path: userconfig.Path(), Status: userConfigStatusOK}
+	if _, err := f.loadUserConfig(); err != nil {
+		report.UserConfig.Status = userConfigStatusInvalid
+		report.UserConfig.Error = err.Error()
+		report.Issues = append(report.Issues, fmt.Sprintf(
+			"the user config file %s cannot be parsed and is ignored (settings and aliases are unavailable): %v",
+			report.UserConfig.Path, err))
+	}
 
 	credFound := map[string]bool{}
 	primaryEnvVar := map[string]string{}
@@ -398,7 +424,14 @@ func describeDMRStatus(status string) string {
 }
 
 func printDoctorReport(w io.Writer, report *doctorReport) {
-	fmt.Fprintln(w, "Model provider credentials")
+	fmt.Fprintln(w, "User configuration")
+	if report.UserConfig.Status == userConfigStatusOK {
+		fmt.Fprintf(w, "  %s: ok\n", report.UserConfig.Path)
+	} else {
+		fmt.Fprintf(w, "  %s: %s\n", report.UserConfig.Path, report.UserConfig.Error)
+	}
+
+	fmt.Fprintln(w, "\nModel provider credentials")
 	tw := tabwriter.NewWriter(w, 0, 2, 3, ' ', 0)
 	fmt.Fprintln(tw, "  PROVIDER\tSTATUS\tCREDENTIAL\tSOURCE")
 	for _, p := range report.Providers {

--- a/cmd/root/doctor_test.go
+++ b/cmd/root/doctor_test.go
@@ -183,6 +183,22 @@ func TestDoctorCommand_DMRPrefersLocalModel(t *testing.T) {
 	assert.Contains(t, output, "No issues found.")
 }
 
+func TestDoctorCommand_InvalidUserConfig(t *testing.T) {
+	t.Parallel()
+
+	output, err := executeDoctor(t, nil,
+		withDoctorTestEnv(map[string]string{"ANTHROPIC_API_KEY": "sk-secret"}, []string{"ai/qwen3:latest"}, nil),
+		func(f *doctorFlags) {
+			f.loadUserConfig = func() (*userconfig.Config, error) {
+				return nil, errors.New("failed to parse config file")
+			}
+		})
+
+	require.Error(t, err)
+	assert.Contains(t, output, "User configuration")
+	assert.Contains(t, output, "cannot be parsed")
+}
+
 func TestDoctorCommand_DefaultModelWithoutCredential(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/root/sandbox_cmd.go
+++ b/cmd/root/sandbox_cmd.go
@@ -1,6 +1,7 @@
 package root
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -10,6 +11,10 @@ import (
 	"github.com/docker/docker-agent/pkg/telemetry"
 	"github.com/docker/docker-agent/pkg/userconfig"
 )
+
+// errSandboxHostAbsent aborts a deny update before the save so removing an
+// already-absent host never rewrites the config file.
+var errSandboxHostAbsent = errors.New("host not on the allowlist")
 
 // newSandboxCmd assembles the `docker agent sandbox` subcommand
 // group. The group is intentionally narrow today: it only manages
@@ -80,17 +85,13 @@ func runSandboxAllowCommand(cmd *cobra.Command, args []string) (commandErr error
 
 	out := cli.NewPrinter(cmd.OutOrStdout())
 
-	cfg, err := userconfig.Load()
-	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
-	}
-
-	added, err := cfg.AddSandboxHosts(args...)
-	if err != nil {
+	var added []string
+	if err := userconfig.Update(func(cfg *userconfig.Config) error {
+		var err error
+		added, err = cfg.AddSandboxHosts(args...)
 		return err
-	}
-	if err := cfg.Save(); err != nil {
-		return fmt.Errorf("failed to save config: %w", err)
+	}); err != nil {
+		return err
 	}
 
 	if len(added) == 0 {
@@ -116,19 +117,19 @@ func runSandboxDenyCommand(cmd *cobra.Command, args []string) (commandErr error)
 	out := cli.NewPrinter(cmd.OutOrStdout())
 	host := strings.TrimSpace(args[0])
 
-	cfg, err := userconfig.Load()
-	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
-	}
-
-	if !cfg.RemoveSandboxHost(host) {
-		// Idempotent: removing an already-absent host is a no-op so
-		// scripts can `sandbox deny <host>` without first checking.
-		out.Printf("Host %q is not on the persistent sandbox allowlist.\n", host)
+	if err := userconfig.Update(func(cfg *userconfig.Config) error {
+		if !cfg.RemoveSandboxHost(host) {
+			return errSandboxHostAbsent
+		}
 		return nil
-	}
-	if err := cfg.Save(); err != nil {
-		return fmt.Errorf("failed to save config: %w", err)
+	}); err != nil {
+		if errors.Is(err, errSandboxHostAbsent) {
+			// Idempotent: removing an already-absent host is a no-op so
+			// scripts can `sandbox deny <host>` without first checking.
+			out.Printf("Host %q is not on the persistent sandbox allowlist.\n", host)
+			return nil
+		}
+		return err
 	}
 	out.Printf("Removed %s from the persistent sandbox allowlist.\n", host)
 	return nil

--- a/docs/getting-started/set-up-a-model/index.md
+++ b/docs/getting-started/set-up-a-model/index.md
@@ -74,6 +74,9 @@ $ docker agent doctor
 ```
 
 ```text
+User configuration
+  ~/.config/cagent/config.yaml: ok
+
 Model provider credentials
   PROVIDER    STATUS    CREDENTIAL          SOURCE
   anthropic   found     ANTHROPIC_API_KEY   environment
@@ -142,6 +145,9 @@ $ docker agent doctor
 ```
 
 ```text
+User configuration
+  ~/.config/cagent/config.yaml: ok
+
 Model provider credentials
   PROVIDER    STATUS    CREDENTIAL          SOURCE
   anthropic   not set   ANTHROPIC_API_KEY   -

--- a/pkg/board/app.go
+++ b/pkg/board/app.go
@@ -116,7 +116,11 @@ func (a *App) SetColumnPrompt(colID, prompt string) error {
 }
 
 // saveConfigLocked persists the projects and columns to the global config
-// file. Callers must hold a.mu.
+// file. Callers must hold a.mu. The board section is written from the
+// board's in-memory view (authoritative for projects and columns) onto the
+// freshest on-disk config, so changes other processes made to unrelated
+// sections while the board was open are never overwritten; a.config is then
+// swapped to that fresh copy.
 func (a *App) saveConfigLocked() error {
 	board := &userconfig.Board{}
 	if a.config.Board != nil {
@@ -132,8 +136,11 @@ func (a *App) saveConfigLocked() error {
 			board.Columns = append(board.Columns, userconfig.BoardColumn{ID: c.ID, Name: c.Name, Emoji: c.Emoji, Prompt: c.Prompt})
 		}
 	}
-	a.config.Board = board
-	return a.config.Save()
+	return userconfig.Update(func(cfg *userconfig.Config) error {
+		cfg.Board = board
+		a.config = cfg
+		return nil
+	})
 }
 
 // Projects returns the configured projects.

--- a/pkg/config/resolve.go
+++ b/pkg/config/resolve.go
@@ -43,6 +43,7 @@ func ResolveAlias(agentFilename string) *userconfig.Alias {
 
 	cfg, err := userconfig.Load()
 	if err != nil {
+		slog.Warn("Failed to load user config; aliases are unavailable", "error", err)
 		return nil
 	}
 
@@ -191,6 +192,8 @@ func resolve(agentFilename string) (string, error) {
 			slog.Debug("Resolved alias", "alias", agentFilename, "path", alias.Path)
 			agentFilename = alias.Path
 		}
+	} else {
+		slog.Warn("Failed to load user config; aliases are unavailable", "error", err)
 	}
 
 	// Built-in agent names (e.g. "default", "coder") are either user defined aliases or embedded agents

--- a/pkg/environment/default.go
+++ b/pkg/environment/default.go
@@ -59,8 +59,11 @@ func DefaultSources() []Source {
 	// explicit sources so a user-supplied value always wins.
 	sources = append(sources, Source{Name: "chatgpt-login", Provider: NewChatGPTLoginProvider()})
 
-	// Add credential helper provider if configured
-	if cfg, err := userconfig.Load(); err == nil && cfg.CredentialHelper != nil && cfg.CredentialHelper.Command != "" {
+	// Add credential helper provider if configured. A broken user config is
+	// only logged: the rest of the source chain must keep working.
+	if cfg, err := userconfig.Load(); err != nil {
+		slog.Warn("Ignoring unreadable user config for credential helper", "path", userconfig.Path(), "error", err)
+	} else if cfg.CredentialHelper != nil && cfg.CredentialHelper.Command != "" {
 		sources = append(sources, Source{
 			Name:     "credential-helper",
 			Provider: NewCredentialHelperProvider(cfg.CredentialHelper.Command, cfg.CredentialHelper.Args...),

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -430,16 +430,14 @@ func (m *appModel) handleToggleSplitDiff() (tea.Model, tea.Cmd) {
 // config without blocking the UI. Errors are logged but otherwise ignored
 // because losing the persistence is non-fatal.
 func persistSplitDiffView(enabled bool) {
-	cfg, err := userconfig.Load()
+	err := userconfig.Update(func(cfg *userconfig.Config) error {
+		if cfg.Settings == nil {
+			cfg.Settings = &userconfig.Settings{}
+		}
+		cfg.Settings.SplitDiffView = &enabled
+		return nil
+	})
 	if err != nil {
-		slog.Warn("Failed to load userconfig for split diff toggle", "error", err)
-		return
-	}
-	if cfg.Settings == nil {
-		cfg.Settings = &userconfig.Settings{}
-	}
-	cfg.Settings.SplitDiffView = &enabled
-	if err := cfg.Save(); err != nil {
 		slog.Warn("Failed to persist split diff setting to userconfig", "error", err)
 	}
 }
@@ -843,31 +841,29 @@ func layoutSettingsFromConfig(l userconfig.LayoutSettings) messages.LayoutSettin
 // saveLayoutToUserConfig persists layout settings to the user config file.
 // Default settings clear the layout entry to keep the config file minimal.
 func saveLayoutToUserConfig(s messages.LayoutSettings) error {
-	cfg, err := userconfig.Load()
-	if err != nil {
-		return err
-	}
-	if cfg.Settings == nil {
-		cfg.Settings = &userconfig.Settings{}
-	}
+	return userconfig.Update(func(cfg *userconfig.Config) error {
+		if cfg.Settings == nil {
+			cfg.Settings = &userconfig.Settings{}
+		}
 
-	if s == (messages.LayoutSettings{SidebarPosition: messages.SidebarRight}) {
-		cfg.Settings.Layout = nil
-		return cfg.Save()
-	}
+		if s == (messages.LayoutSettings{SidebarPosition: messages.SidebarRight}) {
+			cfg.Settings.Layout = nil
+			return nil
+		}
 
-	position := string(s.SidebarPosition)
-	if s.SidebarPosition == messages.SidebarRight {
-		position = ""
-	}
-	cfg.Settings.Layout = &userconfig.LayoutSettings{
-		SidebarPosition: position,
-		HideUsage:       s.HideUsage,
-		HideAgents:      s.HideAgents,
-		HideTools:       s.HideTools,
-		HideTodos:       s.HideTodos,
-	}
-	return cfg.Save()
+		position := string(s.SidebarPosition)
+		if s.SidebarPosition == messages.SidebarRight {
+			position = ""
+		}
+		cfg.Settings.Layout = &userconfig.LayoutSettings{
+			SidebarPosition: position,
+			HideUsage:       s.HideUsage,
+			HideAgents:      s.HideAgents,
+			HideTools:       s.HideTools,
+			HideTodos:       s.HideTodos,
+		}
+		return nil
+	})
 }
 
 // handleColorSchemeChange reacts to a terminal light/dark report (a DEC mode

--- a/pkg/tui/styles/theme.go
+++ b/pkg/tui/styles/theme.go
@@ -488,23 +488,20 @@ func UserThemeExists(ref string) bool {
 // SaveThemeToUserConfig persists the theme reference to the user config file.
 // If themeRef equals DefaultThemeRef, the setting is cleared (empty string).
 func SaveThemeToUserConfig(themeRef string) error {
-	cfg, err := userconfig.Load()
+	err := userconfig.Update(func(cfg *userconfig.Config) error {
+		if cfg.Settings == nil {
+			cfg.Settings = &userconfig.Settings{}
+		}
+
+		// Clear the setting if using the default theme
+		if themeRef == DefaultThemeRef {
+			cfg.Settings.Theme = ""
+		} else {
+			cfg.Settings.Theme = themeRef
+		}
+		return nil
+	})
 	if err != nil {
-		return fmt.Errorf("loading user config: %w", err)
-	}
-
-	if cfg.Settings == nil {
-		cfg.Settings = &userconfig.Settings{}
-	}
-
-	// Clear the setting if using the default theme
-	if themeRef == DefaultThemeRef {
-		cfg.Settings.Theme = ""
-	} else {
-		cfg.Settings.Theme = themeRef
-	}
-
-	if err := cfg.Save(); err != nil {
 		return fmt.Errorf("saving user config: %w", err)
 	}
 

--- a/pkg/tui/tabs.go
+++ b/pkg/tui/tabs.go
@@ -65,7 +65,7 @@ func (m *appModel) restoreTabs(
 
 	var savedTabs []tuistate.TabEntry
 	var savedActiveID string
-	if *userconfig.Get().RestoreTabs {
+	if userconfig.Get().GetRestoreTabs() {
 		savedTabs, savedActiveID, _ = ts.GetTabs(ctx)
 	}
 

--- a/pkg/userconfig/lock.go
+++ b/pkg/userconfig/lock.go
@@ -1,0 +1,45 @@
+package userconfig
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	lockTimeout       = 5 * time.Second
+	lockRetryInterval = 20 * time.Millisecond
+)
+
+// acquireFileLock takes an exclusive advisory lock on path, waiting up to
+// lockTimeout for another process to release it. The lock serializes
+// read-modify-write cycles on the config file across processes so concurrent
+// writers (TUI toggles, alias and sandbox commands, the board) cannot
+// overwrite each other's changes. The returned release function unlocks and
+// closes the lock file.
+func acquireFileLock(path string) (release func(), err error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("create config directory: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open config lock: %w", err)
+	}
+	deadline := time.Now().Add(lockTimeout)
+	for {
+		err := flockExclusive(f)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			_ = f.Close()
+			return nil, fmt.Errorf("timed out waiting for config lock %s: %w", path, err)
+		}
+		time.Sleep(lockRetryInterval)
+	}
+	return func() {
+		flockRelease(f)
+		_ = f.Close()
+	}, nil
+}

--- a/pkg/userconfig/lock_unix.go
+++ b/pkg/userconfig/lock_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package userconfig
+
+import (
+	"os"
+	"syscall"
+)
+
+func flockExclusive(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+}
+
+func flockRelease(f *os.File) {
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/pkg/userconfig/lock_windows.go
+++ b/pkg/userconfig/lock_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package userconfig
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func flockExclusive(f *os.File) error {
+	return windows.LockFileEx(windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0, 1, 0, &windows.Overlapped{})
+}
+
+func flockRelease(f *os.File) {
+	_ = windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, &windows.Overlapped{})
+}

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -94,6 +94,9 @@ type Settings struct {
 	// Layout customizes the TUI chat layout (sidebar position and which
 	// sidebar sections are visible). Managed via the /custom command.
 	Layout *LayoutSettings `yaml:"layout,omitempty"`
+	// Extra preserves settings keys this version does not know about (e.g.
+	// written by a newer docker-agent) across a load/save round trip.
+	Extra map[string]any `yaml:",inline"`
 }
 
 // LayoutSettings customizes the TUI chat layout. The zero value is the
@@ -176,14 +179,30 @@ func (s *Settings) GetSplitDiffView() bool {
 	return *s.SplitDiffView
 }
 
+// GetRestoreTabs returns whether previously open tabs are restored on
+// launch, defaulting to false.
+func (s *Settings) GetRestoreTabs() bool {
+	if s == nil || s.RestoreTabs == nil {
+		return false
+	}
+	return *s.RestoreTabs
+}
+
 // SnapshotsEnabled returns whether global snapshot auto-injection is enabled.
 func (s *Settings) SnapshotsEnabled() bool {
 	return s != nil && s.Snapshot != nil && *s.Snapshot
 }
 
-// GlobalHooks returns the user-level hooks config, if configured.
+// GlobalHooks returns the user-level hooks config, if configured. Invalid
+// hooks are skipped with a warning, mirroring hook drop-ins: a bad entry
+// must never reach the runtime, but the section is kept as loaded so a
+// later save does not destroy the user's data.
 func (s *Settings) GlobalHooks() *latest.HooksConfig {
-	if s == nil {
+	if s == nil || s.Hooks == nil {
+		return nil
+	}
+	if err := s.Hooks.Validate(); err != nil {
+		slog.Warn("Ignoring invalid global hooks from user config", "path", Path(), "error", err)
 		return nil
 	}
 	return s.Hooks
@@ -259,6 +278,13 @@ type Config struct {
 	// is a hostname with an optional ":port" suffix; commas and
 	// whitespace are rejected at write time.
 	SandboxAllowlist []string `yaml:"sandbox_allowlist,omitempty"`
+	// Extra preserves top-level keys this version does not know about (e.g.
+	// written by a newer docker-agent) across a load/save round trip.
+	Extra map[string]any `yaml:",inline"`
+
+	// comments preserves the YAML comments read from the config file so
+	// hand-written notes survive a load/save round trip.
+	comments yaml.CommentMap
 }
 
 // Path returns the path to the config file
@@ -296,7 +322,7 @@ func loadFrom(configPath, legacyPath string) (*Config, error) {
 
 // readConfig reads and parses the config file, returning an empty config if file doesn't exist.
 func readConfig(configPath string) (*Config, error) {
-	config := &Config{Aliases: make(map[string]*Alias)}
+	config := &Config{Aliases: make(map[string]*Alias), comments: yaml.CommentMap{}}
 
 	data, err := os.ReadFile(configPath)
 	if err != nil {
@@ -306,12 +332,17 @@ func readConfig(configPath string) (*Config, error) {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
 
-	if err := yaml.Unmarshal(data, config); err != nil {
+	if err := yaml.UnmarshalWithOptions(data, config, yaml.CommentToMap(config.comments)); err != nil {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
 
 	if config.Aliases == nil {
 		config.Aliases = make(map[string]*Alias)
+	}
+
+	if config.Version != "" && config.Version != CurrentVersion {
+		slog.Warn("User config file has an unexpected version; treating it as "+CurrentVersion,
+			"path", configPath, "version", config.Version)
 	}
 
 	return config, nil
@@ -359,7 +390,12 @@ func (c *Config) migrateFromLegacy(legacyPath string) bool {
 	return true
 }
 
-// Save saves the configuration to the config file
+// Save saves the configuration to the config file.
+//
+// Save alone does not guard against concurrent writers: another process
+// saving between this config's load and this call would be overwritten.
+// Callers doing a load-mutate-save cycle should prefer [Update], which
+// serializes the whole cycle behind a file lock.
 func (c *Config) Save() error {
 	return c.saveTo(Path())
 }
@@ -369,10 +405,15 @@ func (c *Config) saveTo(path string) error {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
+	// The mutex keeps the marshaled snapshot consistent when another
+	// goroutine mutates the config (e.g. SetAlias) during the save.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	// Ensure version is always set to current version when saving
 	c.Version = CurrentVersion
 
-	data, err := yaml.Marshal(c)
+	data, err := c.marshal()
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
@@ -380,6 +421,45 @@ func (c *Config) saveTo(path string) error {
 	// The config may contain a credential helper command, so restrict it
 	// to the user.
 	return atomicfile.Write(path, bytes.NewReader(data), 0o600)
+}
+
+// marshal serializes the config, re-attaching the comments captured at load
+// time. A comment whose node no longer exists could fail the marshal, so a
+// comment-related failure falls back to plain serialization: losing comments
+// beats failing the save.
+func (c *Config) marshal() ([]byte, error) {
+	if len(c.comments) > 0 {
+		data, err := yaml.MarshalWithOptions(c, yaml.WithComment(c.comments))
+		if err == nil {
+			return data, nil
+		}
+		slog.Warn("Failed to preserve config comments; saving without them", "error", err)
+	}
+	return yaml.Marshal(c)
+}
+
+// Update atomically applies mutate to the freshest on-disk configuration and
+// saves the result. An advisory file lock serializes the whole
+// load-mutate-save cycle against other docker-agent processes, so concurrent
+// writers cannot overwrite each other's changes. Returning an error from
+// mutate aborts the update and leaves the file untouched. When the lock
+// cannot be acquired the update proceeds unlocked (best effort) rather than
+// failing the save.
+func Update(mutate func(*Config) error) error {
+	if release, err := acquireFileLock(Path() + ".lock"); err == nil {
+		defer release()
+	} else {
+		slog.Warn("Proceeding without config file lock", "error", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		return err
+	}
+	if err := mutate(cfg); err != nil {
+		return err
+	}
+	return cfg.Save()
 }
 
 // GetAlias retrieves the alias configuration for a given name.
@@ -455,6 +535,9 @@ func (c *Config) DeleteAlias(name string) bool {
 
 // GetSettings returns the global settings with defaults applied.
 func (c *Config) GetSettings() *Settings {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.Settings == nil {
 		return &Settings{RestoreTabs: new(false)}
 	}
@@ -465,11 +548,14 @@ func (c *Config) GetSettings() *Settings {
 }
 
 // Get returns the global user settings from the config file.
-// Returns an empty Settings if the config file doesn't exist or has no settings.
+// Returns default settings if the config file doesn't exist, has no
+// settings, or cannot be read: a broken config must never take the caller
+// down, but it is logged so the ignored settings are not a silent mystery.
 func Get() *Settings {
 	cfg, err := Load()
 	if err != nil {
-		return &Settings{}
+		slog.Warn("Failed to load user config; using default settings", "path", Path(), "error", err)
+		return (&Config{}).GetSettings()
 	}
 	return cfg.GetSettings()
 }

--- a/pkg/userconfig/userconfig_test.go
+++ b/pkg/userconfig/userconfig_test.go
@@ -1,8 +1,11 @@
 package userconfig
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/goccy/go-yaml"
@@ -10,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/paths"
 )
 
 func TestConfig_Empty(t *testing.T) {
@@ -1112,4 +1116,176 @@ func TestConfig_Settings_HooksEmpty(t *testing.T) {
 	assert.Nil(t, cfg.Settings.Hooks)
 	assert.Nil(t, cfg.Settings.GlobalHooks())
 	assert.Nil(t, (*Settings)(nil).GlobalHooks())
+}
+
+func TestGet_MalformedConfigReturnsSafeDefaults(t *testing.T) {
+	// Not parallel: SetConfigDir mutates process-global state.
+	dir := t.TempDir()
+	paths.SetConfigDir(dir)
+	t.Cleanup(func() { paths.SetConfigDir("") })
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("settings: [not a map"), 0o600))
+
+	settings := Get()
+	require.NotNil(t, settings)
+	require.NotNil(t, settings.RestoreTabs, "RestoreTabs must be non-nil even when the config cannot be loaded")
+	assert.False(t, settings.GetRestoreTabs())
+}
+
+func TestSettings_GetRestoreTabs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		settings *Settings
+		expected bool
+	}{
+		{"nil settings", nil, false},
+		{"empty settings", &Settings{}, false},
+		{"explicitly disabled", &Settings{RestoreTabs: new(false)}, false},
+		{"explicitly enabled", &Settings{RestoreTabs: new(true)}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, tt.settings.GetRestoreTabs())
+		})
+	}
+}
+
+func TestLoadSave_PreservesCommentsAndUnknownKeys(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	input := `# docker agent user configuration
+version: v1
+aliases:
+  dev:
+    path: ./dev.yaml
+settings:
+  theme: dark # my favorite
+  future_flag: true
+top_secret_future: keep-me
+`
+	require.NoError(t, os.WriteFile(configFile, []byte(input), 0o600))
+
+	cfg, err := loadFrom(configFile, "")
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetAlias("extra", &Alias{Path: "./extra.yaml"}))
+	require.NoError(t, cfg.saveTo(configFile))
+
+	data, err := os.ReadFile(configFile)
+	require.NoError(t, err)
+	out := string(data)
+
+	assert.Contains(t, out, "# docker agent user configuration")
+	assert.Contains(t, out, "# my favorite")
+	assert.Contains(t, out, "future_flag: true")
+	assert.Contains(t, out, "top_secret_future: keep-me")
+	assert.Contains(t, out, "extra")
+
+	reloaded, err := loadFrom(configFile, "")
+	require.NoError(t, err)
+	assert.Equal(t, "dark", reloaded.Settings.Theme)
+	assert.Len(t, reloaded.Aliases, 2)
+}
+
+func TestSave_ClearedCommentedSectionStillSaves(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	input := `version: v1
+settings:
+  theme: dark
+  # sidebar on the left
+  layout:
+    sidebar_position: left
+`
+	require.NoError(t, os.WriteFile(configFile, []byte(input), 0o600))
+
+	cfg, err := loadFrom(configFile, "")
+	require.NoError(t, err)
+	cfg.Settings.Layout = nil
+	require.NoError(t, cfg.saveTo(configFile))
+
+	reloaded, err := loadFrom(configFile, "")
+	require.NoError(t, err)
+	assert.Nil(t, reloaded.Settings.Layout)
+	assert.Equal(t, "dark", reloaded.Settings.Theme)
+}
+
+func TestUpdate_ConcurrentWritersDoNotLoseChanges(t *testing.T) {
+	// Not parallel: SetConfigDir mutates process-global state.
+	dir := t.TempDir()
+	paths.SetConfigDir(dir)
+	t.Cleanup(func() { paths.SetConfigDir("") })
+
+	const writers = 8
+	var wg sync.WaitGroup
+	errs := make([]error, writers)
+	for i := range writers {
+		wg.Go(func() {
+			errs[i] = Update(func(cfg *Config) error {
+				return cfg.SetAlias(fmt.Sprintf("alias-%d", i), &Alias{Path: fmt.Sprintf("./agent-%d.yaml", i)})
+			})
+		})
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "writer %d", i)
+	}
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	assert.Len(t, cfg.Aliases, writers, "every concurrent update must be persisted")
+}
+
+func TestUpdate_MutateErrorLeavesFileUntouched(t *testing.T) {
+	// Not parallel: SetConfigDir mutates process-global state.
+	dir := t.TempDir()
+	paths.SetConfigDir(dir)
+	t.Cleanup(func() { paths.SetConfigDir("") })
+
+	original := []byte("version: v1\nmodels_gateway: https://gw.example.com\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), original, 0o600))
+
+	boom := errors.New("boom")
+	err := Update(func(*Config) error { return boom })
+	require.ErrorIs(t, err, boom)
+
+	data, err := os.ReadFile(filepath.Join(dir, "config.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, original, data)
+}
+
+func TestSettings_GlobalHooksValidation(t *testing.T) {
+	t.Parallel()
+
+	valid := &latest.HooksConfig{
+		SessionStart: []latest.HookDefinition{{Type: "command", Command: "echo hi"}},
+	}
+	invalid := &latest.HooksConfig{
+		SessionStart: []latest.HookDefinition{{Type: "command"}},
+	}
+
+	assert.Nil(t, (*Settings)(nil).GlobalHooks())
+	assert.Nil(t, (&Settings{}).GlobalHooks())
+	assert.Same(t, valid, (&Settings{Hooks: valid}).GlobalHooks())
+	assert.Nil(t, (&Settings{Hooks: invalid}).GlobalHooks(), "invalid hooks must not reach the runtime")
+}
+
+func TestLoad_UnknownVersionStillLoads(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte("version: v99\nmodels_gateway: https://gw.example.com\n"), 0o600))
+
+	cfg, err := loadFrom(configFile, "")
+	require.NoError(t, err)
+	assert.Equal(t, "https://gw.example.com", cfg.ModelsGateway)
 }


### PR DESCRIPTION
## Summary

A check-up of the global config file management (`~/.config/cagent/config.yaml`)
surfaced one crash and several silent data-loss paths in the load/save cycle.
Every issue found is fixed here.

## Issues and fixes

| # | Issue | Fix |
|---|---|---|
| 1 | TUI panics at startup when the config file is malformed: `Get()` returns `Settings{RestoreTabs: nil}` on load error and `tabs.go` dereferences it unconditionally | Nil-safe `GetRestoreTabs()` getter (consistent with `GetSound()` etc.); `Get()` error path returns normalized defaults |
| 2 | A YAML typo silently reverts all settings to defaults and disables aliases, with no message anywhere | Load errors are logged in `Get()`, `ResolveAlias`, `resolve()`, and the credential-helper source; `docker agent doctor` gains a "User configuration" section and reports an unparseable config as an issue (non-zero exit) |
| 3 | Any TUI toggle (theme, layout, split-diff) rewrites the whole file, destroying hand-written comments and keys from newer versions | Comments round-trip via goccy `CommentMap`; unknown keys are preserved through `,inline` maps on `Config` and `Settings` (marshal falls back to plain serialization if comment re-attachment fails, so a save never fails because of a comment) |
| 4 | Concurrent writers overwrite each other (last writer wins): e.g. `docker agent sandbox allow` while the board is open is wiped by the board's next save | New `userconfig.Update(mutate)` serializes load-mutate-save behind an advisory file lock (flock on unix, `LockFileEx` on windows, 5s timeout, best effort); all writers migrated: alias add/rm, sandbox allow/deny, theme, layout, split-diff, board |
| 5 | `settings.hooks` is consumed without validation, unlike hook drop-ins | `GlobalHooks()` validates and skips invalid hooks with a warning; the section stays untouched on disk |
| 6 | `version:` is stamped on save but never checked on load | Unknown versions are logged and loaded as v1 |
| 7 | `Save()` marshals without the mutex that guards `Aliases` | `saveTo` and `GetSettings` take the config mutex |

## Write path after the change

```
writer (CLI command, TUI toggle, board)
  └─ userconfig.Update(mutate)
       ├─ flock config.yaml.lock        (cross-process serialization)
       ├─ Load()                        (freshest on-disk state + comments)
       ├─ mutate(cfg)                   (error aborts, file untouched)
       └─ Save()                        (atomic write, comments and unknown keys preserved)
```

The board now refreshes its cached config from disk on every save instead of
rewriting a snapshot held since startup, so changes made by other processes to
non-board sections survive a board session.

## Behavior notes

- `sandbox deny` of an absent host no longer rewrites the config file.
- Read-only paths (`Get`, alias resolution, completion) take no lock: the
  atomic write already guarantees a consistent view.
- If the lock cannot be acquired within 5s, the update proceeds unlocked and
  logs a warning, matching the previous behavior rather than failing the save.

## Tests

- Malformed config: `Get()` returns safe defaults, no panic
- Comments, unknown keys (both levels), and hooks survive a load/save cycle
- Clearing a commented section still saves
- 8 concurrent `Update` writers lose no changes (also run with `-race`)
- Mutate error leaves the file byte-identical
- Invalid global hooks never reach the runtime; valid ones pass through
- Unknown config version still loads
- `doctor` reports an unparseable user config and exits non-zero

Pre-existing SSRF/network test failures (`TestURLSource_Read_RejectsLocalAddresses`,
`TestNewSSRFSafeTransport_RefusesPrivateIP`, ...) are unrelated: they fail
identically on a clean tree in this environment because a local proxy
intercepts the requests those tests expect to be refused.
