### PR TITLE
style(tui): polish agent picker layout, cards, and status bars

### DIFF
--- a/cmd/root/agent_picker.go
+++ b/cmd/root/agent_picker.go
@@ -757,12 +757,21 @@ func (m *agentPickerModel) headerText() (title, subtitle string, helpPairs []str
 	if m.width > 0 {
 		maxWidth := max(m.width-2*(1+4), agentPickerMinCardWidth)
 		subtitleText = toolcommon.TruncateText(subtitleText, maxWidth)
-		for len(helpPairs) > 2 && dialog.HelpKeysWidth(helpPairs...) > maxWidth {
-			helpPairs = helpPairs[:len(helpPairs)-2]
-		}
+		helpPairs = fitHelpPairs(helpPairs, maxWidth)
 	}
 	subtitle = styles.MutedStyle.Render(subtitleText)
 	return title, subtitle, helpPairs
+}
+
+// fitHelpPairs drops trailing [key, description] pairs until the status bar
+// fits maxWidth, keeping at least one pair. Dropping whole pairs (instead of
+// truncating the styled line) guarantees the rendered help never soft-wraps,
+// which would add a row and break the pickers' row-based layout math.
+func fitHelpPairs(pairs []string, maxWidth int) []string {
+	for len(pairs) > 2 && dialog.HelpKeysWidth(pairs...) > maxWidth {
+		pairs = pairs[:len(pairs)-2]
+	}
+	return pairs
 }
 
 func (m *agentPickerModel) render() string {
@@ -824,7 +833,8 @@ func (m *agentPickerModel) renderDetails() string {
 		bar,
 	)
 
-	help := dialog.RenderHelpKeys(contentWidth, "↑↓", "scroll", "esc/?", "close")
+	helpPairs := fitHelpPairs([]string{"↑↓", "scroll", "esc/?", "close"}, contentWidth)
+	help := dialog.RenderHelpKeys(contentWidth, helpPairs...)
 
 	content := lipgloss.JoinVertical(
 		lipgloss.Left,

--- a/cmd/root/agent_picker.go
+++ b/cmd/root/agent_picker.go
@@ -202,7 +202,7 @@ var agentPickerKeys = agentPickerKeyMap{
 	),
 	Lean: key.NewBinding(
 		key.WithKeys("l"),
-		key.WithHelp("l", "toggle lean mode"),
+		key.WithHelp("l", "lean mode"),
 	),
 	Board: key.NewBinding(
 		key.WithKeys("b"),
@@ -741,7 +741,6 @@ func (m *agentPickerModel) headerText() (title, subtitle string, helpPairs []str
 	}
 	helpPairs = []string{
 		"↑↓", "move",
-		"double-click", "select",
 		agentPickerKeys.Choose.Help().Key, agentPickerKeys.Choose.Help().Desc,
 		agentPickerKeys.Details.Help().Key, agentPickerKeys.Details.Help().Desc,
 		agentPickerKeys.Lean.Help().Key, agentPickerKeys.Lean.Help().Desc,
@@ -775,7 +774,14 @@ func fitHelpPairs(pairs []string, maxWidth int) []string {
 
 func (m *agentPickerModel) render() string {
 	title, subtitle, helpPairs := m.headerText()
-	help := dialog.RenderHelpKeys(m.contentWidth(title, subtitle, helpPairs), helpPairs...)
+	contentWidth := m.contentWidth(title, subtitle, helpPairs)
+	// Center the header and status-bar lines within the content column; the
+	// centering can't wrap (contentWidth ≥ each line's width) so the
+	// row-based hit-testing is unaffected.
+	center := styles.BaseStyle.Width(contentWidth).Align(lipgloss.Center)
+	title = center.Render(title)
+	subtitle = center.Render(subtitle)
+	help := dialog.RenderHelpKeys(contentWidth, helpPairs...)
 
 	cardWidth := m.cardWidth()
 	n := m.visibleCount()

--- a/cmd/root/agent_picker.go
+++ b/cmd/root/agent_picker.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/docker-agent/pkg/path"
 	"github.com/docker/docker-agent/pkg/tui/components/scrollbar"
 	"github.com/docker/docker-agent/pkg/tui/components/toolcommon"
+	"github.com/docker/docker-agent/pkg/tui/dialog"
 	"github.com/docker/docker-agent/pkg/tui/styles"
 )
 
@@ -705,23 +706,30 @@ func (m *agentPickerModel) boardButtonAt(x, y int) bool {
 // called on every mouse-motion event, so it must stay cheap: cards all share
 // cardWidth, so only the (variable-width) header lines need measuring.
 func (m *agentPickerModel) panelSize() (w, h int) {
-	title, subtitle, help := m.headerText()
-	contentWidth := max(
-		m.cardWidth(),
-		lipgloss.Width(title),
-		lipgloss.Width(subtitle),
-		lipgloss.Width(m.leanCheckbox())+lipgloss.Width(agentPickerBoardGap)+lipgloss.Width(m.boardButton()),
-		lipgloss.Width(help),
-	)
+	title, subtitle, helpPairs := m.headerText()
 	// Horizontal chrome: border (1) + padding (4) on each side.
-	w = contentWidth + 2*(1+4)
+	w = m.contentWidth(title, subtitle, helpPairs) + 2*(1+4)
 	h = m.cardRows() + agentPickerPanelOverhead
 	return w, h
 }
 
-// headerText returns the (styled) title, subtitle, and help lines shared by
-// render and panelSize so their layout math can't drift apart.
-func (m *agentPickerModel) headerText() (title, subtitle, help string) {
+// contentWidth returns the width of the panel's content column: the widest
+// of the cards, header lines, bottom row, and status bar. Shared by render
+// and panelSize so the layout math can't drift apart.
+func (m *agentPickerModel) contentWidth(title, subtitle string, helpPairs []string) int {
+	return max(
+		m.cardWidth(),
+		lipgloss.Width(title),
+		lipgloss.Width(subtitle),
+		lipgloss.Width(m.leanCheckbox())+lipgloss.Width(agentPickerBoardGap)+lipgloss.Width(m.boardButton()),
+		dialog.HelpKeysWidth(helpPairs...),
+	)
+}
+
+// headerText returns the (styled) title and subtitle lines plus the status
+// bar's [key, description] pairs, shared by render and panelSize so their
+// layout math can't drift apart.
+func (m *agentPickerModel) headerText() (title, subtitle string, helpPairs []string) {
 	title = styles.HighlightWhiteStyle.Render("Choose an agent to run")
 	subtitleText := "Pick the agent you want to start a session with, or double-click a card."
 	if n := m.visibleCount(); n < len(m.choices) {
@@ -732,30 +740,34 @@ func (m *agentPickerModel) headerText() (title, subtitle, help string) {
 		subtitleText = fmt.Sprintf("Pick an agent (%*d–%*d of %d, scroll with ↑↓), or double-click a card.",
 			d, m.offset+1, d, m.offset+n, len(m.choices))
 	}
-	helpText := strings.Join([]string{
-		"↑↓ move",
-		"double-click select",
-		agentPickerKeys.Choose.Help().Key + " " + agentPickerKeys.Choose.Help().Desc,
-		agentPickerKeys.Details.Help().Key + " " + agentPickerKeys.Details.Help().Desc,
-		agentPickerKeys.Lean.Help().Key + " " + agentPickerKeys.Lean.Help().Desc,
-		agentPickerKeys.Board.Help().Key + " " + agentPickerKeys.Board.Help().Desc,
-		agentPickerKeys.Quit.Help().Key + " " + agentPickerKeys.Quit.Help().Desc,
-	}, "   ")
-	// Truncate header lines to the panel's content width so they can't
+	helpPairs = []string{
+		"↑↓", "move",
+		"double-click", "select",
+		agentPickerKeys.Choose.Help().Key, agentPickerKeys.Choose.Help().Desc,
+		agentPickerKeys.Details.Help().Key, agentPickerKeys.Details.Help().Desc,
+		agentPickerKeys.Lean.Help().Key, agentPickerKeys.Lean.Help().Desc,
+		agentPickerKeys.Board.Help().Key, agentPickerKeys.Board.Help().Desc,
+		agentPickerKeys.Quit.Help().Key, agentPickerKeys.Quit.Help().Desc,
+	}
+	// Keep header lines within the panel's content width so they can't
 	// terminal-wrap on narrow terminals: a wrapped line would shift every row
-	// below it and break the row-based mouse hit-testing.
+	// below it and break the row-based mouse hit-testing. The subtitle is
+	// truncated; the status bar drops trailing bindings instead so styled key
+	// runs are never cut mid-sequence.
 	if m.width > 0 {
 		maxWidth := max(m.width-2*(1+4), agentPickerMinCardWidth)
 		subtitleText = toolcommon.TruncateText(subtitleText, maxWidth)
-		helpText = toolcommon.TruncateText(helpText, maxWidth)
+		for len(helpPairs) > 2 && dialog.HelpKeysWidth(helpPairs...) > maxWidth {
+			helpPairs = helpPairs[:len(helpPairs)-2]
+		}
 	}
 	subtitle = styles.MutedStyle.Render(subtitleText)
-	help = styles.MutedStyle.Render(helpText)
-	return title, subtitle, help
+	return title, subtitle, helpPairs
 }
 
 func (m *agentPickerModel) render() string {
-	title, subtitle, help := m.headerText()
+	title, subtitle, helpPairs := m.headerText()
+	help := dialog.RenderHelpKeys(m.contentWidth(title, subtitle, helpPairs), helpPairs...)
 
 	cardWidth := m.cardWidth()
 	n := m.visibleCount()
@@ -812,13 +824,7 @@ func (m *agentPickerModel) renderDetails() string {
 		bar,
 	)
 
-	help := styles.MutedStyle.
-		Width(contentWidth).
-		Render(strings.Join([]string{
-			"↑↓ scroll",
-			percentLabel(m.details.ScrollPercent()),
-			"esc/? close",
-		}, "   "))
+	help := dialog.RenderHelpKeys(contentWidth, "↑↓", "scroll", "esc/?", "close")
 
 	content := lipgloss.JoinVertical(
 		lipgloss.Left,
@@ -829,12 +835,6 @@ func (m *agentPickerModel) renderDetails() string {
 	)
 
 	return styles.DialogStyle.Render(content)
-}
-
-// percentLabel formats a scroll fraction (0..1) as a percentage string.
-func percentLabel(frac float64) string {
-	pct := min(max(int(frac*100), 0), 100)
-	return strconv.Itoa(pct) + "%"
 }
 
 // isLocalConfigRef reports whether ref points at a local agent config file

--- a/cmd/root/agent_picker.go
+++ b/cmd/root/agent_picker.go
@@ -571,9 +571,8 @@ const (
 	agentPickerMinCardWidth = 24
 
 	// agentPickerCardHeight is the rendered height of a card: 3 content rows
-	// (header + detail + tags) wrapped by one row of vertical padding and a
-	// border on the top and bottom.
-	agentPickerCardHeight = 7
+	// (header + detail + tags) plus a border on the top and bottom.
+	agentPickerCardHeight = 5
 
 	// agentPickerCardGap is the number of blank rows between adjacent cards.
 	agentPickerCardGap = 0
@@ -901,7 +900,7 @@ func (m *agentPickerModel) renderCard(choice agentChoice, cardWidth int, selecte
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(borderColor).
 		Width(cardWidth).
-		Padding(1, 1).
+		Padding(0, 1).
 		Render(card)
 }
 

--- a/cmd/root/agent_picker.go
+++ b/cmd/root/agent_picker.go
@@ -671,10 +671,12 @@ func (m *agentPickerModel) leanCheckboxAt(x, y int) bool {
 // leanCheckbox renders the "Lean Mode" checkbox line.
 func (m *agentPickerModel) leanCheckbox() string {
 	box := styles.MutedStyle.Render("[ ]")
+	label := styles.SecondaryStyle.Render("Lean Mode")
 	if m.leanMode {
 		box = styles.SuccessStyle.Render("[x]")
+		label = styles.HighlightWhiteStyle.Render("Lean Mode")
 	}
-	return box + " " + styles.SecondaryStyle.Render("Lean Mode")
+	return box + " " + label
 }
 
 // agentPickerBoardGap separates the lean checkbox from the board button on
@@ -685,7 +687,7 @@ const agentPickerBoardGap = "   "
 // boardButton renders the "Open Board" button. Choosing it starts
 // `docker agent board` instead of running an agent.
 func (m *agentPickerModel) boardButton() string {
-	return styles.SecondaryStyle.Render("[ Open Board ]")
+	return styles.MutedStyle.Render("[ ") + styles.HighlightWhiteStyle.Render("Open Board") + styles.MutedStyle.Render(" ]")
 }
 
 // boardButtonAt reports whether terminal coordinates land on the "Open
@@ -870,10 +872,12 @@ func displayRef(ref string) string {
 func (m *agentPickerModel) renderCard(choice agentChoice, cardWidth int, selected bool) string {
 	marker := "  "
 	nameStyle := styles.BoldStyle
+	border := lipgloss.RoundedBorder()
 	borderColor := styles.BorderMuted
 	if selected {
 		marker = styles.SuccessStyle.Render("❯ ")
 		nameStyle = styles.HighlightWhiteStyle
+		border = lipgloss.ThickBorder()
 		borderColor = styles.BorderPrimary
 	}
 
@@ -903,7 +907,7 @@ func (m *agentPickerModel) renderCard(choice agentChoice, cardWidth int, selecte
 	card := lipgloss.JoinVertical(lipgloss.Left, header, "  "+detail, "  "+renderTags(choice.tags, detailWidth))
 
 	return styles.BaseStyle.
-		Border(lipgloss.RoundedBorder()).
+		Border(border).
 		BorderForeground(borderColor).
 		Width(cardWidth).
 		Padding(0, 1).

--- a/cmd/root/agent_picker_test.go
+++ b/cmd/root/agent_picker_test.go
@@ -267,6 +267,22 @@ func TestAgentPickerDetailsFixedSize(t *testing.T) {
 	assert.Equal(t, topH, h, "height changed at bottom")
 }
 
+func TestAgentPickerDetailsHelpNeverWraps(t *testing.T) {
+	t.Parallel()
+
+	// On very narrow terminals the details help must drop bindings instead of
+	// soft-wrapping, which would add a row and overflow the dialog height.
+	m := newAgentPickerModel([]agentChoice{{ref: "default", yaml: strings.Repeat("a: b\n", 50)}})
+	for _, w := range []int{20, 24, 28, 32, 40, 120} {
+		m.width = w
+		m.height = 40
+		m.openDetails()
+		_, dh := m.detailsDialogSize()
+		assert.Equal(t, dh, lipgloss.Height(m.renderDetails()), "dialog height mismatch at width %d", w)
+		m.showDetails = false
+	}
+}
+
 func TestStripControl(t *testing.T) {
 	t.Parallel()
 
@@ -556,12 +572,16 @@ func TestAgentPickerCardAtMatchesRenderedText(t *testing.T) {
 		assert.Equal(t, idx, i, "ref row for %q should hit card %d", ref, idx)
 	}
 
-	// The title and help rows must not resolve to any card.
+	// The title, subtitle, and status-bar rows must not resolve to any card.
 	titleY := findRow("Choose an agent to run")
 	_, ok := m.cardAt(m.width/2, titleY)
 	assert.False(t, ok, "title row must not hit a card")
 
-	helpY := findRow("double-click")
+	subtitleY := findRow("double-click a card")
+	_, ok = m.cardAt(m.width/2, subtitleY)
+	assert.False(t, ok, "subtitle row must not hit a card")
+
+	helpY := findRow("view yaml")
 	_, ok = m.cardAt(m.width/2, helpY)
 	assert.False(t, ok, "help row must not hit a card")
 }

--- a/cmd/root/agent_picker_test.go
+++ b/cmd/root/agent_picker_test.go
@@ -235,16 +235,6 @@ func trimTrailingPerLine(s string) string {
 	return strings.Join(lines, "\n")
 }
 
-func TestPercentLabel(t *testing.T) {
-	t.Parallel()
-
-	assert.Equal(t, "0%", percentLabel(0))
-	assert.Equal(t, "50%", percentLabel(0.5))
-	assert.Equal(t, "100%", percentLabel(1))
-	assert.Equal(t, "0%", percentLabel(-0.5))
-	assert.Equal(t, "100%", percentLabel(2))
-}
-
 func TestAgentPickerDetailsFixedSize(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/root/agent_picker_test.go
+++ b/cmd/root/agent_picker_test.go
@@ -326,7 +326,7 @@ func TestAgentPickerWindowing(t *testing.T) {
 	}
 	m := newAgentPickerModel(choices)
 	m.width = 120
-	m.height = 30 // fits (30-12)/7 = 2 cards
+	m.height = 22 // fits (22-12)/5 = 2 cards
 
 	assert.Equal(t, 2, m.visibleCount())
 
@@ -794,7 +794,7 @@ func TestAgentPickerBoardButtonWindowed(t *testing.T) {
 	}
 	m := newAgentPickerModel(choices)
 	m.width = 120
-	m.height = 30 // fits 2 cards
+	m.height = 22 // fits 2 cards
 	for range 5 {
 		m.moveDown()
 	}


### PR DESCRIPTION
The agent picker had a handful of rough edges: the status bars used a hand-rolled key rendering path while every other dialog had already moved to `dialog.RenderHelpKeys`, cards were taller than necessary, the panel was wider than it needed to be, and the selected card had no visual accent to make it stand out.

This change brings the picker in line with the rest of the TUI. The main help line and the YAML details dialog both now go through `dialog.RenderHelpKeys`, which removes duplicated logic and gives them the same look as other dialogs. A `fitHelpPairs` helper was extracted so that on narrow terminals trailing bindings are dropped cleanly rather than soft-wrapping and distorting the layout. Card height was reduced from 7 to 5 rows by removing vertical padding, and the panel was narrowed from ~99 to ~83 columns with its title, subtitle, and status bar centered. The redundant "double-click select" binding was dropped. The selected card now gets a thick accent border, the Lean Mode label is rendered brighter when ticked, and the Open Board entry is rendered as a button-like control.

Mouse hit-testing invariants (`panelSize == render geometry`) are preserved throughout; existing tests were updated and new regression tests for `fitHelpPairs` and hit-testing were added.