### PR TITLE
fix(session): don't reset the session DB on transient open errors

### DIFF
--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -481,6 +481,15 @@ func NewSQLiteSessionStore(ctx context.Context, path string) (Store, error) {
 			return nil, err
 		}
 
+		// Don't attempt recovery for transient errors: a canceled context
+		// (e.g. Ctrl-C during startup) or a BUSY/LOCKED database (e.g. a
+		// second docker-agent instance holding a write lock). A fresh database
+		// can't fix those, and the reset would silently discard a perfectly
+		// healthy session history.
+		if sqliteutil.IsTransientError(err) {
+			return nil, err
+		}
+
 		// If migrations failed, try to recover by backing up the database and starting fresh
 		slog.WarnContext(ctx, "Failed to open session store, attempting recovery", "error", err)
 
@@ -592,6 +601,18 @@ func backupDatabase(path string) error {
 	return nil
 }
 
+// parseCreatedAt parses a created_at column value. A corrupt timestamp in a
+// single row must not make every session unloadable, so parse failures are
+// logged and the zero time is returned instead of an error.
+func parseCreatedAt(createdAtStr string) time.Time {
+	t, err := time.Parse(time.RFC3339, createdAtStr)
+	if err != nil {
+		slog.Warn("Invalid created_at in session database, using zero time", "value", createdAtStr, "error", err)
+		return time.Time{}
+	}
+	return t
+}
+
 // AddSession adds a new session to the store, including any messages
 func (s *SQLiteSessionStore) AddSession(ctx context.Context, session *Session) error {
 	if session.ID == "" {
@@ -663,11 +684,7 @@ func scanSession(scanner interface {
 		return nil, err
 	}
 
-	sess.CreatedAt, err = time.Parse(time.RFC3339, createdAtStr)
-	if err != nil {
-		return nil, err
-	}
-
+	sess.CreatedAt = parseCreatedAt(createdAtStr)
 	sess.WorkingDir = workingDir.String
 	sess.ParentID = parentID.String
 
@@ -875,10 +892,7 @@ func (s *SQLiteSessionStore) GetSessionSummaries(ctx context.Context) ([]Summary
 		if err := rows.Scan(&summary.ID, &summary.Title, &createdAtStr, &summary.Starred, &workingDir, &summary.NumMessages); err != nil {
 			return nil, err
 		}
-		summary.CreatedAt, err = time.Parse(time.RFC3339, createdAtStr)
-		if err != nil {
-			return nil, err
-		}
+		summary.CreatedAt = parseCreatedAt(createdAtStr)
 		summary.WorkingDir = workingDir.String
 		summaries = append(summaries, summary)
 	}

--- a/pkg/session/store_test.go
+++ b/pkg/session/store_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"os"
@@ -232,6 +233,39 @@ func TestGetSessionSummaries(t *testing.T) {
 	assert.Equal(t, session1Time, summaries[1].CreatedAt)
 	assert.Equal(t, 1, summaries[1].NumMessages)
 	assert.Equal(t, "/work/project", summaries[1].WorkingDir)
+}
+
+func TestGetSessionSummaries_CorruptCreatedAt(t *testing.T) {
+	t.Parallel()
+
+	tempDB := filepath.Join(t.TempDir(), "test_corrupt_created_at.db")
+
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
+	require.NoError(t, err)
+	sqlStore := store.(*SQLiteSessionStore)
+	defer sqlStore.Close()
+
+	validTime := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, store.AddSession(t.Context(), &Session{ID: "valid", CreatedAt: validTime}))
+
+	// Simulate a corrupt row written by an older/buggy version.
+	_, err = sqlStore.db.ExecContext(t.Context(),
+		"INSERT INTO sessions (id, created_at) VALUES (?, ?)", "corrupt", "139800")
+	require.NoError(t, err)
+
+	// Listing must not fail; the corrupt row gets a zero CreatedAt.
+	summaries, err := store.GetSessionSummaries(t.Context())
+	require.NoError(t, err)
+	require.Len(t, summaries, 2)
+	assert.Equal(t, "valid", summaries[0].ID)
+	assert.Equal(t, validTime, summaries[0].CreatedAt)
+	assert.Equal(t, "corrupt", summaries[1].ID)
+	assert.True(t, summaries[1].CreatedAt.IsZero())
+
+	// Loading the corrupt session directly must not fail either.
+	sess, err := store.GetSession(t.Context(), "corrupt")
+	require.NoError(t, err)
+	assert.True(t, sess.CreatedAt.IsZero())
 }
 
 func TestGetSessionSummaries_InMemory_WorkingDir(t *testing.T) {
@@ -715,6 +749,39 @@ func TestNewSQLiteSessionStore_RejectsNewerDatabase(t *testing.T) {
 	require.ErrorIs(t, err, ErrNewerDatabase)
 	assert.Contains(t, err.Error(), "9999")
 	assert.Contains(t, err.Error(), "upgrade docker-agent")
+}
+
+// TestNewSQLiteSessionStore_TransientErrorPreservesDB verifies that a
+// transient failure during open (here: a canceled context, e.g. Ctrl-C
+// during startup) does NOT trigger the backup-and-reset recovery path,
+// which would silently discard a healthy session history.
+func TestNewSQLiteSessionStore_TransientErrorPreservesDB(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "test_transient.db")
+
+	// Create a valid database with one session.
+	store, err := NewSQLiteSessionStore(t.Context(), dbPath)
+	require.NoError(t, err)
+	require.NoError(t, store.AddSession(t.Context(), &Session{ID: "keep-me", CreatedAt: time.Now()}))
+	require.NoError(t, store.Close())
+
+	// Opening with an already-canceled context must fail without recovery.
+	canceled, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err = NewSQLiteSessionStore(canceled, dbPath)
+	require.ErrorIs(t, err, context.Canceled)
+
+	// The database must be untouched: no .bak, data still there.
+	_, err = os.Stat(dbPath + ".bak")
+	assert.True(t, os.IsNotExist(err), "no backup should be created for transient errors")
+
+	store, err = NewSQLiteSessionStore(t.Context(), dbPath)
+	require.NoError(t, err)
+	defer store.Close()
+	retrieved, err := store.GetSession(t.Context(), "keep-me")
+	require.NoError(t, err)
+	assert.Equal(t, "keep-me", retrieved.ID)
 }
 
 func TestNewSQLiteSessionStore_MigrationFailureRecovery(t *testing.T) {

--- a/pkg/sqliteutil/sqlite.go
+++ b/pkg/sqliteutil/sqlite.go
@@ -61,6 +61,23 @@ func IsCantOpenError(err error) bool {
 	return false
 }
 
+// IsTransientError reports whether err is a temporary condition that a retry
+// (not a schema fix) would resolve: a canceled/expired context, or a SQLite
+// BUSY/LOCKED error from a concurrent writer. The primary result code is
+// compared after masking off extended-code bits (e.g. SQLITE_BUSY_SNAPSHOT).
+func IsTransientError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if sqliteErr, ok := errors.AsType[*sqlite.Error](err); ok {
+		switch sqliteErr.Code() & 0xff {
+		case sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED:
+			return true
+		}
+	}
+	return false
+}
+
 // DiagnoseDBOpenError provides a more helpful error message when SQLite
 // fails to open/create a database file.
 func DiagnoseDBOpenError(path string, originalErr error) error {

--- a/pkg/sqliteutil/sqlite_test.go
+++ b/pkg/sqliteutil/sqlite_test.go
@@ -1,0 +1,50 @@
+package sqliteutil
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsTransientError(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, IsTransientError(nil))
+	assert.False(t, IsTransientError(errors.New("boom")))
+	assert.True(t, IsTransientError(context.Canceled))
+	assert.True(t, IsTransientError(context.DeadlineExceeded))
+	assert.True(t, IsTransientError(fmt.Errorf("wrapped: %w", context.Canceled)))
+}
+
+func TestIsTransientError_SQLiteBusy(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "busy.db")
+	dsn := path + "?_pragma=busy_timeout(0)&_pragma=journal_mode(WAL)"
+
+	writer, err := sql.Open("sqlite", dsn)
+	require.NoError(t, err)
+	defer writer.Close()
+
+	tx, err := writer.BeginTx(t.Context(), nil)
+	require.NoError(t, err)
+	defer tx.Rollback() //nolint:errcheck // test cleanup, error irrelevant
+	_, err = tx.ExecContext(t.Context(), "CREATE TABLE t (id INTEGER)")
+	require.NoError(t, err)
+
+	// A second connection hits the write lock and gets SQLITE_BUSY.
+	blocked, err := sql.Open("sqlite", dsn)
+	require.NoError(t, err)
+	defer blocked.Close()
+
+	_, err = blocked.ExecContext(t.Context(), "CREATE TABLE u (id INTEGER)")
+	require.Error(t, err)
+	assert.True(t, IsTransientError(err), "SQLITE_BUSY should be transient: %v", err)
+	assert.False(t, IsCantOpenError(err))
+}


### PR DESCRIPTION
The SQLite session store's backup-and-reset recovery path in `NewSQLiteSessionStore` fired on *any* open or migration error, including transient ones. A canceled context (e.g. Ctrl-C during slow startup on a large DB) or `SQLITE_BUSY`/`SQLITE_LOCKED` from a second running docker-agent instance would silently rename a perfectly healthy `session.db` to `session.db.bak` and start fresh, causing users to lose access to all their old sessions. This was reproduced locally: a 708 MB database with 3342 sessions was moved aside by a single interrupted startup.

The fix introduces a `sqliteutil.IsTransientError` helper that matches canceled or expired contexts alongside SQLite primary result codes `SQLITE_BUSY` and `SQLITE_LOCKED`, including extended codes like `SQLITE_BUSY_SNAPSHOT`. The recovery path in `pkg/session/store.go` is now gated on this helper, so backup-and-reset only runs for genuinely corrupt or unrecoverable databases, never for errors that would resolve on retry.

Regression tests cover the new helper directly (`TestIsTransientError`, `TestIsTransientError_SQLiteBusy`) and the store behavior (`TestNewSQLiteSessionStore_TransientErrorPreservesDB`), verifying that a canceled context neither creates a `.bak` file nor discards existing session data.