### PR TITLE
fix(tui): make selection copy reliable and improve copy affordances

### DIFF
--- a/e2e/tui/chat_test.go
+++ b/e2e/tui/chat_test.go
@@ -55,6 +55,26 @@ func TestChat_CopyAssistantMessageToClipboard(t *testing.T) {
 	d.MoveMouseToText("2 + 2 equals 4.").
 		WaitFor(tuitest.Contains(types.AssistantMessageCopyLabel)).
 		ClickText(types.AssistantMessageCopyLabel).
+		WaitForClipboard("2 + 2 equals 4.").
+		// The clicked label transiently reads "copied" instead of "⎘ copy".
+		WaitFor(tuitest.Not(tuitest.Contains(types.AssistantMessageCopyLabel))).
+		WaitFor(tuitest.Contains(types.CopiedFeedbackLabel))
+}
+
+// TestChat_DragSelectionCopiesAcrossRegions guards the mouse routing that
+// keeps a text-selection drag alive outside the chat content region: the
+// drag starts on the response text and releases near the bottom of the
+// screen (over the editor/status area). The release must still finalize the
+// selection and copy it.
+func TestChat_DragSelectionCopiesAcrossRegions(t *testing.T) {
+	d := newTUI(t, "testdata/basic.yaml", 120, 40, tui.WithHideSidebar())
+
+	d.Type("What's 2+2?").
+		Enter().
+		WaitFor(tuitest.Contains("2 + 2 equals 4."))
+
+	x, y := d.MustFindText("2 + 2 equals 4.")
+	d.Drag(x, y, x+30, 37).
 		WaitForClipboard("2 + 2 equals 4.")
 }
 

--- a/e2e/tui/testdata/cassettes/TestChat_DragSelectionCopiesAcrossRegions.yaml
+++ b/e2e/tui/testdata/cassettes/TestChat_DragSelectionCopiesAcrossRegions.yaml
@@ -1,0 +1,95 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.openai.com
+        body: '{"messages":[{"content":"You are a knowledgeable assistant that helps users with various tasks.\nBe helpful, accurate, and concise in your responses.\n","role":"system"},{"content":"What''s 2+2?","role":"user"}],"model":"gpt-3.5-turbo","stream_options":{"include_usage":true},"stream":true}'
+        url: https://api.openai.com/v1/chat/completions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: |+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"31MAoT3T"}
+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"2"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"f989QXFJX"}
+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" +"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"LjplBv32"}
+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" "},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"OS4QsUws6"}
+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"2"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"TW89LuVuk"}
+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" equals"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"vrL"}
+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" "},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"T8WY0RY3s"}
+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"4"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"0kTGMpnIE"}
+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"1pmLrWtWp"}
+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"Rsle"}
+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":41,"completion_tokens":8,"total_tokens":49,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"FdScpa1UzO"}
+
+            data: [DONE]
+
+        headers: {}
+        status: 200 OK
+        code: 200
+        duration: 376.601459ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.openai.com
+        body: '{"messages":[{"content":"You are a helpful AI assistant that generates concise, descriptive titles for conversations. You will be given up to 2 recent user messages and asked to create a single-line title that captures the main topic. Never use newlines or line breaks in your response.","role":"system"},{"content":"Based on the following recent user messages from a conversation with an AI assistant, generate a short, descriptive title (maximum 50 characters) that captures the main topic or purpose of the conversation. Return ONLY the title text on a single line, nothing else. Do not include any newlines, explanations, or formatting.\n\nRecent user messages:\n1. What''s 2+2?\n\n\n","role":"user"}],"model":"gpt-3.5-turbo","stream_options":{"include_usage":true},"stream":true}'
+        url: https://api.openai.com/v1/chat/completions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: |+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"3praRFP3"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"Simple"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"0Qwz"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" Math"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"j2ifs"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"NiTsH3kiT"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" Addition"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"x"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" of"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"eHDT8Y6"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" "},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ImGlkQ1UD"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"2"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"r0pbd1luX"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" and"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"fbgjGd"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" "},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"zJqaxx5ri"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"2"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"irCJfvsMd"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"psUW"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":100,"completion_tokens":10,"total_tokens":110,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"3lP94vJ"}
+
+            data: [DONE]
+
+        headers: {}
+        status: 200 OK
+        code: 200
+        duration: 443.446208ms

--- a/pkg/tui/components/markdown/codeblock.go
+++ b/pkg/tui/components/markdown/codeblock.go
@@ -1,11 +1,11 @@
 package markdown
 
-// CodeBlockCopyIcon is the unicode glyph rendered at the top-right corner of
-// every fenced code block. Clicking on it copies the block's raw content to
-// the clipboard. It matches the glyph used for the message-level copy
-// affordance so the visual language stays consistent; the two are
-// disambiguated by line index, not by glyph.
-const CodeBlockCopyIcon = "\u2398"
+// CodeBlockCopyIcon is the label rendered at the top-right corner of every
+// fenced code block. Clicking on it copies the block's raw content to the
+// clipboard. It matches the message-level copy affordance so the visual
+// language stays consistent; the two are disambiguated by line index, not by
+// label text.
+const CodeBlockCopyIcon = "\u2398 copy"
 
 // CodeBlock describes a fenced code block emitted by the renderer.
 //

--- a/pkg/tui/components/messages/clipboard.go
+++ b/pkg/tui/components/messages/clipboard.go
@@ -1,6 +1,7 @@
 package messages
 
 import (
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -10,7 +11,9 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/mattn/go-runewidth"
 
+	"github.com/docker/docker-agent/pkg/tui/components/markdown"
 	"github.com/docker/docker-agent/pkg/tui/components/notification"
+	"github.com/docker/docker-agent/pkg/tui/types"
 )
 
 var (
@@ -118,6 +121,32 @@ func runeIndexToDisplayWidth(s string, runeIdx int) int {
 	return width
 }
 
+// uiAffordanceLines lists the purely decorative click affordances (copy,
+// edit, retry labels, collapse indicator) that can appear on their own line
+// in rendered messages. Built as a slice because some labels share the same
+// text (message-level and code-block copy), which a switch would reject as
+// duplicate cases.
+var uiAffordanceLines = []string{
+	types.AssistantMessageCopyLabel,
+	markdown.CodeBlockCopyIcon,
+	types.UserMessageEditLabel,
+	types.ErrorRetryLabel,
+	"[-] collapse",
+}
+
+// isUIAffordanceLine reports whether a selected line, once trimmed, is one of
+// the purely decorative click affordances. Those lines are UI chrome, not
+// message content, so they are dropped from clipboard copies.
+func isUIAffordanceLine(trimmed string) bool {
+	if trimmed == "" {
+		return false
+	}
+	if slices.Contains(uiAffordanceLines, trimmed) {
+		return true
+	}
+	return strings.HasPrefix(trimmed, "[+] expand ") && strings.HasSuffix(trimmed, " more lines")
+}
+
 // extractSelectedText extracts the currently selected text from rendered content
 func (m *model) extractSelectedText() string {
 	if !m.selection.active {
@@ -135,7 +164,7 @@ func (m *model) extractSelectedText() string {
 		endLine = len(lines) - 1
 	}
 
-	var result strings.Builder
+	var selected []string
 	for i := startLine; i <= endLine && i < len(lines); i++ {
 		originalLine := lines[i]
 		// Strip ANSI codes first to get the displayed text with borders
@@ -160,45 +189,97 @@ func (m *model) extractSelectedText() string {
 		}
 
 		// Find the closest rune index for the start and end columns
-		startRuneIdx := findClosestRuneIndex(visualToRune, startCol, len(runes))
-		endRuneIdx := findClosestRuneIndex(visualToRune, endCol, len(runes))
+		lineWidth := visualCol
+		startRuneIdx := findClosestRuneIndex(visualToRune, startCol, len(runes), lineWidth)
+		endRuneIdx := findClosestRuneIndex(visualToRune, endCol, len(runes), lineWidth)
 
 		var lineText string
 		switch i {
 		case startLine:
 			if startLine == endLine {
 				if startRuneIdx < len(runes) && startRuneIdx < endRuneIdx {
-					lineText = strings.TrimSpace(string(runes[startRuneIdx:endRuneIdx]))
+					lineText = string(runes[startRuneIdx:endRuneIdx])
 				}
 				break
 			}
 			// First line: from startCol to end
 			if startRuneIdx < len(runes) {
-				lineText = strings.TrimSpace(string(runes[startRuneIdx:]))
+				lineText = string(runes[startRuneIdx:])
 			}
 		case endLine:
 			// Last line: from start to endCol
-			lineText = strings.TrimSpace(string(runes[:endRuneIdx]))
+			lineText = string(runes[:endRuneIdx])
 		default:
 			// Middle lines: entire line
-			lineText = strings.TrimSpace(line)
+			lineText = line
 		}
 
-		if lineText != "" {
-			result.WriteString(lineText)
+		// Keep leading whitespace (indentation) but drop the width padding
+		// that rendered lines carry on the right.
+		lineText = strings.TrimRight(lineText, " \t")
+		if isUIAffordanceLine(strings.TrimSpace(lineText)) {
+			continue
 		}
-		result.WriteString("\n")
+		selected = append(selected, lineText)
 	}
 
-	return result.String()
+	return cleanSelectedLines(selected)
+}
+
+// cleanSelectedLines normalizes extracted selection lines for the clipboard:
+// blank lines at both ends are dropped (message padding, separators) and the
+// common leading whitespace shared by all non-blank lines is removed, so text
+// loses the message envelope's padding but keeps its relative indentation
+// (essential when copying code).
+func cleanSelectedLines(lines []string) string {
+	start, end := 0, len(lines)
+	for start < end && lines[start] == "" {
+		start++
+	}
+	for end > start && lines[end-1] == "" {
+		end--
+	}
+	lines = lines[start:end]
+	if len(lines) == 0 {
+		return ""
+	}
+
+	indent := -1
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		n := len(line) - len(strings.TrimLeft(line, " "))
+		if indent < 0 || n < indent {
+			indent = n
+		}
+	}
+	if indent <= 0 {
+		return strings.Join(lines, "\n")
+	}
+
+	out := make([]string, len(lines))
+	for i, line := range lines {
+		if line != "" {
+			out[i] = line[indent:]
+		}
+	}
+	return strings.Join(out, "\n")
 }
 
 // findClosestRuneIndex finds the rune index for a given visual column,
-// or the closest next rune if the exact column doesn't exist
-func findClosestRuneIndex(visualToRune map[int]int, visualCol, maxRunes int) int {
+// or the closest next rune if the exact column doesn't exist.
+// Columns at or beyond the end of the line map to one past the last rune, so
+// a selection dragged past the end of an unpadded line still includes its
+// last character (slicing treats the end index as exclusive).
+func findClosestRuneIndex(visualToRune map[int]int, visualCol, maxRunes, lineWidth int) int {
 	// Try exact match first
 	if runeIdx, ok := visualToRune[visualCol]; ok {
 		return runeIdx
+	}
+
+	if visualCol >= lineWidth {
+		return maxRunes
 	}
 
 	// Find the next available rune index after the visual column
@@ -225,7 +306,7 @@ func (m *model) copySelectionToClipboard() tea.Cmd {
 		return nil
 	}
 
-	selectedText := strings.TrimSpace(m.extractSelectedText())
+	selectedText := m.extractSelectedText()
 	if selectedText == "" {
 		return nil
 	}

--- a/pkg/tui/components/messages/clipboard_test.go
+++ b/pkg/tui/components/messages/clipboard_test.go
@@ -1,0 +1,197 @@
+package messages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tui/components/markdown"
+	"github.com/docker/docker-agent/pkg/tui/service"
+	"github.com/docker/docker-agent/pkg/tui/types"
+)
+
+// newSelectionModel builds a model whose rendered lines are set directly so
+// selection extraction can be exercised without rendering real messages.
+func newSelectionModel(lines []string) *model {
+	m := NewScrollableView(80, 24, &service.SessionState{}).(*model)
+	m.renderedLines = lines
+	m.totalHeight = len(lines)
+	m.renderDirty = false
+	return m
+}
+
+func (m *model) selectRange(startLine, startCol, endLine, endCol int) {
+	m.selection.active = true
+	m.selection.startLine = startLine
+	m.selection.startCol = startCol
+	m.selection.endLine = endLine
+	m.selection.endCol = endCol
+}
+
+func TestExtractSelectedTextStripsPaddingAndAffordances(t *testing.T) {
+	t.Parallel()
+
+	m := newSelectionModel([]string{
+		"                                       " + types.AssistantMessageCopyLabel,
+		"  Here is the code:                    ",
+		"",
+		"                          " + markdown.CodeBlockCopyIcon,
+		"    func main() {                      ",
+		"        fmt.Println()                  ",
+		"    }                                  ",
+		"",
+	})
+	m.selectRange(0, 0, 7, 79)
+
+	got := m.extractSelectedText()
+	want := "Here is the code:\n\n  func main() {\n      fmt.Println()\n  }"
+	assert.Equal(t, want, got)
+}
+
+func TestExtractSelectedTextPreservesRelativeIndentation(t *testing.T) {
+	t.Parallel()
+
+	// Selecting only code lines: the shared envelope padding is removed but
+	// the code's own indentation must survive.
+	m := newSelectionModel([]string{
+		"  Some intro text                      ",
+		"    if ok {                            ",
+		"        return nil                     ",
+		"    }                                  ",
+	})
+	m.selectRange(1, 0, 3, 79)
+
+	got := m.extractSelectedText()
+	want := "if ok {\n    return nil\n}"
+	assert.Equal(t, want, got)
+}
+
+func TestExtractSelectedTextSingleLine(t *testing.T) {
+	t.Parallel()
+
+	m := newSelectionModel([]string{"  hello world                          "})
+	m.selectRange(0, 1, 0, 79)
+
+	assert.Equal(t, "hello world", m.extractSelectedText())
+}
+
+func TestExtractSelectedTextPastEndOfLineKeepsLastChar(t *testing.T) {
+	t.Parallel()
+
+	// Dragging past the end of an unpadded line must include its last
+	// character, not stop one rune short.
+	m := newSelectionModel([]string{"hello world"})
+	m.selectRange(0, 0, 0, 42)
+
+	assert.Equal(t, "hello world", m.extractSelectedText())
+}
+
+func TestExtractSelectedTextDropsUserEditAffordance(t *testing.T) {
+	t.Parallel()
+
+	m := newSelectionModel([]string{
+		"┃                             " + types.UserMessageEditLabel,
+		"┃ do the thing                 ",
+	})
+	m.selectRange(0, 0, 1, 79)
+
+	assert.Equal(t, "do the thing", m.extractSelectedText())
+}
+
+func TestExtractSelectedTextOnAffordanceOnlySelectionIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	m := newSelectionModel([]string{
+		"                                       " + types.AssistantMessageCopyLabel,
+	})
+	m.selectRange(0, 0, 0, 79)
+
+	assert.Empty(t, m.extractSelectedText())
+	require.Nil(t, m.copySelectionToClipboard())
+}
+
+func TestExtractSelectedTextKeepsInteriorBlankLines(t *testing.T) {
+	t.Parallel()
+
+	m := newSelectionModel([]string{
+		"  first paragraph                      ",
+		"",
+		"  second paragraph                     ",
+	})
+	m.selectRange(0, 0, 2, 79)
+
+	assert.Equal(t, "first paragraph\n\nsecond paragraph", m.extractSelectedText())
+}
+
+func TestIsUIAffordanceLine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		line string
+		want bool
+	}{
+		{types.AssistantMessageCopyLabel, true},
+		{markdown.CodeBlockCopyIcon, true},
+		{types.UserMessageEditLabel, true},
+		{types.ErrorRetryLabel, true},
+		{"[-] collapse", true},
+		{"[+] expand 12 more lines", true},
+		{"", false},
+		{"copy", false},
+		{"[+] expand stuff", false},
+		{"regular content line", false},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, isUIAffordanceLine(tt.line), "line %q", tt.line)
+	}
+}
+
+func TestCleanSelectedLines(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		lines []string
+		want  string
+	}{
+		{
+			name:  "empty input",
+			lines: nil,
+			want:  "",
+		},
+		{
+			name:  "only blank lines",
+			lines: []string{"", "", ""},
+			want:  "",
+		},
+		{
+			name:  "boundary blanks dropped",
+			lines: []string{"", "text", ""},
+			want:  "text",
+		},
+		{
+			name:  "common indent removed",
+			lines: []string{"  a", "    b", "  c"},
+			want:  "a\n  b\nc",
+		},
+		{
+			name:  "blank lines ignored for indent",
+			lines: []string{"  a", "", "  b"},
+			want:  "a\n\nb",
+		},
+		{
+			name:  "no indent left untouched",
+			lines: []string{"a", "  b"},
+			want:  "a\n  b",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, cleanSelectedLines(tt.lines))
+		})
+	}
+}

--- a/pkg/tui/components/messages/copyfeedback.go
+++ b/pkg/tui/components/messages/copyfeedback.go
@@ -1,0 +1,96 @@
+package messages
+
+import (
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/docker/docker-agent/pkg/tui/components/markdown"
+	"github.com/docker/docker-agent/pkg/tui/styles"
+	"github.com/docker/docker-agent/pkg/tui/types"
+)
+
+// copiedFlashDuration is how long a clicked copy label reads "copied" before
+// reverting.
+const copiedFlashDuration = 1500 * time.Millisecond
+
+// copiedFlash tracks the transient "copied" confirmation shown in place of a
+// copy label after it is clicked. The label is addressed by message index and
+// line within that message's view so it stays put when content above shifts.
+type copiedFlash struct {
+	msgIdx    int
+	localLine int
+	codeBlock bool
+	seq       int
+}
+
+// copiedFlashExpiredMsg reverts the "copied" confirmation once the flash
+// duration elapsed. Seq guards against reverting a newer flash.
+type copiedFlashExpiredMsg struct {
+	Seq int
+}
+
+// flashCopiedLabel swaps the clicked copy label for a transient "copied"
+// confirmation and schedules its revert.
+func (m *model) flashCopiedLabel(msgIdx, localLine int, codeBlock bool) tea.Cmd {
+	m.copiedFlashSeq++
+	seq := m.copiedFlashSeq
+	m.copiedFlash = &copiedFlash{msgIdx: msgIdx, localLine: localLine, codeBlock: codeBlock, seq: seq}
+	return tea.Tick(copiedFlashDuration, func(time.Time) tea.Msg {
+		return copiedFlashExpiredMsg{Seq: seq}
+	})
+}
+
+// handleCopiedFlashExpired clears the flash unless a newer one replaced it.
+func (m *model) handleCopiedFlashExpired(msg copiedFlashExpiredMsg) {
+	if m.copiedFlash != nil && m.copiedFlash.seq == msg.Seq {
+		m.copiedFlash = nil
+	}
+}
+
+// applyCopiedFlash replaces the flashed copy label with the same-width
+// "copied" confirmation on the visible line it lives on. It is a view-time
+// overlay: rendered caches are left untouched and the swap disappears on its
+// own once the flash state is cleared.
+func (m *model) applyCopiedFlash(lines []string, viewportStartLine int) []string {
+	f := m.copiedFlash
+	if f == nil || f.msgIdx < 0 || f.msgIdx >= len(m.lineOffsets) {
+		return lines
+	}
+	idx := m.lineOffsets[f.msgIdx] + f.localLine - viewportStartLine
+	if idx < 0 || idx >= len(lines) {
+		return lines
+	}
+
+	label := types.AssistantMessageCopyLabel
+	if f.codeBlock {
+		label = markdown.CodeBlockCopyIcon
+	}
+
+	line := lines[idx]
+	plain := ansi.Strip(line)
+	before, _, ok := strings.Cut(plain, label)
+	if !ok {
+		return lines
+	}
+	start := ansi.StringWidth(before)
+	end := start + ansi.StringWidth(label)
+
+	style := styles.SuccessStyle.Bold(true)
+	if f.codeBlock {
+		// Keep the code block's background band intact behind the swap.
+		if bg := styles.MarkdownStyle().CodeBlock.BackgroundColor; bg != nil {
+			style = style.Background(lipgloss.Color(*bg))
+		}
+	}
+
+	result := make([]string, len(lines))
+	copy(result, lines)
+	result[idx] = ansi.Cut(line, 0, start) +
+		style.Render(types.CopiedFeedbackLabel) +
+		ansi.Cut(line, end, ansi.StringWidth(plain))
+	return result
+}

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -82,6 +82,9 @@ type Model interface {
 	// IsScrollbarDragging returns true when the scrollbar thumb is being dragged.
 	IsScrollbarDragging() bool
 
+	// IsSelecting returns true while a text-selection drag is in progress.
+	IsSelecting() bool
+
 	// IsMouseOnScrollbar returns true when the given screen coordinates are on the scrollbar.
 	IsMouseOnScrollbar(x, y int) bool
 
@@ -158,6 +161,10 @@ type model struct {
 
 	// Hover state for showing copy button on assistant messages
 	hoveredMessageIndex int // Index of message under mouse (-1 = none)
+
+	// Transient "copied" confirmation over the last clicked copy label
+	copiedFlash    *copiedFlash
+	copiedFlashSeq int
 
 	// Hovered URL for underline-on-hover effect (nil = no URL hovered)
 	hoveredURL *hoveredURL
@@ -241,6 +248,10 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	case DebouncedCopyMsg:
 		cmd := m.handleDebouncedCopy(msg)
 		return m, cmd
+
+	case copiedFlashExpiredMsg:
+		m.handleCopiedFlashExpired(msg)
+		return m, nil
 
 	case scrollToBottomMsg:
 		if !m.userHasScrolled {
@@ -345,12 +356,15 @@ func (m *model) handleMouseClick(msg tea.MouseClickMsg) (layout.Model, tea.Cmd) 
 		}
 
 		if content, ok := m.codeBlockAt(msgIdx, localLine, col); ok {
-			return m, copyTextToClipboard(content)
+			return m, tea.Batch(copyTextToClipboard(content), m.flashCopiedLabel(msgIdx, localLine, true))
 		}
 
 		if m.isCopyLabelClick(msgIdx, localLine, col) {
 			cmd := m.copyMessageToClipboard(msgIdx)
-			return m, cmd
+			if cmd == nil {
+				return m, nil
+			}
+			return m, tea.Batch(cmd, m.flashCopiedLabel(msgIdx, localLine, false))
 		}
 
 		if m.isRetryLabelClick(msgIdx, localLine, col) {
@@ -365,15 +379,32 @@ func (m *model) handleMouseClick(msg tea.MouseClickMsg) (layout.Model, tea.Cmd) 
 	clickCount := m.selection.detectClickType(line, col)
 
 	switch clickCount {
-	case 3: // Triple-click: select line
-		m.selectLineAt(line)
-		m.selection.pendingCopyID++ // Cancel any pending double-click copy
-		cmd := m.copySelectionToClipboard()
-		return m, cmd
-	case 2: // Double-click: select word with debounced copy
-		m.selectWordAt(line, col)
-		cmd := m.scheduleDebouncedCopy()
-		return m, cmd
+	case 3: // Triple-click: select line, drag extends it, copy on release/debounce
+		if m.selectLineAt(line) {
+			m.selection.mouseButtonDown = true
+			m.selection.mouseY = msg.Y
+			m.selection.anchorTo()
+			cmd := m.scheduleDebouncedCopy()
+			return m, cmd
+		}
+		// Blank line: fall back to a plain drag selection.
+		m.selection.start(line, col)
+		m.selection.mouseY = msg.Y
+		return m, nil
+	case 2: // Double-click: select word, drag extends it, copy on release/debounce
+		if m.selectWordAt(line, col) {
+			// Keep tracking the button so a double-click drag extends the
+			// selection word-anchored instead of being ignored.
+			m.selection.mouseButtonDown = true
+			m.selection.mouseY = msg.Y
+			m.selection.anchorTo()
+			cmd := m.scheduleDebouncedCopy()
+			return m, cmd
+		}
+		// Blank line: fall back to a plain drag selection.
+		m.selection.start(line, col)
+		m.selection.mouseY = msg.Y
+		return m, nil
 	default: // Single click: start drag selection
 		m.selection.start(line, col)
 		m.selection.mouseY = msg.Y
@@ -416,6 +447,11 @@ func (m *model) handleMouseMotion(msg tea.MouseMotionMsg) (layout.Model, tea.Cmd
 
 	if m.selection.mouseButtonDown && m.selection.active {
 		line, col := m.mouseToLineCol(msg.X, msg.Y)
+		// Any real movement turns a multi-click into a drag: the copy now
+		// belongs to the release handler, not the debounced word copy.
+		if line != m.selection.lastClickLine || col != m.selection.lastClickCol {
+			m.selection.pendingCopyID++
+		}
 		m.selection.update(line, col)
 		m.selection.mouseY = msg.Y
 		cmd := m.autoScroll()
@@ -456,10 +492,16 @@ func (m *model) handleMouseRelease(msg tea.MouseReleaseMsg) (layout.Model, tea.C
 	if msg.Button == tea.MouseLeft && m.selection.mouseButtonDown {
 		if m.selection.active {
 			line, col := m.mouseToLineCol(msg.X, msg.Y)
-			m.selection.update(line, col)
 
-			// If the mouse didn't move, this was a plain click — open URL if any
-			if line == m.selection.startLine && col == m.selection.startCol {
+			// If the mouse didn't move since the press, this wasn't a drag.
+			if line == m.selection.lastClickLine && col == m.selection.lastClickCol {
+				if m.selection.hasRange() {
+					// Word/line selection from a multi-click: keep it, the
+					// debounced copy fires.
+					m.selection.end()
+					return m, nil
+				}
+				// Plain click — open URL if any
 				m.selection.clear()
 				if url := m.urlAt(line, col); url != "" {
 					return m, core.CmdHandler(messages.OpenURLMsg{URL: url})
@@ -467,7 +509,12 @@ func (m *model) handleMouseRelease(msg tea.MouseReleaseMsg) (layout.Model, tea.C
 				return m, nil
 			}
 
+			m.selection.update(line, col)
 			m.selection.end()
+			m.selection.pendingCopyID++ // The drag copy supersedes any pending word copy
+			// A completed drag is not part of a multi-click sequence: the next
+			// press must start a fresh selection, not a word/line selection.
+			m.selection.resetClickTracking()
 			cmd := m.copySelectionToClipboard()
 			return m, cmd
 		}
@@ -613,6 +660,7 @@ func (m *model) View() string {
 	}
 
 	visibleLines = m.applyURLUnderline(visibleLines, startLine)
+	visibleLines = m.applyCopiedFlash(visibleLines, startLine)
 
 	// Sync scroll state and delegate rendering to scrollview which guarantees
 	// fixed-width padding, pinned scrollbar, and exact height. Selection and
@@ -1979,6 +2027,13 @@ func (m *model) isMouseOnScrollbar(x, y int) bool {
 
 func (m *model) IsScrollbarDragging() bool {
 	return m.scrollview.IsDragging()
+}
+
+// IsSelecting returns true while a text-selection drag is in progress. The
+// app-level mouse routing uses it to keep delivering motion and release
+// events to this component even when the cursor leaves the chat region.
+func (m *model) IsSelecting() bool {
+	return m.selection.mouseButtonDown && m.selection.active
 }
 
 func (m *model) IsMouseOnScrollbar(x, y int) bool {

--- a/pkg/tui/components/messages/selection.go
+++ b/pkg/tui/components/messages/selection.go
@@ -21,6 +21,14 @@ type selectionState struct {
 	mouseButtonDown bool
 	mouseY          int // Screen Y coordinate for autoscroll
 
+	// Word anchor for double-click drags: while anchored, the selection
+	// always covers at least the anchored word and extends around it.
+	anchored        bool
+	anchorStartLine int
+	anchorStartCol  int
+	anchorEndLine   int
+	anchorEndCol    int
+
 	// Multi-click detection
 	lastClickTime time.Time
 	lastClickLine int
@@ -35,16 +43,41 @@ type selectionState struct {
 func (s *selectionState) start(line, col int) {
 	s.active = true
 	s.mouseButtonDown = true
+	s.anchored = false
 	s.startLine = line
 	s.startCol = col
 	s.endLine = line
 	s.endCol = col
 }
 
-// update updates the end position of the selection
+// update updates the end position of the selection. While a word anchor is
+// set (double-click drag), the selection extends around the anchor instead of
+// collapsing to the cursor, so the anchored word always stays selected.
 func (s *selectionState) update(line, col int) {
+	if s.anchored {
+		switch {
+		case line < s.anchorStartLine || (line == s.anchorStartLine && col < s.anchorStartCol):
+			s.startLine, s.startCol = s.anchorEndLine, s.anchorEndCol
+			s.endLine, s.endCol = line, col
+		case line > s.anchorEndLine || (line == s.anchorEndLine && col > s.anchorEndCol):
+			s.startLine, s.startCol = s.anchorStartLine, s.anchorStartCol
+			s.endLine, s.endCol = line, col
+		default:
+			s.startLine, s.startCol = s.anchorStartLine, s.anchorStartCol
+			s.endLine, s.endCol = s.anchorEndLine, s.anchorEndCol
+		}
+		return
+	}
 	s.endLine = line
 	s.endCol = col
+}
+
+// anchorTo pins the current selection bounds as the anchor that drag
+// extension grows around.
+func (s *selectionState) anchorTo() {
+	s.anchored = true
+	s.anchorStartLine, s.anchorStartCol = s.startLine, s.startCol
+	s.anchorEndLine, s.anchorEndCol = s.endLine, s.endCol
 }
 
 // end finalizes the selection and stops mouse tracking
@@ -52,9 +85,29 @@ func (s *selectionState) end() {
 	s.mouseButtonDown = false
 }
 
-// clear resets all selection state
+// clear resets the selection geometry but keeps the multi-click tracking:
+// a double-click is a click-release-click sequence whose first release lands
+// here, so wiping lastClickTime/clickCount would make multi-click selection
+// impossible.
 func (s *selectionState) clear() {
-	*s = selectionState{}
+	s.active = false
+	s.mouseButtonDown = false
+	s.anchored = false
+	s.startLine, s.startCol = 0, 0
+	s.endLine, s.endCol = 0, 0
+	s.mouseY = 0
+}
+
+// hasRange reports whether the selection covers at least one character.
+func (s *selectionState) hasRange() bool {
+	return s.active && (s.startLine != s.endLine || s.startCol != s.endCol)
+}
+
+// resetClickTracking forgets the multi-click history so the next press is
+// treated as a fresh single click.
+func (s *selectionState) resetClickTracking() {
+	s.lastClickTime = time.Time{}
+	s.clickCount = 0
 }
 
 // normalized returns the selection bounds in normalized order (start <= end)
@@ -69,7 +122,9 @@ func (s *selectionState) normalized() (startLine, startCol, endLine, endCol int)
 	return startLine, startCol, endLine, endCol
 }
 
-// detectClickType records the click and returns the click count (1=single, 2=double, 3=triple)
+// detectClickType records the click and returns the click count (1=single,
+// 2=double, 3=triple). Counting cycles after a triple-click so a fourth
+// quick click starts a fresh drag selection.
 func (s *selectionState) detectClickType(line, col int) int {
 	now := time.Now()
 	colDiff := col - s.lastClickCol
@@ -80,6 +135,9 @@ func (s *selectionState) detectClickType(line, col int) int {
 
 	if isConsecutive {
 		s.clickCount++
+		if s.clickCount > 3 {
+			s.clickCount = 1
+		}
 	} else {
 		s.clickCount = 1
 	}
@@ -114,8 +172,10 @@ func (m *model) autoScroll() tea.Cmd {
 		m.scrollUp()
 		// Update endLine to reflect new scroll position
 		m.selection.endLine = max(0, m.selection.endLine-1)
-	} else if viewportY >= m.height-scrollThreshold && viewportY < m.height {
-		// Scroll down - mouse is near bottom of viewport
+	} else if viewportY >= m.height-scrollThreshold {
+		// Scroll down - mouse is near or below the bottom of the viewport
+		// (drag motion keeps flowing even when the cursor leaves the chat
+		// region, e.g. over the editor).
 		maxScrollOffset := max(0, m.totalHeight-m.height)
 		if m.scrollOffset < maxScrollOffset {
 			direction = 1
@@ -134,18 +194,19 @@ func (m *model) autoScroll() tea.Cmd {
 	})
 }
 
-// selectWordAt selects the word at the given line and column position
-func (m *model) selectWordAt(line, col int) {
+// selectWordAt selects the word at the given line and column position.
+// It reports whether a word was actually selected.
+func (m *model) selectWordAt(line, col int) bool {
 	m.ensureAllItemsRendered()
 	lines := m.renderedLines
 	if line < 0 || line >= len(lines) {
-		return
+		return false
 	}
 
 	originalLine := lines[line]
 	plainLine := stripBorderChars(ansi.Strip(originalLine))
 	if plainLine == "" {
-		return
+		return false
 	}
 
 	// Calculate border offset to adjust column position
@@ -155,7 +216,7 @@ func (m *model) selectWordAt(line, col int) {
 	// Convert display column to rune index
 	runeIdx := min(max(0, displayWidthToRuneIndex(plainLine, max(0, col-borderOffset))), len(runes)-1)
 	if runeIdx < 0 {
-		return
+		return false
 	}
 
 	// Find word boundaries - determine if we're on a word or non-word char
@@ -176,26 +237,29 @@ func (m *model) selectWordAt(line, col int) {
 
 	// Set selection
 	m.selection.active = true
+	m.selection.anchored = false
 	m.selection.startLine = line
 	m.selection.startCol = startCol
 	m.selection.endLine = line
 	m.selection.endCol = endCol
 	m.selection.mouseButtonDown = false
+	return true
 }
 
-// selectLineAt selects the entire line at the given line position
-func (m *model) selectLineAt(line int) {
+// selectLineAt selects the entire line at the given line position.
+// It reports whether a non-blank line was actually selected.
+func (m *model) selectLineAt(line int) bool {
 	m.ensureAllItemsRendered()
 	lines := m.renderedLines
 	if line < 0 || line >= len(lines) {
-		return
+		return false
 	}
 
 	originalLine := lines[line]
 	plainLine := ansi.Strip(originalLine)
 	trimmedLine := strings.TrimSpace(plainLine)
 	if trimmedLine == "" {
-		return
+		return false
 	}
 
 	// Find start column: position of first non-whitespace character
@@ -205,11 +269,13 @@ func (m *model) selectLineAt(line int) {
 
 	// Set selection to cover only the text content (excluding padding/borders)
 	m.selection.active = true
+	m.selection.anchored = false
 	m.selection.startLine = line
 	m.selection.startCol = startCol
 	m.selection.endLine = line
 	m.selection.endCol = endCol
 	m.selection.mouseButtonDown = false
+	return true
 }
 
 // applySelectionHighlight applies selection highlighting to visible lines

--- a/pkg/tui/components/messages/selection_test.go
+++ b/pkg/tui/components/messages/selection_test.go
@@ -1,0 +1,295 @@
+package messages
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tui/components/markdown"
+	"github.com/docker/docker-agent/pkg/tui/service"
+	"github.com/docker/docker-agent/pkg/tui/types"
+)
+
+func TestDoubleClickDragExtendsSelectionAndCopiesRange(t *testing.T) {
+	t.Parallel()
+
+	m := newSelectionModel([]string{
+		"hello world foo",
+		"second line here",
+		"third line ends",
+	})
+
+	// Click + release at the same spot: plain click, selection cleared but
+	// multi-click tracking must survive.
+	m.handleMouseClick(tea.MouseClickMsg{X: 2, Y: 0, Button: tea.MouseLeft})
+	m.handleMouseRelease(tea.MouseReleaseMsg{X: 2, Y: 0, Button: tea.MouseLeft})
+	require.False(t, m.selection.active)
+
+	// Second press at the same spot: double-click selects the word and keeps
+	// tracking the button for drag extension.
+	m.handleMouseClick(tea.MouseClickMsg{X: 2, Y: 0, Button: tea.MouseLeft})
+	require.True(t, m.selection.active, "double-click should select the word under the cursor")
+	require.True(t, m.selection.mouseButtonDown, "double-click must keep tracking the button for drags")
+	require.True(t, m.selection.anchored)
+	pendingID := m.selection.pendingCopyID
+
+	// Drag down to the third line: the selection must extend from the
+	// anchored word instead of being ignored.
+	m.handleMouseMotion(tea.MouseMotionMsg{X: 5, Y: 2})
+	startLine, startCol, endLine, endCol := m.selection.normalized()
+	assert.Equal(t, 0, startLine)
+	assert.Equal(t, 0, startCol, "selection should start at the anchored word start")
+	assert.Equal(t, 2, endLine)
+	assert.Equal(t, 5, endCol)
+
+	// Release copies the extended range.
+	_, cmd := m.handleMouseRelease(tea.MouseReleaseMsg{X: 5, Y: 2, Button: tea.MouseLeft})
+	require.NotNil(t, cmd, "drag release should trigger a copy")
+	assert.Equal(t, "hello world foo\nsecond line here\nthird", m.extractSelectedText())
+
+	// The debounced word copy scheduled by the double-click must be dead.
+	assert.Nil(t, m.handleDebouncedCopy(DebouncedCopyMsg{ClickID: pendingID}),
+		"drag must cancel the pending double-click word copy")
+}
+
+func TestDoubleClickWithoutDragStillCopiesWord(t *testing.T) {
+	t.Parallel()
+
+	m := newSelectionModel([]string{"hello world foo"})
+
+	m.handleMouseClick(tea.MouseClickMsg{X: 2, Y: 0, Button: tea.MouseLeft})
+	m.handleMouseRelease(tea.MouseReleaseMsg{X: 2, Y: 0, Button: tea.MouseLeft})
+	m.handleMouseClick(tea.MouseClickMsg{X: 2, Y: 0, Button: tea.MouseLeft})
+	m.handleMouseRelease(tea.MouseReleaseMsg{X: 2, Y: 0, Button: tea.MouseLeft})
+
+	require.True(t, m.selection.active, "word selection must survive the release")
+	assert.Equal(t, "hello", m.extractSelectedText())
+
+	// The debounced copy is still pending and must fire.
+	assert.NotNil(t, m.handleDebouncedCopy(DebouncedCopyMsg{ClickID: m.selection.pendingCopyID}))
+}
+
+func TestDoubleClickDragUpwardsExtendsBackwards(t *testing.T) {
+	t.Parallel()
+
+	m := newSelectionModel([]string{
+		"first line here",
+		"hello world foo",
+	})
+
+	m.handleMouseClick(tea.MouseClickMsg{X: 7, Y: 1, Button: tea.MouseLeft})
+	m.handleMouseRelease(tea.MouseReleaseMsg{X: 7, Y: 1, Button: tea.MouseLeft})
+	m.handleMouseClick(tea.MouseClickMsg{X: 7, Y: 1, Button: tea.MouseLeft})
+	require.True(t, m.selection.anchored)
+
+	m.handleMouseMotion(tea.MouseMotionMsg{X: 6, Y: 0})
+	startLine, startCol, endLine, endCol := m.selection.normalized()
+	assert.Equal(t, 0, startLine)
+	assert.Equal(t, 6, startCol)
+	assert.Equal(t, 1, endLine)
+	assert.Equal(t, 11, endCol, "anchored word end must stay selected when dragging up")
+
+	_, cmd := m.handleMouseRelease(tea.MouseReleaseMsg{X: 6, Y: 0, Button: tea.MouseLeft})
+	require.NotNil(t, cmd)
+	assert.Equal(t, "line here\nhello world", m.extractSelectedText())
+}
+
+func TestSelectionClearKeepsMultiClickTracking(t *testing.T) {
+	t.Parallel()
+
+	s := &selectionState{}
+	s.detectClickType(3, 7)
+	s.start(3, 7)
+	s.clear()
+
+	assert.False(t, s.active)
+	assert.Equal(t, 1, s.clickCount, "clear must not erase click tracking")
+	assert.False(t, s.lastClickTime.IsZero(), "clear must not erase the last click time")
+	assert.Equal(t, 2, s.detectClickType(3, 7), "the next nearby click must register as a double-click")
+}
+
+func TestTripleClickSelectsLineAndCopiesViaDebounce(t *testing.T) {
+	t.Parallel()
+
+	m := newSelectionModel([]string{"  hello world foo   ", "second line"})
+
+	for range 2 {
+		m.handleMouseClick(tea.MouseClickMsg{X: 4, Y: 0, Button: tea.MouseLeft})
+		m.handleMouseRelease(tea.MouseReleaseMsg{X: 4, Y: 0, Button: tea.MouseLeft})
+	}
+	m.handleMouseClick(tea.MouseClickMsg{X: 4, Y: 0, Button: tea.MouseLeft})
+	require.True(t, m.selection.active)
+	require.True(t, m.selection.anchored, "triple-click must anchor the line for drag extension")
+	m.handleMouseRelease(tea.MouseReleaseMsg{X: 4, Y: 0, Button: tea.MouseLeft})
+
+	assert.Equal(t, "hello world foo", m.extractSelectedText())
+	assert.NotNil(t, m.handleDebouncedCopy(DebouncedCopyMsg{ClickID: m.selection.pendingCopyID}),
+		"stationary triple-click must copy the line via the debounce")
+}
+
+func TestTripleClickDragExtendsSelection(t *testing.T) {
+	t.Parallel()
+
+	m := newSelectionModel([]string{"first line", "second line", "third line"})
+
+	for range 2 {
+		m.handleMouseClick(tea.MouseClickMsg{X: 3, Y: 0, Button: tea.MouseLeft})
+		m.handleMouseRelease(tea.MouseReleaseMsg{X: 3, Y: 0, Button: tea.MouseLeft})
+	}
+	m.handleMouseClick(tea.MouseClickMsg{X: 3, Y: 0, Button: tea.MouseLeft})
+	require.True(t, m.selection.mouseButtonDown, "triple-click must keep tracking the button")
+
+	m.handleMouseMotion(tea.MouseMotionMsg{X: 6, Y: 2})
+	_, cmd := m.handleMouseRelease(tea.MouseReleaseMsg{X: 6, Y: 2, Button: tea.MouseLeft})
+	require.NotNil(t, cmd, "triple-click drag release should copy the extended range")
+	assert.Equal(t, "first line\nsecond line\nthird", m.extractSelectedText())
+}
+
+func TestDoubleClickOnBlankLineFallsBackToDragSelection(t *testing.T) {
+	t.Parallel()
+
+	m := newSelectionModel([]string{"hello world", "", "second line"})
+
+	// Click-release then press again on the blank line: the word selection
+	// cannot anchor, so the press must start a live drag instead of dying.
+	m.handleMouseClick(tea.MouseClickMsg{X: 3, Y: 1, Button: tea.MouseLeft})
+	m.handleMouseRelease(tea.MouseReleaseMsg{X: 3, Y: 1, Button: tea.MouseLeft})
+	m.handleMouseClick(tea.MouseClickMsg{X: 3, Y: 1, Button: tea.MouseLeft})
+	require.True(t, m.selection.mouseButtonDown, "press on blank line must start a live drag")
+	require.True(t, m.IsSelecting())
+
+	m.handleMouseMotion(tea.MouseMotionMsg{X: 8, Y: 2})
+	_, cmd := m.handleMouseRelease(tea.MouseReleaseMsg{X: 8, Y: 2, Button: tea.MouseLeft})
+	require.NotNil(t, cmd, "drag from a blank line must still copy on release")
+	assert.Equal(t, "second l", m.extractSelectedText())
+	assert.False(t, m.IsSelecting())
+}
+
+func TestDragReleaseResetsClickTracking(t *testing.T) {
+	t.Parallel()
+
+	m := newSelectionModel([]string{"first line here", "second line here"})
+
+	// Full drag selection.
+	m.handleMouseClick(tea.MouseClickMsg{X: 0, Y: 0, Button: tea.MouseLeft})
+	m.handleMouseMotion(tea.MouseMotionMsg{X: 10, Y: 1})
+	_, cmd := m.handleMouseRelease(tea.MouseReleaseMsg{X: 10, Y: 1, Button: tea.MouseLeft})
+	require.NotNil(t, cmd)
+
+	// An immediate retry at the same spot must be a fresh single-click drag,
+	// not a double-click word selection.
+	m.handleMouseClick(tea.MouseClickMsg{X: 0, Y: 0, Button: tea.MouseLeft})
+	assert.Equal(t, 1, m.selection.clickCount, "a completed drag must reset multi-click tracking")
+	require.True(t, m.selection.mouseButtonDown)
+	require.False(t, m.selection.anchored)
+
+	m.handleMouseMotion(tea.MouseMotionMsg{X: 11, Y: 1})
+	_, cmd = m.handleMouseRelease(tea.MouseReleaseMsg{X: 11, Y: 1, Button: tea.MouseLeft})
+	require.NotNil(t, cmd)
+	assert.Equal(t, "first line here\nsecond line", m.extractSelectedText())
+}
+
+func TestFourthQuickClickCyclesBackToDragSelection(t *testing.T) {
+	t.Parallel()
+
+	s := &selectionState{}
+	assert.Equal(t, 1, s.detectClickType(0, 5))
+	assert.Equal(t, 2, s.detectClickType(0, 5))
+	assert.Equal(t, 3, s.detectClickType(0, 5))
+	assert.Equal(t, 1, s.detectClickType(0, 5), "click count must cycle after a triple-click")
+}
+
+func TestCopiedFeedbackLabelWidthMatchesCopyLabels(t *testing.T) {
+	t.Parallel()
+
+	want := ansi.StringWidth(types.CopiedFeedbackLabel)
+	assert.Equal(t, want, ansi.StringWidth(types.AssistantMessageCopyLabel),
+		"copied feedback must keep the message copy label width")
+	assert.Equal(t, want, ansi.StringWidth(markdown.CodeBlockCopyIcon),
+		"copied feedback must keep the code block copy label width")
+}
+
+func TestApplyCopiedFlashSwapsLabel(t *testing.T) {
+	t.Parallel()
+
+	line := "        " + types.AssistantMessageCopyLabel
+	m := newSelectionModel([]string{line})
+	m.lineOffsets = []int{0}
+
+	m.copiedFlash = &copiedFlash{msgIdx: 0, localLine: 0, seq: 1}
+	out := m.applyCopiedFlash([]string{line}, 0)
+
+	plain := ansi.Strip(out[0])
+	assert.Contains(t, plain, types.CopiedFeedbackLabel)
+	assert.NotContains(t, plain, types.AssistantMessageCopyLabel)
+	assert.Equal(t, ansi.StringWidth(line), ansi.StringWidth(out[0]), "swap must preserve line width")
+
+	// Expiry with a stale sequence keeps the flash; the right one clears it.
+	m.handleCopiedFlashExpired(copiedFlashExpiredMsg{Seq: 0})
+	require.NotNil(t, m.copiedFlash)
+	m.handleCopiedFlashExpired(copiedFlashExpiredMsg{Seq: 1})
+	assert.Nil(t, m.copiedFlash)
+
+	// Without flash state the lines pass through untouched.
+	out = m.applyCopiedFlash([]string{line}, 0)
+	assert.Equal(t, line, out[0])
+}
+
+func TestApplyCopiedFlashOffscreenIsNoop(t *testing.T) {
+	t.Parallel()
+
+	line := "        " + types.AssistantMessageCopyLabel
+	m := newSelectionModel([]string{line})
+	m.lineOffsets = []int{0}
+	m.copiedFlash = &copiedFlash{msgIdx: 0, localLine: 0, seq: 1}
+
+	// Viewport starts below the flashed line.
+	out := m.applyCopiedFlash([]string{"other"}, 5)
+	assert.Equal(t, "other", out[0])
+}
+
+func TestClickOnCopyLabelFlashesCopied(t *testing.T) {
+	t.Parallel()
+
+	m := NewScrollableView(80, 24, &service.SessionState{}).(*model)
+	m.SetSize(80, 24)
+	msg := types.Agent(types.MessageTypeAssistant, "", "hello response")
+	m.messages = append(m.messages, msg)
+	m.views = append(m.views, m.createMessageView(msg))
+	m.renderDirty = true
+	m.View()
+
+	// Hover the message so the copy label renders, then re-render.
+	m.handleMouseMotion(tea.MouseMotionMsg{X: 5, Y: 0})
+	m.View()
+
+	var line, col int
+	found := false
+	for i, rendered := range m.renderedLines {
+		plain := ansi.Strip(rendered)
+		if before, _, ok := strings.Cut(plain, types.AssistantMessageCopyLabel); ok {
+			line = i
+			col = ansi.StringWidth(before)
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "hovered assistant message should render the copy label")
+
+	_, cmd := m.handleMouseClick(tea.MouseClickMsg{X: col, Y: line, Button: tea.MouseLeft})
+	require.NotNil(t, cmd, "copy label click should produce a command")
+	require.NotNil(t, m.copiedFlash, "copy label click should start the copied flash")
+
+	out := ansi.Strip(m.View())
+	assert.Contains(t, out, types.CopiedFeedbackLabel)
+	assert.NotContains(t, out, types.AssistantMessageCopyLabel)
+
+	// Once expired, the label comes back.
+	m.handleCopiedFlashExpired(copiedFlashExpiredMsg{Seq: m.copiedFlash.seq})
+	out = ansi.Strip(m.View())
+	assert.Contains(t, out, types.AssistantMessageCopyLabel)
+}

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -135,6 +135,8 @@ type Page interface {
 	IsWorking() bool
 	// IsInlineEditing returns true if a past user message is being edited inline
 	IsInlineEditing() bool
+	// IsSelecting returns true while a text-selection drag is active in the messages panel
+	IsSelecting() bool
 	// QueueLength returns the number of queued messages
 	QueueLength() int
 	// FocusMessages gives focus to the messages panel for keyboard scrolling
@@ -1165,6 +1167,12 @@ func (p *chatPage) IsWorking() bool {
 // IsInlineEditing returns true if a past user message is being edited inline.
 func (p *chatPage) IsInlineEditing() bool {
 	return p.messages.IsInlineEditing()
+}
+
+// IsSelecting returns true while a text-selection drag is active in the
+// messages panel.
+func (p *chatPage) IsSelecting() bool {
+	return p.messages.IsSelecting()
 }
 
 // QueueLength returns the number of queued messages

--- a/pkg/tui/page/chat/input_handlers.go
+++ b/pkg/tui/page/chat/input_handlers.go
@@ -217,6 +217,15 @@ func (p *chatPage) handleMouseMotion(msg tea.MouseMotionMsg) (layout.Model, tea.
 		return p, tea.Batch(cmds...)
 	}
 
+	// During a text-selection drag, keep feeding motion to the messages
+	// component even when the cursor drifts over the sidebar, so the
+	// selection keeps extending until the button is released.
+	if p.messages.IsSelecting() {
+		model, cmd := p.messages.Update(msg)
+		p.messages = model.(messages.Model)
+		return p, cmd
+	}
+
 	cmd := p.routeMouseEvent(msg, msg.Y)
 	return p, cmd
 }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -2442,6 +2442,14 @@ func (m *appModel) handleMouseMotion(msg tea.MouseMotionMsg) (tea.Model, tea.Cmd
 		return model, batchWith(cmd)
 	}
 
+	// A text-selection drag must keep receiving motion wherever the cursor
+	// goes (editor, tab bar, status bar), otherwise the selection freezes
+	// and the release-copy pair is lost.
+	if m.chatPage.IsSelecting() {
+		model, cmd := m.forwardChat(msg)
+		return model, batchWith(cmd)
+	}
+
 	// Update hover state for resize handle
 	region := m.hitTestRegion(msg.Y)
 	m.isHoveringHandle = region == regionResizeHandle
@@ -2479,6 +2487,12 @@ func (m *appModel) handleMouseRelease(msg tea.MouseReleaseMsg) (tea.Model, tea.C
 
 	if m.dialogMgr.Open() {
 		return m.forwardDialog(msg)
+	}
+
+	// Finish a text-selection drag in the chat no matter where the button
+	// was released; this is what triggers the selection copy.
+	if m.chatPage.IsSelecting() {
+		return m.forwardChat(msg)
 	}
 
 	region := m.hitTestRegion(msg.Y)

--- a/pkg/tui/tui_exit_test.go
+++ b/pkg/tui/tui_exit_test.go
@@ -41,6 +41,7 @@ func (m *mockChatPage) SetTitleRegenerating(bool) tea.Cmd        { return nil }
 func (m *mockChatPage) ScrollToBottom() tea.Cmd                  { return nil }
 func (m *mockChatPage) IsWorking() bool                          { return false }
 func (m *mockChatPage) IsInlineEditing() bool                    { return false }
+func (m *mockChatPage) IsSelecting() bool                        { return false }
 func (m *mockChatPage) QueueLength() int                         { return 0 }
 func (m *mockChatPage) FocusMessages() tea.Cmd                   { return nil }
 func (m *mockChatPage) FocusMessageAt(int, int) tea.Cmd          { return nil }

--- a/pkg/tui/tuitest/mouse.go
+++ b/pkg/tui/tuitest/mouse.go
@@ -20,6 +20,16 @@ func (d *Driver) Click(x, y int) *Driver {
 	return d
 }
 
+// Drag presses the left button at (fromX, fromY), moves through a midpoint,
+// and releases at (toX, toY).
+func (d *Driver) Drag(fromX, fromY, toX, toY int) *Driver {
+	d.sendSync(tea.MouseClickMsg{X: fromX, Y: fromY, Button: tea.MouseLeft})
+	d.sendSync(tea.MouseMotionMsg{X: (fromX + toX) / 2, Y: (fromY + toY) / 2, Button: tea.MouseLeft})
+	d.sendSync(tea.MouseMotionMsg{X: toX, Y: toY, Button: tea.MouseLeft})
+	d.sendSync(tea.MouseReleaseMsg{X: toX, Y: toY, Button: tea.MouseLeft})
+	return d
+}
+
 // FindText returns the coordinates of the first occurrence of text in the
 // latest captured frame. The x coordinate is display width, not byte offset,
 // so it works for wide Unicode before the matched text.

--- a/pkg/tui/types/types.go
+++ b/pkg/tui/types/types.go
@@ -26,8 +26,12 @@ const (
 
 const (
 	UserMessageEditLabel      = "✎"
-	AssistantMessageCopyLabel = "⎘"
+	AssistantMessageCopyLabel = "⎘ copy"
 	ErrorRetryLabel           = "↻ retry"
+	// CopiedFeedbackLabel transiently replaces a clicked copy label. It must
+	// keep the exact display width of the copy labels so the swap never
+	// shifts the layout of the line it happens on.
+	CopiedFeedbackLabel = "copied"
 )
 
 const (


### PR DESCRIPTION
## Summary

Copying from the chat via cursor selection was unreliable (random one-word or one-line copies, trailing padding, UI glyphs in the clipboard), and the message copy button was a 1-cell target with no click feedback. This PR makes the selection copy path deterministic and improves the copy affordances.

## Selection copy fixes

| Cause | Symptom | Fix |
|---|---|---|
| Motion/release routed by vertical region; a drag ending over the editor never reached the messages component | No copy, stale drag, late debounced copy wrote one word | Motion and release forwarded to the chat whenever a selection drag is active (`IsSelecting()` plumbed messages -> chat page -> app) |
| Triple-click (often a misdetected quick retry) copied the line on press and dropped the drag | One-line copies while dragging | Triple-click anchors the line, drag extends it, copy on release or debounce |
| Double/triple-click on a blank line failed silently | Dead drag, clipboard unchanged | Falls back to a plain drag selection |
| Completed drags fed the multi-click counter | Retries misdetected as double/triple clicks | Click tracking reset after a drag; count cycles after triple |
| Per-line TrimSpace and no content filtering | Lost code indentation; copied `⎘ copy`, `✎`, `[+] expand ...` labels and padding lines | TrimRight, common-prefix dedent, affordance-line filter, boundary blank trim |
| `findClosestRuneIndex` walked backwards past end-of-line | Last character missing | Columns beyond the line map one past the last rune |

Drag lifecycle after the routing fix:

```
press (chat)       motion (anywhere)            release (anywhere)
  start/anchor  ->  IsSelecting() forwards to ->  finalize + copy
                    chat, selection extends
```

## Copy affordances

- `⎘` becomes `⎘ copy` on assistant messages and code blocks (7-cell click target instead of 1)
- The clicked label flashes a same-width `copied` confirmation for 1.5s; view-time overlay, render caches untouched

## Tests

- New unit tests for selection extraction, anchored drags, click tracking, and the flash overlay
- New tuitest `Drag` helper and e2e `TestChat_DragSelectionCopiesAcrossRegions`: drags from the response text and releases over the editor region; verified to fail without the routing fix
- Full `pkg/tui` and `e2e/tui` suites and linters pass
