### PR TITLE
feat(teamloader): add WithModelOptions passthrough for provider-agnostic HTTP transport wrapping

### DIFF
--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -46,6 +46,7 @@ type loadOptions struct {
 	promptFiles      []string
 	toolsetRegistry  ToolsetRegistry
 	providerRegistry *provider.Registry
+	modelOpts        []options.Opt
 }
 
 type Opt func(*loadOptions) error
@@ -80,6 +81,23 @@ func WithProviderRegistry(registry *provider.Registry) Opt {
 		if registry != nil {
 			opts.providerRegistry = registry
 		}
+		return nil
+	}
+}
+
+// WithModelOptions appends caller-supplied [options.Opt] values to every model
+// client teamloader constructs for this load: primary, fallback, title, and
+// compaction models, as well as models built while loading external
+// (OCI/URL-referenced) sub-agents. Use this to thread cross-cutting model
+// configuration — most notably options.WithHTTPTransportWrapper, which lets an
+// embedder authenticate every outbound LLM request (regardless of provider)
+// without depending on provider-specific environment variables or
+// environment.IsTrustedDockerURL. The opts are appended after teamloader's own
+// built-in opts (options.WithGateway, options.WithStructuredOutput, etc.), so
+// they take precedence for any option that both sides set.
+func WithModelOptions(opts ...options.Opt) Opt {
+	return func(o *loadOptions) error {
+		o.modelOpts = append(o.modelOpts, opts...)
 		return nil
 	}
 }
@@ -264,7 +282,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 			}
 			opts = append(opts, agent.WithHarness(&harnessCfg))
 		} else {
-			models, err := getModelsForAgent(ctx, cfg, &agentConfig, autoModel, dmrFallbackSelectors, runConfig, loadOpts.providerRegistry)
+			models, err := getModelsForAgent(ctx, cfg, &agentConfig, autoModel, dmrFallbackSelectors, runConfig, loadOpts.providerRegistry, loadOpts.modelOpts)
 			if err != nil {
 				// Return auto model fallback errors, DMR not installed errors,
 				// DMR pull failures, and DMR model-not-available errors directly
@@ -283,7 +301,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 			// Load fallback models if configured
 			fallbackModelRefs := agentConfig.GetFallbackModels()
 			if len(fallbackModelRefs) > 0 {
-				fallbackModels, err := getFallbackModelsForAgent(ctx, cfg, &agentConfig, runConfig, loadOpts.providerRegistry)
+				fallbackModels, err := getFallbackModelsForAgent(ctx, cfg, &agentConfig, runConfig, loadOpts.providerRegistry, loadOpts.modelOpts)
 				if err != nil {
 					return nil, fmt.Errorf("failed to get fallback models: %w", err)
 				}
@@ -297,7 +315,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 			}
 
 			// A model may delegate session-title generation to another model.
-			titleModel, err := getTitleModelForAgent(ctx, cfg, &agentConfig, runConfig, loadOpts.providerRegistry)
+			titleModel, err := getTitleModelForAgent(ctx, cfg, &agentConfig, runConfig, loadOpts.providerRegistry, loadOpts.modelOpts)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get title model: %w", err)
 			}
@@ -307,7 +325,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 
 			// A model may delegate session compaction (summary generation) to
 			// another, cheaper/faster model.
-			compactionModel, err := getCompactionModelForAgent(ctx, cfg, &agentConfig, runConfig, loadOpts.providerRegistry)
+			compactionModel, err := getCompactionModelForAgent(ctx, cfg, &agentConfig, runConfig, loadOpts.providerRegistry, loadOpts.modelOpts)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get compaction model: %w", err)
 			}
@@ -425,7 +443,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 	}, nil
 }
 
-func getModelsForAgent(ctx context.Context, cfg *latest.Config, a *latest.AgentConfig, autoModelFn func() latest.ModelConfig, dmrFallbackSelectors map[string]bool, runConfig *config.RuntimeConfig, providerRegistry *provider.Registry) ([]provider.Provider, error) {
+func getModelsForAgent(ctx context.Context, cfg *latest.Config, a *latest.AgentConfig, autoModelFn func() latest.ModelConfig, dmrFallbackSelectors map[string]bool, runConfig *config.RuntimeConfig, providerRegistry *provider.Registry, modelOpts []options.Opt) ([]provider.Provider, error) {
 	var models []provider.Provider
 
 	// Obtain the singleton store once, outside the loop.
@@ -473,6 +491,7 @@ func getModelsForAgent(ctx context.Context, cfg *latest.Config, a *latest.AgentC
 		if modelsStoreErr == nil {
 			opts = append(opts, options.WithModelsDevStore(modelsStore))
 		}
+		opts = append(opts, modelOpts...)
 
 		// Pass the full models map for routing rules to resolve model references
 		model, err := providerRegistry.NewWithModels(ctx,
@@ -498,7 +517,7 @@ func getModelsForAgent(ctx context.Context, cfg *latest.Config, a *latest.AgentC
 
 // getFallbackModelsForAgent returns fallback providers for an agent based on its fallback configuration.
 // It uses the same resolution logic as primary models (named model, inline provider/model format).
-func getFallbackModelsForAgent(ctx context.Context, cfg *latest.Config, a *latest.AgentConfig, runConfig *config.RuntimeConfig, providerRegistry *provider.Registry) ([]provider.Provider, error) {
+func getFallbackModelsForAgent(ctx context.Context, cfg *latest.Config, a *latest.AgentConfig, runConfig *config.RuntimeConfig, providerRegistry *provider.Registry, modelOpts []options.Opt) ([]provider.Provider, error) {
 	var fallbackModels []provider.Provider
 
 	// Obtain the singleton store once, outside the loop.
@@ -538,6 +557,7 @@ func getFallbackModelsForAgent(ctx context.Context, cfg *latest.Config, a *lates
 		if modelsStoreErr == nil {
 			opts = append(opts, options.WithModelsDevStore(modelsStore))
 		}
+		opts = append(opts, modelOpts...)
 
 		// Pass the full models map for routing rules to resolve model references
 		model, err := providerRegistry.NewWithModels(ctx,
@@ -558,7 +578,7 @@ func getFallbackModelsForAgent(ctx context.Context, cfg *latest.Config, a *lates
 // getTitleModelForAgent resolves the dedicated title-generation model for an
 // agent, if any. It returns the model named by the `title_model` field of the
 // first of the agent's configured models that sets it, or nil when none do.
-func getTitleModelForAgent(ctx context.Context, cfg *latest.Config, a *latest.AgentConfig, runConfig *config.RuntimeConfig, providerRegistry *provider.Registry) (provider.Provider, error) {
+func getTitleModelForAgent(ctx context.Context, cfg *latest.Config, a *latest.AgentConfig, runConfig *config.RuntimeConfig, providerRegistry *provider.Registry, modelOpts []options.Opt) (provider.Provider, error) {
 	var titleRef string
 	for name := range strings.SplitSeq(a.Model, ",") {
 		if modelCfg, ok := cfg.Models[name]; ok && modelCfg.TitleModel != "" {
@@ -603,6 +623,7 @@ func getTitleModelForAgent(ctx context.Context, cfg *latest.Config, a *latest.Ag
 	if modelsStoreErr == nil {
 		opts = append(opts, options.WithModelsDevStore(modelsStore))
 	}
+	opts = append(opts, modelOpts...)
 
 	model, err := providerRegistry.NewWithModels(ctx, &modelCfg, cfg.Models, runConfig.EnvProvider(), opts...)
 	if err != nil {
@@ -616,7 +637,7 @@ func getTitleModelForAgent(ctx context.Context, cfg *latest.Config, a *latest.Ag
 // `compaction_model` field of the first of the agent's configured models that
 // sets it, or nil when none do. It mirrors getTitleModelForAgent: the value may
 // be a named model from the models section or an inline "provider/model" spec.
-func getCompactionModelForAgent(ctx context.Context, cfg *latest.Config, a *latest.AgentConfig, runConfig *config.RuntimeConfig, providerRegistry *provider.Registry) (provider.Provider, error) {
+func getCompactionModelForAgent(ctx context.Context, cfg *latest.Config, a *latest.AgentConfig, runConfig *config.RuntimeConfig, providerRegistry *provider.Registry, modelOpts []options.Opt) (provider.Provider, error) {
 	var compactionRef string
 	for name := range strings.SplitSeq(a.Model, ",") {
 		if modelCfg, ok := cfg.Models[name]; ok && modelCfg.CompactionModel != "" {
@@ -661,6 +682,7 @@ func getCompactionModelForAgent(ctx context.Context, cfg *latest.Config, a *late
 	if modelsStoreErr == nil {
 		opts = append(opts, options.WithModelsDevStore(modelsStore))
 	}
+	opts = append(opts, modelOpts...)
 
 	model, err := providerRegistry.NewWithModels(ctx, &modelCfg, cfg.Models, runConfig.EnvProvider(), opts...)
 	if err != nil {
@@ -984,6 +1006,10 @@ func loadExternalAgent(ctx context.Context, ref string, runConfig *config.Runtim
 
 	if loadOpts.providerRegistry != nil {
 		opts = append(opts, WithProviderRegistry(loadOpts.providerRegistry))
+	}
+
+	if len(loadOpts.modelOpts) > 0 {
+		opts = append(opts, WithModelOptions(loadOpts.modelOpts...))
 	}
 
 	result, err := Load(contextWithExternalDepth(ctx, depth+1), source, runConfig, opts...)

--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -2,22 +2,28 @@ package teamloader
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io/fs"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync/atomic"
 	"testing"
 
 	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/js"
 	"github.com/docker/docker-agent/pkg/model/provider/dmr"
+	"github.com/docker/docker-agent/pkg/model/provider/options"
 	providerdefaults "github.com/docker/docker-agent/pkg/model/provider/providers"
 	"github.com/docker/docker-agent/pkg/tools"
 )
@@ -981,4 +987,122 @@ func TestLoadWithConfig_MergesAgentGlobalAndCLIHooks(t *testing.T) {
 	assert.Equal(t, "global-pre", hooks.PreToolUse[1].Hooks[0].Command)
 	assert.Empty(t, hooks.PreToolUse[2].Matcher)
 	assert.Equal(t, "cli-pre", hooks.PreToolUse[2].Hooks[0].Command)
+}
+
+// countingTransport wraps a base RoundTripper and counts how many times
+// RoundTrip is called. Mirrors the helper in
+// pkg/model/provider/anthropic/wrap_transport_test.go (unexported there, so
+// duplicated here for this package's own end-to-end assertion).
+type countingTransport struct {
+	base  http.RoundTripper
+	calls atomic.Int64
+}
+
+func (c *countingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.calls.Add(1)
+	return c.base.RoundTrip(req)
+}
+
+// writeMinimalAnthropicSSE writes a bare-minimum valid Anthropic SSE stream so
+// the streaming client does not error before the transport wrapper can be
+// observed.
+func writeMinimalAnthropicSSE(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	flusher, _ := w.(http.Flusher)
+
+	writeEvent := func(eventType string, payload map[string]any) {
+		data, _ := json.Marshal(payload)
+		_, _ = w.Write([]byte("event: " + eventType + "\n"))
+		_, _ = w.Write([]byte("data: " + string(data) + "\n\n"))
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+
+	writeEvent("message_start", map[string]any{
+		"type":    "message_start",
+		"message": map[string]any{"id": "msg_test", "model": "claude-test", "role": "assistant", "type": "message", "content": []any{}, "stop_reason": nil, "usage": map[string]any{"input_tokens": 5, "output_tokens": 0}},
+	})
+	writeEvent("content_block_start", map[string]any{
+		"type":  "content_block_start",
+		"index": 0,
+		"content_block": map[string]any{
+			"type": "text",
+			"text": "",
+		},
+	})
+	writeEvent("content_block_delta", map[string]any{
+		"type":  "content_block_delta",
+		"index": 0,
+		"delta": map[string]any{"type": "text_delta", "text": "hi"},
+	})
+	writeEvent("content_block_stop", map[string]any{
+		"type":  "content_block_stop",
+		"index": 0,
+	})
+	writeEvent("message_delta", map[string]any{
+		"type":  "message_delta",
+		"delta": map[string]any{"stop_reason": "end_turn", "stop_sequence": nil},
+		"usage": map[string]any{"output_tokens": 1},
+	})
+	writeEvent("message_stop", map[string]any{"type": "message_stop"})
+}
+
+// TestWithModelOptions_TransportWrapperReachesAgentModel is the regression
+// guard for the teamloader-level model-options passthrough: it proves that an
+// options.Opt supplied via WithModelOptions (e.g.
+// options.WithHTTPTransportWrapper, used to inject gateway auth
+// provider-agnostically) actually reaches the HTTP client of a model
+// constructed through Load — not just teamloader's own built-in opts
+// (WithGateway, WithStructuredOutput, WithProviders). Before this passthrough
+// existed, there was no way for an embedder to wrap the transport of
+// teamloader-constructed models at all; this test exercises the full Load ->
+// agent -> provider -> HTTP round trip to prove the wrapper is live, not just
+// that WithModelOptions compiles.
+func TestWithModelOptions_TransportWrapperReachesAgentModel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeMinimalAnthropicSSE(w)
+	}))
+	defer server.Close()
+
+	t.Setenv("ANTHROPIC_API_KEY", "dummy")
+
+	data := []byte(`models:
+  primary:
+    provider: anthropic
+    model: claude-sonnet-4-5
+    base_url: ` + server.URL + `
+agents:
+  root:
+    model: primary
+    instruction: test
+`)
+
+	var counter countingTransport
+	opts := append(withTestProviderRegistry(), WithModelOptions(
+		options.WithHTTPTransportWrapper(func(base http.RoundTripper) http.RoundTripper {
+			counter.base = base
+			return &counter
+		}),
+	))
+
+	team, err := Load(t.Context(), config.NewBytesSource("transport-wrapper.yaml", data), &config.RuntimeConfig{}, opts...)
+	require.NoError(t, err)
+
+	root, err := team.Agent("root")
+	require.NoError(t, err)
+
+	stream, err := root.Model(t.Context()).CreateChatCompletionStream(t.Context(), []chat.Message{
+		{Role: chat.MessageRoleUser, Content: "hello"},
+	}, nil)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	for {
+		if _, err := stream.Recv(); err != nil {
+			break
+		}
+	}
+
+	assert.Positive(t, counter.calls.Load(), "transport wrapper supplied via WithModelOptions should have been invoked when the agent's model made a request")
 }


### PR DESCRIPTION
🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

## Problem

`teamloader.Load`/`LoadWithConfig` has no way for a caller to inject a custom `options.Opt` into the model clients it constructs internally. In particular, `options.WithHTTPTransportWrapper` (#3089) already lets a caller wrap the HTTP transport used by anthropic/openai/gemini provider clients — e.g. to inject a bearer token provider-agnostically, decoupled from `environment.IsTrustedDockerURL` — but that only works today for callers who build a provider client directly (e.g. `agentic-platform`'s `internal/gordon`). Any caller going through `teamloader.Load` (which resolves providers dynamically from a cagent.yml config, so it can't build clients directly) has no equivalent hook.

This surfaced while investigating a credential-injection gap in `agentic-platform`'s autonomous sandbox-runner sessions (tracked there as APT-632): the runner uses `teamloader.Load`, so it can't currently apply a transport wrapper for gateway auth across arbitrary configured providers.

## Change

- Adds `WithModelOptions(opts ...options.Opt) Opt`, appended after teamloader's own built-in opts (`options.WithGateway`, `options.WithStructuredOutput`, etc.) at all 4 internal provider-construction sites (`getModelsForAgent`, `getFallbackModelsForAgent`, `getTitleModelForAgent`, `getCompactionModelForAgent`), so caller-supplied opts take precedence for anything both sides set.
- Threads it into `loadExternalAgent` so external (OCI/URL-referenced) sub-agents inherit it too.
- Adds an end-to-end regression test (`TestWithModelOptions_TransportWrapperReachesAgentModel`): loads a team from an inline cagent config via `WithModelOptions(options.WithHTTPTransportWrapper(...))`, drives the resulting agent's model through a real `httptest` streaming call, and asserts the wrapper's `RoundTrip` was invoked — proving the opt reaches the actual HTTP client, not just that it compiles. (Confirmed by reverting only `teamloader.go`: the test then fails to compile with `undefined: WithModelOptions`.)

## Testing

- `go build ./pkg/teamloader/...`, `go vet ./pkg/teamloader/...`, `go test ./pkg/teamloader/...` — all pass.
- `go mod tidy --diff` — empty.
- `go run ./lint .` — no offenses (1491 files).
- `golangci-lint v2.12.2 run ./pkg/teamloader/...` — 0 issues.
- Independently reviewed by a sub-agent; verdict: approve. One non-blocking note: the new test only exercises the primary-model site end-to-end (the other 3 sites apply the identical one-line append, verified by code reading); happy to extend coverage if maintainers want it before merge.
