### PR TITLE
feat(skills): discover skills in .github/skills directories

### DIFF
--- a/docs/configuration/sandbox/index.md
+++ b/docs/configuration/sandbox/index.md
@@ -176,7 +176,7 @@ The kit is built whenever `--sandbox` is used with an agent reference. It is opt
 
 For the agent referenced on the command line, the kit collects:
 
-- **Local [skills](../../features/skills/index.md)** — every `SKILL.md` discovered on the host (global `~/.codex/skills/`, `~/.claude/skills/`, `~/.agents/skills/`, plus project `.claude/skills/` and `.agents/skills/`) is copied under `<kit>/skills/<skill-name>/`. The in-sandbox skills loader reads from the kit instead of the (non-existent) host `$HOME`.
+- **Local [skills](../../features/skills/index.md)** — every `SKILL.md` discovered on the host (global `~/.codex/skills/`, `~/.claude/skills/`, `~/.agents/skills/`, plus project `.claude/skills/`, `.github/skills/` and `.agents/skills/`) is copied under `<kit>/skills/<skill-name>/`. The in-sandbox skills loader reads from the kit instead of the (non-existent) host `$HOME`.
 - **Prompt files** — every file referenced via the agent's `add_prompt_files` (`AGENTS.md`, `CLAUDE.md`, …) is collected. Files that already live under the working directory are left alone (the live workspace mount surfaces them); files outside it (e.g. an `AGENTS.md` in `$HOME`) are copied under `<kit>/prompt_files/`.
 - **A manifest** — `<kit>/manifest.json` records what was staged. The on-disk copy is sanitised so it cannot be used to map the host filesystem from inside the sandbox.
 

--- a/docs/features/skills/index.md
+++ b/docs/features/skills/index.md
@@ -312,6 +312,7 @@ Skills are discovered from these locations (later overrides earlier):
 | Path              | Search Type                                |
 | ----------------- | ------------------------------------------ |
 | `.claude/skills/` | Flat (cwd only)                            |
+| `.github/skills/` | Flat (each directory from git root to cwd) |
 | `.agents/skills/` | Flat (each directory from git root to cwd) |
 
 ## Invoking Skills
@@ -337,6 +338,7 @@ When multiple skills share the same name:
 1. Global skills load first
 2. Project skills load next, from git root toward current directory
 3. Skills closer to the current directory override those further away
+4. At the same directory level, `.agents/skills/` overrides `.github/skills/`
 
 ## Skills in Sandbox Mode
 

--- a/pkg/skills/local.go
+++ b/pkg/skills/local.go
@@ -43,8 +43,10 @@ type localSearchPath struct {
 //
 //  1. Global directories (under $HOME).
 //  2. .claude/skills under cwd (Claude project format, flat).
-//  3. .agents/skills in each ancestor of cwd up to $HOME — or the enclosing
-//     git root when cwd is outside $HOME — down to cwd (closest wins).
+//  3. .github/skills (GitHub Copilot format) and .agents/skills in each
+//     ancestor of cwd up to $HOME — or the enclosing git root when cwd is
+//     outside $HOME — down to cwd (closest wins; .agents/skills overrides
+//     .github/skills at the same level).
 func localSearchPaths() []localSearchPath {
 	if kit := os.Getenv(KitDirEnv); kit != "" {
 		return []localSearchPath{{filepath.Join(kit, KitSkillsSubdir), true}}
@@ -63,7 +65,10 @@ func localSearchPaths() []localSearchPath {
 
 	searchPaths = append(searchPaths, localSearchPath{filepath.Join(cwd, ".claude", "skills"), false})
 	for _, dir := range projectSearchDirs(cwd) {
-		searchPaths = append(searchPaths, localSearchPath{filepath.Join(dir, ".agents", "skills"), false})
+		searchPaths = append(searchPaths,
+			localSearchPath{filepath.Join(dir, ".github", "skills"), false},
+			localSearchPath{filepath.Join(dir, ".agents", "skills"), false},
+		)
 	}
 	return searchPaths
 }
@@ -102,8 +107,9 @@ func homeSkillSearchPaths(home string) []localSearchPath {
 	}
 }
 
-// projectSearchDirs returns the directories to scan for repo-local
-// .agents/skills, ordered from the topmost ancestor down to cwd (inclusive).
+// projectSearchDirs returns the directories to scan for repo-local skill
+// roots (.github/skills, .agents/skills), ordered from the topmost ancestor
+// down to cwd (inclusive).
 // Ordering matters: later (deeper) entries override skills from parents, so a
 // project subdirectory can shadow a skill defined higher up.
 //

--- a/pkg/skills/skills.go
+++ b/pkg/skills/skills.go
@@ -66,8 +66,10 @@ func (s Skill) IsFork() bool {
 //
 // Project locations (under cwd, closest wins):
 //   - .claude/skills/ (flat, only at cwd)
-//   - .agents/skills/ (flat, scanned from each ancestor up to $HOME — or the
+//   - .github/skills/ (flat, scanned from each ancestor up to $HOME — or the
 //     enclosing git root outside $HOME — down to cwd)
+//   - .agents/skills/ (flat, same ancestor scan; overrides .github/skills at
+//     the same level)
 //
 // The returned slice is sorted by skill name for deterministic ordering.
 func Load(ctx context.Context, sources []string) []Skill {

--- a/pkg/skills/skills_test.go
+++ b/pkg/skills/skills_test.go
@@ -628,6 +628,93 @@ description: A skill from repo root
 	assert.True(t, found, "Expected to find repo-skill from .agents/skills at git root")
 }
 
+func TestLoad_GithubSkillsProjectFromNestedDir(t *testing.T) {
+	// Reproduces #3548: GitHub Copilot teams commit shared skills under
+	// .github/skills at the repo root. They must be discoverable from any
+	// nested working directory, like .agents/skills.
+	tmpRepo := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(tmpRepo, ".git"), 0o755))
+
+	githubSkillDir := filepath.Join(tmpRepo, ".github", "skills", "copilot-skill")
+	require.NoError(t, os.MkdirAll(githubSkillDir, 0o755))
+
+	skillContent := `---
+name: copilot-skill
+description: A skill from .github/skills
+---
+
+# Copilot Skill
+`
+	require.NoError(t, os.WriteFile(filepath.Join(githubSkillDir, "SKILL.md"), []byte(skillContent), 0o644))
+
+	nestedDir := filepath.Join(tmpRepo, "sub", "nested")
+	require.NoError(t, os.MkdirAll(nestedDir, 0o755))
+	t.Chdir(nestedDir)
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	skills := Load(t.Context(), []string{"local"})
+
+	found := false
+	for _, s := range skills {
+		if s.Name == "copilot-skill" {
+			found = true
+			assert.Equal(t, "A skill from .github/skills", s.Description)
+			assert.Equal(t, filepath.Join(githubSkillDir, "SKILL.md"), s.FilePath)
+			break
+		}
+	}
+	assert.True(t, found, "Expected to find copilot-skill from .github/skills at git root")
+}
+
+func TestLoad_GithubSkillsPrecedence_AgentsOverridesGithub(t *testing.T) {
+	// Same skill name in .github/skills and .agents/skills at the same level:
+	// the native .agents/skills version must win.
+	tmpRepo := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(tmpRepo, ".git"), 0o755))
+
+	githubSkillDir := filepath.Join(tmpRepo, ".github", "skills", "shared-skill")
+	require.NoError(t, os.MkdirAll(githubSkillDir, 0o755))
+	githubContent := `---
+name: shared-skill
+description: Github version
+---
+
+# Github
+`
+	require.NoError(t, os.WriteFile(filepath.Join(githubSkillDir, "SKILL.md"), []byte(githubContent), 0o644))
+
+	agentsSkillDir := filepath.Join(tmpRepo, ".agents", "skills", "shared-skill")
+	require.NoError(t, os.MkdirAll(agentsSkillDir, 0o755))
+	agentsContent := `---
+name: shared-skill
+description: Agents version
+---
+
+# Agents
+`
+	require.NoError(t, os.WriteFile(filepath.Join(agentsSkillDir, "SKILL.md"), []byte(agentsContent), 0o644))
+
+	t.Chdir(tmpRepo)
+
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	skills := Load(t.Context(), []string{"local"})
+
+	found := false
+	for _, s := range skills {
+		if s.Name == "shared-skill" {
+			found = true
+			assert.Equal(t, "Agents version", s.Description)
+			assert.Equal(t, filepath.Join(agentsSkillDir, "SKILL.md"), s.FilePath)
+			break
+		}
+	}
+	assert.True(t, found, ".agents/skills must override .github/skills at the same level")
+}
+
 func TestLoad_AgentsSkillsFromNonGitGroupingParent(t *testing.T) {
 	// Reproduces #3056: several independent repos grouped under a non-git
 	// parent, with a shared skill at the grouping root's .agents/skills. It


### PR DESCRIPTION
Closes #3548.

Adds `.github/skills` to the local skill discovery paths. GitHub Copilot teams commit shared skills there, and they were previously invisible to docker-agent.

## Issue expectation vs implementation

| Issue expectation | Implemented |
| --- | --- |
| Discover skills in `.github/skills` | yes, scanned as a project-level search path |
| Work with team skills shared in a repo | yes, scanned at each level from git root (or grouping root) down to cwd, so repo-root skills are found from any nested working directory |

## Discovery flow

```
localSearchPaths()  (pkg/skills/local.go)
  global: ~/.codex/skills, ~/.claude/skills, ~/.agents/skills
  cwd:    .claude/skills
  per projectSearchDirs level (root -> cwd):
          .github/skills   (new)
          .agents/skills   (overrides .github/skills at the same level)
```

- Flat scan (`<skill>/SKILL.md`), same as the other project paths.
- Closest-to-cwd still wins across levels; at the same level the native `.agents/skills` wins over `.github/skills`. If the opposite precedence seems more appropriate, it can always be swapped (one-line change).
- The sandbox auto-kit (`pkg/sandbox/kit`) reuses `skills.Load`, so staged kits pick up `.github/skills` with no further change.

## Changes

| File | Change |
| --- | --- |
| `pkg/skills/local.go` | add `.github/skills` to the project search loop |
| `pkg/skills/skills.go` | update `Load` doc comment |
| `pkg/skills/skills_test.go` | add discovery-from-nested-dir and precedence tests |
| `docs/features/skills/index.md` | search path table and precedence rules |
| `docs/configuration/sandbox/index.md` | auto-kit staged directories list |

## Validation

- `go build ./...`, `go test ./pkg/skills/ ./pkg/sandbox/...`: pass.
- `golangci-lint run pkg/skills/...` and `go run ./lint .`: no issues.
- Real scenario: repo with `.github/skills/deploy-service/SKILL.md` at the root, `docker-agent debug skills` run from a nested `backend/api` directory lists the skill.
