### PR TITLE
fix(shell): return clear error when working directory does not exist

### DIFF
--- a/pkg/tools/builtin/shell/shell.go
+++ b/pkg/tools/builtin/shell/shell.go
@@ -144,6 +144,9 @@ func (h *shellHandler) RunShell(ctx context.Context, params RunShellArgs, rt too
 	defer cancel()
 
 	cwd := h.resolveWorkDir(params.Cwd)
+	if msg := checkWorkDir(cwd); msg != "" {
+		return tools.ResultError(msg), nil
+	}
 
 	// Stamp the call shape (cmd, cwd, timeout) onto the active span.
 	// Cmd ships unconditionally — it's the main signal of what the
@@ -299,6 +302,27 @@ func New(env []string, runConfig *config.RuntimeConfig) *ToolSet {
 // PATH hijacking (CWE-426).
 func detectShell() (shell string, argsPrefix []string) {
 	return shellpath.DetectShell()
+}
+
+// checkWorkDir verifies the working directory exists and is a directory,
+// returning a user-facing error message (empty when OK). Without this check,
+// a missing cwd surfaces as the cryptic "fork/exec <shell>: no such file or
+// directory": the child's chdir failure is misattributed to the shell binary
+// when SysProcAttr forces the raw fork+exec path.
+func checkWorkDir(cwd string) string {
+	if cwd == "" {
+		return "" // empty Dir means "inherit the process cwd", always valid
+	}
+	info, err := os.Stat(cwd)
+	switch {
+	case os.IsNotExist(err):
+		return "Error: working directory does not exist: " + cwd
+	case err != nil:
+		return fmt.Sprintf("Error: cannot access working directory %s: %s", cwd, err)
+	case !info.IsDir():
+		return "Error: working directory is not a directory: " + cwd
+	}
+	return ""
 }
 
 // resolveWorkDir returns the effective working directory.

--- a/pkg/tools/builtin/shell/shell.go
+++ b/pkg/tools/builtin/shell/shell.go
@@ -5,7 +5,9 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -144,9 +146,6 @@ func (h *shellHandler) RunShell(ctx context.Context, params RunShellArgs, rt too
 	defer cancel()
 
 	cwd := h.resolveWorkDir(params.Cwd)
-	if msg := checkWorkDir(cwd); msg != "" {
-		return tools.ResultError(msg), nil
-	}
 
 	// Stamp the call shape (cmd, cwd, timeout) onto the active span.
 	// Cmd ships unconditionally — it's the main signal of what the
@@ -162,6 +161,10 @@ func (h *shellHandler) RunShell(ctx context.Context, params RunShellArgs, rt too
 	}
 
 	slog.DebugContext(ctx, "Executing native shell command", "command", params.Cmd, "cwd", cwd)
+
+	if msg := checkWorkDir(cwd); msg != "" {
+		return tools.ResultError(msg), nil
+	}
 
 	return h.runNativeCommand(timeoutCtx, ctx, rt, params.Cmd, cwd, timeout), nil
 }
@@ -308,14 +311,15 @@ func detectShell() (shell string, argsPrefix []string) {
 // returning a user-facing error message (empty when OK). Without this check,
 // a missing cwd surfaces as the cryptic "fork/exec <shell>: no such file or
 // directory": the child's chdir failure is misattributed to the shell binary
-// when SysProcAttr forces the raw fork+exec path.
+// when SysProcAttr forces the raw fork+exec path. Best-effort: the directory
+// can still disappear before exec; this only improves the common-case message.
 func checkWorkDir(cwd string) string {
 	if cwd == "" {
 		return "" // empty Dir means "inherit the process cwd", always valid
 	}
 	info, err := os.Stat(cwd)
 	switch {
-	case os.IsNotExist(err):
+	case errors.Is(err, fs.ErrNotExist):
 		return "Error: working directory does not exist: " + cwd
 	case err != nil:
 		return fmt.Sprintf("Error: cannot access working directory %s: %s", cwd, err)

--- a/pkg/tools/builtin/shell/shell_test.go
+++ b/pkg/tools/builtin/shell/shell_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
@@ -228,6 +229,24 @@ func TestResolveWorkDir(t *testing.T) {
 			assert.Equal(t, tt.expected, h.resolveWorkDir(tt.cwd))
 		})
 	}
+}
+
+// Regression test: a session working directory that no longer exists (e.g. a
+// removed git worktree restored for a new tab) must yield a clear error, not
+// the misleading "fork/exec <shell>: no such file or directory" produced by
+// the child's chdir failure.
+func TestShellTool_MissingWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	missing := filepath.Join(t.TempDir(), "gone")
+	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: missing}})
+
+	result, err := tool.handler.RunShell(t.Context(), RunShellArgs{Cmd: "pwd"}, tools.NopRuntime{})
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Output, "working directory does not exist")
+	assert.Contains(t, result.Output, missing)
+	assert.NotContains(t, result.Output, "fork/exec")
 }
 
 func TestShellTool_RelativeCwdResolvesAgainstWorkingDir(t *testing.T) {

--- a/pkg/tools/builtin/shell/shell_test.go
+++ b/pkg/tools/builtin/shell/shell_test.go
@@ -231,6 +231,18 @@ func TestResolveWorkDir(t *testing.T) {
 	}
 }
 
+func TestCheckWorkDir(t *testing.T) {
+	t.Parallel()
+
+	file := filepath.Join(t.TempDir(), "f")
+	require.NoError(t, os.WriteFile(file, nil, 0o644))
+
+	assert.Empty(t, checkWorkDir(""), "empty cwd inherits the process cwd")
+	assert.Empty(t, checkWorkDir(t.TempDir()))
+	assert.Contains(t, checkWorkDir(filepath.Join(t.TempDir(), "gone")), "does not exist")
+	assert.Contains(t, checkWorkDir(file), "not a directory")
+}
+
 // Regression test: a session working directory that no longer exists (e.g. a
 // removed git worktree restored for a new tab) must yield a clear error, not
 // the misleading "fork/exec <shell>: no such file or directory" produced by


### PR DESCRIPTION
When Go forks a child process with `SysProcAttr{Setpgid: true}` (which the shell toolset sets to keep child processes in their own process group), the kernel's fork+exec path performs the working-directory `chdir` inside the child. If that directory no longer exists, the error surfaces as "fork/exec /bin/zsh: no such file or directory", making it look like the shell binary itself is missing rather than the cwd.

This is a real problem for TUI sessions that restore a shell tab tied to a git worktree that has since been removed. Every tool call in that tab fails with a cryptic, misleading error.

The fix adds a `checkWorkDir()` pre-flight in the shell tool that runs before the process is spawned. It detects the three actionable cases — path does not exist, path exists but is not a directory, and a stat error — and returns a clear tool-level error message for each. An empty cwd is left alone (meaning "inherit the process cwd"), matching the existing behaviour. The check runs after the OTel span is opened so failed calls remain traceable. A `TestCheckWorkDir` table-driven test covers all cases, and a `TestShellTool_MissingWorkingDir` regression test exercises the full tool path.