### PR TITLE
fix(memory): open sqlite db under file lock to avoid SQLITE_BUSY races

### DIFF
--- a/pkg/memory/database/sqlite/sqlite.go
+++ b/pkg/memory/database/sqlite/sqlite.go
@@ -60,17 +60,19 @@ func (m *MemoryDatabase) ensureDB(ctx context.Context) (*sql.DB, error) {
 		return m.db, nil
 	}
 
+	// Open under the file lock: the first open of a fresh database converts
+	// it to WAL mode, which needs an exclusive lock and can fail with
+	// SQLITE_BUSY (not covered by busy_timeout) if opens race.
+	lock := database.NewFileLock(m.lockPath)
+	if err := lock.Lock(ctx); err != nil {
+		return nil, err
+	}
+	defer func() { _ = lock.Unlock() }()
+
 	db, err := sqliteutil.OpenDB(ctx, m.path)
 	if err != nil {
 		return nil, err
 	}
-
-	lock := database.NewFileLock(m.lockPath)
-	if err := lock.Lock(ctx); err != nil {
-		db.Close()
-		return nil, err
-	}
-	defer func() { _ = lock.Unlock() }()
 
 	if _, err = db.ExecContext(ctx, "CREATE TABLE IF NOT EXISTS memories (id TEXT PRIMARY KEY, created_at TEXT, memory TEXT)"); err != nil {
 		db.Close()


### PR DESCRIPTION
`TestConcurrentAddsPreserveAllRows` was flaky, failing with `database is locked (5) (SQLITE_BUSY)`, reliably reproducible with `go test -run TestConcurrent -count=10 -race ./pkg/memory/database/sqlite/`. The root cause was in `MemoryDatabase.ensureDB`: `sqliteutil.OpenDB` was called *before* acquiring the advisory file lock. Opening pings the database and the `journal_mode(WAL)` DSN pragma converts a fresh database to WAL mode; that conversion needs an exclusive lock and is not retried by `busy_timeout`. With multiple workers opening the same brand-new file concurrently, first-open attempts raced and whole workers failed.

The fix moves the `OpenDB` call to after the file lock is acquired, so the open, WAL conversion, and schema migration all happen under the lock. The lock is already held for migrations; extending its scope one step earlier costs nothing and eliminates the race entirely.

No behaviour changes for existing callers. `TestConcurrent*` now passes 30 iterations with `-race` where it previously failed within 10.