### PR TITLE
fix(tui): drop the redundant copy toast when the inline "copied" flash shows

### DIFF
--- a/pkg/tui/components/messages/clipboard.go
+++ b/pkg/tui/components/messages/clipboard.go
@@ -330,15 +330,25 @@ func (m *model) copySelectedMessageToClipboard() tea.Cmd {
 	return copyTextToClipboard(content)
 }
 
-// copyTextToClipboard copies text to the system clipboard
+// copyTextToClipboard copies text to the system clipboard and confirms with
+// a toast. Copy buttons that flash an inline "copied" label must use
+// copyTextToClipboardSilent instead to avoid double feedback.
 func copyTextToClipboard(text string) tea.Cmd {
+	return tea.Sequence(
+		copyTextToClipboardSilent(text),
+		notification.SuccessCmd("Text copied to clipboard."),
+	)
+}
+
+// copyTextToClipboardSilent copies text to the system clipboard without a
+// toast notification.
+func copyTextToClipboardSilent(text string) tea.Cmd {
 	return tea.Sequence(
 		func() tea.Msg {
 			_ = clipboardWriter()(text)
 			return nil
 		},
 		tea.SetClipboard(text),
-		notification.SuccessCmd("Text copied to clipboard."),
 	)
 }
 

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -356,7 +356,7 @@ func (m *model) handleMouseClick(msg tea.MouseClickMsg) (layout.Model, tea.Cmd) 
 		}
 
 		if content, ok := m.codeBlockAt(msgIdx, localLine, col); ok {
-			return m, tea.Batch(copyTextToClipboard(content), m.flashCopiedLabel(msgIdx, localLine, true))
+			return m, tea.Batch(copyTextToClipboardSilent(content), m.flashCopiedLabel(msgIdx, localLine, true))
 		}
 
 		if m.isCopyLabelClick(msgIdx, localLine, col) {
@@ -2001,6 +2001,7 @@ func (m *model) isRetryLabelClick(msgIdx, localLine, col int) bool {
 }
 
 // copyMessageToClipboard copies the content of a specific message to clipboard.
+// Silent: the caller flashes an inline "copied" confirmation on the clicked label.
 func (m *model) copyMessageToClipboard(msgIdx int) tea.Cmd {
 	if msgIdx < 0 || msgIdx >= len(m.messages) {
 		return nil
@@ -2009,7 +2010,7 @@ func (m *model) copyMessageToClipboard(msgIdx int) tea.Cmd {
 	if content == "" {
 		return nil
 	}
-	return copyTextToClipboard(content)
+	return copyTextToClipboardSilent(content)
 }
 
 func (m *model) mouseToLineCol(x, y int) (line, col int) {


### PR DESCRIPTION
Clicking a copy button in the TUI — the "⎘ copy" label on an assistant message or the copy icon on a code block — was showing two pieces of feedback at once. The inline "copied" flash (introduced in a recent commit) would appear, and simultaneously the pre-existing "Text copied to clipboard." toast would fire. Because toasts stack and linger for 10 seconds, repeated clicks could pile them up noticeably.

The fix splits `copyTextToClipboard` in `clipboard.go` into two functions: `copyTextToClipboardSilent` (which writes to the clipboard and emits `tea.SetClipboard` only) and a thin wrapper that adds the toast on top. The two click handlers in `messages.go` that already have an inline flash are switched to the silent variant. The drag-selection and keyboard "c" copy paths keep the toast since they have no other visual confirmation.