### PR TITLE
feat(board): preview the dragged card at its insertion point

### DIFF
--- a/pkg/board/tui/tui.go
+++ b/pkg/board/tui/tui.go
@@ -688,6 +688,10 @@ func (m *model) handleClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 	if msg.Button != tea.MouseLeft {
 		return m, nil
 	}
+	// A fresh press while a drag is still armed means the release was lost
+	// (e.g. tea.ExecProcess leaving mouse mode): clear the stale drag before
+	// interpreting the click.
+	m.resetDrag()
 	if m.plusButtonAt(msg.X, msg.Y) {
 		cmd := m.openNewCard()
 		return m, cmd
@@ -718,7 +722,6 @@ func (m *model) handleClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 	col, row, ok := m.cardAt(msg.X, msg.Y)
 	if !ok {
 		m.lastClickCard = ""
-		m.resetDrag() // a lost release must not leak into this gesture
 		return m, nil
 	}
 	m.selCol, m.selRow = col, row
@@ -736,9 +739,7 @@ func (m *model) handleClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 	m.lastClickCard = card.ID
 	m.lastClickTime = time.Now()
 	// The pressed card is a drag candidate: motion before the release turns
-	// the click into a drag (see handleMotion/handleRelease). Rearming also
-	// clears any drag whose release was lost (e.g. to tea.ExecProcess).
-	m.resetDrag()
+	// the click into a drag (see handleMotion/handleRelease).
 	m.dragCardID = card.ID
 	m.dragCol = col
 	return m, nil

--- a/pkg/board/tui/tui_test.go
+++ b/pkg/board/tui/tui_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -192,6 +193,71 @@ func TestDropTargetPreviewsGhostCard(t *testing.T) {
 
 	// …and the preview never persists a scroll change on the target.
 	assert.Equal(t, 0, m.scroll["done"])
+}
+
+func TestDropTargetGhostSlidesToColumnTail(t *testing.T) {
+	t.Parallel()
+
+	// An overfull target column (7 cards, 5 slots at height 40) slides to
+	// its tail so the ghost sits at the real insertion point.
+	m := dragTestModel()
+	m.cards["dev"][0].Title = "Dragged card"
+	done := make([]*board.Card, 0, 7)
+	for i := range 7 {
+		done = append(done, &board.Card{ID: fmt.Sprintf("d%d", i), Column: "done", Title: fmt.Sprintf("Done task %d", i)})
+	}
+	m.cards["done"] = done
+
+	_, _ = m.handleClick(tea.MouseClickMsg{X: 5, Y: 5, Button: tea.MouseLeft})
+	m.handleMotion(tea.MouseMotionMsg{X: 65, Y: 5, Button: tea.MouseLeft})
+
+	boardHeight, colWidth := m.boardSize()
+	target := m.renderColumn(1, m.columns[1], colWidth, boardHeight)
+	assert.Contains(t, target, "Done task 6", "the column tail must be visible")
+	assert.Contains(t, target, "Dragged card", "the ghost follows the last card")
+	assert.NotContains(t, target, "Done task 0")
+	assert.Contains(t, target, "… 3 more", "cards hidden above the window are counted")
+	assert.Equal(t, 0, m.scroll["done"], "the tail scroll must not persist")
+}
+
+func TestDropTargetGhostOnTinyTerminal(t *testing.T) {
+	t.Parallel()
+
+	// With a single visible slot the ghost takes it, and the column's own
+	// cards collapse into the hidden-count line instead of vanishing.
+	m := dragTestModel()
+	m.height = 12 // boardSize floor: one card slot
+	m.cards["dev"][0].Title = "Dragged card"
+	m.cards["done"][0].Title = "Done task"
+
+	_, _ = m.handleClick(tea.MouseClickMsg{X: 5, Y: 5, Button: tea.MouseLeft})
+	m.handleMotion(tea.MouseMotionMsg{X: 65, Y: 5, Button: tea.MouseLeft})
+
+	boardHeight, colWidth := m.boardSize()
+	target := m.renderColumn(1, m.columns[1], colWidth, boardHeight)
+	assert.Contains(t, target, "Dragged card")
+	assert.Contains(t, target, "… 1 more")
+	assert.NotContains(t, target, "Done task")
+}
+
+func TestNoGhostWhenTargetAlreadyHoldsCard(t *testing.T) {
+	t.Parallel()
+
+	// A refresh can move the dragged card under the drag; the column that
+	// now holds it must not render it twice (the drop is a no-op anyway).
+	m := dragTestModel()
+	m.cards["dev"][0].Title = "Dragged card"
+	_, _ = m.handleClick(tea.MouseClickMsg{X: 5, Y: 5, Button: tea.MouseLeft})
+	m.handleMotion(tea.MouseMotionMsg{X: 65, Y: 5, Button: tea.MouseLeft})
+
+	// Simulate an external move of the dragged card into the target column.
+	m.cards["done"] = append(m.cards["done"], m.cards["dev"][0])
+	m.cards["dev"] = m.cards["dev"][1:]
+
+	boardHeight, colWidth := m.boardSize()
+	target := m.renderColumn(1, m.columns[1], colWidth, boardHeight)
+	assert.Equal(t, 1, strings.Count(target, "Dragged card"),
+		"the card must not render twice in its own column")
 }
 
 func TestDragBackToOriginIsANoop(t *testing.T) {

--- a/pkg/board/tui/tui_test.go
+++ b/pkg/board/tui/tui_test.go
@@ -163,6 +163,37 @@ func TestDraggedCardRendersFaded(t *testing.T) {
 	assert.Equal(t, during, m.renderCard(other, 30, false))
 }
 
+func TestDropTargetPreviewsGhostCard(t *testing.T) {
+	t.Parallel()
+
+	m := dragTestModel()
+	m.cards["dev"][0].Title = "Fix the flaky test"
+
+	// Before the drag, the destination column shows only its own card.
+	boardHeight, colWidth := m.boardSize()
+	idle := m.renderColumn(1, m.columns[1], colWidth, boardHeight)
+	assert.NotContains(t, idle, "Fix the flaky")
+
+	// Mid-drag, the drop target previews the dragged card at its insertion
+	// point: after the column's last card.
+	_, _ = m.handleClick(tea.MouseClickMsg{X: 5, Y: 5, Button: tea.MouseLeft})
+	m.handleMotion(tea.MouseMotionMsg{X: 65, Y: 5, Button: tea.MouseLeft})
+	target := m.renderColumn(1, m.columns[1], colWidth, boardHeight)
+	assert.Contains(t, target, "Fix the flaky")
+
+	// The source column shows no ghost — a drop there is a no-op.
+	source := m.renderColumn(0, m.columns[0], colWidth, boardHeight)
+	assert.Equal(t, 1, strings.Count(source, "Fix the flaky"),
+		"the source column must only show the card itself")
+
+	// The ghost vanishes when the pointer leaves the column…
+	m.handleMotion(tea.MouseMotionMsg{X: 59, Y: 5, Button: tea.MouseLeft})
+	assert.NotContains(t, m.renderColumn(1, m.columns[1], colWidth, boardHeight), "Fix the flaky")
+
+	// …and the preview never persists a scroll change on the target.
+	assert.Equal(t, 0, m.scroll["done"])
+}
+
 func TestDragBackToOriginIsANoop(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/board/tui/view.go
+++ b/pkg/board/tui/view.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"image/color"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -244,7 +245,11 @@ func (m *model) renderBoard() string {
 
 func (m *model) renderColumn(idx int, col board.Column, colWidth, boardHeight int) string {
 	selected := idx == m.selCol
-	dropTarget := m.dragging && idx == m.dragCol && idx != m.selCol
+	cards := m.cards[col.ID]
+	// A column already holding the dragged card is not a drop target: the
+	// move would be a no-op. This also covers a refresh moving the card
+	// under the drag — the card must never render twice in one column.
+	dropTarget := m.dragging && idx == m.dragCol && !containsCard(cards, m.dragCardID)
 	// The border box's Width/Height are outer sizes; the content area is two
 	// cells narrower (and shorter).
 	innerWidth := colWidth - 2
@@ -256,7 +261,6 @@ func (m *model) renderColumn(idx int, col board.Column, colWidth, boardHeight in
 	if selected {
 		nameStyle = styles.HighlightWhiteStyle
 	}
-	cards := m.cards[col.ID]
 	header := " " + columnLabel(col, nameStyle)
 	// Right-aligned: a clickable + to create a card on the first column
 	// (see plusButtonAt), then the card count rightmost.
@@ -292,6 +296,11 @@ func (m *model) renderColumn(idx int, col board.Column, colWidth, boardHeight in
 	}
 
 	lines := []string{header, rule}
+	// The tail scroll can hide cards above the window; without this line a
+	// full column would collapse to just the ghost on short terminals.
+	if ghost != "" && scroll > 0 {
+		lines = append(lines, styles.MutedStyle.Render(fmt.Sprintf(" … %d more", scroll)))
+	}
 	end := min(scroll+slots, len(cards))
 	for i := scroll; i < end; i++ {
 		lines = append(lines, m.renderCard(cards[i], innerWidth, selected && i == m.selRow))
@@ -417,6 +426,11 @@ func (m *model) renderCard(card *board.Card, colInnerWidth int, selected bool) s
 		Width(colInnerWidth).
 		Padding(0, 1).
 		Render(content)
+}
+
+// containsCard reports whether one of the cards has the given ID.
+func containsCard(cards []*board.Card, id string) bool {
+	return slices.ContainsFunc(cards, func(c *board.Card) bool { return c.ID == id })
 }
 
 // renderGhost previews the dragged card in the drop-target column: a faded
@@ -582,7 +596,11 @@ func (m *model) columnAt(x, y int) (int, bool) {
 }
 
 // cardAt maps terminal coordinates to the (column, card) under them. It
-// mirrors the layout produced by renderBoard.
+// mirrors the layout produced by renderBoard — except the drop-target
+// column mid-drag, whose window slides for the ghost preview. That
+// divergence is safe: the only drag-time caller (handleRelease) just
+// checks the hit against the dragged card, which sits in the source
+// column, whose layout is unchanged.
 func (m *model) cardAt(x, y int) (col, row int, ok bool) {
 	col, ok = m.columnAt(x, y)
 	if !ok {

--- a/pkg/board/tui/view.go
+++ b/pkg/board/tui/view.go
@@ -244,6 +244,7 @@ func (m *model) renderBoard() string {
 
 func (m *model) renderColumn(idx int, col board.Column, colWidth, boardHeight int) string {
 	selected := idx == m.selCol
+	dropTarget := m.dragging && idx == m.dragCol && idx != m.selCol
 	// The border box's Width/Height are outer sizes; the content area is two
 	// cells narrower (and shorter).
 	innerWidth := colWidth - 2
@@ -277,10 +278,26 @@ func (m *model) renderColumn(idx int, col board.Column, colWidth, boardHeight in
 	}
 	m.scroll[col.ID] = scroll
 
+	// The drop target previews the dragged card at its insertion point: a
+	// faded ghost takes the last slot and the window slides to the column's
+	// tail, where a dropped card lands. The forced scroll is not persisted,
+	// so a cancelled drag leaves the column's window untouched.
+	ghost := ""
+	if dropTarget {
+		if card := m.cardByID(m.dragCardID); card != nil {
+			ghost = m.renderGhost(card, innerWidth)
+			slots--
+			scroll = max(len(cards)-slots, 0)
+		}
+	}
+
 	lines := []string{header, rule}
 	end := min(scroll+slots, len(cards))
 	for i := scroll; i < end; i++ {
 		lines = append(lines, m.renderCard(cards[i], innerWidth, selected && i == m.selRow))
+	}
+	if ghost != "" {
+		lines = append(lines, ghost)
 	}
 	switch {
 	case len(cards) == 0 && selected:
@@ -293,7 +310,7 @@ func (m *model) renderColumn(idx int, col board.Column, colWidth, boardHeight in
 	// dimmed secondary border.
 	borderColor := darken(styles.BorderSecondary, 0.35)
 	switch {
-	case m.dragging && idx == m.dragCol && idx != m.selCol:
+	case dropTarget:
 		borderColor = styles.Success
 	case selected:
 		borderColor = styles.White
@@ -397,6 +414,26 @@ func (m *model) renderCard(card *board.Card, colInnerWidth int, selected bool) s
 	return styles.BaseStyle.
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(borderColor).
+		Width(colInnerWidth).
+		Padding(0, 1).
+		Render(content)
+}
+
+// renderGhost previews the dragged card in the drop-target column: a faded
+// clone of the card at the column's tail, where the card lands on release.
+func (m *model) renderGhost(card *board.Card, colInnerWidth int) string {
+	textWidth := max(colInnerWidth-4, 1)
+	style := styles.BaseStyle.Foreground(fade(styles.SecondaryStyle.GetForeground()))
+	title1, title2 := splitTitle(sanitize(card.Title), textWidth)
+	content := strings.Join([]string{
+		style.Render(title1),
+		style.Render(title2),
+		style.Render(toolcommon.TruncateText(sanitize("◆ "+card.Project), textWidth)),
+		"",
+	}, "\n")
+	return styles.BaseStyle.
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(fade(styles.Success)).
 		Width(colInnerWidth).
 		Padding(0, 1).
 		Render(content)


### PR DESCRIPTION
When dragging a card in the board TUI, there was no visual indication of where the card would land. Drop targets highlight the destination column with a green border, but the exact insertion point — always the tail of the column — was invisible.

While a drag is in progress and a column is highlighted as the drop target, the column now renders a faded "ghost" clone of the dragged card at the tail position, exactly where the card will be appended on drop. The column's scroll window shifts temporarily to reveal that tail slot, giving the user a clear preview of the outcome. If the drag is cancelled the scroll is restored, leaving the column untouched. The ghost uses faded title and project text with a border in faded success green, matching the existing green column-highlight treatment.

A second commit hardens the feature against edge cases: terminals too small to show even one real card get a `… N more` line instead of a ghost-only view, the ghost is suppressed when the dragged card is already in the target column to handle mid-drag refresh races, and stale drag state is cleared at the top of `handleClick` to recover from lost release events. Tests cover tail-scroll behaviour, the tiny-terminal fallback, and duplicate-card suppression.