### PR TITLE
feat(tui): add section spacing setting to /custom layout dialog

### DIFF
--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -77,7 +77,7 @@ Type `/` during a session to see available commands, or press <kbd>Ctrl</kbd>+<k
 | `/sessions`        | Browse and load past sessions                                                        |
 | `/model`           | Change the model for the current agent                                               |
 | `/effort`          | Set the current model's reasoning-effort level (`/effort <none\|minimal\|low\|medium\|high\|xhigh\|max>`, or `/effort` alone to pick from the supported levels; reasoning models only) |
-| `/custom`          | Customize the TUI layout: sidebar position and visible sidebar sections              |
+| `/custom`          | Customize the TUI layout: sidebar position, section spacing, and visible sidebar sections |
 | `/theme`           | Change the color theme                                                               |
 | `/yolo`            | Toggle automatic tool call approval                                                  |
 | `/title`           | Set or regenerate session title                                                      |
@@ -325,6 +325,7 @@ Press <kbd>Ctrl</kbd>+<kbd>R</kbd> to enter incremental history search mode. Sta
 Run `/custom` to open the layout dialog. It shows a live schematic preview of the resulting layout and applies every change immediately to the UI behind the dialog:
 
 - **Sidebar position**: `Right` (default), `Left`, `Top`, or `Bottom`. Left/right keep the full vertical sidebar next to the chat; top/bottom render it as a compact horizontal band above or below the chat (session title, working directory, usage, plus a one-line summary of the current agent, tools, and todos).
+- **Section spacing**: `Compact`, `Normal` (default), or `Relaxed`, the number of blank lines between the sidebar sections (1, 2, or 3).
 - **Sidebar sections**: toggle the visibility of the **Token usage**, **Agents**, **Tools**, and **Todos** sections. The session block (title and working directory) is always shown.
 
 Press <kbd>Enter</kbd> to apply and persist, or <kbd>Escape</kbd> to cancel and restore the previous layout. The settings are saved globally in `~/.config/cagent/config.yaml`:
@@ -334,6 +335,7 @@ Press <kbd>Enter</kbd> to apply and persist, or <kbd>Escape</kbd> to cancel and 
 settings:
   layout:
     sidebar_position: left # right (default), left, top, bottom
+    section_spacing: compact # normal (default), compact, relaxed
     hide_usage: true
     hide_agents: false
     hide_tools: false

--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -389,7 +389,7 @@ func builtInSettingsCommands() []Item {
 			ID:           "settings.customize",
 			Label:        "Customize Layout",
 			SlashCommand: "/custom",
-			Description:  "Customize the layout: sidebar position and visible sections",
+			Description:  "Customize the layout: sidebar position, section spacing, and visible sections",
 			Category:     "Settings",
 			Immediate:    true,
 			Execute: func(string) tea.Cmd {

--- a/pkg/tui/components/sidebar/layout.go
+++ b/pkg/tui/components/sidebar/layout.go
@@ -32,6 +32,10 @@ const (
 	// minGap is the minimum gap between elements when laying out side-by-side.
 	minGap = 2
 
+	// defaultSectionGap is the default number of blank lines between sidebar
+	// sections in vertical mode (the "normal" section spacing).
+	defaultSectionGap = 2
+
 	// DefaultWidth is the default sidebar width in vertical mode.
 	DefaultWidth = 40
 

--- a/pkg/tui/components/sidebar/section_visibility_test.go
+++ b/pkg/tui/components/sidebar/section_visibility_test.go
@@ -139,6 +139,64 @@ func TestCollapsedLineCount_GrowsWithInfoLine(t *testing.T) {
 	assert.Equal(t, withoutInfo+1, withInfo, "the info line adds one band line")
 }
 
+// sectionTitleGap returns the number of consecutive blank lines immediately
+// above the rendered line containing title, or -1 when the title is absent.
+func sectionTitleGap(lines []string, title string) int {
+	for i, line := range lines {
+		if !strings.Contains(ansi.Strip(line), title) {
+			continue
+		}
+		gap := 0
+		for j := i - 1; j >= 0 && strings.TrimSpace(ansi.Strip(lines[j])) == ""; j-- {
+			gap++
+		}
+		return gap
+	}
+	return -1
+}
+
+func TestRenderSections_SectionGap(t *testing.T) {
+	t.Parallel()
+
+	s := newVisibilityTestSidebar(t)
+
+	for _, gap := range []int{1, 2, 3} {
+		s.SetSectionGap(gap)
+		lines := s.renderSections(40)
+		assert.Equal(t, gap, sectionTitleGap(lines, "Token Usage"), "gap %d before Token Usage", gap)
+		assert.Equal(t, gap, sectionTitleGap(lines, "Tools"), "gap %d before Tools", gap)
+	}
+}
+
+func TestRenderSections_SectionGapKeepsAgentClickZones(t *testing.T) {
+	t.Parallel()
+
+	s := newVisibilityTestSidebar(t)
+	s.SetSectionGap(3)
+	lines := s.renderSections(40)
+
+	require.NotEmpty(t, s.agentClickZones)
+	for lineIdx, agentName := range s.agentClickZones {
+		require.Less(t, lineIdx, len(lines))
+		assert.Contains(t, ansi.Strip(lines[lineIdx-1])+ansi.Strip(lines[lineIdx]), agentName,
+			"click zone %d must map onto a line of agent %q", lineIdx, agentName)
+	}
+}
+
+func TestSetSectionGap_NoopWhenUnchanged(t *testing.T) {
+	t.Parallel()
+
+	s := newTestSidebar(t)
+	s.renderSections(40)
+	s.cacheDirty = false
+
+	s.SetSectionGap(defaultSectionGap)
+	assert.False(t, s.cacheDirty, "identical gap must not invalidate the cache")
+
+	s.SetSectionGap(1)
+	assert.True(t, s.cacheDirty)
+}
+
 func TestSetSectionVisibility_NoopWhenUnchanged(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -70,6 +70,8 @@ type Model interface {
 	SetQueuedMessages(messages ...string)
 	// SetSectionVisibility controls which optional sidebar sections are rendered.
 	SetSectionVisibility(v SectionVisibility)
+	// SetSectionGap sets the number of blank lines between sidebar sections.
+	SetSectionGap(lines int)
 	GetSize() (width, height int)
 	LoadFromSession(sess *session.Session)
 	// ResetStreamTracking clears the active-stream stack so a new top-level run
@@ -164,6 +166,7 @@ type model struct {
 	titleInput         textinput.Model
 	lastTitleClickTime time.Time         // for double-click detection on title
 	sectionVisibility  SectionVisibility // which optional sections are rendered
+	sectionGap         int               // blank lines between sections in vertical mode
 
 	ctx func() context.Context
 
@@ -210,6 +213,7 @@ func New(ctx context.Context, sessionState *service.SessionState) Model {
 		workingDirectory: wd,
 		gitBranchName:    branch,
 		preferredWidth:   DefaultWidth,
+		sectionGap:       defaultSectionGap,
 		titleInput:       ti,
 		cacheDirty:       true, // Initial render needed
 		layoutDirty:      true, // First render must probe scrollbar visibility
@@ -365,6 +369,18 @@ func (m *model) SetSectionVisibility(v SectionVisibility) {
 		return
 	}
 	m.sectionVisibility = v
+	m.invalidateCache()
+}
+
+// SetSectionGap sets the number of blank lines between sidebar sections.
+func (m *model) SetSectionGap(lines int) {
+	if lines < 0 {
+		lines = 0
+	}
+	if m.sectionGap == lines {
+		return
+	}
+	m.sectionGap = lines
 	m.invalidateCache()
 }
 
@@ -1093,13 +1109,23 @@ func (m *model) renderFromCache() string {
 }
 
 // renderSections renders all sidebar sections and returns them as lines.
+// Sections are separated by sectionGap blank lines; each appendSection call
+// returns the index of the section's first line so click zones can be anchored.
 func (m *model) renderSections(contentWidth int) []string {
 	var lines []string
 
-	appendSection := func(section string) {
-		if section != "" {
-			lines = append(lines, strings.Split(section, "\n")...)
+	appendSection := func(section string) int {
+		if section == "" {
+			return len(lines)
 		}
+		if len(lines) > 0 {
+			for range m.sectionGap {
+				lines = append(lines, "")
+			}
+		}
+		start := len(lines)
+		lines = append(lines, strings.Split(section, "\n")...)
+		return start
 	}
 
 	appendSection(m.sessionInfo(contentWidth))
@@ -1113,7 +1139,7 @@ func (m *model) renderSections(contentWidth int) []string {
 	if m.sectionVisibility.HideAgents {
 		m.agentLineOwners = nil
 	} else {
-		appendSection(m.agentInfo(contentWidth))
+		agentSectionStart = appendSection(m.agentInfo(contentWidth))
 	}
 	m.buildAgentClickZones(agentSectionStart)
 
@@ -1123,7 +1149,7 @@ func (m *model) renderSections(contentWidth int) []string {
 
 	if !m.sectionVisibility.HideTodos {
 		m.todoComp.SetSize(contentWidth)
-		appendSection(strings.TrimSuffix(m.todoComp.Render(), "\n"))
+		appendSection(m.todoComp.Render())
 	}
 
 	return lines

--- a/pkg/tui/components/tab/tab.go
+++ b/pkg/tui/components/tab/tab.go
@@ -6,18 +6,18 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/styles"
 )
 
+// Render renders a titled section flush: the blank space that separates
+// consecutive sections is owned by the caller (see sidebar section spacing).
 func Render(title, content string, width int) string {
 	styleTitle := styles.TabTitleStyle
 	styleBody := styles.TabStyle
 
-	return styles.NoStyle.PaddingBottom(1).Render(
-		lipgloss.JoinVertical(lipgloss.Top,
-			lipgloss.PlaceHorizontal(width, lipgloss.Left,
-				styleTitle.PaddingRight(1).Render(title),
-				lipgloss.WithWhitespaceChars("─"),
-				lipgloss.WithWhitespaceStyle(styleTitle),
-			),
-			styles.RenderComposite(styleBody.Width(width), content),
+	return lipgloss.JoinVertical(lipgloss.Top,
+		lipgloss.PlaceHorizontal(width, lipgloss.Left,
+			styleTitle.PaddingRight(1).Render(title),
+			lipgloss.WithWhitespaceChars("─"),
+			lipgloss.WithWhitespaceStyle(styleTitle),
 		),
+		styles.RenderComposite(styleBody.Width(width).PaddingBottom(0), content),
 	)
 }

--- a/pkg/tui/dialog/customize.go
+++ b/pkg/tui/dialog/customize.go
@@ -27,6 +27,7 @@ const (
 // customizeRows enumerates the selectable rows of the customize dialog.
 const (
 	rowPosition = iota
+	rowSpacing
 	rowUsage
 	rowAgents
 	rowTools
@@ -50,10 +51,24 @@ var positionLabels = map[messages.SidebarPosition]string{
 	messages.SidebarBottom: "Bottom",
 }
 
-// customizeDialog lets the user customize the TUI layout: sidebar position
-// and which sidebar sections are visible. Changes are previewed live (both in
-// the schematic and in the UI behind the dialog); Enter persists them, Esc
-// restores the original layout.
+// sectionSpacings is the ←/→ cycle order of the section-spacing selector.
+var sectionSpacings = []messages.SectionSpacing{
+	messages.SpacingCompact,
+	messages.SpacingNormal,
+	messages.SpacingRelaxed,
+}
+
+// spacingLabels maps spacings to their display labels.
+var spacingLabels = map[messages.SectionSpacing]string{
+	messages.SpacingCompact: "Compact",
+	messages.SpacingNormal:  "Normal",
+	messages.SpacingRelaxed: "Relaxed",
+}
+
+// customizeDialog lets the user customize the TUI layout: sidebar position,
+// spacing between sidebar sections, and which sections are visible. Changes
+// are previewed live (both in the schematic and in the UI behind the dialog);
+// Enter persists them, Esc restores the original layout.
 type customizeDialog struct {
 	BaseDialog
 
@@ -66,6 +81,7 @@ type customizeDialog struct {
 // currently active settings.
 func NewCustomizeDialog(current messages.LayoutSettings) Dialog {
 	current.SidebarPosition = messages.ParseSidebarPosition(string(current.SidebarPosition))
+	current.SectionSpacing = messages.ParseSectionSpacing(string(current.SectionSpacing))
 	return &customizeDialog{
 		original: current,
 		current:  current,
@@ -124,7 +140,9 @@ func (d *customizeDialog) handleKey(msg tea.KeyPressMsg) tea.Cmd {
 func (d *customizeDialog) changeValue(delta int) tea.Cmd {
 	switch d.selected {
 	case rowPosition:
-		d.current.SidebarPosition = cyclePosition(d.current.SidebarPosition, delta)
+		d.current.SidebarPosition = cycleValue(sidebarPositions, d.current.SidebarPosition, delta)
+	case rowSpacing:
+		d.current.SectionSpacing = cycleValue(sectionSpacings, d.current.SectionSpacing, delta)
 	case rowUsage:
 		d.current.HideUsage = !d.current.HideUsage
 	case rowAgents:
@@ -139,17 +157,17 @@ func (d *customizeDialog) changeValue(delta int) tea.Cmd {
 	return core.CmdHandler(messages.PreviewLayoutMsg{Layout: d.current})
 }
 
-// cyclePosition returns the position delta steps away in the cycle order.
-func cyclePosition(current messages.SidebarPosition, delta int) messages.SidebarPosition {
+// cycleValue returns the value delta steps away from current in the cycle order.
+func cycleValue[T comparable](values []T, current T, delta int) T {
 	idx := 0
-	for i, p := range sidebarPositions {
-		if p == current {
+	for i, v := range values {
+		if v == current {
 			idx = i
 			break
 		}
 	}
-	idx = (idx + delta + len(sidebarPositions)) % len(sidebarPositions)
-	return sidebarPositions[idx]
+	idx = (idx + delta + len(values)) % len(values)
+	return values[idx]
 }
 
 // apply closes the dialog and commits the current settings.
@@ -193,7 +211,8 @@ func (d *customizeDialog) View() string {
 		AddSpace().
 		AddContent(preview).
 		AddSpace().
-		AddContent(d.renderPositionRow(inner)).
+		AddContent(d.renderSelectorRow(rowPosition, "Sidebar position", positionLabels[d.current.SidebarPosition], inner)).
+		AddContent(d.renderSelectorRow(rowSpacing, "Section spacing", spacingLabels[d.current.SectionSpacing], inner)).
 		AddSpace().
 		AddContent(styles.MutedStyle.Render("Sidebar sections")).
 		AddContent(d.renderToggleRow(rowUsage, "Token usage", d.current.HideUsage)).
@@ -207,15 +226,14 @@ func (d *customizeDialog) View() string {
 	return styles.DialogStyle.Width(width).Render(content)
 }
 
-// renderPositionRow renders the sidebar-position selector row.
-func (d *customizeDialog) renderPositionRow(width int) string {
-	label := "Sidebar position"
-	value := "‹ " + positionLabels[d.current.SidebarPosition] + " ›"
+// renderSelectorRow renders a row with a ‹ value › selector aligned to the right.
+func (d *customizeDialog) renderSelectorRow(row int, label, valueLabel string, width int) string {
+	value := "‹ " + valueLabel + " ›"
 
 	labelStyle := styles.PaletteUnselectedActionStyle
 	valueStyle := styles.SecondaryStyle
 	prefix := "  "
-	if d.selected == rowPosition {
+	if d.selected == row {
 		labelStyle = styles.PaletteSelectedActionStyle
 		valueStyle = styles.HighlightWhiteStyle
 		prefix = styles.HighlightWhiteStyle.Render("› ")

--- a/pkg/tui/dialog/customize_test.go
+++ b/pkg/tui/dialog/customize_test.go
@@ -37,6 +37,9 @@ func TestCustomizeDialogNavigation(t *testing.T) {
 	require.Equal(t, rowPosition, d.selected)
 
 	d.Update(down)
+	require.Equal(t, rowSpacing, d.selected)
+
+	d.Update(down)
 	require.Equal(t, rowUsage, d.selected)
 
 	for range 10 {
@@ -68,6 +71,30 @@ func TestCustomizeDialogCyclesPositionAndPreviews(t *testing.T) {
 	d.current.SidebarPosition = messages.SidebarRight
 	d.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
 	assert.Equal(t, messages.SidebarBottom, d.current.SidebarPosition)
+}
+
+func TestCustomizeDialogCyclesSpacingAndPreviews(t *testing.T) {
+	t.Parallel()
+
+	d := newTestCustomizeDialog(t, messages.LayoutSettings{})
+	require.Equal(t, messages.SpacingNormal, d.current.SectionSpacing,
+		"empty spacing normalizes to normal")
+	d.selected = rowSpacing
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	require.NotNil(t, cmd)
+	msgs := collectMsgs(cmd)
+	require.Len(t, msgs, 1)
+	preview, ok := msgs[0].(messages.PreviewLayoutMsg)
+	require.True(t, ok, "changing the spacing must emit a live preview")
+	assert.Equal(t, messages.SpacingRelaxed, preview.Layout.SectionSpacing)
+
+	d.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	assert.Equal(t, messages.SpacingCompact, d.current.SectionSpacing, "cycling wraps around")
+
+	d.current.SectionSpacing = messages.SpacingNormal
+	d.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
+	assert.Equal(t, messages.SpacingCompact, d.current.SectionSpacing)
 }
 
 func TestCustomizeDialogTogglesSection(t *testing.T) {
@@ -119,7 +146,7 @@ func TestCustomizeDialogApplyWithoutChangesOnlyCloses(t *testing.T) {
 func TestCustomizeDialogEscapeRestoresOriginal(t *testing.T) {
 	t.Parallel()
 
-	original := messages.LayoutSettings{SidebarPosition: messages.SidebarLeft}
+	original := messages.LayoutSettings{SidebarPosition: messages.SidebarLeft, SectionSpacing: messages.SpacingNormal}
 	d := newTestCustomizeDialog(t, original)
 	d.Update(tea.KeyPressMsg{Code: tea.KeyRight})
 
@@ -154,6 +181,8 @@ func TestCustomizeDialogViewShowsRows(t *testing.T) {
 	assert.Contains(t, view, "Customize Layout")
 	assert.Contains(t, view, "Sidebar position")
 	assert.Contains(t, view, "Right")
+	assert.Contains(t, view, "Section spacing")
+	assert.Contains(t, view, "Normal")
 	assert.Contains(t, view, "Token usage")
 	assert.Contains(t, view, "Agents")
 	assert.Contains(t, view, "Tools")

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -805,6 +805,7 @@ func (m *appModel) handleOpenCustomizeDialog() (tea.Model, tea.Cmd) {
 // share the same layout) and optionally persists it to the user config.
 func (m *appModel) applyLayoutSettings(settings messages.LayoutSettings, persist bool) (tea.Model, tea.Cmd) {
 	settings.SidebarPosition = messages.ParseSidebarPosition(string(settings.SidebarPosition))
+	settings.SectionSpacing = messages.ParseSectionSpacing(string(settings.SectionSpacing))
 	m.layoutSettings = settings
 
 	var cmds []tea.Cmd
@@ -831,6 +832,7 @@ func (m *appModel) applyLayoutSettings(settings messages.LayoutSettings, persist
 func layoutSettingsFromConfig(l userconfig.LayoutSettings) messages.LayoutSettings {
 	return messages.LayoutSettings{
 		SidebarPosition: messages.ParseSidebarPosition(l.SidebarPosition),
+		SectionSpacing:  messages.ParseSectionSpacing(l.SectionSpacing),
 		HideUsage:       l.HideUsage,
 		HideAgents:      l.HideAgents,
 		HideTools:       l.HideTools,
@@ -846,7 +848,7 @@ func saveLayoutToUserConfig(s messages.LayoutSettings) error {
 			cfg.Settings = &userconfig.Settings{}
 		}
 
-		if s == (messages.LayoutSettings{SidebarPosition: messages.SidebarRight}) {
+		if s == (messages.LayoutSettings{SidebarPosition: messages.SidebarRight, SectionSpacing: messages.SpacingNormal}) {
 			cfg.Settings.Layout = nil
 			return nil
 		}
@@ -855,8 +857,13 @@ func saveLayoutToUserConfig(s messages.LayoutSettings) error {
 		if s.SidebarPosition == messages.SidebarRight {
 			position = ""
 		}
+		spacing := string(s.SectionSpacing)
+		if s.SectionSpacing == messages.SpacingNormal {
+			spacing = ""
+		}
 		cfg.Settings.Layout = &userconfig.LayoutSettings{
 			SidebarPosition: position,
+			SectionSpacing:  spacing,
 			HideUsage:       s.HideUsage,
 			HideAgents:      s.HideAgents,
 			HideTools:       s.HideTools,

--- a/pkg/tui/layout_settings_test.go
+++ b/pkg/tui/layout_settings_test.go
@@ -23,17 +23,18 @@ func TestLayoutSettingsFromConfig(t *testing.T) {
 	t.Parallel()
 
 	assert.Equal(t,
-		messages.LayoutSettings{SidebarPosition: messages.SidebarRight},
+		messages.LayoutSettings{SidebarPosition: messages.SidebarRight, SectionSpacing: messages.SpacingNormal},
 		layoutSettingsFromConfig(userconfig.LayoutSettings{}),
-		"empty config falls back to the default position")
+		"empty config falls back to the default position and spacing")
 
 	assert.Equal(t,
-		messages.LayoutSettings{SidebarPosition: messages.SidebarRight},
-		layoutSettingsFromConfig(userconfig.LayoutSettings{SidebarPosition: "bogus"}),
-		"unknown positions fall back to the default")
+		messages.LayoutSettings{SidebarPosition: messages.SidebarRight, SectionSpacing: messages.SpacingNormal},
+		layoutSettingsFromConfig(userconfig.LayoutSettings{SidebarPosition: "bogus", SectionSpacing: "bogus"}),
+		"unknown values fall back to the defaults")
 
 	got := layoutSettingsFromConfig(userconfig.LayoutSettings{
 		SidebarPosition: "bottom",
+		SectionSpacing:  "compact",
 		HideUsage:       true,
 		HideAgents:      true,
 		HideTools:       true,
@@ -41,6 +42,7 @@ func TestLayoutSettingsFromConfig(t *testing.T) {
 	})
 	assert.Equal(t, messages.LayoutSettings{
 		SidebarPosition: messages.SidebarBottom,
+		SectionSpacing:  messages.SpacingCompact,
 		HideUsage:       true,
 		HideAgents:      true,
 		HideTools:       true,
@@ -53,6 +55,7 @@ func TestSaveLayoutToUserConfig_RoundTrip(t *testing.T) {
 
 	saved := messages.LayoutSettings{
 		SidebarPosition: messages.SidebarLeft,
+		SectionSpacing:  messages.SpacingRelaxed,
 		HideTools:       true,
 	}
 	require.NoError(t, saveLayoutToUserConfig(saved))
@@ -68,6 +71,7 @@ func TestSaveLayoutToUserConfig_DefaultsClearEntry(t *testing.T) {
 	}))
 	require.NoError(t, saveLayoutToUserConfig(messages.LayoutSettings{
 		SidebarPosition: messages.SidebarRight,
+		SectionSpacing:  messages.SpacingNormal,
 	}))
 
 	cfg, err := userconfig.Load()
@@ -80,6 +84,7 @@ func TestSaveLayoutToUserConfig_OmitsDefaultPosition(t *testing.T) {
 
 	require.NoError(t, saveLayoutToUserConfig(messages.LayoutSettings{
 		SidebarPosition: messages.SidebarRight,
+		SectionSpacing:  messages.SpacingNormal,
 		HideUsage:       true,
 	}))
 
@@ -88,5 +93,6 @@ func TestSaveLayoutToUserConfig_OmitsDefaultPosition(t *testing.T) {
 	layout := cfg.GetSettings().Layout
 	require.NotNil(t, layout)
 	assert.Empty(t, layout.SidebarPosition, "the default position is not written out")
+	assert.Empty(t, layout.SectionSpacing, "the default spacing is not written out")
 	assert.True(t, layout.HideUsage)
 }

--- a/pkg/tui/messages/layout.go
+++ b/pkg/tui/messages/layout.go
@@ -27,11 +27,51 @@ func ParseSidebarPosition(raw string) SidebarPosition {
 	}
 }
 
+// SectionSpacing identifies how much blank space separates the sidebar
+// sections (blocks) in the vertical sidebar.
+type SectionSpacing string
+
+const (
+	// SpacingNormal is the default spacing between sidebar sections.
+	SpacingNormal SectionSpacing = "normal"
+	// SpacingCompact tightens the sidebar by using less space between sections.
+	SpacingCompact SectionSpacing = "compact"
+	// SpacingRelaxed adds extra breathing room between sections.
+	SpacingRelaxed SectionSpacing = "relaxed"
+)
+
+// ParseSectionSpacing normalizes a raw spacing string, falling back to
+// SpacingNormal for empty or unknown values so persisted configs can never
+// break the layout.
+func ParseSectionSpacing(raw string) SectionSpacing {
+	switch SectionSpacing(raw) {
+	case SpacingCompact, SpacingRelaxed:
+		return SectionSpacing(raw)
+	default:
+		return SpacingNormal
+	}
+}
+
+// BlankLines returns the number of blank lines rendered between sidebar
+// sections for this spacing.
+func (s SectionSpacing) BlankLines() int {
+	switch ParseSectionSpacing(string(s)) {
+	case SpacingCompact:
+		return 1
+	case SpacingRelaxed:
+		return 3
+	default:
+		return 2
+	}
+}
+
 // LayoutSettings describes the user-customizable TUI layout: where the
-// sidebar sits and which of its optional sections are rendered. The zero
-// value is the default layout (sidebar on the right, everything visible).
+// sidebar sits, which of its optional sections are rendered, and how much
+// space separates them. The zero value is the default layout (sidebar on
+// the right, everything visible, normal spacing).
 type LayoutSettings struct {
 	SidebarPosition SidebarPosition
+	SectionSpacing  SectionSpacing
 	HideUsage       bool
 	HideAgents      bool
 	HideTools       bool

--- a/pkg/tui/messages/layout_test.go
+++ b/pkg/tui/messages/layout_test.go
@@ -1,0 +1,43 @@
+package messages
+
+import "testing"
+
+func TestParseSectionSpacing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		raw  string
+		want SectionSpacing
+	}{
+		{"", SpacingNormal},
+		{"normal", SpacingNormal},
+		{"compact", SpacingCompact},
+		{"relaxed", SpacingRelaxed},
+		{"bogus", SpacingNormal},
+	}
+	for _, tt := range tests {
+		if got := ParseSectionSpacing(tt.raw); got != tt.want {
+			t.Errorf("ParseSectionSpacing(%q) = %q, want %q", tt.raw, got, tt.want)
+		}
+	}
+}
+
+func TestSectionSpacingBlankLines(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		spacing SectionSpacing
+		want    int
+	}{
+		{SpacingCompact, 1},
+		{SpacingNormal, 2},
+		{SpacingRelaxed, 3},
+		{SectionSpacing(""), 2},
+		{SectionSpacing("bogus"), 2},
+	}
+	for _, tt := range tests {
+		if got := tt.spacing.BlankLines(); got != tt.want {
+			t.Errorf("SectionSpacing(%q).BlankLines() = %d, want %d", tt.spacing, got, tt.want)
+		}
+	}
+}

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -147,8 +147,8 @@ type Page interface {
 	GetSidebarSettings() SidebarSettings
 	// SetSidebarSettings applies sidebar display settings
 	SetSidebarSettings(settings SidebarSettings)
-	// SetLayoutSettings applies layout customization (sidebar position and
-	// section visibility) and relayouts the page.
+	// SetLayoutSettings applies layout customization (sidebar position,
+	// section spacing, and section visibility) and relayouts the page.
 	SetLayoutSettings(settings msgtypes.LayoutSettings) tea.Cmd
 }
 
@@ -358,12 +358,13 @@ func WithCommandParser(p *commands.Parser) PageOption {
 	}
 }
 
-// WithLayoutSettings applies initial layout customization (sidebar position
-// and section visibility).
+// WithLayoutSettings applies initial layout customization (sidebar position,
+// section spacing, and section visibility).
 func WithLayoutSettings(settings msgtypes.LayoutSettings) PageOption {
 	return func(p *chatPage) {
 		p.layoutSettings = settings
 		p.sidebar.SetSectionVisibility(sectionVisibility(settings))
+		p.sidebar.SetSectionGap(settings.SectionSpacing.BlankLines())
 	}
 }
 
@@ -1103,6 +1104,7 @@ func (p *chatPage) SetSidebarSettings(settings SidebarSettings) {
 func (p *chatPage) SetLayoutSettings(settings msgtypes.LayoutSettings) tea.Cmd {
 	p.layoutSettings = settings
 	p.sidebar.SetSectionVisibility(sectionVisibility(settings))
+	p.sidebar.SetSectionGap(settings.SectionSpacing.BlankLines())
 	if p.width <= 0 || p.height <= 0 {
 		return nil
 	}

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -100,11 +100,15 @@ type Settings struct {
 }
 
 // LayoutSettings customizes the TUI chat layout. The zero value is the
-// default layout: sidebar on the right with every section visible.
+// default layout: sidebar on the right with every section visible and
+// normal spacing between sections.
 type LayoutSettings struct {
 	// SidebarPosition places the session info sidebar: "right" (default),
 	// "left", "top", or "bottom".
 	SidebarPosition string `yaml:"sidebar_position,omitempty"`
+	// SectionSpacing controls the blank space between sidebar sections:
+	// "normal" (default), "compact", or "relaxed".
+	SectionSpacing string `yaml:"section_spacing,omitempty"`
 	// HideUsage hides the token usage section in the sidebar.
 	HideUsage bool `yaml:"hide_usage,omitempty"`
 	// HideAgents hides the agents section in the sidebar.

--- a/pkg/userconfig/userconfig_test.go
+++ b/pkg/userconfig/userconfig_test.go
@@ -185,6 +185,7 @@ func TestSettings_LayoutRoundTrip(t *testing.T) {
 		Settings: &Settings{
 			Layout: &LayoutSettings{
 				SidebarPosition: "left",
+				SectionSpacing:  "compact",
 				HideUsage:       true,
 				HideTodos:       true,
 			},
@@ -198,6 +199,7 @@ func TestSettings_LayoutRoundTrip(t *testing.T) {
 
 	layout := loaded.GetSettings().GetLayout()
 	assert.Equal(t, "left", layout.SidebarPosition)
+	assert.Equal(t, "compact", layout.SectionSpacing)
 	assert.True(t, layout.HideUsage)
 	assert.False(t, layout.HideAgents)
 	assert.False(t, layout.HideTools)


### PR DESCRIPTION
## Summary

The `/custom` layout dialog gains a **Section spacing** selector controlling the vertical gap between the sidebar sections (blocks). The gap was previously hardcoded in the tab component (2 blank lines).

| Value | Blank lines between sections |
|---|---|
| Compact | 1 |
| Normal (default) | 2 (identical to the previous rendering) |
| Relaxed | 3 |

```
│  › Sidebar position                   ‹ Right ›  │
│    Section spacing                   ‹ Normal ›  │
│                                                  │
│  Sidebar sections                                │
│    [x] Token usage                               │
│    [x] Agents                                    │
│    [x] Tools                                     │
│    [x] Todos                                     │
```

## Behavior

- Cycles with left/right arrows and previews live behind the dialog, exactly like the position selector; Enter persists, Esc restores
- Persisted as `settings.layout.section_spacing` in `~/.config/cagent/config.yaml`; omitted when `normal`, and the whole `layout` entry is cleared when every setting is at its default
- Empty or unknown persisted values fall back to `normal`, so existing configs can never break the layout
- Spacing has no effect in the collapsed band (top/bottom) mode, which has no inter-block blank lines

## Implementation

| Piece | Change |
|---|---|
| `pkg/tui/messages/layout.go` | New `SectionSpacing` type with `ParseSectionSpacing` and `BlankLines()`, mirroring the `SidebarPosition` pattern |
| `pkg/tui/components/tab/tab.go` | Sections now render flush: the trailing gap is no longer baked into the tab render |
| `pkg/tui/components/sidebar/sidebar.go` | `SetSectionGap` on the model; `renderSections` inserts the configured blank lines between sections. `appendSection` returns the section start index so agent click zones stay anchored for any gap |
| `pkg/tui/dialog/customize.go` | New selector row; `cyclePosition`/`renderPositionRow` generalized to `cycleValue`/`renderSelectorRow`, shared by both selectors |
| `pkg/tui/handlers.go` | Normalization on apply/load, persistence with default omission |
| `pkg/userconfig/userconfig.go` | New `section_spacing` field (`omitempty`) |
| `docs/features/tui/index.md` | Documents the new setting and the config key |

The tab header structure (title line + one padding line) is intentionally unchanged: it is load-bearing for click-zone offsets (`tabHeaderLines`, `verticalStarY`).

## Testing

- New tests: dialog spacing cycling and live preview, rendered gap at 1/2/3 blank lines, agent click zones with a non-default gap, `ParseSectionSpacing`/`BlankLines` mapping, user config round trip and default omission
- `go build ./...`, `golangci-lint run` (0 issues), full `pkg/tui/...` and `pkg/userconfig` suites pass
