### PR TITLE
docs: sync documentation with recent code changes

### DIFF
--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -143,6 +143,20 @@ The **effort gauge** is a fixed-width six-cell indicator (`▰` filled, `▱` em
 
 Harness-backed agents (e.g. `claude-code`) show the harness type as their model and no thinking gauge. Press **Shift+Tab** to cycle the current model's thinking-effort level; a `✻ Thinking: <level>` toast confirms the change (useful when the sidebar is hidden).
 
+### Context-Usage Gauge
+
+The context-usage gauge (the fill bar and percentage shown in the sidebar token-usage section and in the lean TUI status line) color-escalates as the active session approaches the auto-compaction threshold:
+
+| Gauge color | When it appears |
+| ----------- | --------------- |
+| Green (normal) | Usage is below 75% of the configured compaction threshold |
+| Orange (warning) | Usage reaches 75% of the compaction threshold |
+| Red (critical) | Usage reaches 95% of the compaction threshold |
+
+While a compaction is running the percentage is replaced by a **"compacting…"** indicator; token counts remain visible in the lean TUI status line.
+
+The thresholds are proportional to the agent's configured `compaction_threshold` (default `0.9`), so a custom value keeps a predictable visual runway. See [Compaction Threshold](../../configuration/models/index.md#delegating-session-compaction) for configuration details.
+
 ### Thinking and Tool Details
 
 Reasoning/thinking blocks are collapsed by default and carry a `Thinking` header badge. When collapsed, the TUI shows a short preview and compact tool summaries. Expand a block to see the full thinking content and the real tool renderers, including detailed tool output such as file edit diffs.

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -145,13 +145,13 @@ Harness-backed agents (e.g. `claude-code`) show the harness type as their model 
 
 ### Context-Usage Gauge
 
-The context-usage gauge (the fill bar and percentage shown in the sidebar token-usage section and in the lean TUI status line) color-escalates as the active session approaches the auto-compaction threshold:
+The context percentage shown in the sidebar token-usage section, and the fill bar in the lean TUI status line, both color-escalate as the active session approaches the auto-compaction threshold:
 
-| Gauge color | When it appears |
-| ----------- | --------------- |
-| Green (normal) | Usage is below 75% of the configured compaction threshold |
-| Orange (warning) | Usage reaches 75% of the compaction threshold |
-| Red (critical) | Usage reaches 95% of the compaction threshold |
+| State   | Color  | Trigger |
+| ------- | ------ | ------- |
+| Normal  | (default) | Usage below 75% of the compaction threshold |
+| Warning | Orange | Usage at or above 75% of the compaction threshold |
+| Critical | Red   | Usage at or above 95% of the compaction threshold |
 
 While a compaction is running the percentage is replaced by a **"compacting…"** indicator; token counts remain visible in the lean TUI status line.
 


### PR DESCRIPTION
Documents user-visible changes from PRs merged in the last 36 hours.

**PR addressed:**
- docker/docker-agent#3537 — adds a new `### Context-Usage Gauge` subsection to `docs/features/tui/index.md` explaining that the context percentage (sidebar) and fill bar (lean TUI) color-escalate as usage approaches the auto-compaction threshold (orange ≥75%, red ≥95%), and that `compacting…` replaces the percentage while a compaction runs.

**PRs already self-documented** (included docs changes in their own commits):
- #3512 (chatgpt provider): created `docs/providers/chatgpt/index.md`, updated model reference and config docs
- #3533 (section spacing): updated `docs/features/tui/index.md`
- #3529 (doctor user config): updated `docs/getting-started/set-up-a-model/index.md`
- #3522, #3517, #3514, #3513 (board features): updated `docs/features/board/index.md`
- #3531, #3526 (hook/notification docs): docs-only PRs