### PR TITLE
feat(board): let the user configure their own columns

### DIFF
--- a/docs/features/board/index.md
+++ b/docs/features/board/index.md
@@ -31,7 +31,8 @@ Requirements: `tmux` and `git` must be installed.
   agent loading config, models, and tools) → `attaching` (control-plane socket
   bound; board waiting for the first snapshot).
 - **Columns are a pipeline.** The default pipeline is
-  Dev → Review → Push → Done. Moving a card forward (`]`)
+  Dev → Review → Push → Done, and it's fully customizable: manage columns
+  from the board (`c`) or in the config file. Moving a card forward (`]`)
   sends the destination column's prompt to the card's agent; moving it back
   (`[`) sends nothing.
 - **Attach anytime.** Press `enter` (or double-click a card) to attach your
@@ -57,6 +58,7 @@ Requirements: `tmux` and `git` must be installed.
 | `1`-`9`       | Move the card to column N                           |
 | `x`           | Delete the card, its session, worktree, and branch  |
 | `p`           | Manage projects (add, edit, reorder, remove)        |
+| `c`           | Manage columns (add, edit, reorder, remove)         |
 | `e`           | Edit the selected column's prompt                   |
 | `←↓↑→` `hjkl` | Navigate                                            |
 | mouse         | Click selects, double-click attaches, drag moves, wheel scrolls |
@@ -67,7 +69,7 @@ Requirements: `tmux` and `git` must be installed.
 
 Everything is configured in the global config file
 (`~/.config/cagent/config.yaml`) or through the TUI itself (`p` for projects,
-`e` for column prompts):
+`c` for columns, `e` for column prompts):
 
 ```yaml
 board:
@@ -88,6 +90,8 @@ board:
       emoji: ✅
 ```
 
-Omitting `columns` keeps the default pipeline. When a card enters a column
-with a `prompt`, that prompt is delivered to the card's agent as its next
-message.
+Omitting `columns` keeps the default pipeline. Column `id`s identify a
+column across renames (cards remember the column they are in by id); when
+omitted, the id is derived from the column's name. When a card enters a
+column with a `prompt`, that prompt is delivered to the card's agent as its
+next message.

--- a/pkg/board/app.go
+++ b/pkg/board/app.go
@@ -115,6 +115,117 @@ func (a *App) SetColumnPrompt(colID, prompt string) error {
 	return a.saveConfigLocked()
 }
 
+// AddColumn validates and appends a column to the pipeline, persisting it
+// to the user's global config file. The column's id is derived from its
+// name and kept unique; the saved column (with its id) is returned so the
+// UI can select it.
+func (a *App) AddColumn(col Column) (Column, error) {
+	col, err := normalizeColumn(col)
+	if err != nil {
+		return Column{}, err
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	col.ID = a.uniqueColumnIDLocked(col.Name)
+	a.columns = append(a.columns, col)
+	if err := a.saveConfigLocked(); err != nil {
+		return Column{}, err
+	}
+	return col, nil
+}
+
+// UpdateColumn replaces the column with the given id, applying the same
+// validation as AddColumn and persisting the change. The id never changes
+// on an update, so existing cards stay attached to the column across a
+// rename.
+func (a *App) UpdateColumn(id string, col Column) (Column, error) {
+	col, err := normalizeColumn(col)
+	if err != nil {
+		return Column{}, err
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	idx := slices.IndexFunc(a.columns, func(c Column) bool { return c.ID == id })
+	if idx < 0 {
+		return Column{}, fmt.Errorf("unknown column %q", id)
+	}
+	col.ID = id
+	a.columns[idx] = col
+	if err := a.saveConfigLocked(); err != nil {
+		return Column{}, err
+	}
+	return col, nil
+}
+
+// MoveColumn moves the column with the given id delta positions in the
+// pipeline (negative moves it left) and persists the new order. The
+// destination is clamped, so moves past either end are safe no-ops.
+func (a *App) MoveColumn(id string, delta int) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	idx := slices.IndexFunc(a.columns, func(c Column) bool { return c.ID == id })
+	if idx < 0 {
+		return fmt.Errorf("unknown column %q", id)
+	}
+	dst := min(max(idx+delta, 0), len(a.columns)-1)
+	if dst == idx {
+		return nil
+	}
+	col := a.columns[idx]
+	a.columns = slices.Insert(slices.Delete(a.columns, idx, idx+1), dst, col)
+	return a.saveConfigLocked()
+}
+
+// RemoveColumn deletes a column by id and persists the change. A column
+// that still holds cards cannot be removed (its cards would silently pile
+// up in the first column), and neither can the last remaining column.
+func (a *App) RemoveColumn(id string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	idx := slices.IndexFunc(a.columns, func(c Column) bool { return c.ID == id })
+	if idx < 0 {
+		return fmt.Errorf("unknown column %q", id)
+	}
+	if len(a.columns) == 1 {
+		return errors.New("the board needs at least one column")
+	}
+	for _, card := range a.store.ListCards() {
+		if card.Column == id {
+			return fmt.Errorf("column %q still has cards; move or delete them first", a.columns[idx].Name)
+		}
+	}
+	a.columns = slices.Delete(a.columns, idx, idx+1)
+	return a.saveConfigLocked()
+}
+
+// normalizeColumn checks a column's name and trims its fields. The prompt
+// keeps inner newlines: multi-line prompts are the norm.
+func normalizeColumn(col Column) (Column, error) {
+	col.Name = strings.TrimSpace(col.Name)
+	if col.Name == "" {
+		return Column{}, errors.New("column name is required")
+	}
+	col.Emoji = strings.TrimSpace(col.Emoji)
+	col.Prompt = strings.TrimSpace(col.Prompt)
+	return col, nil
+}
+
+// uniqueColumnIDLocked derives an id from a column name, suffixing it until
+// it collides with no existing column. Callers must hold a.mu.
+func (a *App) uniqueColumnIDLocked(name string) string {
+	base := columnID(name)
+	if base == "" {
+		base = "col-" + newID()[:4]
+	}
+	id := base
+	for n := 2; slices.ContainsFunc(a.columns, func(c Column) bool { return c.ID == id }); n++ {
+		id = fmt.Sprintf("%s-%d", base, n)
+	}
+	return id
+}
+
 // saveConfigLocked persists the projects and columns to the global config
 // file. Callers must hold a.mu. The board section is written from the
 // board's in-memory view (authoritative for projects and columns) onto the

--- a/pkg/board/app.go
+++ b/pkg/board/app.go
@@ -95,13 +95,6 @@ func (a *App) Columns() []Column {
 	return slices.Clone(a.columns)
 }
 
-// ColumnIndex returns the position of a column in the pipeline, or -1.
-func (a *App) ColumnIndex(colID string) int {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	return slices.IndexFunc(a.columns, func(c Column) bool { return c.ID == colID })
-}
-
 // SetColumnPrompt updates a column's prompt and persists it to the user's
 // global config file.
 func (a *App) SetColumnPrompt(colID, prompt string) error {
@@ -180,7 +173,9 @@ func (a *App) MoveColumn(id string, delta int) error {
 
 // RemoveColumn deletes a column by id and persists the change. A column
 // that still holds cards cannot be removed (its cards would silently pile
-// up in the first column), and neither can the last remaining column.
+// up in the first column), and neither can the last remaining column. The
+// cards check is advisory: a card creation or move in flight can still
+// land in the removed column, where the UI rescues it into the first one.
 func (a *App) RemoveColumn(id string) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -490,11 +485,16 @@ func (a *App) MoveCard(cardID, colID string) error {
 		return err
 	}
 
-	dstIdx := a.ColumnIndex(colID)
+	// One pipeline snapshot for the whole move: columns can be edited
+	// concurrently from the UI, and re-indexing a fresh snapshot later
+	// could deliver another column's prompt (or panic on a removed one).
+	columns := a.Columns()
+	dstIdx := slices.IndexFunc(columns, func(c Column) bool { return c.ID == colID })
 	if dstIdx < 0 {
 		return fmt.Errorf("unknown column %q", colID)
 	}
-	movedForward := dstIdx > a.ColumnIndex(card.Column)
+	srcIdx := slices.IndexFunc(columns, func(c Column) bool { return c.ID == card.Column })
+	movedForward := dstIdx > srcIdx
 
 	moved, err := a.store.MoveCard(cardID, colID, movedForward)
 	if err != nil {
@@ -504,7 +504,7 @@ func (a *App) MoveCard(cardID, colID string) error {
 	a.onChanged()
 
 	if movedForward {
-		return a.controller.SendPrompt(moved, a.Columns()[dstIdx].Prompt)
+		return a.controller.SendPrompt(moved, columns[dstIdx].Prompt)
 	}
 	return nil
 }

--- a/pkg/board/app.go
+++ b/pkg/board/app.go
@@ -195,14 +195,16 @@ func (a *App) RemoveColumn(id string) error {
 	return a.saveConfigLocked()
 }
 
-// normalizeColumn checks a column's name and trims its fields. The prompt
-// keeps inner newlines: multi-line prompts are the norm.
+// normalizeColumn checks a column's name and normalizes its fields: name
+// and emoji are single-line display strings (inner whitespace collapses to
+// spaces), the prompt keeps inner newlines — multi-line prompts are the
+// norm.
 func normalizeColumn(col Column) (Column, error) {
-	col.Name = strings.TrimSpace(col.Name)
+	col.Name = collapseSpace(col.Name)
 	if col.Name == "" {
 		return Column{}, errors.New("column name is required")
 	}
-	col.Emoji = strings.TrimSpace(col.Emoji)
+	col.Emoji = collapseSpace(col.Emoji)
 	col.Prompt = strings.TrimSpace(col.Prompt)
 	return col, nil
 }
@@ -212,7 +214,7 @@ func normalizeColumn(col Column) (Column, error) {
 func (a *App) uniqueColumnIDLocked(name string) string {
 	base := columnID(name)
 	if base == "" {
-		base = "col-" + newID()[:4]
+		base = fallbackColumnID(name)
 	}
 	id := base
 	for n := 2; slices.ContainsFunc(a.columns, func(c Column) bool { return c.ID == id }); n++ {

--- a/pkg/board/app_test.go
+++ b/pkg/board/app_test.go
@@ -119,6 +119,93 @@ func TestMoveProject(t *testing.T) {
 	assert.Equal(t, "c", reloaded.Board.Projects[1].Name)
 }
 
+func TestColumnCRUD(t *testing.T) {
+	paths.SetConfigDir(t.TempDir())
+	t.Cleanup(func() { paths.SetConfigDir("") })
+
+	cfg, err := userconfig.Load()
+	require.NoError(t, err)
+	store, err := OpenStore(filepath.Join(t.TempDir(), "cards.json"))
+	require.NoError(t, err)
+	app := &App{ctx: t.Context(), config: cfg, columns: ColumnsFromConfig(nil), store: store, onChanged: func() {}}
+
+	ids := func() []string {
+		var out []string
+		for _, c := range app.Columns() {
+			out = append(out, c.ID)
+		}
+		return out
+	}
+
+	// Add derives the id from the name and keeps it unique.
+	col, err := app.AddColumn(Column{Name: "  QA Check ", Emoji: " \U0001f9ea ", Prompt: "run the tests"})
+	require.NoError(t, err)
+	assert.Equal(t, Column{ID: "qa-check", Name: "QA Check", Emoji: "\U0001f9ea", Prompt: "run the tests"}, col)
+	dup, err := app.AddColumn(Column{Name: "QA Check"})
+	require.NoError(t, err)
+	assert.Equal(t, "qa-check-2", dup.ID)
+	_, err = app.AddColumn(Column{Name: "   "})
+	require.Error(t, err)
+
+	// Update keeps the id stable across a rename.
+	updated, err := app.UpdateColumn("qa-check", Column{Name: "Verify", Prompt: "run the tests"})
+	require.NoError(t, err)
+	assert.Equal(t, Column{ID: "qa-check", Name: "Verify", Prompt: "run the tests"}, updated)
+	_, err = app.UpdateColumn("nope", Column{Name: "x"})
+	require.Error(t, err)
+	_, err = app.UpdateColumn("qa-check", Column{Name: ""})
+	require.Error(t, err)
+
+	// Move clamps at both ends.
+	require.NoError(t, app.MoveColumn("qa-check", -2))
+	assert.Equal(t, []string{"dev", "review", "qa-check", "push", "done", "qa-check-2"}, ids())
+	require.NoError(t, app.MoveColumn("dev", -1))
+	require.NoError(t, app.MoveColumn("qa-check-2", 5))
+	assert.Equal(t, []string{"dev", "review", "qa-check", "push", "done", "qa-check-2"}, ids())
+	require.Error(t, app.MoveColumn("nope", 1))
+
+	// A column that still has cards cannot be removed.
+	require.NoError(t, store.InsertCard(&Card{ID: "c1", Column: "qa-check"}))
+	require.Error(t, app.RemoveColumn("qa-check"))
+	require.NoError(t, app.RemoveColumn("qa-check-2"))
+	require.Error(t, app.RemoveColumn("nope"))
+	assert.Equal(t, []string{"dev", "review", "qa-check", "push", "done"}, ids())
+
+	// The customized pipeline is persisted to the config file.
+	reloaded, err := userconfig.Load()
+	require.NoError(t, err)
+	require.NotNil(t, reloaded.Board)
+	assert.Equal(t, ids(), func() []string {
+		var out []string
+		for _, c := range reloaded.Board.Columns {
+			out = append(out, c.ID)
+		}
+		return out
+	}())
+
+	// Restoring the defaults drops the columns section from the config, so
+	// future default-pipeline changes reach the user again.
+	require.NoError(t, store.DeleteCard("c1"))
+	require.NoError(t, app.RemoveColumn("qa-check"))
+	reloaded, err = userconfig.Load()
+	require.NoError(t, err)
+	assert.Empty(t, reloaded.Board.Columns)
+}
+
+func TestRemoveColumnKeepsAtLeastOne(t *testing.T) {
+	paths.SetConfigDir(t.TempDir())
+	t.Cleanup(func() { paths.SetConfigDir("") })
+
+	cfg, err := userconfig.Load()
+	require.NoError(t, err)
+	store, err := OpenStore(filepath.Join(t.TempDir(), "cards.json"))
+	require.NoError(t, err)
+	app := &App{ctx: t.Context(), config: cfg, columns: []Column{{ID: "only", Name: "Only"}}, store: store, onChanged: func() {}}
+
+	require.Error(t, app.RemoveColumn("only"))
+	assert.Len(t, app.Columns(), 1)
+}
+
 func TestAttachCommandExplainsFailedRelaunch(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/board/model.go
+++ b/pkg/board/model.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/docker/docker-agent/pkg/paths"
@@ -34,16 +35,52 @@ var DefaultColumns = []Column{
 }
 
 // ColumnsFromConfig maps user-configured columns to board columns, falling
-// back to [DefaultColumns] when none are configured.
+// back to [DefaultColumns] when none are configured. The config file is
+// hand-editable, so entries are normalized instead of trusted: a missing id
+// is derived from the name, an id-less and nameless entry is dropped, and a
+// duplicate id is dropped (card moves address columns by id, so duplicates
+// would be ambiguous).
 func ColumnsFromConfig(cols []userconfig.BoardColumn) []Column {
-	if len(cols) == 0 {
-		return DefaultColumns
-	}
 	out := make([]Column, 0, len(cols))
+	seen := make(map[string]bool, len(cols))
 	for _, c := range cols {
-		out = append(out, Column{ID: c.ID, Name: c.Name, Emoji: c.Emoji, Prompt: c.Prompt})
+		id := strings.TrimSpace(c.ID)
+		if id == "" {
+			id = columnID(c.Name)
+		}
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		name := strings.TrimSpace(c.Name)
+		if name == "" {
+			name = id
+		}
+		out = append(out, Column{ID: id, Name: name, Emoji: c.Emoji, Prompt: c.Prompt})
+	}
+	if len(out) == 0 {
+		// Cloned: the caller may edit the pipeline in place.
+		return slices.Clone(DefaultColumns)
 	}
 	return out
+}
+
+// columnID derives a column id from its display name: lowercased, with
+// runs of separators collapsed to a dash and anything else non-alphanumeric
+// dropped. Names that slug to nothing (e.g. emoji-only) yield "".
+func columnID(name string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(strings.TrimSpace(name)) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == ' ' || r == '-' || r == '_':
+			if s := b.String(); s != "" && !strings.HasSuffix(s, "-") {
+				b.WriteByte('-')
+			}
+		}
+	}
+	return strings.TrimSuffix(b.String(), "-")
 }
 
 // CardStatus tracks what a card's agent is doing.

--- a/pkg/board/model.go
+++ b/pkg/board/model.go
@@ -8,6 +8,8 @@ package board
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
+	"hash/fnv"
 	"os"
 	"path/filepath"
 	"slices"
@@ -37,26 +39,32 @@ var DefaultColumns = []Column{
 // ColumnsFromConfig maps user-configured columns to board columns, falling
 // back to [DefaultColumns] when none are configured. The config file is
 // hand-editable, so entries are normalized instead of trusted: a missing id
-// is derived from the name, an id-less and nameless entry is dropped, and a
-// duplicate id is dropped (card moves address columns by id, so duplicates
-// would be ambiguous).
+// is derived from the name (hashed when the name slugs to nothing, e.g.
+// non-ASCII, so the id stays stable across restarts), an id-less and
+// nameless entry is dropped, and a duplicate id is dropped (card moves
+// address columns by id, so duplicates would be ambiguous).
 func ColumnsFromConfig(cols []userconfig.BoardColumn) []Column {
 	out := make([]Column, 0, len(cols))
 	seen := make(map[string]bool, len(cols))
 	for _, c := range cols {
 		id := strings.TrimSpace(c.ID)
+		name := strings.TrimSpace(c.Name)
 		if id == "" {
-			id = columnID(c.Name)
+			id = columnID(name)
+		}
+		if id == "" && name != "" {
+			h := fnv.New32a()
+			h.Write([]byte(name))
+			id = fmt.Sprintf("col-%08x", h.Sum32())
 		}
 		if id == "" || seen[id] {
 			continue
 		}
 		seen[id] = true
-		name := strings.TrimSpace(c.Name)
 		if name == "" {
 			name = id
 		}
-		out = append(out, Column{ID: id, Name: name, Emoji: c.Emoji, Prompt: c.Prompt})
+		out = append(out, Column{ID: id, Name: name, Emoji: strings.TrimSpace(c.Emoji), Prompt: c.Prompt})
 	}
 	if len(out) == 0 {
 		// Cloned: the caller may edit the pipeline in place.

--- a/pkg/board/model.go
+++ b/pkg/board/model.go
@@ -48,14 +48,12 @@ func ColumnsFromConfig(cols []userconfig.BoardColumn) []Column {
 	seen := make(map[string]bool, len(cols))
 	for _, c := range cols {
 		id := strings.TrimSpace(c.ID)
-		name := strings.TrimSpace(c.Name)
+		name := collapseSpace(c.Name)
 		if id == "" {
 			id = columnID(name)
 		}
 		if id == "" && name != "" {
-			h := fnv.New32a()
-			h.Write([]byte(name))
-			id = fmt.Sprintf("col-%08x", h.Sum32())
+			id = fallbackColumnID(name)
 		}
 		if id == "" || seen[id] {
 			continue
@@ -64,7 +62,7 @@ func ColumnsFromConfig(cols []userconfig.BoardColumn) []Column {
 		if name == "" {
 			name = id
 		}
-		out = append(out, Column{ID: id, Name: name, Emoji: strings.TrimSpace(c.Emoji), Prompt: c.Prompt})
+		out = append(out, Column{ID: id, Name: name, Emoji: collapseSpace(c.Emoji), Prompt: c.Prompt})
 	}
 	if len(out) == 0 {
 		// Cloned: the caller may edit the pipeline in place.
@@ -89,6 +87,23 @@ func columnID(name string) string {
 		}
 	}
 	return strings.TrimSuffix(b.String(), "-")
+}
+
+// fallbackColumnID returns a stable id for a name [columnID] slugs to
+// nothing (e.g. non-ASCII or emoji-only): a hash of the name, so the id
+// stays the same across restarts and cards stay attached to their column.
+func fallbackColumnID(name string) string {
+	h := fnv.New32a()
+	h.Write([]byte(name))
+	return fmt.Sprintf("col-%08x", h.Sum32())
+}
+
+// collapseSpace trims a string and collapses inner whitespace (including
+// newlines) to single spaces. Column names and emoji are rendered on
+// single-line headers whose mouse hitboxes are computed arithmetically, so
+// an embedded newline from a hand-edited config would break the layout.
+func collapseSpace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
 }
 
 // CardStatus tracks what a card's agent is doing.

--- a/pkg/board/model_test.go
+++ b/pkg/board/model_test.go
@@ -51,6 +51,32 @@ func TestColumnsFromConfig(t *testing.T) {
 		{ID: "todo", Name: "Todo", Emoji: "📝", Prompt: "do it"},
 	})
 	assert.Equal(t, []Column{{ID: "todo", Name: "Todo", Emoji: "📝", Prompt: "do it"}}, cols)
+
+	// Hand-edited configs are normalized: a missing id is derived from the
+	// name, duplicate ids and unusable entries are dropped, and a missing
+	// name falls back to the id.
+	cols = ColumnsFromConfig([]userconfig.BoardColumn{
+		{Name: "In Review"},
+		{ID: "in-review", Name: "Dup"},
+		{Emoji: "🚧"},
+		{ID: " done "},
+	})
+	assert.Equal(t, []Column{
+		{ID: "in-review", Name: "In Review"},
+		{ID: "done", Name: "done"},
+	}, cols)
+
+	// An entirely unusable config falls back to the defaults.
+	assert.Equal(t, DefaultColumns, ColumnsFromConfig([]userconfig.BoardColumn{{Emoji: "🚧"}}))
+}
+
+func TestColumnID(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "qa-check", columnID("  QA   Check "))
+	assert.Equal(t, "fix-2", columnID("Fix_2"))
+	assert.Empty(t, columnID("🚧"))
+	assert.Empty(t, columnID("  "))
 }
 
 func TestCardStatusBusy(t *testing.T) {

--- a/pkg/board/model_test.go
+++ b/pkg/board/model_test.go
@@ -53,18 +53,26 @@ func TestColumnsFromConfig(t *testing.T) {
 	assert.Equal(t, []Column{{ID: "todo", Name: "Todo", Emoji: "📝", Prompt: "do it"}}, cols)
 
 	// Hand-edited configs are normalized: a missing id is derived from the
-	// name, duplicate ids and unusable entries are dropped, and a missing
-	// name falls back to the id.
+	// name, duplicate ids and unusable entries are dropped, a missing name
+	// falls back to the id, and emoji padding is trimmed.
 	cols = ColumnsFromConfig([]userconfig.BoardColumn{
-		{Name: "In Review"},
+		{Name: "In Review", Emoji: " 🔍 "},
 		{ID: "in-review", Name: "Dup"},
 		{Emoji: "🚧"},
 		{ID: " done "},
 	})
 	assert.Equal(t, []Column{
-		{ID: "in-review", Name: "In Review"},
+		{ID: "in-review", Name: "In Review", Emoji: "🔍"},
 		{ID: "done", Name: "done"},
 	}, cols)
+
+	// A name that slugs to nothing (non-ASCII) still gets an id, hashed
+	// from the name so cards stay attached across restarts.
+	hashed := ColumnsFromConfig([]userconfig.BoardColumn{{Name: "レビュー"}})
+	require.Len(t, hashed, 1)
+	assert.NotEmpty(t, hashed[0].ID)
+	assert.Equal(t, "レビュー", hashed[0].Name)
+	assert.Equal(t, hashed, ColumnsFromConfig([]userconfig.BoardColumn{{Name: "レビュー"}}))
 
 	// An entirely unusable config falls back to the defaults.
 	assert.Equal(t, DefaultColumns, ColumnsFromConfig([]userconfig.BoardColumn{{Emoji: "🚧"}}))

--- a/pkg/board/model_test.go
+++ b/pkg/board/model_test.go
@@ -54,9 +54,10 @@ func TestColumnsFromConfig(t *testing.T) {
 
 	// Hand-edited configs are normalized: a missing id is derived from the
 	// name, duplicate ids and unusable entries are dropped, a missing name
-	// falls back to the id, and emoji padding is trimmed.
+	// falls back to the id, and whitespace (including newlines, which would
+	// break the single-line headers) collapses to single spaces.
 	cols = ColumnsFromConfig([]userconfig.BoardColumn{
-		{Name: "In Review", Emoji: " 🔍 "},
+		{Name: "In\nReview", Emoji: " 🔍 "},
 		{ID: "in-review", Name: "Dup"},
 		{Emoji: "🚧"},
 		{ID: " done "},

--- a/pkg/board/tui/dialogs.go
+++ b/pkg/board/tui/dialogs.go
@@ -237,6 +237,250 @@ func (d *promptDialog) View(width, height int) string {
 	)
 }
 
+// --- columns manager ---
+
+// columnsMode is the columns dialog's active view.
+type columnsMode int
+
+const (
+	columnsList columnsMode = iota
+	columnsEditing
+	columnsConfirming
+)
+
+// columnsDialog lists and edits the pipeline's columns, stored in the
+// user's global config file. Editing keeps the column's id (and prompt),
+// so existing cards stay attached across a rename. Removal asks for
+// confirmation first.
+type columnsDialog struct {
+	columns []board.Column
+	idx     int
+
+	mode   columnsMode
+	inputs []textinput.Model // name, emoji
+	focus  int
+	// editing is the column being edited (its id and prompt survive the
+	// form); the zero value means the form adds a new column.
+	editing board.Column
+	// deleting is the column awaiting delete confirmation.
+	deleting    board.Column
+	confirmKeys tuidialog.ConfirmKeyMap
+}
+
+func newColumnsDialog(columns []board.Column) *columnsDialog {
+	return &columnsDialog{columns: columns, confirmKeys: tuidialog.DefaultConfirmKeyMap()}
+}
+
+// setColumns refreshes the list after an add, edit or delete and returns
+// to the list view, keeping the cursor position (clamped).
+func (d *columnsDialog) setColumns(columns []board.Column) {
+	d.refreshColumns(columns)
+	d.mode = columnsList
+	d.editing = board.Column{}
+	d.deleting = board.Column{}
+	d.inputs = nil
+}
+
+// refreshColumns updates the list data without leaving the current view.
+func (d *columnsDialog) refreshColumns(columns []board.Column) {
+	d.columns = columns
+	d.idx = min(max(d.idx, 0), max(len(columns)-1, 0))
+}
+
+// selectColumn moves the cursor to the column with the given id, if present.
+func (d *columnsDialog) selectColumn(id string) {
+	if i := slices.IndexFunc(d.columns, func(c board.Column) bool { return c.ID == id }); i >= 0 {
+		d.idx = i
+	}
+}
+
+var columnFields = []struct{ label, placeholder string }{
+	{"Name", "Review"},
+	{"Emoji", "\U0001f50d (optional)"},
+}
+
+// startForm opens the add/edit form. editing is the column being edited
+// (the zero value when adding); its name and emoji pre-fill the fields.
+func (d *columnsDialog) startForm(editing board.Column) tea.Cmd {
+	d.mode = columnsEditing
+	d.editing = editing
+	d.focus = 0
+	d.inputs = make([]textinput.Model, len(columnFields))
+	for i, f := range columnFields {
+		ti := textinput.New()
+		ti.SetStyles(styles.DialogInputStyle)
+		ti.Placeholder = f.placeholder
+		ti.SetWidth(56)
+		d.inputs[i] = ti
+	}
+	d.inputs[0].SetValue(editing.Name)
+	d.inputs[1].SetValue(editing.Emoji)
+	d.inputs[0].Focus()
+	return textinput.Blink
+}
+
+func (d *columnsDialog) Init() tea.Cmd { return nil }
+
+func (d *columnsDialog) Update(msg tea.Msg) (dialog, tea.Cmd) {
+	press, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return d, nil
+	}
+	switch d.mode {
+	case columnsEditing:
+		return d.updateEditing(press)
+	case columnsConfirming:
+		return d.updateConfirming(press)
+	}
+
+	switch press.String() {
+	case "esc", "q":
+		return d, closeDialog
+	case "up", "k":
+		d.idx = max(d.idx-1, 0)
+	case "down", "j":
+		d.idx = min(d.idx+1, max(len(d.columns)-1, 0))
+	case "a", "n":
+		cmd := d.startForm(board.Column{})
+		return d, cmd
+	case "e", "enter":
+		if len(d.columns) > 0 {
+			cmd := d.startForm(d.columns[d.idx])
+			return d, cmd
+		}
+	case "p":
+		// The prompt is long-form: hand it to the dedicated prompt editor.
+		if len(d.columns) > 0 {
+			column := d.columns[d.idx]
+			return d, func() tea.Msg { return editColumnPromptMsg{column: column} }
+		}
+	case "shift+up", "K":
+		cmd := d.moveColumn(-1)
+		return d, cmd
+	case "shift+down", "J":
+		cmd := d.moveColumn(1)
+		return d, cmd
+	case "x", "d", "backspace", "delete":
+		if len(d.columns) > 0 {
+			d.mode = columnsConfirming
+			d.deleting = d.columns[d.idx]
+		}
+	}
+	return d, nil
+}
+
+// updateConfirming handles the delete confirmation prompt.
+func (d *columnsDialog) updateConfirming(press tea.KeyPressMsg) (dialog, tea.Cmd) {
+	switch {
+	case key.Matches(press, d.confirmKeys.Yes), press.String() == "enter":
+		id := d.deleting.ID
+		d.mode = columnsList
+		d.deleting = board.Column{}
+		return d, func() tea.Msg { return deleteColumnMsg{id: id} }
+	case key.Matches(press, d.confirmKeys.No), press.String() == "esc", press.String() == "q":
+		d.mode = columnsList
+		d.deleting = board.Column{}
+	}
+	return d, nil
+}
+
+// moveColumn asks the model to reorder the selected column by delta
+// positions; the model persists the order and moves the cursor along.
+func (d *columnsDialog) moveColumn(delta int) tea.Cmd {
+	if len(d.columns) == 0 {
+		return nil
+	}
+	id := d.columns[d.idx].ID
+	return func() tea.Msg { return moveColumnMsg{id: id, delta: delta} }
+}
+
+func (d *columnsDialog) updateEditing(press tea.KeyPressMsg) (dialog, tea.Cmd) {
+	switch press.String() {
+	case "esc":
+		d.mode = columnsList
+		d.editing = board.Column{}
+		d.inputs = nil
+		return d, nil
+	case "tab", "down":
+		cmd := d.setFocus((d.focus + 1) % len(d.inputs))
+		return d, cmd
+	case "shift+tab", "up":
+		cmd := d.setFocus((d.focus + len(d.inputs) - 1) % len(d.inputs))
+		return d, cmd
+	case "enter":
+		// The id and prompt ride along untouched: the form only edits the
+		// display fields.
+		column := d.editing
+		column.Name = strings.TrimSpace(d.inputs[0].Value())
+		column.Emoji = strings.TrimSpace(d.inputs[1].Value())
+		oldID := d.editing.ID
+		return d, func() tea.Msg { return submitColumnMsg{column: column, oldID: oldID} }
+	}
+	var cmd tea.Cmd
+	d.inputs[d.focus], cmd = d.inputs[d.focus].Update(press)
+	return d, cmd
+}
+
+func (d *columnsDialog) setFocus(focus int) tea.Cmd {
+	d.inputs[d.focus].Blur()
+	d.focus = focus
+	return d.inputs[d.focus].Focus()
+}
+
+func (d *columnsDialog) View(width, _ int) string {
+	w := dialogWidth(70, width)
+	switch d.mode {
+	case columnsEditing:
+		return d.viewForm(w)
+	case columnsConfirming:
+		return renderDialog("Remove column?", w,
+			styles.BaseStyle.Render(toolcommon.TruncateText(sanitize(strings.TrimSpace(d.deleting.Emoji+" "+d.deleting.Name)), w)),
+			styles.MutedStyle.Render("A column that still has cards cannot be removed."),
+			"",
+			helpLine(w, d.confirmKeys.Yes.Help().Key, "remove", d.confirmKeys.No.Help().Key+"/esc", "cancel"),
+		)
+	}
+
+	rows := make([]string, 0, len(d.columns))
+	for i, c := range d.columns {
+		marker, nameStyle := "  ", styles.BaseStyle.Foreground(columnHeaderColor(i, len(d.columns)))
+		if i == d.idx {
+			marker, nameStyle = styles.SuccessStyle.Render("\u276f "), nameStyle.Bold(true)
+		}
+		line := marker + nameStyle.Render(sanitize(strings.TrimSpace(c.Emoji+" "+c.Name)))
+		if prompt := strings.Join(strings.Fields(sanitize(c.Prompt)), " "); prompt != "" {
+			line += styles.MutedStyle.Render("  " + prompt)
+		}
+		rows = append(rows, toolcommon.TruncateText(line, w))
+	}
+
+	return renderDialog("Columns", w,
+		lipgloss.JoinVertical(lipgloss.Left, rows...),
+		"",
+		helpLine(w, "a", "add", "e", "edit", "p", "prompt", "x", "remove", "shift+\u2191\u2193", "reorder", "esc", "close"),
+	)
+}
+
+func (d *columnsDialog) viewForm(w int) string {
+	rows := make([]string, 0, len(columnFields)*2)
+	for i, f := range columnFields {
+		label := styles.SecondaryStyle.Render(f.label)
+		if i == d.focus {
+			label = styles.HighlightWhiteStyle.Render(f.label)
+		}
+		rows = append(rows, label, d.inputs[i].View())
+	}
+	title := "Add column"
+	if d.editing.ID != "" {
+		title = "Edit column"
+	}
+	return renderDialog(title, w,
+		lipgloss.JoinVertical(lipgloss.Left, rows...),
+		"",
+		helpLine(w, "enter", "save", "tab", "next field", "esc", "back"),
+	)
+}
+
 // --- projects manager ---
 
 // projectsMode is the projects dialog's active view.
@@ -707,6 +951,7 @@ func (d *helpDialog) View(width, _ int) string {
 		{keys.MoveTo.Help().Key, keys.MoveTo.Help().Desc},
 		{keys.Delete.Help().Key, "delete card, its session and worktree"},
 		{keys.Projects.Help().Key, keys.Projects.Help().Desc},
+		{keys.Columns.Help().Key, "manage columns (add, edit, reorder, remove)"},
 		{keys.Prompt.Help().Key, "edit the selected column's prompt"},
 		{"←↓↑→ hjkl", "navigate (g/G first/last card)"},
 		{"mouse", "click selects · double-click attaches · drag moves · wheel scrolls"},
@@ -720,8 +965,8 @@ func (d *helpDialog) View(width, _ int) string {
 		rows = append(rows, keyStyle.Render(b.key)+descStyle.Render(b.desc))
 	}
 	rows = append(rows, "",
-		styles.MutedStyle.Render("Projects and column prompts are stored in the global config"),
-		styles.MutedStyle.Render("file ("+toolcommon.TruncateText(configPathHint(), w-8)+")."),
+		styles.MutedStyle.Render("Projects, columns, and their prompts are stored in the global"),
+		styles.MutedStyle.Render("config file ("+toolcommon.TruncateText(configPathHint(), w-8)+")."),
 	)
 	return renderDialog("Help", w, lipgloss.JoinVertical(lipgloss.Left, rows...))
 }

--- a/pkg/board/tui/dialogs.go
+++ b/pkg/board/tui/dialogs.go
@@ -457,7 +457,7 @@ func (d *columnsDialog) View(width, _ int) string {
 	return renderDialog("Columns", w,
 		lipgloss.JoinVertical(lipgloss.Left, rows...),
 		"",
-		helpLine(w, "a", "add", "e", "edit", "p", "prompt", "x", "remove", "shift+\u2191\u2193", "reorder", "esc", "close"),
+		helpLine(w, "a", "add", "e", "edit", "p", "prompt", "x", "remove", "shift+\u2191\u2193", "reorder", "\u2191\u2193", "select", "esc", "close"),
 	)
 }
 

--- a/pkg/board/tui/dialogs.go
+++ b/pkg/board/tui/dialogs.go
@@ -198,6 +198,12 @@ type promptDialog struct {
 }
 
 func newPromptDialog(column board.Column) *promptDialog {
+	// The column's name and emoji come from the hand-editable config file:
+	// strip terminal controls (and collapse whitespace) before rendering,
+	// like every other column render site.
+	column.Name = strings.Join(strings.Fields(sanitize(column.Name)), " ")
+	column.Emoji = strings.Join(strings.Fields(sanitize(column.Emoji)), " ")
+
 	ta := textarea.New()
 	ta.SetStyles(styles.InputStyle)
 	ta.Placeholder = "Prompt sent to a card's agent when it enters " + column.Name + "…"

--- a/pkg/board/tui/dialogs_test.go
+++ b/pkg/board/tui/dialogs_test.go
@@ -88,3 +88,80 @@ func TestProjectsDialogBrowseKeepsFormInProgress(t *testing.T) {
 	assert.Equal(t, root, d.inputs[1].Value())
 	assert.Equal(t, "coder", d.inputs[2].Value())
 }
+
+func TestColumnsDialogDeleteAsksConfirmation(t *testing.T) {
+	d := newColumnsDialog([]board.Column{{ID: "dev", Name: "Dev"}, {ID: "done", Name: "Done"}})
+
+	// x opens the confirmation instead of deleting right away.
+	_, cmd := d.Update(keyPress("x"))
+	require.Nil(t, cmd)
+	assert.Equal(t, columnsConfirming, d.mode)
+	assert.Contains(t, d.View(80, 40), "Remove column?")
+
+	// esc cancels: back to the list, nothing deleted.
+	_, cmd = d.Update(keyPress("esc"))
+	require.Nil(t, cmd)
+	assert.Equal(t, columnsList, d.mode)
+
+	// x then y confirms and emits the delete for the selected column.
+	_, _ = d.Update(keyPress("x"))
+	_, cmd = d.Update(keyPress("y"))
+	require.NotNil(t, cmd)
+	assert.Equal(t, deleteColumnMsg{id: "dev"}, cmd())
+}
+
+// Editing a column keeps its id and prompt: the form only exposes the
+// display fields, and the id is what cards are attached to.
+func TestColumnsDialogEditKeepsIDAndPrompt(t *testing.T) {
+	d := newColumnsDialog([]board.Column{{ID: "dev", Name: "Dev", Emoji: "🔨", Prompt: "build it"}})
+
+	_, _ = d.Update(keyPress("e"))
+	require.Equal(t, columnsEditing, d.mode)
+	assert.Equal(t, "Dev", d.inputs[0].Value())
+	assert.Equal(t, "🔨", d.inputs[1].Value())
+	assert.Contains(t, d.View(80, 40), "Edit column")
+
+	_, cmd := d.Update(keyPress("enter"))
+	require.NotNil(t, cmd)
+	assert.Equal(t, submitColumnMsg{
+		column: board.Column{ID: "dev", Name: "Dev", Emoji: "🔨", Prompt: "build it"},
+		oldID:  "dev",
+	}, cmd())
+}
+
+func TestColumnsDialogAddSubmitsNewColumn(t *testing.T) {
+	d := newColumnsDialog([]board.Column{{ID: "dev", Name: "Dev"}})
+
+	_, _ = d.Update(keyPress("a"))
+	require.Equal(t, columnsEditing, d.mode)
+	for _, r := range "QA" {
+		_, _ = d.Update(keyPress(string(r)))
+	}
+	_, cmd := d.Update(keyPress("enter"))
+	require.NotNil(t, cmd)
+	// No oldID: the model adds a new column (the engine derives its id).
+	assert.Equal(t, submitColumnMsg{column: board.Column{Name: "QA"}}, cmd())
+}
+
+func TestColumnsDialogMoveEmitsReorder(t *testing.T) {
+	d := newColumnsDialog([]board.Column{{ID: "dev", Name: "Dev"}, {ID: "done", Name: "Done"}})
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyDown, Mod: tea.ModShift})
+	require.NotNil(t, cmd)
+	assert.Equal(t, moveColumnMsg{id: "dev", delta: 1}, cmd())
+
+	_, cmd = d.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift})
+	require.NotNil(t, cmd)
+	assert.Equal(t, moveColumnMsg{id: "dev", delta: -1}, cmd())
+}
+
+// p hands the selected column to the dedicated prompt editor: prompts are
+// long-form and do not fit the single-line form.
+func TestColumnsDialogPromptOpensEditor(t *testing.T) {
+	col := board.Column{ID: "dev", Name: "Dev", Prompt: "build it"}
+	d := newColumnsDialog([]board.Column{col})
+
+	_, cmd := d.Update(keyPress("p"))
+	require.NotNil(t, cmd)
+	assert.Equal(t, editColumnPromptMsg{column: col}, cmd())
+}

--- a/pkg/board/tui/dialogs_test.go
+++ b/pkg/board/tui/dialogs_test.go
@@ -165,3 +165,15 @@ func TestColumnsDialogPromptOpensEditor(t *testing.T) {
 	require.NotNil(t, cmd)
 	assert.Equal(t, editColumnPromptMsg{column: col}, cmd())
 }
+
+// The prompt editor's title and placeholder render the column's name and
+// emoji, which come from the hand-editable config file: terminal controls
+// must be stripped like at every other column render site.
+func TestPromptDialogSanitizesColumnName(t *testing.T) {
+	d := newPromptDialog(board.Column{ID: "dev", Name: "Dev\x1b]0;pwned\x07", Emoji: "\x1b[31m🔨"})
+
+	view := d.View(80, 40)
+	assert.NotContains(t, view, "\x1b]0;pwned")
+	assert.NotContains(t, view, "\x1b[31m🔨")
+	assert.Contains(t, view, "Dev")
+}

--- a/pkg/board/tui/tui.go
+++ b/pkg/board/tui/tui.go
@@ -112,6 +112,23 @@ type (
 		colID  string
 		prompt string
 	}
+	// submitColumnMsg adds a column from the columns dialog, or updates the
+	// one with id oldID when set.
+	submitColumnMsg struct {
+		column board.Column
+		oldID  string
+	}
+	// deleteColumnMsg removes a column from the columns dialog.
+	deleteColumnMsg struct{ id string }
+	// moveColumnMsg reorders a column from the columns dialog; delta is the
+	// number of positions to move (negative moves it left).
+	moveColumnMsg struct {
+		id    string
+		delta int
+	}
+	// editColumnPromptMsg opens the prompt editor for a column, from the
+	// columns dialog (prompts are long-form and get the big editor).
+	editColumnPromptMsg struct{ column board.Column }
 	// confirmDeleteMsg deletes a card after confirmation.
 	confirmDeleteMsg struct{ cardID string }
 )
@@ -140,6 +157,7 @@ type keyMap struct {
 	MoveTo   key.Binding
 	Delete   key.Binding
 	Projects key.Binding
+	Columns  key.Binding
 	Prompt   key.Binding
 	Editor   key.Binding
 	Shell    key.Binding
@@ -162,6 +180,7 @@ var keys = keyMap{
 	MoveTo:   key.NewBinding(key.WithKeys("1", "2", "3", "4", "5", "6", "7", "8", "9"), key.WithHelp("1-9", "move card to column N")),
 	Delete:   key.NewBinding(key.WithKeys("x", "backspace", "delete"), key.WithHelp("x", "delete card")),
 	Projects: key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "manage projects")),
+	Columns:  key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "manage columns")),
 	Prompt:   key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "edit column prompt")),
 	Editor:   key.NewBinding(key.WithKeys("o"), key.WithHelp("o", "open worktree in editor")),
 	Shell:    key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "open shell in worktree")),
@@ -512,6 +531,59 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmd := m.setFlash("Prompt saved to the global config", false)
 		return m, cmd
 
+	case submitColumnMsg:
+		var (
+			saved board.Column
+			err   error
+		)
+		if msg.oldID == "" {
+			saved, err = m.app.AddColumn(msg.column)
+		} else {
+			saved, err = m.app.UpdateColumn(msg.oldID, msg.column)
+		}
+		if err != nil {
+			cmd := m.setFlash(err.Error(), true)
+			return m, cmd
+		}
+		m.reload()
+		if d, ok := m.dialog.(*columnsDialog); ok {
+			d.setColumns(m.columns)
+			d.selectColumn(saved.ID) // the cursor follows the saved column
+		}
+		action := "added to"
+		if msg.oldID != "" {
+			action = "updated in"
+		}
+		cmd := m.setFlash("Column "+action+" the global config", false)
+		return m, cmd
+
+	case deleteColumnMsg:
+		if err := m.app.RemoveColumn(msg.id); err != nil {
+			cmd := m.setFlash(err.Error(), true)
+			return m, cmd
+		}
+		m.reload()
+		if d, ok := m.dialog.(*columnsDialog); ok {
+			d.setColumns(m.columns)
+		}
+		return m, nil
+
+	case moveColumnMsg:
+		if err := m.app.MoveColumn(msg.id, msg.delta); err != nil {
+			cmd := m.setFlash(err.Error(), true)
+			return m, cmd
+		}
+		m.reload()
+		if d, ok := m.dialog.(*columnsDialog); ok {
+			d.refreshColumns(m.columns)
+			d.selectColumn(msg.id) // the cursor follows the moved column
+		}
+		return m, nil
+
+	case editColumnPromptMsg:
+		cmd := m.openDialog(newPromptDialog(msg.column))
+		return m, cmd
+
 	case confirmDeleteMsg:
 		m.dialog = nil
 		cmd := m.deleteCard(msg.cardID)
@@ -606,6 +678,10 @@ func (m *model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	case key.Matches(msg, keys.Projects):
 		cmd := m.openDialog(newProjectsDialog(m.projects))
+		return m, cmd
+
+	case key.Matches(msg, keys.Columns):
+		cmd := m.openDialog(newColumnsDialog(m.columns))
 		return m, cmd
 
 	case key.Matches(msg, keys.Prompt):

--- a/pkg/board/tui/tui.go
+++ b/pkg/board/tui/tui.go
@@ -547,7 +547,13 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.reload()
 		if d, ok := m.dialog.(*columnsDialog); ok {
-			d.setColumns(m.columns)
+			if d.mode == columnsEditing {
+				d.setColumns(m.columns)
+			} else {
+				// The save is asynchronous and the user may have moved on:
+				// refresh without leaving the dialog's current view.
+				d.refreshColumns(m.columns)
+			}
 			d.selectColumn(saved.ID) // the cursor follows the saved column
 		}
 		action := "added to"

--- a/pkg/board/tui/view.go
+++ b/pkg/board/tui/view.go
@@ -530,7 +530,7 @@ func (m *model) renderFooter() string {
 	// descriptions on the left, muted context on the right.
 	hints := []string{
 		"n", "new", "⏎", "attach", "d", "diff", "o", "editor", "s", "shell", "[ ] 1-9", "move",
-		"x", "delete", "p", "projects", "e", "prompt", "?", "help", "q", "quit",
+		"x", "delete", "p", "projects", "c", "columns", "e", "prompt", "?", "help", "q", "quit",
 	}
 	parts := make([]string, 0, len(hints)/2)
 	for i := 0; i < len(hints); i += 2 {

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -236,8 +236,8 @@ type BoardColumn struct {
 type Board struct {
 	// Projects are the repositories cards can be created against.
 	Projects []BoardProject `yaml:"projects,omitempty"`
-	// Columns overrides the default pipeline (Dev → Simplify → Review →
-	// Fix → Push → Done). Leave empty to keep the defaults.
+	// Columns overrides the default pipeline (Dev → Review → Push → Done).
+	// Leave empty to keep the defaults.
 	Columns []BoardColumn `yaml:"columns,omitempty"`
 }
 


### PR DESCRIPTION
The `docker agent board` Kanban view previously used a fixed set of columns
that could not be changed without editing the raw config file. This adds a
first-class, in-TUI columns manager so teams can name, reorder, and tune each
column's LLM prompt without ever leaving the board.

Pressing `c` opens the columns dialog. From there you can add a column,
edit its name or emoji inline, reorder it with shift+↑/↓, open the full
prompt editor with `p`, or remove it (guarded by a confirmation step that
also blocks deletion when cards remain or only one column exists). Renames
preserve the column's stable id, so existing cards stay attached. Restoring
the default pipeline removes the custom columns section from the config entirely.
All changes are persisted to the global user config immediately. Config loading
is also hardened: ids are derived from names when absent, duplicates are dropped,
and defaults are cloned before mutation — fixing a latent bug where editing a
default column's prompt would silently mutate the package-level `DefaultColumns`
slice for the lifetime of the process.

Two follow-up fixes are included: `MoveCard` now resolves the destination column
from a single pipeline snapshot so a concurrent column removal or reorder can
no longer panic or land a card in the wrong column; and column names/emoji are
normalized to a single line at the source so newlines can't break the header
layout or mouse hit-boxes, closing a terminal-escape injection path in the
prompt editor render path.