### PR TITLE
feat(setup): add custom OpenAI-compatible providers usable across commands

### DIFF
--- a/cmd/root/flags.go
+++ b/cmd/root/flags.go
@@ -144,6 +144,13 @@ func addGatewayFlags(cmd *cobra.Command, runConfig *config.RuntimeConfig, loadUs
 			runConfig.DefaultModel = &userCfg.DefaultModel.ModelConfig
 		}
 
+		// User-level custom providers (registered via `docker agent setup` or
+		// hand-written in the user config) apply to every run; agent-file
+		// definitions with the same name win when configs are loaded.
+		if runConfig.Providers == nil {
+			runConfig.Providers = userCfg.GetProviders()
+		}
+
 		return setupWorkingDirectory(runConfig.WorkingDir)
 	}
 }

--- a/cmd/root/flags_test.go
+++ b/cmd/root/flags_test.go
@@ -330,6 +330,33 @@ func TestDefaultModelLogic(t *testing.T) {
 	}
 }
 
+// User-level custom providers from the user config must seed the runtime
+// config so custom `--model myprovider/mymodel` references resolve in every
+// command (issue #3557).
+func TestGatewayFlags_SeedsUserConfigProviders(t *testing.T) {
+	t.Parallel()
+
+	userCfg := &userconfig.Config{
+		Providers: map[string]latest.ProviderConfig{
+			"myprovider": {BaseURL: "https://llm.corp.example.com/v1", TokenKey: "MY_KEY"},
+		},
+	}
+
+	cmd := &cobra.Command{
+		RunE: func(*cobra.Command, []string) error { return nil },
+	}
+	runConfig := config.RuntimeConfig{
+		EnvProviderForTests: environment.NewMapEnvProvider(nil),
+	}
+	addGatewayFlags(cmd, &runConfig, func() (*userconfig.Config, error) { return userCfg, nil })
+
+	cmd.SetArgs(nil)
+	require.NoError(t, cmd.Execute())
+
+	require.Contains(t, runConfig.Providers, "myprovider")
+	assert.Equal(t, "https://llm.corp.example.com/v1", runConfig.Providers["myprovider"].BaseURL)
+}
+
 // A missing or malformed --env-from-file must abort the run instead of being
 // logged and skipped: the flag is the documented way to supply credentials
 // (issue #3442).

--- a/cmd/root/models.go
+++ b/cmd/root/models.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net/http"
 	"slices"
 	"strings"
@@ -62,6 +63,11 @@ type modelRow struct {
 type modelsCmdOption func(*config.RuntimeConfig)
 
 func newModelsCmd(opts ...modelsCmdOption) *cobra.Command {
+	var flags modelsListFlags
+	for _, opt := range opts {
+		opt(&flags.runConfig)
+	}
+
 	cmd := &cobra.Command{
 		Use:   "models",
 		Short: "List available models",
@@ -73,7 +79,7 @@ you have credentials for. Use --all to include all providers.`,
 		GroupID: "diagnose",
 	}
 
-	listCmd := newModelsListCmd(opts...)
+	listCmd := newModelsListCmd(&flags)
 	cmd.AddCommand(listCmd)
 
 	// Default to "list" when no subcommand given.
@@ -83,15 +89,15 @@ you have credentials for. Use --all to include all providers.`,
 	// "docker agent models --provider openai" form as well.
 	cmd.Flags().AddFlagSet(listCmd.Flags())
 
+	// The gateway/user-config pre-run must live on the parent: cobra only
+	// runs the nearest ancestor's PersistentPreRunE, so a pre-run registered
+	// on the list subcommand would never fire for the bare "models" form.
+	addGatewayFlags(cmd, &flags.runConfig, userconfig.Load)
+
 	return cmd
 }
 
-func newModelsListCmd(opts ...modelsCmdOption) *cobra.Command {
-	var flags modelsListFlags
-	for _, opt := range opts {
-		opt(&flags.runConfig)
-	}
-
+func newModelsListCmd(flags *modelsListFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
@@ -107,7 +113,6 @@ func newModelsListCmd(opts ...modelsCmdOption) *cobra.Command {
 	cmd.Flags().StringVarP(&flags.providerFilter, "provider", "p", "", "Filter by provider name")
 	cmd.Flags().StringVar(&flags.format, "format", "table", "Output format: table, json")
 	cmd.Flags().BoolVarP(&flags.all, "all", "a", false, "Include models from all providers, not just those with credentials")
-	addGatewayFlags(cmd, &flags.runConfig, userconfig.Load)
 
 	return cmd
 }
@@ -133,6 +138,18 @@ func (f *modelsListFlags) runModelsListCommand(cmd *cobra.Command, args []string
 	availableProviders := make(map[string]bool)
 	for _, p := range config.AvailableProviders(ctx, f.runConfig.ModelsGateway, env) {
 		availableProviders[p] = true
+	}
+
+	// User-defined custom providers are available when they need no API key
+	// or their token variable is set.
+	for name, p := range f.runConfig.Providers {
+		if p.TokenKey == "" {
+			availableProviders[strings.ToLower(name)] = true
+			continue
+		}
+		if token, _ := env.Get(ctx, p.TokenKey); token != "" {
+			availableProviders[strings.ToLower(name)] = true
+		}
 	}
 
 	// Determine which model auto-selection would pick. DMR discovery is left
@@ -202,6 +219,11 @@ func (f *modelsListFlags) collectModels(ctx context.Context, env environment.Pro
 		})
 	}
 
+	// User-defined custom providers are queried before the models.dev catalog
+	// so they still list in internet-restricted environments where the catalog
+	// fetch below fails and returns early.
+	rows = append(rows, f.collectCustomProviderModels(ctx, env, availableProviders, seen)...)
+
 	// Fetch catalog and add all text-capable models.
 	store, err := f.runConfig.ModelsDevStore()
 	if err != nil {
@@ -266,6 +288,53 @@ func (f *modelsListFlags) collectModels(ctx context.Context, env environment.Pro
 	return rows
 }
 
+// collectCustomProviderModels queries each usable user-defined provider's own
+// /models endpoint, since custom providers have no models.dev catalog entry.
+// Unlike built-in aliases, a custom provider's endpoint was explicitly
+// registered by the user for this purpose, so the live fetch is not gated on
+// --provider. Unavailable providers (token variable unset) are skipped unless
+// --all is given; endpoints that cannot be reached degrade to an empty list.
+func (f *modelsListFlags) collectCustomProviderModels(ctx context.Context, env environment.Provider, availableProviders, seen map[string]bool) []modelRow {
+	var rows []modelRow
+	for _, name := range slices.Sorted(maps.Keys(f.runConfig.Providers)) {
+		provCfg := f.runConfig.Providers[name]
+		if provCfg.BaseURL == "" {
+			// Native-provider defaults (e.g. a providers entry that only sets
+			// temperature on anthropic) have no endpoint of their own to query.
+			continue
+		}
+		if f.providerFilter != "" && !strings.EqualFold(name, f.providerFilter) {
+			continue
+		}
+		if !f.all && !availableProviders[strings.ToLower(name)] {
+			continue
+		}
+
+		var token string
+		if provCfg.TokenKey != "" {
+			token, _ = env.Get(ctx, provCfg.TokenKey)
+		}
+		baseURL, err := environment.Expand(ctx, provCfg.BaseURL, env)
+		if err != nil {
+			slog.WarnContext(ctx, "failed to expand custom provider base_url", "provider", name, "error", err)
+			continue
+		}
+
+		for _, m := range fetchOpenAICompatibleModels(ctx, baseURL, token) {
+			if isEmbeddingModel(m, m) {
+				continue
+			}
+			ref := name + "/" + m
+			if seen[ref] {
+				continue
+			}
+			seen[ref] = true
+			rows = append(rows, modelRow{Provider: name, Model: m})
+		}
+	}
+	return rows
+}
+
 // openAIModelsResponse is the standard OpenAI-compatible models list format.
 type openAIModelsResponse struct {
 	Data []struct {
@@ -289,7 +358,23 @@ func fetchProviderModels(ctx context.Context, providerName string, env environme
 		return nil
 	}
 
-	modelsURL := strings.TrimRight(alias.BaseURL, "/") + "/models"
+	var token string
+	// Send the alias's declared API key so providers that require it on
+	// /v1/models authenticate the request instead of returning 401/403.
+	if alias.TokenEnvVar != "" {
+		token, _ = env.Get(ctx, alias.TokenEnvVar)
+	}
+
+	return fetchOpenAICompatibleModels(ctx, alias.BaseURL, token)
+}
+
+// fetchOpenAICompatibleModels fetches the model list from an OpenAI-compatible
+// endpoint's /models route, sending Bearer auth when token is non-empty. It
+// backs both alias live-fetches and user-defined custom providers (which have
+// no models.dev catalog entry to read from), and the setup wizard's endpoint
+// check. Bounded by listTimeout; returns nil on any failure.
+func fetchOpenAICompatibleModels(ctx context.Context, baseURL, token string) []string {
+	modelsURL := strings.TrimRight(baseURL, "/") + "/models"
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, modelsURL, http.NoBody)
 	if err != nil {
@@ -297,12 +382,8 @@ func fetchProviderModels(ctx context.Context, providerName string, env environme
 		return nil
 	}
 
-	// Send the alias's declared API key so providers that require it on
-	// /v1/models authenticate the request instead of returning 401/403.
-	if alias.TokenEnvVar != "" {
-		if token, _ := env.Get(ctx, alias.TokenEnvVar); token != "" {
-			req.Header.Set("Authorization", "Bearer "+token)
-		}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, listTimeout)

--- a/cmd/root/models_test.go
+++ b/cmd/root/models_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/modelsdev"
 )
@@ -332,4 +333,117 @@ func TestModelsListCommand_NoCredentials(t *testing.T) {
 
 	// DMR is always available as fallback
 	assert.Contains(t, buf.String(), "dmr")
+}
+
+// withProviders seeds user-defined custom providers into the models command,
+// standing in for the user-config providers the gateway pre-run would load.
+func withProviders(providers map[string]latest.ProviderConfig) modelsCmdOption {
+	return func(rc *config.RuntimeConfig) {
+		rc.Providers = providers
+	}
+}
+
+// newCustomProviderServer serves an OpenAI-style /models listing and records
+// the Authorization header of the last request.
+func newCustomProviderServer(t *testing.T, models []string) (*httptest.Server, *atomic.Value) {
+	t.Helper()
+
+	var lastAuth atomic.Value
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lastAuth.Store(r.Header.Get("Authorization"))
+		if r.URL.Path != "/models" {
+			http.NotFound(w, r)
+			return
+		}
+		type entry struct {
+			ID string `json:"id"`
+		}
+		var data []entry
+		for _, m := range models {
+			data = append(data, entry{ID: m})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{"data": data}))
+	}))
+	t.Cleanup(server.Close)
+	return server, &lastAuth
+}
+
+func TestModelsListCommand_CustomProviderListsEndpointModels(t *testing.T) {
+	t.Parallel()
+
+	server, lastAuth := newCustomProviderServer(t, []string{"corp-model-a", "corp-embeddings"})
+
+	var buf bytes.Buffer
+	cmd := newModelsCmd(
+		withTestConfig(map[string]string{"MYPROVIDER_API_KEY": "custom-key"}),
+		withProviders(map[string]latest.ProviderConfig{
+			"myprovider": {BaseURL: server.URL, TokenKey: "MYPROVIDER_API_KEY"},
+		}),
+	)
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(nil)
+
+	require.NoError(t, cmd.Execute())
+
+	output := buf.String()
+	assert.Contains(t, output, "myprovider")
+	assert.Contains(t, output, "corp-model-a")
+	assert.NotContains(t, output, "corp-embeddings", "embedding models are filtered out")
+	assert.Equal(t, "Bearer custom-key", lastAuth.Load(), "the token variable must authenticate the listing request")
+}
+
+func TestModelsListCommand_CustomProviderFilter(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newCustomProviderServer(t, []string{"corp-model-a"})
+
+	var buf bytes.Buffer
+	cmd := newModelsCmd(
+		// No token variable: the provider is intentionally unauthenticated.
+		withTestConfig(map[string]string{"ANTHROPIC_API_KEY": "test-key"}),
+		withProviders(map[string]latest.ProviderConfig{
+			"myprovider": {BaseURL: server.URL},
+		}),
+	)
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--provider", "myprovider"})
+
+	require.NoError(t, cmd.Execute())
+
+	output := buf.String()
+	assert.Contains(t, output, "corp-model-a")
+	assert.NotContains(t, output, "anthropic", "--provider must filter other providers out")
+}
+
+func TestModelsListCommand_CustomProviderWithoutCredentials(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newCustomProviderServer(t, []string{"corp-model-a"})
+	providers := map[string]latest.ProviderConfig{
+		"myprovider": {BaseURL: server.URL, TokenKey: "MYPROVIDER_API_KEY"},
+	}
+
+	// Token variable unset: the provider is not available, so its endpoint is
+	// not queried.
+	var buf bytes.Buffer
+	cmd := newModelsCmd(withTestConfig(map[string]string{}), withProviders(providers))
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(nil)
+
+	require.NoError(t, cmd.Execute())
+	assert.NotContains(t, buf.String(), "corp-model-a")
+
+	// --all includes it anyway.
+	buf.Reset()
+	cmd = newModelsCmd(withTestConfig(map[string]string{}), withProviders(providers))
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--all"})
+
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, buf.String(), "corp-model-a")
 }

--- a/cmd/root/new.go
+++ b/cmd/root/new.go
@@ -46,7 +46,7 @@ Optionally provide a description as an argument to skip the initial prompt.`,
 		RunE:    flags.runNewCommand,
 	}
 
-	cmd.PersistentFlags().StringVar(&flags.modelParam, "model", "", "Model to use, optionally as provider/model where provider is one of: anthropic, openai, google, dmr. If omitted, provider is auto-selected based on available credentials or gateway")
+	cmd.PersistentFlags().StringVar(&flags.modelParam, "model", "", "Model to use, optionally as provider/model where provider is one of: anthropic, openai, google, dmr, or a custom provider from `docker agent setup`. If omitted, provider is auto-selected based on available credentials or gateway")
 	cmd.PersistentFlags().IntVar(&flags.maxIterationsParam, "max-iterations", 0, "Maximum number of agentic loop iterations to prevent infinite loops (default: 20 for DMR, unlimited for other providers)")
 	addRuntimeConfigFlags(cmd, &flags.runConfig)
 

--- a/cmd/root/setup.go
+++ b/cmd/root/setup.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/url"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -18,10 +20,13 @@ import (
 	"github.com/docker/docker-agent/pkg/chatgpt"
 	"github.com/docker/docker-agent/pkg/cli"
 	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/input"
+	"github.com/docker/docker-agent/pkg/model/provider"
 	"github.com/docker/docker-agent/pkg/model/provider/dmr"
 	"github.com/docker/docker-agent/pkg/telemetry"
+	"github.com/docker/docker-agent/pkg/userconfig"
 )
 
 // errSetupCancelled is returned when the user aborts the wizard (EOF or an
@@ -41,6 +46,10 @@ type setupResult struct {
 	Value  string
 	// Model is set when the local path selected or pulled a DMR model.
 	Model string
+	// ProviderName and Provider are set when the custom path registered an
+	// OpenAI-compatible provider in the user config.
+	ProviderName string
+	Provider     *latest.ProviderConfig
 }
 
 // setupWizard drives the interactive model setup. The function fields are
@@ -58,20 +67,26 @@ type setupWizard struct {
 	dmrLister    config.DMRModelLister
 	pullModel    func(ctx context.Context, model string) error
 	chatgptLogin func(ctx context.Context, out io.Writer) (*chatgpt.LoginResult, error)
+	saveProvider func(name string, provider latest.ProviderConfig) error
+	listModels   func(ctx context.Context, baseURL, token string) []string
 }
 
 func newSetupCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "setup",
-		Short: "Interactively set up a model (API key or local)",
+		Short: "Interactively set up a model (API key, local, or custom endpoint)",
 		Long: `Set up a model for docker agent, interactively.
 
-Two paths:
+Three paths:
   - Cloud provider: pick a provider, paste its API key, and choose where to
     store it (OS keychain, pass, or the docker agent env file). Picking
     chatgpt signs in with your ChatGPT account in the browser instead of
     asking for an API key.
   - Local model: check Docker Model Runner and pull a model. No API key needed.
+  - OpenAI-compatible provider: register a custom endpoint (vLLM, LiteLLM,
+    a corporate gateway, ...) with its API format and API key variable. The
+    provider is saved to your user configuration and its models become
+    usable everywhere via --model <name>/<model>.
 
 Ends with the exact command to start chatting. Secret values are stored where
 you choose and never printed. Check the result anytime with 'docker agent doctor'.`,
@@ -124,6 +139,12 @@ func newTerminalSetupWizard(in io.Reader, out io.Writer) *setupWizard {
 		dmrLister:    dmr.ListModels,
 		pullModel:    dmr.Pull,
 		chatgptLogin: chatgpt.Login,
+		saveProvider: func(name string, provider latest.ProviderConfig) error {
+			return userconfig.Update(func(cfg *userconfig.Config) error {
+				return cfg.SetProvider(name, provider)
+			})
+		},
+		listModels: fetchOpenAICompatibleModels,
 	}
 }
 
@@ -135,17 +156,21 @@ func (w *setupWizard) run(ctx context.Context) (*setupResult, error) {
 	fmt.Fprintln(w.out, "How do you want to run models?")
 	fmt.Fprintln(w.out, "  1. Cloud provider (needs an API key)")
 	fmt.Fprintln(w.out, "  2. Local model via Docker Model Runner (no API key)")
+	fmt.Fprintln(w.out, "  3. OpenAI-compatible provider (custom endpoint, e.g. vLLM, LiteLLM)")
 
-	choice, err := w.promptChoice(ctx, 2, 1)
+	choice, err := w.promptChoice(ctx, 3, 1)
 	if err != nil {
 		return nil, err
 	}
 
 	var result *setupResult
-	if choice == 1 {
+	switch choice {
+	case 1:
 		result, err = w.setupCloudProvider(ctx)
-	} else {
+	case 2:
 		result, err = w.setupLocalModel(ctx)
+	default:
+		result, err = w.setupCustomProvider(ctx)
 	}
 	if err != nil {
 		return nil, err
@@ -293,9 +318,213 @@ func (w *setupWizard) setupLocalModel(ctx context.Context) (*setupResult, error)
 	return &setupResult{Model: "dmr/" + model}, nil
 }
 
+// customAPITypes maps the wizard's API-format menu entries to the api_type
+// values understood by the providers section.
+var customAPITypes = []string{"openai_chatcompletions", "openai_responses"}
+
+// setupCustomProvider walks the custom path: name an OpenAI-compatible
+// provider, point it at an endpoint, pick the API format, optionally wire an
+// API key, and save the provider to the user config so every command can use
+// its models via --model <name>/<model>.
+func (w *setupWizard) setupCustomProvider(ctx context.Context) (*setupResult, error) {
+	name, err := w.promptProviderName(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	baseURL, err := w.promptBaseURL(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Fprintln(w.out)
+	fmt.Fprintln(w.out, "Which API format does the endpoint use?")
+	fmt.Fprintln(w.out, "  1. Chat Completions (/chat/completions, most common)")
+	fmt.Fprintln(w.out, "  2. Responses (/responses)")
+	formatChoice, err := w.promptChoice(ctx, len(customAPITypes), 1)
+	if err != nil {
+		return nil, err
+	}
+
+	envVar, key, err := w.promptCustomProviderKey(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	providerCfg := latest.ProviderConfig{
+		BaseURL:  baseURL,
+		APIType:  customAPITypes[formatChoice-1],
+		TokenKey: envVar,
+	}
+
+	model, err := w.promptCustomProviderModel(ctx, baseURL, key)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := w.saveProvider(name, providerCfg); err != nil {
+		return nil, fmt.Errorf("saving provider %q to the user config: %w", name, err)
+	}
+	fmt.Fprintf(w.out, "\nSaved provider %q (%s) to %s.\n", name, baseURL, userconfig.Path())
+
+	result := &setupResult{EnvVar: envVar, Value: key, ProviderName: name, Provider: &providerCfg}
+	if model != "" {
+		result.Model = name + "/" + model
+	}
+	return result, nil
+}
+
+// promptProviderName asks for the custom provider's name until a valid,
+// non-conflicting one is entered. Built-in provider names are rejected so a
+// custom definition never silently shadows them.
+func (w *setupWizard) promptProviderName(ctx context.Context) (string, error) {
+	for {
+		fmt.Fprint(w.out, "\nProvider name (e.g. myprovider): ")
+		name, err := w.readLine(ctx)
+		if err != nil {
+			return "", err
+		}
+		name = strings.TrimSpace(name)
+		switch {
+		case name == "":
+			fmt.Fprintln(w.out, "The name is empty; enter one or press Ctrl+C to cancel.")
+		case strings.ContainsAny(name, "/ \t"):
+			fmt.Fprintln(w.out, "The name cannot contain '/' or whitespace.")
+		case name == "auto" || provider.IsKnownProvider(name):
+			fmt.Fprintf(w.out, "%q is a built-in provider name; pick another one.\n", name)
+		default:
+			return name, nil
+		}
+	}
+}
+
+// promptBaseURL asks for the endpoint's base URL until an absolute http(s)
+// URL is entered.
+func (w *setupWizard) promptBaseURL(ctx context.Context) (string, error) {
+	for {
+		fmt.Fprint(w.out, "Base URL of the API endpoint (e.g. https://api.example.com/v1): ")
+		baseURL, err := w.readLine(ctx)
+		if err != nil {
+			return "", err
+		}
+		baseURL = strings.TrimSpace(baseURL)
+		u, parseErr := url.Parse(baseURL)
+		if parseErr != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+			fmt.Fprintln(w.out, "Enter an absolute http(s) URL, e.g. https://api.example.com/v1.")
+			continue
+		}
+		return baseURL, nil
+	}
+}
+
+// promptCustomProviderKey asks which environment variable holds the API key
+// (empty for an unauthenticated endpoint) and, when one is named, collects
+// and stores the key like the cloud path does. The raw key is also returned
+// so the wizard can authenticate its model-discovery request.
+func (w *setupWizard) promptCustomProviderKey(ctx context.Context, name string) (envVar, key string, err error) {
+	for {
+		fmt.Fprint(w.out, "Environment variable that holds the API key (empty if none is needed): ")
+		envVar, err = w.readLine(ctx)
+		if err != nil {
+			return "", "", err
+		}
+		envVar = strings.TrimSpace(envVar)
+		if envVar == "" {
+			return "", "", nil
+		}
+		if !isValidEnvVarName(envVar) {
+			fmt.Fprintln(w.out, "Enter a valid environment variable name (letters, digits and underscores, e.g. MYPROVIDER_API_KEY), or leave it empty.")
+			continue
+		}
+		break
+	}
+
+	key, err = w.promptSecret(ctx, fmt.Sprintf("\nPaste your %s API key (%s, input hidden): ", name, envVar))
+	if err != nil {
+		return "", "", err
+	}
+	if err := w.storeSecret(ctx, envVar, key); err != nil {
+		return "", "", err
+	}
+	return envVar, key, nil
+}
+
+// promptCustomProviderModel queries the endpoint for its models to validate
+// the configuration and suggest a default, then asks which model to use.
+// Discovery failures are not fatal: the user can type a model ID manually or
+// leave it empty and discover models later with `docker agent models`.
+func (w *setupWizard) promptCustomProviderModel(ctx context.Context, baseURL, key string) (string, error) {
+	fmt.Fprintln(w.out)
+	fmt.Fprintln(w.out, "Checking the endpoint for available models...")
+
+	models := w.listModels(ctx, baseURL, key)
+	var defaultModel string
+	if len(models) > 0 {
+		fmt.Fprintf(w.out, "The endpoint lists %d model(s):\n", len(models))
+		for i, m := range models {
+			if i == maxModelsShown {
+				fmt.Fprintf(w.out, "  ... and %d more (see `docker agent models`)\n", len(models)-maxModelsShown)
+				break
+			}
+			fmt.Fprintf(w.out, "  - %s\n", m)
+		}
+		defaultModel = models[0]
+	} else {
+		fmt.Fprintln(w.out, "Could not list models from the endpoint; you can enter one manually.")
+	}
+
+	if defaultModel != "" {
+		fmt.Fprintf(w.out, "Model to use [%s]: ", defaultModel)
+	} else {
+		fmt.Fprint(w.out, "Model to use (leave empty to pick one later): ")
+	}
+	model, err := w.readLine(ctx)
+	if err != nil {
+		return "", err
+	}
+	if model = strings.TrimSpace(model); model == "" {
+		model = defaultModel
+	}
+	return model, nil
+}
+
+// maxModelsShown caps the endpoint's discovered-model listing so a provider
+// serving hundreds of models does not flood the wizard.
+const maxModelsShown = 10
+
+// envVarNameRe matches portable environment variable names.
+var envVarNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+func isValidEnvVarName(name string) bool {
+	return envVarNameRe.MatchString(name)
+}
+
 // printNextSteps ends the wizard with ready-to-copy commands.
 func (w *setupWizard) printNextSteps(result *setupResult) {
 	fmt.Fprintln(w.out)
+
+	// Auto-selection never picks a custom provider, so its next steps must
+	// carry the explicit --model reference (or how to find one) instead of
+	// the bare `docker agent run`.
+	if result.ProviderName != "" {
+		if result.Model != "" {
+			fmt.Fprintln(w.out, "You're all set. Start chatting with:")
+			fmt.Fprintln(w.out)
+			fmt.Fprintf(w.out, "  docker agent run --model %s\n", result.Model)
+		} else {
+			fmt.Fprintf(w.out, "Provider %q is set up. List its models with:\n", result.ProviderName)
+			fmt.Fprintln(w.out)
+			fmt.Fprintf(w.out, "  docker agent models --provider %s\n", result.ProviderName)
+			fmt.Fprintln(w.out)
+			fmt.Fprintln(w.out, "Then start chatting with:")
+			fmt.Fprintln(w.out)
+			fmt.Fprintf(w.out, "  docker agent run --model %s/<model>\n", result.ProviderName)
+		}
+		fmt.Fprintln(w.out)
+		fmt.Fprintln(w.out, "Check your setup anytime with `docker agent doctor`.")
+		return
+	}
+
 	fmt.Fprintln(w.out, "You're all set. Start chatting with:")
 	fmt.Fprintln(w.out)
 	fmt.Fprintln(w.out, "  docker agent run")
@@ -308,6 +537,8 @@ func (w *setupWizard) printNextSteps(result *setupResult) {
 
 // promptChoice reads a 1-based menu choice, re-asking on invalid input. An
 // empty answer selects def; EOF cancels the wizard.
+//
+//nolint:unparam // def is 1 for every current menu; the parameter documents the default-choice contract
 func (w *setupWizard) promptChoice(ctx context.Context, n, def int) (int, error) {
 	for {
 		fmt.Fprintf(w.out, "Choice [%d]: ", def)
@@ -429,6 +660,20 @@ func (f *runExecFlags) offerSetupOnNoModel(ctx context.Context, cmd *cobra.Comma
 	if result.EnvVar != "" {
 		if err := os.Setenv(result.EnvVar, result.Value); err != nil {
 			slog.WarnContext(ctx, "Failed to export the stored key for the retry", "env_var", result.EnvVar, "error", err)
+		}
+	}
+
+	// A provider registered by the wizard was saved after the run config was
+	// seeded from the user config, so bridge it in for the retry too. Auto
+	// model selection never picks a custom provider, so pin the model chosen
+	// in the wizard unless a default model is already configured.
+	if result.ProviderName != "" && result.Provider != nil {
+		if f.runConfig.Providers == nil {
+			f.runConfig.Providers = map[string]latest.ProviderConfig{}
+		}
+		f.runConfig.Providers[result.ProviderName] = *result.Provider
+		if result.Model != "" && f.runConfig.DefaultModel == nil {
+			f.runConfig.DefaultModel = parseModelShorthand(result.Model)
 		}
 	}
 

--- a/cmd/root/setup_test.go
+++ b/cmd/root/setup_test.go
@@ -44,7 +44,8 @@ func (s *fakeSecretStore) Store(_ context.Context, name, value string) error {
 
 // newTestWizard builds a wizard fed by scripted answers, returning the output
 // buffer. Secrets are answered by keys (one per prompt); DMR state comes from
-// dmrModels/dmrErr.
+// dmrModels/dmrErr. The custom-provider seams default to "no models listed"
+// and an in-memory provider store; tests override the fields as needed.
 func newTestWizard(answers string, keys []string, stores []environment.SecretStore, dmrModels []string, dmrErr error) (*setupWizard, *bytes.Buffer, *[]string) {
 	var out bytes.Buffer
 	var pulled []string
@@ -67,6 +68,8 @@ func newTestWizard(answers string, keys []string, stores []environment.SecretSto
 			pulled = append(pulled, model)
 			return nil
 		},
+		saveProvider: func(string, latest.ProviderConfig) error { return nil },
+		listModels:   func(context.Context, string, string) []string { return nil },
 	}
 	return wizard, &out, &pulled
 }
@@ -238,7 +241,7 @@ func TestSetupWizard_InvalidChoiceReasks(t *testing.T) {
 	_, err := wizard.run(t.Context())
 	require.NoError(t, err)
 
-	assert.Contains(t, out.String(), "Enter a number between 1 and 2.")
+	assert.Contains(t, out.String(), "Enter a number between 1 and 3.")
 	assert.Empty(t, *pulled)
 }
 
@@ -249,6 +252,141 @@ func TestSetupWizard_EOFCancels(t *testing.T) {
 
 	_, err := wizard.run(t.Context())
 	require.ErrorIs(t, err, errSetupCancelled)
+}
+
+// customProviderRecorder overrides the wizard's saveProvider seam and records
+// what the custom path persisted.
+type customProviderRecorder struct {
+	name     string
+	provider latest.ProviderConfig
+	err      error
+}
+
+func (r *customProviderRecorder) save(name string, provider latest.ProviderConfig) error {
+	if r.err != nil {
+		return r.err
+	}
+	r.name = name
+	r.provider = provider
+	return nil
+}
+
+func TestSetupWizard_CustomPathSavesProviderAndKey(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeSecretStore{name: "keychain"}
+	recorder := &customProviderRecorder{}
+	// custom -> name -> base URL -> format 2 (responses) -> env var -> store 1 -> model (default)
+	wizard, out, _ := newTestWizard("3\nmyprovider\nhttps://llm.corp.example.com/v1\n2\nMYPROVIDER_API_KEY\n1\n\n",
+		[]string{"sk-custom-key"}, []environment.SecretStore{store}, nil, nil)
+	wizard.saveProvider = recorder.save
+	wizard.listModels = func(_ context.Context, baseURL, token string) []string {
+		assert.Equal(t, "https://llm.corp.example.com/v1", baseURL)
+		assert.Equal(t, "sk-custom-key", token)
+		return []string{"corp-model-a", "corp-model-b"}
+	}
+
+	result, err := wizard.run(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, "myprovider", recorder.name)
+	assert.Equal(t, latest.ProviderConfig{
+		BaseURL:  "https://llm.corp.example.com/v1",
+		APIType:  "openai_responses",
+		TokenKey: "MYPROVIDER_API_KEY",
+	}, recorder.provider)
+
+	assert.Equal(t, "sk-custom-key", store.stored["MYPROVIDER_API_KEY"])
+	assert.Equal(t, "MYPROVIDER_API_KEY", result.EnvVar)
+	assert.Equal(t, "myprovider", result.ProviderName)
+	require.NotNil(t, result.Provider)
+	assert.Equal(t, "myprovider/corp-model-a", result.Model, "empty answer picks the first discovered model")
+
+	output := out.String()
+	assert.Contains(t, output, "corp-model-a")
+	assert.Contains(t, output, "docker agent run --model myprovider/corp-model-a")
+	assert.NotContains(t, output, "sk-custom-key", "secret values must never be printed")
+}
+
+func TestSetupWizard_CustomPathWithoutKeyOrModels(t *testing.T) {
+	t.Parallel()
+
+	recorder := &customProviderRecorder{}
+	// custom -> name -> base URL -> format default -> no env var -> no model
+	wizard, out, _ := newTestWizard("3\nlocal-vllm\nhttp://localhost:8000/v1\n\n\n\n", nil, nil, nil, nil)
+	wizard.saveProvider = recorder.save
+
+	result, err := wizard.run(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, "local-vllm", recorder.name)
+	assert.Equal(t, latest.ProviderConfig{
+		BaseURL: "http://localhost:8000/v1",
+		APIType: "openai_chatcompletions",
+	}, recorder.provider)
+
+	assert.Empty(t, result.EnvVar)
+	assert.Empty(t, result.Model)
+	assert.Equal(t, "local-vllm", result.ProviderName)
+
+	output := out.String()
+	assert.Contains(t, output, "Could not list models from the endpoint")
+	assert.Contains(t, output, "docker agent models --provider local-vllm")
+	assert.Contains(t, output, "docker agent run --model local-vllm/<model>")
+}
+
+func TestSetupWizard_CustomPathValidatesNameAndURL(t *testing.T) {
+	t.Parallel()
+
+	recorder := &customProviderRecorder{}
+	// Rejected names: empty, slash, built-in (openai), reserved (auto); then a
+	// bad URL before a valid one.
+	wizard, out, _ := newTestWizard("3\n\nbad/name\nopenai\nauto\nmyprovider\nnot-a-url\nhttps://ok.example.com/v1\n1\n\ncorp-model\n", nil, nil, nil, nil)
+	wizard.saveProvider = recorder.save
+
+	result, err := wizard.run(t.Context())
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "The name is empty")
+	assert.Contains(t, output, "cannot contain '/'")
+	assert.Contains(t, output, `"openai" is a built-in provider name`)
+	assert.Contains(t, output, `"auto" is a built-in provider name`)
+	assert.Contains(t, output, "Enter an absolute http(s) URL")
+
+	assert.Equal(t, "myprovider", recorder.name)
+	assert.Equal(t, "https://ok.example.com/v1", recorder.provider.BaseURL)
+	assert.Equal(t, "myprovider/corp-model", result.Model)
+}
+
+func TestSetupWizard_CustomPathReasksOnInvalidEnvVarName(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeSecretStore{name: "keychain"}
+	recorder := &customProviderRecorder{}
+	wizard, out, _ := newTestWizard("3\nmyprovider\nhttps://ok.example.com/v1\n1\nMY BAD VAR\nMY_KEY\n1\nm1\n",
+		[]string{"sk-key"}, []environment.SecretStore{store}, nil, nil)
+	wizard.saveProvider = recorder.save
+
+	_, err := wizard.run(t.Context())
+	require.NoError(t, err)
+
+	assert.Contains(t, out.String(), "Enter a valid environment variable name")
+	assert.Equal(t, "MY_KEY", recorder.provider.TokenKey)
+	assert.Equal(t, "sk-key", store.stored["MY_KEY"])
+}
+
+func TestSetupWizard_CustomPathSurfacesSaveFailure(t *testing.T) {
+	t.Parallel()
+
+	recorder := &customProviderRecorder{err: errors.New("disk full")}
+	wizard, _, _ := newTestWizard("3\nmyprovider\nhttps://ok.example.com/v1\n1\n\nm1\n", nil, nil, nil, nil)
+	wizard.saveProvider = recorder.save
+
+	_, err := wizard.run(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `saving provider "myprovider" to the user config`)
+	assert.Contains(t, err.Error(), "disk full")
 }
 
 func TestErrorIndicatesNoUsableModel(t *testing.T) {

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -201,7 +201,7 @@ $ docker agent models --format json | jq
 
 ### `docker agent setup`
 
-Set up a model interactively. Two paths: pick a cloud provider, paste its API key, and choose where to store it (macOS Keychain, `pass`, or the docker agent env file `~/.config/cagent/.env`), or check Docker Model Runner and pull a local model (no API key needed). Ends with the exact command to start chatting. Secret values are never printed.
+Set up a model interactively. Three paths: pick a cloud provider, paste its API key, and choose where to store it (macOS Keychain, `pass`, or the docker agent env file `~/.config/cagent/.env`); check Docker Model Runner and pull a local model (no API key needed); or register a custom OpenAI-compatible provider (endpoint URL, API format, and API key variable) saved to your [user configuration](../../providers/custom/index.md#global-providers-user-configuration) so its models work everywhere via `--model <name>/<model>`. Ends with the exact command to start chatting. Secret values are never printed.
 
 The wizard is also offered automatically when an interactive run finds no usable model (decline-able; set `DOCKER_AGENT_NO_SETUP=1` to suppress the offer).
 

--- a/docs/providers/custom/index.md
+++ b/docs/providers/custom/index.md
@@ -255,6 +255,44 @@ agents:
     model: fast_openai/gpt-4o-mini
 ```
 
+## Global Providers (User Configuration)
+
+Providers defined in an agent file only apply to that file. To make a custom
+provider available to every command (`docker agent run`, `new`, `models`, ...),
+define it once in your user configuration (`~/.config/cagent/config.yaml`)
+under the same `providers` key:
+
+```yaml
+# ~/.config/cagent/config.yaml
+providers:
+  myprovider:
+    base_url: https://llm.corp.example.com/v1
+    api_type: openai_chatcompletions
+    token_key: MYPROVIDER_API_KEY
+```
+
+The easiest way to register one is the interactive wizard:
+
+```bash
+docker agent setup
+# pick "3. OpenAI-compatible provider", then enter the endpoint,
+# API format, and the environment variable holding the API key
+```
+
+Once registered, the provider works everywhere:
+
+```bash
+docker agent models --provider myprovider   # list the endpoint's models
+docker agent new --model myprovider/mymodel # build agents with it
+docker agent run --model myprovider/mymodel # chat with it
+```
+
+Global providers are merged into every loaded agent configuration; when an
+agent file defines a provider with the same name, the agent file wins. Note
+that automatic model selection (`model: auto`) never picks a custom provider,
+so reference its models explicitly with `--model <name>/<model>` or
+`default_model`.
+
 ## How It Works
 
 When you reference a provider:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -387,30 +387,61 @@ func validateProviders(cfg *latest.Config) error {
 	}
 
 	for name, provCfg := range cfg.Providers {
-		// Validate provider name
-		if err := validateProviderName(name); err != nil {
-			return fmt.Errorf("provider '%s': %w", name, err)
+		if err := ValidateProviderConfig(name, provCfg); err != nil {
+			return err
 		}
-
-		// Validate api_type if set
-		if !providerAPITypes[provCfg.APIType] {
-			return fmt.Errorf("provider '%s': invalid api_type '%s' (must be one of: openai_chatcompletions, openai_responses)", name, provCfg.APIType)
-		}
-
-		// base_url is required for OpenAI-compatible providers (the default)
-		// but optional for native providers like anthropic, google, amazon-bedrock
-		if provCfg.BaseURL != "" {
-			if _, err := url.Parse(provCfg.BaseURL); err != nil {
-				return fmt.Errorf("provider '%s': invalid base_url '%s': %w", name, provCfg.BaseURL, err)
-			}
-		} else if isOpenAICustomProvider(provCfg) {
-			return fmt.Errorf("provider '%s': base_url is required for OpenAI-compatible providers", name)
-		}
-
-		// token_key is optional - if not set, requests will be sent without bearer token
 	}
 
 	return nil
+}
+
+// ValidateProviderConfig validates a single named provider configuration, as
+// found in the `providers` section of an agent file or in the user-level
+// config.
+func ValidateProviderConfig(name string, provCfg latest.ProviderConfig) error {
+	// Validate provider name
+	if err := validateProviderName(name); err != nil {
+		return fmt.Errorf("provider '%s': %w", name, err)
+	}
+
+	// Validate api_type if set
+	if !providerAPITypes[provCfg.APIType] {
+		return fmt.Errorf("provider '%s': invalid api_type '%s' (must be one of: openai_chatcompletions, openai_responses)", name, provCfg.APIType)
+	}
+
+	// base_url is required for OpenAI-compatible providers (the default)
+	// but optional for native providers like anthropic, google, amazon-bedrock
+	if provCfg.BaseURL != "" {
+		if _, err := url.Parse(provCfg.BaseURL); err != nil {
+			return fmt.Errorf("provider '%s': invalid base_url '%s': %w", name, provCfg.BaseURL, err)
+		}
+	} else if isOpenAICustomProvider(provCfg) {
+		return fmt.Errorf("provider '%s': base_url is required for OpenAI-compatible providers", name)
+	}
+
+	// token_key is optional - if not set, requests will be sent without bearer token
+
+	return nil
+}
+
+// MergeGlobalProviders merges user-level provider definitions (from the user
+// config) into an agent config's `providers` section. Definitions in the
+// agent file win on name conflicts. Invalid global definitions are skipped
+// with a warning so one bad user-config entry never breaks every run.
+func MergeGlobalProviders(cfg *latest.Config, global map[string]latest.ProviderConfig) {
+	for name, provCfg := range global {
+		if _, exists := cfg.Providers[name]; exists {
+			continue
+		}
+		if err := ValidateProviderConfig(name, provCfg); err != nil {
+			slog.Warn("Ignoring invalid provider from user config", "provider", name, "error", err)
+			continue
+		}
+		if cfg.Providers == nil {
+			cfg.Providers = map[string]latest.ProviderConfig{}
+		}
+		cfg.Providers[name] = provCfg
+	}
 }
 
 // isOpenAICustomProvider returns true if the provider config describes an OpenAI-compatible

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -980,6 +980,58 @@ func TestProviders_Validation(t *testing.T) {
 	}
 }
 
+func TestMergeGlobalProviders(t *testing.T) {
+	t.Parallel()
+
+	global := map[string]latest.ProviderConfig{
+		"myprovider": {BaseURL: "https://global.example.com/v1", TokenKey: "MY_KEY"},
+		"other":      {BaseURL: "https://other.example.com/v1"},
+	}
+
+	t.Run("adds global providers", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &latest.Config{}
+		MergeGlobalProviders(cfg, global)
+
+		require.Len(t, cfg.Providers, 2)
+		assert.Equal(t, "https://global.example.com/v1", cfg.Providers["myprovider"].BaseURL)
+	})
+
+	t.Run("agent file definition wins", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &latest.Config{Providers: map[string]latest.ProviderConfig{
+			"myprovider": {BaseURL: "https://file.example.com/v1"},
+		}}
+		MergeGlobalProviders(cfg, global)
+
+		assert.Equal(t, "https://file.example.com/v1", cfg.Providers["myprovider"].BaseURL)
+		assert.Equal(t, "https://other.example.com/v1", cfg.Providers["other"].BaseURL)
+	})
+
+	t.Run("invalid global provider is skipped", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &latest.Config{}
+		MergeGlobalProviders(cfg, map[string]latest.ProviderConfig{
+			"no-base-url": {APIType: "openai_chatcompletions"},
+			"valid":       {BaseURL: "https://ok.example.com/v1"},
+		})
+
+		require.Len(t, cfg.Providers, 1)
+		assert.Contains(t, cfg.Providers, "valid")
+	})
+
+	t.Run("no global providers leaves config untouched", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &latest.Config{}
+		MergeGlobalProviders(cfg, nil)
+		assert.Nil(t, cfg.Providers)
+	})
+}
+
 func TestLoadUnknownKeyFromNewerVersionHint(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/creator/agent.go
+++ b/pkg/creator/agent.go
@@ -6,11 +6,13 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/goccy/go-yaml"
 
 	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/team"
 	"github.com/docker/docker-agent/pkg/teamloader"
 	loaderdefaults "github.com/docker/docker-agent/pkg/teamloader/defaults"
@@ -36,7 +38,7 @@ const (
 //
 // Returns the configured team or an error if configuration fails.
 func Load(ctx context.Context, runConfig *config.RuntimeConfig, modelNameOverride string) (*teamloader.LoadResult, error) {
-	instructions := buildInstructions(ctx, runConfig)
+	instructions := buildInstructions(ctx, runConfig, modelNameOverride)
 
 	configYAML, err := buildCreatorConfigYAML(instructions)
 	if err != nil {
@@ -62,7 +64,7 @@ func Agent(ctx context.Context, runConfig *config.RuntimeConfig, modelNameOverri
 
 // buildInstructions creates the full instruction set for the creator agent,
 // including provider-specific model configuration examples.
-func buildInstructions(ctx context.Context, runConfig *config.RuntimeConfig) string {
+func buildInstructions(ctx context.Context, runConfig *config.RuntimeConfig, modelNameOverride string) string {
 	usableProviders := config.AvailableProviders(ctx, runConfig.ModelsGateway, runConfig.EnvProvider())
 
 	var b strings.Builder
@@ -83,7 +85,60 @@ func buildInstructions(ctx context.Context, runConfig *config.RuntimeConfig) str
 `, provider, provider, model, *maxTokens)
 	}
 
+	appendCustomProviderInstructions(ctx, &b, runConfig, modelNameOverride)
+
 	return b.String()
+}
+
+// appendCustomProviderInstructions documents the user-defined custom providers
+// (from the user config) that have usable credentials, so the generated agent
+// can target them. Each one is emitted with its `providers` section so the
+// generated YAML stays self-contained and portable.
+func appendCustomProviderInstructions(ctx context.Context, b *strings.Builder, runConfig *config.RuntimeConfig, modelNameOverride string) {
+	env := runConfig.EnvProvider()
+
+	var names []string
+	for name, provCfg := range runConfig.Providers {
+		if provCfg.TokenKey != "" {
+			if token, _ := env.Get(ctx, provCfg.TokenKey); token == "" {
+				continue
+			}
+		}
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return
+	}
+	sort.Strings(names)
+
+	b.WriteString("\nThe user also defined the following custom providers. When one is used, copy its `providers` entry verbatim into the generated YAML and reference it from a model definition:\n")
+
+	for _, name := range names {
+		provCfg := runConfig.Providers[name]
+
+		model := "REPLACE_WITH_MODEL_ID"
+		if parsed, err := latest.ParseModelRef(modelNameOverride); err == nil && parsed.Provider == name {
+			model = parsed.Model
+		}
+
+		fmt.Fprintf(b, "\n\t\tproviders:\n\t\t\t%s:\n", name)
+		if provCfg.Provider != "" {
+			fmt.Fprintf(b, "\t\t\t\tprovider: %s\n", provCfg.Provider)
+		}
+		if provCfg.BaseURL != "" {
+			fmt.Fprintf(b, "\t\t\t\tbase_url: %s\n", provCfg.BaseURL)
+		}
+		if provCfg.APIType != "" {
+			fmt.Fprintf(b, "\t\t\t\tapi_type: %s\n", provCfg.APIType)
+		}
+		if provCfg.TokenKey != "" {
+			fmt.Fprintf(b, "\t\t\t\ttoken_key: %s\n", provCfg.TokenKey)
+		}
+		fmt.Fprintf(b, "\t\tmodels:\n\t\t\t%s:\n\t\t\t\tprovider: %s\n\t\t\t\tmodel: %s\n", name, name, model)
+		if model == "REPLACE_WITH_MODEL_ID" {
+			fmt.Fprintf(b, "\t\tAsk the user which model ID to use with %q (they can list them with `docker agent models --provider %s`).\n", name, name)
+		}
+	}
 }
 
 // buildCreatorConfigYAML generates the YAML configuration for the creator agent.

--- a/pkg/creator/agent_test.go
+++ b/pkg/creator/agent_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
 )
 
@@ -43,7 +44,7 @@ func TestBuildInstructions(t *testing.T) {
 		},
 	}
 
-	instructions := buildInstructions(ctx, runConfig)
+	instructions := buildInstructions(ctx, runConfig, "")
 
 	// Verify the instructions contain the base instructions
 	assert.Contains(t, instructions, agentBuilderInstructions)
@@ -51,6 +52,53 @@ func TestBuildInstructions(t *testing.T) {
 	// Verify the instructions contain provider guidance
 	assert.Contains(t, instructions, "Preferred model providers to use:")
 	assert.Contains(t, instructions, "models:")
+}
+
+func TestBuildInstructions_CustomProviders(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	runConfig := &config.RuntimeConfig{
+		Config: config.Config{
+			WorkingDir: t.TempDir(),
+			Providers: map[string]latest.ProviderConfig{
+				"myprovider": {
+					BaseURL:  "https://llm.corp.example.com/v1",
+					APIType:  "openai_chatcompletions",
+					TokenKey: "MYPROVIDER_API_KEY",
+				},
+				"no-creds": {
+					BaseURL:  "https://other.example.com/v1",
+					TokenKey: "UNSET_KEY",
+				},
+			},
+		},
+		EnvProviderForTests: environment.NewEnvListProvider([]string{
+			"MYPROVIDER_API_KEY=dummy",
+		}),
+	}
+
+	t.Run("without model override", func(t *testing.T) {
+		t.Parallel()
+
+		instructions := buildInstructions(ctx, runConfig, "")
+
+		assert.Contains(t, instructions, "custom providers")
+		assert.Contains(t, instructions, "base_url: https://llm.corp.example.com/v1")
+		assert.Contains(t, instructions, "api_type: openai_chatcompletions")
+		assert.Contains(t, instructions, "token_key: MYPROVIDER_API_KEY")
+		assert.Contains(t, instructions, "docker agent models --provider myprovider")
+		assert.NotContains(t, instructions, "no-creds", "providers without credentials are excluded")
+	})
+
+	t.Run("with model override", func(t *testing.T) {
+		t.Parallel()
+
+		instructions := buildInstructions(ctx, runConfig, "myprovider/corp-model")
+
+		assert.Contains(t, instructions, "model: corp-model")
+		assert.NotContains(t, instructions, "REPLACE_WITH_MODEL_ID")
+	})
 }
 
 func TestAgent(t *testing.T) {

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -164,6 +164,12 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 		)
 	}
 
+	// Merge user-level provider definitions (seeded into the runtime config
+	// from the user config file) so custom providers registered via
+	// `docker agent setup` resolve in every run, including inline
+	// `--model myprovider/mymodel` overrides. Agent-file definitions win.
+	config.MergeGlobalProviders(cfg, runConfig.Providers)
+
 	// Resolve model aliases (e.g., "claude-sonnet-4-5" -> "claude-sonnet-4-5-20250929")
 	// This ensures the API uses the pinned model version. The original name is preserved
 	// in DisplayModel so the sidebar and other UI elements show the user-configured name.

--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -910,6 +910,123 @@ func TestLoadRetainsAgentConfig(t *testing.T) {
 	assert.False(t, ok, "unknown agent reports no retained config")
 }
 
+// TestLoadWithConfig_GlobalProviders covers user-level custom providers
+// (seeded into the runtime config from the user config file): they must
+// resolve inline `provider/model` references in any agent config, while
+// agent-file definitions with the same name keep precedence.
+func TestLoadWithConfig_GlobalProviders(t *testing.T) {
+	t.Parallel()
+
+	globalProviders := map[string]latest.ProviderConfig{
+		"myprovider": {
+			BaseURL:  "https://llm.corp.example.com/v1",
+			APIType:  "openai_chatcompletions",
+			TokenKey: "MYPROVIDER_API_KEY",
+		},
+	}
+	env := environment.NewMapEnvProvider(map[string]string{"MYPROVIDER_API_KEY": "dummy"})
+
+	t.Run("resolves inline model reference", func(t *testing.T) {
+		t.Parallel()
+
+		data := []byte(`agents:
+  root:
+    model: myprovider/corp-model
+    instruction: test
+`)
+		runConfig := &config.RuntimeConfig{
+			Config:              config.Config{Providers: globalProviders},
+			EnvProviderForTests: env,
+		}
+
+		result, err := LoadWithConfig(t.Context(), config.NewBytesSource("global-providers.yaml", data), runConfig, withTestProviderRegistry()...)
+		require.NoError(t, err)
+
+		root, err := result.Team.Agent("root")
+		require.NoError(t, err)
+
+		models := root.ConfiguredModels()
+		require.Len(t, models, 1)
+		assert.Equal(t, "myprovider/corp-model", models[0].ID().String())
+
+		require.Contains(t, result.Providers, "myprovider")
+		assert.Equal(t, "https://llm.corp.example.com/v1", result.Providers["myprovider"].BaseURL)
+	})
+
+	t.Run("resolves --model override", func(t *testing.T) {
+		t.Parallel()
+
+		// The agent file references another provider entirely; the CLI
+		// override must resolve through the merged global provider (the
+		// `docker agent new|run --model myprovider/mymodel` path).
+		data := []byte(`agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+`)
+		runConfig := &config.RuntimeConfig{
+			Config:              config.Config{Providers: globalProviders},
+			EnvProviderForTests: env,
+		}
+
+		result, err := LoadWithConfig(t.Context(), config.NewBytesSource("global-providers.yaml", data), runConfig,
+			withTestProviderRegistry(WithModelOverrides([]string{"myprovider/corp-model"}))...)
+		require.NoError(t, err)
+
+		root, err := result.Team.Agent("root")
+		require.NoError(t, err)
+
+		models := root.ConfiguredModels()
+		require.Len(t, models, 1)
+		assert.Equal(t, "myprovider/corp-model", models[0].ID().String())
+	})
+
+	t.Run("missing token variable fails the preflight check", func(t *testing.T) {
+		t.Parallel()
+
+		data := []byte(`agents:
+  root:
+    model: myprovider/corp-model
+    instruction: test
+`)
+		runConfig := &config.RuntimeConfig{
+			Config:              config.Config{Providers: globalProviders},
+			EnvProviderForTests: &noEnvProvider{},
+		}
+
+		_, err := LoadWithConfig(t.Context(), config.NewBytesSource("global-providers.yaml", data), runConfig, withTestProviderRegistry()...)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "MYPROVIDER_API_KEY")
+	})
+
+	t.Run("agent file definition wins", func(t *testing.T) {
+		t.Parallel()
+
+		data := []byte(`providers:
+  myprovider:
+    base_url: https://file.example.com/v1
+models:
+  corp:
+    provider: myprovider
+    model: corp-model
+agents:
+  root:
+    model: corp
+    instruction: test
+`)
+		runConfig := &config.RuntimeConfig{
+			Config:              config.Config{Providers: globalProviders},
+			EnvProviderForTests: env,
+		}
+
+		result, err := LoadWithConfig(t.Context(), config.NewBytesSource("global-providers.yaml", data), runConfig, withTestProviderRegistry()...)
+		require.NoError(t, err)
+
+		require.Contains(t, result.Providers, "myprovider")
+		assert.Equal(t, "https://file.example.com/v1", result.Providers["myprovider"].BaseURL)
+	})
+}
+
 func TestLoadWithConfig_GlobalHooks(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "dummy")
 

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -281,6 +282,12 @@ type Config struct {
 	DefaultModel *latest.FlexibleModelConfig `yaml:"default_model,omitempty"`
 	// Aliases maps alias names to alias configurations
 	Aliases map[string]*Alias `yaml:"aliases,omitempty"`
+	// Providers maps user-defined provider names to reusable provider
+	// configurations (e.g. custom OpenAI-compatible endpoints registered via
+	// `docker agent setup`). They use the same shape as the `providers`
+	// section of an agent file and are merged into every loaded agent config;
+	// definitions in the agent file win on name conflicts.
+	Providers map[string]latest.ProviderConfig `yaml:"providers,omitempty"`
 	// Settings contains global user settings
 	Settings *Settings `yaml:"settings,omitempty"`
 	// Board configures the `docker agent board` Kanban TUI.
@@ -548,6 +555,40 @@ func (c *Config) DeleteAlias(name string) bool {
 		return true
 	}
 	return false
+}
+
+// GetProviders returns a copy of the user-defined provider configurations.
+//
+// This method is safe for concurrent use; the returned map is detached from
+// the config so callers can read it without holding the lock.
+func (c *Config) GetProviders() map[string]latest.ProviderConfig {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if len(c.Providers) == 0 {
+		return nil
+	}
+	return maps.Clone(c.Providers)
+}
+
+// SetProvider creates or updates a user-defined provider configuration.
+//
+// This method is safe for concurrent use. Writes to the Providers map are
+// protected by a mutex to avoid concurrent map write panics when providers
+// are modified from multiple goroutines.
+func (c *Config) SetProvider(name string, provider latest.ProviderConfig) error {
+	if strings.TrimSpace(name) == "" {
+		return errors.New("provider name cannot be empty")
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.Providers == nil {
+		c.Providers = make(map[string]latest.ProviderConfig)
+	}
+	c.Providers[name] = provider
+	return nil
 }
 
 // GetSettings returns the global settings with defaults applied.

--- a/pkg/userconfig/userconfig_test.go
+++ b/pkg/userconfig/userconfig_test.go
@@ -98,6 +98,55 @@ func TestConfig_SetAlias_Validation(t *testing.T) {
 	}
 }
 
+func TestConfig_SetGetProviders(t *testing.T) {
+	t.Parallel()
+
+	config := &Config{}
+
+	require.Error(t, config.SetProvider("", latest.ProviderConfig{}))
+	require.Error(t, config.SetProvider("   ", latest.ProviderConfig{}))
+	assert.Nil(t, config.GetProviders())
+
+	provider := latest.ProviderConfig{
+		BaseURL:  "https://llm.corp.example.com/v1",
+		APIType:  "openai_chatcompletions",
+		TokenKey: "MYPROVIDER_API_KEY",
+	}
+	require.NoError(t, config.SetProvider("myprovider", provider))
+
+	providers := config.GetProviders()
+	require.Len(t, providers, 1)
+	assert.Equal(t, provider, providers["myprovider"])
+
+	// The returned map is a copy: mutating it must not affect the config.
+	delete(providers, "myprovider")
+	assert.Len(t, config.GetProviders(), 1)
+}
+
+func TestConfig_ProvidersRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+
+	config := &Config{}
+	require.NoError(t, config.SetProvider("myprovider", latest.ProviderConfig{
+		BaseURL:  "https://llm.corp.example.com/v1",
+		APIType:  "openai_responses",
+		TokenKey: "MYPROVIDER_API_KEY",
+	}))
+	require.NoError(t, config.saveTo(configFile))
+
+	loaded, err := loadFrom(configFile, "")
+	require.NoError(t, err)
+
+	providers := loaded.GetProviders()
+	require.Len(t, providers, 1)
+	assert.Equal(t, "https://llm.corp.example.com/v1", providers["myprovider"].BaseURL)
+	assert.Equal(t, "openai_responses", providers["myprovider"].APIType)
+	assert.Equal(t, "MYPROVIDER_API_KEY", providers["myprovider"].TokenKey)
+}
+
 func TestValidateAliasName(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #3557.

`docker agent setup` gains a third path that registers a custom OpenAI-compatible provider (vLLM, LiteLLM, corporate gateways, ...) in the user configuration. Registered providers then work across commands: `docker agent new|run --model <name>/<model>` resolve them and `docker agent models` lists their models.

## Issue expectations

| Expectation | Implemented by |
| --- | --- |
| `setup` offers "OpenAI Compatible provider" (endpoint, format responses/chat_completions, API key env var) | New wizard path in `cmd/root/setup.go`: name, base URL, API format, key env var (key stored via the same secret stores as the cloud path), live `/models` discovery to validate the endpoint and suggest a default model |
| Configuration is persisted | New `providers` key in the user config (`~/.config/cagent/config.yaml`, `pkg/userconfig`), same `latest.ProviderConfig` shape as the agent-file `providers` section |
| `docker agent new --model myprovider/mymodel` works | Gateway pre-run seeds `RuntimeConfig.Providers` from the user config; `teamloader` merges them into every loaded agent config via the new `config.MergeGlobalProviders` (agent-file definitions win, invalid entries are skipped with a warning). Works for `run` too; the agent builder instructions also document available custom providers with a portable `providers` + `models` snippet |
| `docker agent models` lists the provider's models | New `collectCustomProviderModels` queries each usable custom provider's `/models` endpoint (Bearer auth from `token_key`), placed before the models.dev catalog fetch so it still works in internet-restricted environments |

## Flow

```
docker agent setup (option 3)
  └─ writes providers.<name> to ~/.config/cagent/config.yaml
       └─ gateway pre-run seeds RuntimeConfig.Providers        (cmd/root/flags.go)
            └─ teamloader merges into cfg.Providers            (agent file wins)
                 ├─ env preflight (token_key)                  (pkg/config/gather.go, unchanged)
                 └─ model creation via applyProviderDefaults   (unchanged)
```

## Also included

- Moves the models command's user-config pre-run from the `list` subcommand to the parent `models` command: cobra only runs the nearest ancestor's `PersistentPreRunE`, so the bare `docker agent models` form previously ignored the user config (`models_gateway`, `default_model`, and the new providers).
- Auto model selection intentionally never picks a custom provider (no known default model); the wizard's next steps print the explicit `--model` command and the post-failure setup retry pins the chosen model.

## Validation

- Build, `golangci-lint` (0 issues), full test suites of the touched packages.
- 24 new tests: wizard custom path (validation loops, key storage, save failure), models listing against `httptest` endpoints (auth header, filter, `--all`, embedding filtering), teamloader merge (inline ref, `--model` override, file-wins, env preflight), `MergeGlobalProviders`, userconfig YAML round-trip, gateway pre-run seeding, builder instructions.
- End-to-end against a fake OpenAI endpoint with a real binary: interactive `setup` session through a pty (real persistence, live model discovery), `docker agent models` (bare and `--provider` forms), `docker agent run --exec --model myprovider/model` resolving the provider from the user config and dialing the endpoint with the configured credentials.

## Follow-up candidates (not in scope)

- `docker agent doctor` does not report custom providers yet.
- The TUI `/model` picker catalog (models.dev based) does not list custom-provider models; switching to one already works.
