### PR TITLE
fix(mcp): prefer OAuth resource_metadata challenge param

### DIFF
--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -29,8 +29,10 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
-// resourceMetadataFromWWWAuth extracts resource metadata URL from WWW-Authenticate header
-var re = regexp.MustCompile(`resource="([^"]+)"`)
+// resourceMetadataFromWWWAuth extracts resource metadata URL from WWW-Authenticate header.
+var resourceMetadataRe = regexp.MustCompile(`(?i)(?:^|[,\s])resource_metadata\s*=\s*(?:"([^"]+)"|([^,\s]+))`)
+
+var resourceRe = regexp.MustCompile(`(?i)(?:^|[,\s])resource\s*=\s*(?:"([^"]+)"|([^,\s]+))`)
 
 // errorCodeRe extracts the RFC 6750 error= parameter from a WWW-Authenticate header.
 var errorCodeRe = regexp.MustCompile(`error="([^"]+)"`)
@@ -276,11 +278,21 @@ func createDefaultMetadata(authServerURL string) *AuthorizationServerMetadata {
 }
 
 func resourceMetadataFromWWWAuth(wwwAuth string) string {
+	if resourceMetadata := wwwAuthParam(resourceMetadataRe, wwwAuth); resourceMetadata != "" {
+		return resourceMetadata
+	}
+	return wwwAuthParam(resourceRe, wwwAuth)
+}
+
+func wwwAuthParam(re *regexp.Regexp, wwwAuth string) string {
 	matches := re.FindStringSubmatch(wwwAuth)
-	if len(matches) == 2 {
+	if len(matches) != 3 {
+		return ""
+	}
+	if matches[1] != "" {
 		return matches[1]
 	}
-	return ""
+	return matches[2]
 }
 
 // callbackRedirectURLFrom is a nil-safe accessor for the optional

--- a/pkg/tools/mcp/oauth_test.go
+++ b/pkg/tools/mcp/oauth_test.go
@@ -971,6 +971,28 @@ func TestHostScopedHeaderTransport_NormalizesRequestPort(t *testing.T) {
 	assert.False(t, baseCalled, "must not fall through to the header-less branch")
 }
 
+func TestResourceMetadataFromWWWAuth_PrefersResourceMetadataParam(t *testing.T) {
+	t.Parallel()
+
+	const header = `Bearer realm="agentic-platform-mcp", resource="https://mcp.example.test/api/mcp/remote", resource_metadata="https://mcp.example.test/.well-known/oauth-protected-resource"`
+
+	assert.Equal(t,
+		"https://mcp.example.test/.well-known/oauth-protected-resource",
+		resourceMetadataFromWWWAuth(header),
+	)
+}
+
+func TestResourceMetadataFromWWWAuth_FallsBackToLegacyResourceParam(t *testing.T) {
+	t.Parallel()
+
+	const header = `Bearer resource="https://mcp.example.test/.well-known/oauth-protected-resource"`
+
+	assert.Equal(t,
+		"https://mcp.example.test/.well-known/oauth-protected-resource",
+		resourceMetadataFromWWWAuth(header),
+	)
+}
+
 func TestOAuthTransportCoalescesConcurrentAuthorization(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Prefer the WWW-Authenticate resource_metadata parameter when discovering OAuth protected resource metadata
- Keep the legacy resource parameter fallback for existing MCP servers
- Add regression coverage for both header shapes

## Tests
- go test ./pkg/tools/mcp