### PR TITLE
fix(sqlite): avoid WAL journal mode inside docker sandboxes

### DIFF
--- a/pkg/environment/sandbox.go
+++ b/pkg/environment/sandbox.go
@@ -2,6 +2,8 @@ package environment
 
 import "os"
 
+// sandboxVMIDEnv is also read directly by pkg/sqliteutil (journalMode) to
+// avoid a heavy import; update both sites if the detection signal changes.
 const sandboxVMIDEnv = "SANDBOX_VM_ID"
 
 // InSandbox reports whether docker agent is running inside a Docker sandbox.

--- a/pkg/memory/database/sqlite/sqlite_test.go
+++ b/pkg/memory/database/sqlite/sqlite_test.go
@@ -344,6 +344,10 @@ func TestDatabaseOperationsWithCanceledContext(t *testing.T) {
 }
 
 func TestMemoryDatabaseUsesWALAndBusyTimeout(t *testing.T) {
+	// WAL is only expected outside a Docker sandbox (sqliteutil falls back
+	// to DELETE inside one), so pin the detection env var.
+	t.Setenv("SANDBOX_VM_ID", "")
+
 	db := setupTestDB(t)
 	memDB := db.(*MemoryDatabase)
 

--- a/pkg/sqliteutil/sqlite.go
+++ b/pkg/sqliteutil/sqlite.go
@@ -23,9 +23,9 @@ func OpenDB(ctx context.Context, path string) (*sql.DB, error) {
 
 	// Add query parameters for better concurrency handling and data integrity
 	// _pragma=busy_timeout(5000): Wait up to 5 seconds if database is locked
-	// _pragma=journal_mode(WAL): Enable Write-Ahead Logging for better concurrent access
+	// _pragma=journal_mode(...): WAL outside sandboxes, DELETE inside (see journalMode)
 	// _pragma=foreign_keys(1): Enable foreign key constraints (critical for ON DELETE CASCADE)
-	dsn := path + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(1)"
+	dsn := path + "?_pragma=busy_timeout(5000)&_pragma=journal_mode(" + journalMode() + ")&_pragma=foreign_keys(1)"
 
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
@@ -51,6 +51,22 @@ func OpenDB(ctx context.Context, path string) (*sql.DB, error) {
 	}
 
 	return db, nil
+}
+
+// journalMode picks the SQLite journal mode. WAL is preferred, but it relies
+// on a shared-memory index (the -shm file) mmap'd by every connection. Inside
+// a Docker sandbox the data dir is bind-mounted from the host (virtiofs),
+// where that mapping is not coherent across the VM boundary and WAL corrupts
+// the database. DELETE mode uses only ordinary file locks, which the mount
+// forwards correctly; it also folds any leftover -wal file back into the main
+// database on open.
+func journalMode() string {
+	// Mirrors environment.InSandbox; checked directly to keep sqliteutil
+	// dependency-free.
+	if os.Getenv("SANDBOX_VM_ID") != "" {
+		return "DELETE"
+	}
+	return "WAL"
 }
 
 // IsCantOpenError checks if the error is a SQLite CANTOPEN error (code 14).

--- a/pkg/sqliteutil/sqlite_test.go
+++ b/pkg/sqliteutil/sqlite_test.go
@@ -12,6 +12,64 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// queryJournalMode opens path via OpenDB and reports the effective journal mode.
+func queryJournalMode(t *testing.T, path string) string {
+	t.Helper()
+
+	db, err := OpenDB(t.Context(), path)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var mode string
+	require.NoError(t, db.QueryRowContext(t.Context(), "PRAGMA journal_mode").Scan(&mode))
+	return mode
+}
+
+func TestOpenDB_UsesWALOnHost(t *testing.T) {
+	t.Setenv("SANDBOX_VM_ID", "")
+
+	mode := queryJournalMode(t, filepath.Join(t.TempDir(), "host.db"))
+	assert.Equal(t, "wal", mode)
+}
+
+// WAL is unsafe on the bind-mounted data dir inside a Docker sandbox (its
+// shared-memory index is not coherent across the VM boundary and corrupts the
+// database), so OpenDB must fall back to the DELETE journal there.
+func TestOpenDB_UsesDeleteJournalInSandbox(t *testing.T) {
+	t.Setenv("SANDBOX_VM_ID", "vm-1")
+
+	mode := queryJournalMode(t, filepath.Join(t.TempDir(), "sandbox.db"))
+	assert.Equal(t, "delete", mode)
+}
+
+// A database created in WAL mode on the host must convert cleanly when
+// reopened inside a sandbox: same data, persistent journal mode flipped to
+// DELETE, no -wal file on disk.
+func TestOpenDB_ConvertsExistingWALInSandbox(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.db")
+
+	t.Setenv("SANDBOX_VM_ID", "")
+	hostDB, err := OpenDB(t.Context(), path)
+	require.NoError(t, err)
+	_, err = hostDB.ExecContext(t.Context(), "CREATE TABLE t (id INTEGER); INSERT INTO t VALUES (42)")
+	require.NoError(t, err)
+	require.NoError(t, hostDB.Close())
+
+	t.Setenv("SANDBOX_VM_ID", "vm-1")
+	sandboxDB, err := OpenDB(t.Context(), path)
+	require.NoError(t, err)
+	defer sandboxDB.Close()
+
+	var mode string
+	require.NoError(t, sandboxDB.QueryRowContext(t.Context(), "PRAGMA journal_mode").Scan(&mode))
+	assert.Equal(t, "delete", mode)
+
+	var id int
+	require.NoError(t, sandboxDB.QueryRowContext(t.Context(), "SELECT id FROM t").Scan(&id))
+	assert.Equal(t, 42, id)
+	assert.NoFileExists(t, path+"-wal")
+}
+
 func TestIsTransientError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When `~/.cagent` is bind-mounted into a Docker sandbox VM (virtiofs), SQLite's WAL journal mode breaks down. WAL relies on a shared-memory index (the `-shm` file, mmap'd by every connection) that is not coherent across the VM boundary — SQLite itself documents WAL as unsafe on such filesystems — so any database opened in WAL mode inside a sandbox is prone to corruption.

`sqliteutil.OpenDB` now picks the journal mode at open time via a `journalMode()` helper: WAL on a regular host, DELETE when running inside a Docker sandbox (`SANDBOX_VM_ID` set — the same signal `environment.InSandbox()` uses, read directly to keep `sqliteutil` dependency-free). DELETE mode relies only on ordinary file locks that virtiofs forwards correctly. Opening an existing WAL database in DELETE mode automatically folds any leftover `-wal` file back into the main database. Pragma ordering keeps `busy_timeout` first so the WAL→DELETE demotion benefits from the 5s timeout; `PRAGMA wal_checkpoint` on a DELETE-mode database is a harmless no-op, so `CheckpointAndClose` is unaffected.

New tests verify WAL on the host, DELETE inside a simulated sandbox, and clean conversion of a host-created WAL database (data intact, mode flipped, no `-wal` file left behind). The existing in-memory WAL test now pins `SANDBOX_VM_ID=""` so it passes when the suite itself runs inside a sandbox. A cross-reference comment on `sandboxVMIDEnv` in `pkg/environment` prevents the duplicated env-var literal from drifting.