### PR TITLE
fix(tui): unreadable emphasized text on light themes

### DIFF
--- a/pkg/tui/dialog/elicitation.go
+++ b/pkg/tui/dialog/elicitation.go
@@ -631,7 +631,7 @@ func (d *ElicitationDialog) renderEnumField(content *Content, i int, field Elici
 }
 
 func (d *ElicitationDialog) renderSelectionField(content *Content, options []string, selectedIdx int, isFocused bool) {
-	selectedStyle := styles.DialogContentStyle.Foreground(styles.White).Bold(true)
+	selectedStyle := styles.DialogContentStyle.Foreground(styles.TextBright).Bold(true)
 	unselectedStyle := styles.DialogContentStyle.Foreground(styles.TextMuted)
 
 	for j, option := range options {

--- a/pkg/tui/styles/auto_theme_test.go
+++ b/pkg/tui/styles/auto_theme_test.go
@@ -1,10 +1,12 @@
 package styles
 
 import (
+	"image/color"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"charm.land/lipgloss/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -157,5 +159,35 @@ func TestDefaultLightThemeContrast(t *testing.T) {
 		require.True(t, ok, "%s: invalid colors %q on %q", check.name, check.fg, check.bg)
 		assert.GreaterOrEqual(t, ratio, check.minRatio,
 			"%s: contrast of %s on %s is %.2f, want >= %.2f", check.name, check.fg, check.bg, ratio, check.minRatio)
+	}
+}
+
+// TestEmphasisStylesReadableOnLightTheme guards against emphasized text drawn
+// directly on the app background (key hints such as "Esc to interrupt",
+// palette categories, the active resize handle) using the selection
+// foreground. That color is near-white in light themes, which made the text
+// invisible; these styles must stay readable after applying the light theme.
+func TestEmphasisStylesReadableOnLightTheme(t *testing.T) { //nolint:paralleltest // ApplyTheme mutates package-wide style variables.
+	original := CurrentTheme()
+	t.Cleanup(func() { ApplyTheme(original) })
+
+	theme, err := LoadTheme(DefaultLightThemeRef)
+	require.NoError(t, err)
+	ApplyTheme(theme)
+
+	checks := []struct {
+		name  string
+		style lipgloss.Style
+		bg    color.Color
+	}{
+		{"HighlightWhiteStyle", HighlightWhiteStyle, Background},
+		{"PaletteCategoryStyle", PaletteCategoryStyle, Background},
+		{"ResizeHandleActiveStyle", ResizeHandleActiveStyle, Background},
+		{"ThumbActiveStyle", ThumbActiveStyle, BackgroundAlt},
+	}
+	for _, check := range checks {
+		ratio := contrastRatio(check.style.GetForeground(), check.bg)
+		assert.GreaterOrEqual(t, ratio, 4.5,
+			"%s foreground must be readable on the light theme background", check.name)
 	}
 }

--- a/pkg/tui/styles/styles.go
+++ b/pkg/tui/styles/styles.go
@@ -40,6 +40,7 @@ var (
 
 	// Text hierarchy
 
+	TextBright    color.Color
 	TextPrimary   color.Color
 	TextSecondary color.Color
 	TextMuted     color.Color
@@ -131,7 +132,10 @@ var (
 
 // Text Styles
 var (
-	HighlightWhiteStyle = BaseStyle.Foreground(White).Bold(true)
+	// HighlightWhiteStyle emphasizes text drawn on the app background (key
+	// hints, selected values). It uses TextBright, not White: White is the
+	// selection foreground and would be unreadable on light themes.
+	HighlightWhiteStyle = BaseStyle.Foreground(TextBright).Bold(true)
 	MutedStyle          = BaseStyle.Foreground(TextMutedGray)
 	SecondaryStyle      = BaseStyle.Foreground(TextSecondary)
 	BoldStyle           = BaseStyle.Bold(true)
@@ -257,7 +261,7 @@ var (
 var (
 	PaletteCategoryStyle = BaseStyle.
 				Bold(true).
-				Foreground(White).
+				Foreground(TextBright).
 				MarginTop(1)
 
 	PaletteUnselectedActionStyle = BaseStyle.
@@ -436,7 +440,7 @@ var (
 var (
 	TrackStyle       = lipgloss.NewStyle().Foreground(BorderSecondary)
 	ThumbStyle       = lipgloss.NewStyle().Foreground(Info).Background(BackgroundAlt)
-	ThumbActiveStyle = lipgloss.NewStyle().Foreground(White).Background(BackgroundAlt)
+	ThumbActiveStyle = lipgloss.NewStyle().Foreground(TextBright).Background(BackgroundAlt)
 )
 
 // Resize Handle Style
@@ -449,7 +453,7 @@ var (
 				Bold(true)
 
 	ResizeHandleActiveStyle = BaseStyle.
-				Foreground(White).
+				Foreground(TextBright).
 				Bold(true)
 )
 

--- a/pkg/tui/styles/theme.go
+++ b/pkg/tui/styles/theme.go
@@ -1077,6 +1077,7 @@ func ApplyTheme(theme *Theme) {
 	BackgroundAlt = lipgloss.Color(c.BackgroundAlt)
 	// Text colors
 	White = lipgloss.Color(c.SelectedFg)
+	TextBright = lipgloss.Color(c.TextBright)
 	TextPrimary = lipgloss.Color(c.TextPrimary)
 	TextSecondary = lipgloss.Color(c.TextSecondary)
 	TextMuted = lipgloss.Color(c.AccentMuted)
@@ -1154,7 +1155,7 @@ func rebuildStyles() {
 	AppStyle = BaseStyle.Padding(0, AppPadding, 0, AppPadding)
 
 	// Text styles
-	HighlightWhiteStyle = BaseStyle.Foreground(White).Bold(true)
+	HighlightWhiteStyle = BaseStyle.Foreground(TextBright).Bold(true)
 	MutedStyle = BaseStyle.Foreground(TextMutedGray)
 	SecondaryStyle = BaseStyle.Foreground(TextSecondary)
 	BoldStyle = BaseStyle.Bold(true)
@@ -1260,7 +1261,7 @@ func rebuildStyles() {
 	// Command palette styles
 	PaletteCategoryStyle = BaseStyle.
 		Bold(true).
-		Foreground(White).
+		Foreground(TextBright).
 		MarginTop(1)
 
 	PaletteUnselectedActionStyle = BaseStyle.
@@ -1354,12 +1355,12 @@ func rebuildStyles() {
 	// Scrollbar styles
 	TrackStyle = lipgloss.NewStyle().Foreground(BorderSecondary)
 	ThumbStyle = lipgloss.NewStyle().Foreground(Info).Background(BackgroundAlt)
-	ThumbActiveStyle = lipgloss.NewStyle().Foreground(White).Background(BackgroundAlt)
+	ThumbActiveStyle = lipgloss.NewStyle().Foreground(TextBright).Background(BackgroundAlt)
 
 	// Resize handle styles
 	ResizeHandleStyle = BaseStyle.Foreground(BorderSecondary)
 	ResizeHandleHoverStyle = BaseStyle.Foreground(Info).Bold(true)
-	ResizeHandleActiveStyle = BaseStyle.Foreground(White).Bold(true)
+	ResizeHandleActiveStyle = BaseStyle.Foreground(TextBright).Bold(true)
 
 	// Notification styles
 	NotificationStyle = BaseStyle.


### PR DESCRIPTION
## Summary

Key hints such as "Esc to interrupt" were invisible on light themes: emphasized styles used `styles.White`, which maps to the theme's `selected_fg` (pure white in `default-light`). That color is meant for text on the blue selection background, not for text drawn directly on the app background.

| | |
|---|---|
| Cause | `White` = `selected_fg` (`#FFFFFF` in light) used as foreground on the app background (`#FAFAFA`), contrast ratio ~1.02 |
| Fix | Expose the theme's existing `text_bright` color as `styles.TextBright` (`#0F1420` light / `#E5F2FC` dark) and use it for on-background emphasis |
| Dark theme impact | None visible: `#E5F2FC` is nearly identical to the previous white |

## Affected styles

| Style | Visible as |
|---|---|
| `HighlightWhiteStyle` | "Esc to interrupt", "/pause to resume", statusbar keys, dialog help keys, tour, customize dialog, working dir picker tabs |
| `PaletteCategoryStyle` | command palette category headers |
| `ThumbActiveStyle` | active scrollbar thumb |
| `ResizeHandleActiveStyle` | sidebar resize handle |
| selection in `elicitation.go` | Yes/No and enum options in MCP elicitation dialogs |

Styles rendering on the blue selection background (`PaletteSelected*`, `CompletionSelected*`) keep `White`, which is correct there.

## Testing

- New `TestEmphasisStylesReadableOnLightTheme` applies `default-light` and asserts WCAG contrast >= 4.5 for each emphasized style against the background it renders on (fails at ~1.02 before the fix).
- `go build ./...`, `golangci-lint run` and `go test ./pkg/tui/...` pass. The only `go test ./...` failures (`pkg/tools/builtin/fetch`, `pkg/tools/builtin/openapi`) are network-dependent and pre-exist on `main`.
