### PR TITLE
fix(modelinfo): strip provider prefix from model ids in name-pattern predicates

### DIFF
--- a/pkg/modelinfo/modelinfo.go
+++ b/pkg/modelinfo/modelinfo.go
@@ -293,9 +293,18 @@ func IsClaudeFamily(family string) bool {
 }
 
 // normalize returns the lowercased, whitespace-trimmed model identifier used
-// by every name-pattern predicate in this package.
+// by every name-pattern predicate in this package. Provider-qualified ids as
+// used by gateways and aggregators ("openai/gpt-5-nano" on OpenRouter,
+// "openrouter/openai/o3" in custom configs) are reduced to their last path
+// segment: the predicates match on the bare model name, and without this a
+// prefixed id would silently disable model-specific behavior (e.g. a
+// thinking_budget on "openai/gpt-5-nano" was never sent as reasoning_effort).
 func normalize(modelID string) string {
-	return strings.ToLower(strings.TrimSpace(modelID))
+	m := strings.ToLower(strings.TrimSpace(modelID))
+	if i := strings.LastIndexByte(m, '/'); i >= 0 {
+		m = m[i+1:]
+	}
+	return m
 }
 
 // isOSeries reports whether the (already-normalized) identifier names an

--- a/pkg/modelinfo/modelinfo_test.go
+++ b/pkg/modelinfo/modelinfo_test.go
@@ -31,6 +31,12 @@ func TestSupportsResponsesAPI(t *testing.T) {
 		{"codex-mini", true},
 		{"gpt-5-codex", true},
 
+		// Provider-qualified ids (gateways/aggregators) match the bare name.
+		{"openai/gpt-5", true},
+		{"openai/o3-mini", true},
+		{"openrouter/openai/gpt-4.1", true},
+		{"openai/gpt-4o", false},
+
 		// Older models stay on Chat Completions.
 		{"gpt-4", false},
 		{"gpt-4o", false},
@@ -73,6 +79,13 @@ func TestUsesReasoningEffort(t *testing.T) {
 		{"gpt-5-turbo", true},
 		{"GPT-5", true},
 
+		// Provider-qualified ids (gateways/aggregators) match the bare name.
+		{"openai/gpt-5-nano", true},
+		{"openai/o3", true},
+		{"openrouter/openai/gpt-5", true},
+		{"openai/gpt-5-chat", false},
+		{"openai/gpt-4o", false},
+
 		// gpt-5-chat is a non-reasoning chat model.
 		{"gpt-5-chat", false},
 		{"gpt-5-chat-latest", false},
@@ -109,6 +122,9 @@ func TestAlwaysReasons(t *testing.T) {
 		{"o3", true},
 		{"o3-mini", true},
 		{"o4-mini", true},
+		// Provider-qualified ids (gateways/aggregators) match the bare name.
+		{"openai/o3-mini", true},
+		{"openai/gpt-5", false},
 		// gpt-5 can produce visible output without reasoning, so it is not
 		// classified as "always reasons".
 		{"gpt-5", false},
@@ -206,6 +222,10 @@ func TestSupportsAdaptiveThinking(t *testing.T) {
 		{"us.anthropic.claude-sonnet-4-6-v1:0", true},
 		{"global.anthropic.claude-sonnet-4-5-20250929-v1:0", false},
 		{"us.anthropic.claude-haiku-4-5-v1:0", false},
+		// Provider-qualified ids (gateways/aggregators) match the bare name.
+		{"anthropic/claude-opus-4.6", true},
+		{"openrouter/anthropic/claude-sonnet-4-6", true},
+		{"anthropic/claude-haiku-4-5", false},
 		// Case-insensitive and whitespace-tolerant.
 		{"CLAUDE-SONNET-4-6", true},
 		{"  claude-opus-4-8  ", true},
@@ -256,6 +276,7 @@ func TestUsesThinkingLevel(t *testing.T) {
 		"gemini-3.5-pro", "gemini-3.5-flash",
 		"GEMINI-3-PRO", // case-insensitive
 		"  gemini-3-pro  ",
+		"google/gemini-3-pro", // provider-qualified id
 	}
 	noMatch := []string{
 		"gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.0-flash",


### PR DESCRIPTION
Provider-qualified model ids such as `openai/gpt-5-nano` or `openrouter/openai/o3` — common in gateway and aggregator setups — never matched the name-pattern predicates in `pkg/modelinfo` (`UsesReasoningEffort`, `SupportsResponsesAPI`, `AlwaysReasons`, `SupportsAdaptiveThinking`, `RejectsTokenThinking`, `UsesThinkingLevel`, `IsClaude`). The predicates only lowercased and trimmed the id before prefix-matching, so the provider prefix silently broke every match and model-specific behaviour was disabled.

The most measurable symptom: a configured `thinking_budget: minimal` on `openai/gpt-5-nano` was silently ignored because `UsesReasoningEffort` returned false, so `reasoning_effort` was never sent and the model reasoned at its API default (medium). In benchmarks this cost a median of 1,600 hidden reasoning tokens per summary (~17.9 s latency, 14.2 s TTFT); after the fix it drops to 0 reasoning tokens (~7.0 s latency, 1.1 s TTFT, 30% cheaper).

`normalize()` now strips everything up to and including the last `/` before matching, making every predicate provider-prefix agnostic. Responses-API auto-selection is additionally gated on the provider name in the OpenAI client, so prefixed ids on third-party gateways stay on chat completions unless `api_type` is pinned explicitly — this change cannot mis-route API selection.

Provider-qualified id cases have been added to the test tables of `SupportsResponsesAPI`, `UsesReasoningEffort`, `AlwaysReasons`, `SupportsAdaptiveThinking`, and `UsesThinkingLevel`.