### PR TITLE
feat(tui): add Ctrl+R force-refresh to the model picker

### DIFF
--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -216,6 +216,8 @@ Change the AI model during a session with `/model` or <kbd>Ctrl</kbd>+<kbd>M</kb
 
 When a models gateway is configured (`--models-gateway`) and it exposes an OpenAI-style `/v1/models` endpoint, the picker lists the models actually served by the gateway (merged with the models defined in the agent config). When the gateway doesn't expose `/v1/models`, the picker falls back to the regular catalog.
 
+The picker's catalog entries come from [models.dev](https://models.dev) and are cached locally for a day. Press <kbd>Ctrl</kbd>+<kbd>R</kbd> in the picker to force model discovery to run again, including a refetch of the models.dev catalog.
+
 > [!TIP]
 > Use model switching to try a more capable model for complex tasks, or a cheaper one for simple queries — without modifying your YAML config.
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1190,6 +1190,20 @@ func (a *App) refreshAgentInfo(ctx context.Context) {
 	})
 }
 
+// RefreshModelsCatalog forces a refetch of the models.dev catalog that
+// backs catalog-driven model discovery. Refreshing is an optional
+// runtime capability: only the local runtime exposes it, so remote
+// runtimes report [runtime.ErrUnsupported].
+func (a *App) RefreshModelsCatalog(ctx context.Context) error {
+	refresher, ok := a.runtime.(interface {
+		RefreshModelsCatalog(ctx context.Context) error
+	})
+	if !ok {
+		return runtime.ErrUnsupported
+	}
+	return refresher.RefreshModelsCatalog(ctx)
+}
+
 // AvailableModels returns the list of models available for selection.
 // Returns nil if model switching is not supported.
 func (a *App) AvailableModels(ctx context.Context) []runtime.ModelChoice {

--- a/pkg/modelsdev/store.go
+++ b/pkg/modelsdev/store.go
@@ -3,6 +3,7 @@ package modelsdev
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -43,8 +44,9 @@ type Store struct {
 	// fetch retrieves the catalog from the network. It defaults to
 	// fetchFromAPI and is overridable via WithFetcher so tests can stub the
 	// network out without mutating package-level state.
-	fetch fetcher
-	mu    sync.Mutex
+	fetch     fetcher
+	refreshMu sync.Mutex
+	mu        sync.Mutex
 	// db is the authoritative catalog from the full (fetch-eligible) load path.
 	db *Database
 	// cacheDB is a cache-only snapshot served to fetch-disallowed lookups. It is
@@ -189,12 +191,13 @@ func (s *Store) getDatabase(ctx context.Context, allowFetch bool) (*Database, er
 // and the on-disk cache. A memory-only store (no cache file, e.g. one built
 // with NewDatabaseStore) keeps serving its pre-populated database.
 func (s *Store) Refresh(ctx context.Context) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	if s.cacheFile == "" {
-		return nil
+		return errors.New("models.dev catalog refresh is unavailable for an in-memory store")
 	}
+
+	// Serialize refreshes without blocking catalog readers during network I/O.
+	s.refreshMu.Lock()
+	defer s.refreshMu.Unlock()
 
 	var etag string
 	cached, err := loadFromCache(s.cacheFile)
@@ -211,11 +214,16 @@ func (s *Store) Refresh(ctx context.Context) error {
 	// is already current, so only its LastRefresh timestamp needs bumping.
 	if db == nil {
 		if cached == nil {
-			return nil
+			return errors.New("models.dev returned not modified without a cached catalog")
 		}
 		db = &cached.Database
 		newETag = cached.ETag
 	}
+
+	// Keep file replacement and in-memory installation atomic with respect to
+	// normal store loads, but never hold this lock during the network request.
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if saveErr := saveToCache(s.cacheFile, db, newETag); saveErr != nil {
 		slog.WarnContext(ctx, "Failed to save refreshed catalog to cache", "error", saveErr)
 	}

--- a/pkg/modelsdev/store.go
+++ b/pkg/modelsdev/store.go
@@ -183,6 +183,47 @@ func (s *Store) getDatabase(ctx context.Context, allowFetch bool) (*Database, er
 	return db, nil
 }
 
+// Refresh forces a catalog fetch, bypassing the refresh interval. The ETag
+// of the on-disk cache is still sent so an unchanged catalog costs only a
+// cheap 304 round-trip. On success the catalog replaces the in-memory copies
+// and the on-disk cache. A memory-only store (no cache file, e.g. one built
+// with NewDatabaseStore) keeps serving its pre-populated database.
+func (s *Store) Refresh(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.cacheFile == "" {
+		return nil
+	}
+
+	var etag string
+	cached, err := loadFromCache(s.cacheFile)
+	if err == nil {
+		etag = cached.ETag
+	}
+
+	db, newETag, err := s.fetcher()(ctx, etag)
+	if err != nil {
+		return fmt.Errorf("failed to refresh models.dev catalog: %w", err)
+	}
+
+	// db is nil when the server returned 304 Not Modified: the cached catalog
+	// is already current, so only its LastRefresh timestamp needs bumping.
+	if db == nil {
+		if cached == nil {
+			return nil
+		}
+		db = &cached.Database
+		newETag = cached.ETag
+	}
+	if saveErr := saveToCache(s.cacheFile, db, newETag); saveErr != nil {
+		slog.WarnContext(ctx, "Failed to save refreshed catalog to cache", "error", saveErr)
+	}
+	s.db = db
+	s.cacheDB = nil
+	return nil
+}
+
 // fetcher returns the Store's catalog fetcher, defaulting to fetchFromAPI when
 // unset. The constructors always populate s.fetch, but defaulting here guards
 // against a zero-value or partially-constructed Store panicking on a nil call.

--- a/pkg/modelsdev/store_test.go
+++ b/pkg/modelsdev/store_test.go
@@ -258,6 +258,66 @@ func TestRefreshFetchError(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestRefreshInMemoryStoreReturnsError(t *testing.T) {
+	t.Parallel()
+
+	store := NewDatabaseStore(&Database{})
+	assert.Error(t, store.Refresh(t.Context()))
+}
+
+func TestRefreshNotModifiedWithoutCacheReturnsError(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewStore(
+		WithCache(filepath.Join(t.TempDir(), "models_dev.json")),
+		WithFetcher(func(context.Context, string) (*Database, string, error) {
+			return nil, "", nil
+		}),
+	)
+	require.NoError(t, err)
+	assert.Error(t, store.Refresh(t.Context()))
+}
+
+func TestRefreshDoesNotBlockReadersDuringFetch(t *testing.T) {
+	t.Parallel()
+
+	cacheFile := filepath.Join(t.TempDir(), "models_dev.json")
+	writeCache(t, cacheFile, Database{Providers: map[string]Provider{
+		"openai": {Models: map[string]Model{"gpt-4o": {Name: "GPT-4o"}}},
+	}})
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	store, err := NewStore(WithCache(cacheFile), WithFetcher(func(context.Context, string) (*Database, string, error) {
+		close(started)
+		<-release
+		return &Database{}, "", nil
+	}))
+	require.NoError(t, err)
+
+	// Warm the authoritative in-memory database before refreshing.
+	_, err = store.GetDatabase(t.Context())
+	require.NoError(t, err)
+
+	refreshDone := make(chan error, 1)
+	go func() { refreshDone <- store.Refresh(t.Context()) }()
+	<-started
+
+	readDone := make(chan struct{})
+	go func() {
+		_, _ = store.GetDatabase(t.Context())
+		close(readDone)
+	}()
+	select {
+	case <-readDone:
+	case <-time.After(time.Second):
+		t.Fatal("GetDatabase blocked behind the refresh network request")
+	}
+
+	close(release)
+	require.NoError(t, <-refreshDone)
+}
+
 func TestResolveModelAlias(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/modelsdev/store_test.go
+++ b/pkg/modelsdev/store_test.go
@@ -164,6 +164,100 @@ func BenchmarkGetModelFetchDisallowed(b *testing.B) {
 	}
 }
 
+// TestRefreshBypassesFreshCache checks that Refresh forces a fetch even when
+// the on-disk cache is fresh (GetDatabase would not have fetched), replaces
+// the memoized catalog, and rewrites the cache file.
+func TestRefreshBypassesFreshCache(t *testing.T) {
+	t.Parallel()
+
+	cacheFile := filepath.Join(t.TempDir(), "models_dev.json")
+	writeCache(t, cacheFile, Database{Providers: map[string]Provider{
+		"openai": {Models: map[string]Model{"gpt-old": {Name: "GPT Old"}}},
+	}})
+
+	fetched := false
+	store, err := NewStore(WithCache(cacheFile), WithFetcher(func(context.Context, string) (*Database, string, error) {
+		fetched = true
+		return &Database{Providers: map[string]Provider{
+			"openai": {Models: map[string]Model{"gpt-new": {Name: "GPT New"}}},
+		}}, `"etag-2"`, nil
+	}))
+	require.NoError(t, err)
+
+	// Warm the store from the fresh cache: no fetch happens.
+	_, err = store.GetModel(t.Context(), NewID("openai", "gpt-old"))
+	require.NoError(t, err)
+	assert.False(t, fetched, "a fresh cache must not trigger a fetch")
+
+	require.NoError(t, store.Refresh(t.Context()))
+	assert.True(t, fetched, "Refresh must fetch even when the cache is fresh")
+
+	// The memoized catalog now serves the refreshed data.
+	_, err = store.GetModel(t.Context(), NewID("openai", "gpt-new"))
+	require.NoError(t, err)
+	_, err = store.GetModel(t.Context(), NewID("openai", "gpt-old"))
+	require.Error(t, err)
+
+	// And the on-disk cache was rewritten with the fresh catalog and ETag.
+	cached, err := loadFromCache(cacheFile)
+	require.NoError(t, err)
+	assert.Contains(t, cached.Database.Providers["openai"].Models, "gpt-new")
+	assert.Equal(t, `"etag-2"`, cached.ETag)
+}
+
+// TestRefreshNotModifiedKeepsCache checks the 304 path: an unchanged catalog
+// keeps the cached data and only bumps its LastRefresh timestamp.
+func TestRefreshNotModifiedKeepsCache(t *testing.T) {
+	t.Parallel()
+
+	cacheFile := filepath.Join(t.TempDir(), "models_dev.json")
+	data, err := json.Marshal(CachedData{
+		Database: Database{Providers: map[string]Provider{
+			"openai": {Models: map[string]Model{"gpt-4o": {Name: "GPT-4o"}}},
+		}},
+		LastRefresh: time.Now().Add(-48 * time.Hour),
+		ETag:        `"etag-1"`,
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(cacheFile, data, 0o600))
+
+	store, err := NewStore(WithCache(cacheFile), WithFetcher(func(_ context.Context, etag string) (*Database, string, error) {
+		assert.Equal(t, `"etag-1"`, etag, "Refresh must send the cached ETag")
+		return nil, etag, nil // 304 Not Modified
+	}))
+	require.NoError(t, err)
+
+	require.NoError(t, store.Refresh(t.Context()))
+
+	m, err := store.GetModel(t.Context(), NewID("openai", "gpt-4o"))
+	require.NoError(t, err)
+	assert.Equal(t, "GPT-4o", m.Name)
+
+	cached, err := loadFromCache(cacheFile)
+	require.NoError(t, err)
+	assert.WithinDuration(t, time.Now(), cached.LastRefresh, time.Minute, "304 must bump LastRefresh")
+}
+
+// TestRefreshFetchError leaves the store usable on a failed refresh.
+func TestRefreshFetchError(t *testing.T) {
+	t.Parallel()
+
+	cacheFile := filepath.Join(t.TempDir(), "models_dev.json")
+	writeCache(t, cacheFile, Database{Providers: map[string]Provider{
+		"openai": {Models: map[string]Model{"gpt-4o": {Name: "GPT-4o"}}},
+	}})
+
+	_, fetch := trackingFetcher()
+	store, err := NewStore(WithCache(cacheFile), WithFetcher(fetch))
+	require.NoError(t, err)
+
+	require.Error(t, store.Refresh(t.Context()))
+
+	// The cached catalog still serves lookups.
+	_, err = store.GetModel(t.Context(), NewID("openai", "gpt-4o"))
+	require.NoError(t, err)
+}
+
 func TestResolveModelAlias(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runtime/lazy_model_store.go
+++ b/pkg/runtime/lazy_model_store.go
@@ -51,3 +51,11 @@ func (l *lazyModelStore) GetDatabase(ctx context.Context) (*modelsdev.Database, 
 	}
 	return st.GetDatabase(ctx)
 }
+
+func (l *lazyModelStore) Refresh(ctx context.Context) error {
+	st, err := l.load()
+	if err != nil {
+		return err
+	}
+	return st.Refresh(ctx)
+}

--- a/pkg/runtime/model_switcher.go
+++ b/pkg/runtime/model_switcher.go
@@ -188,6 +188,20 @@ func (r *LocalRuntime) SupportsModelSwitching() bool {
 	return r.modelSwitcherCfg != nil
 }
 
+// RefreshModelsCatalog forces a refetch of the models.dev catalog backing
+// the model picker, bypassing the store's refresh interval. It returns
+// [ErrUnsupported] when the runtime's model store cannot refresh (e.g. an
+// in-memory test store).
+func (r *LocalRuntime) RefreshModelsCatalog(ctx context.Context) error {
+	refresher, ok := r.modelsStore.(interface {
+		Refresh(ctx context.Context) error
+	})
+	if !ok {
+		return ErrUnsupported
+	}
+	return refresher.Refresh(ctx)
+}
+
 // CycleAgentThinkingLevel implements [Runtime.CycleAgentThinkingLevel] for
 // LocalRuntime. It reads the agent's current effective model, advances the
 // thinking-effort level by one step through the levels that specific model

--- a/pkg/tui/dialog/model_picker.go
+++ b/pkg/tui/dialog/model_picker.go
@@ -163,6 +163,8 @@ func (d *modelPickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		case key.Matches(msg, d.keyMap.Enter):
 			cmd := d.handleSelection()
 			return d, cmd
+		case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+r"))):
+			return d, core.CmdHandler(messages.RefreshModelPickerMsg{})
 		default:
 			cmd := d.handleInputChange(msg)
 			return d, cmd
@@ -384,7 +386,7 @@ func (d *modelPickerDialog) View() string {
 		AddSeparator().
 		AddContent(details).
 		AddSpace().
-		AddHelpKeys("↑/↓", "navigate", "enter", "select", "esc", "cancel").
+		AddHelpKeys("↑/↓", "navigate", "enter", "select", "ctrl+r", "refresh", "esc", "cancel").
 		Build()
 	contentBuildDuration := time.Since(contentBuildStart)
 

--- a/pkg/tui/dialog/model_picker.go
+++ b/pkg/tui/dialog/model_picker.go
@@ -29,6 +29,7 @@ type modelPickerDialog struct {
 	models   []runtime.ModelChoice
 	filtered []runtime.ModelChoice
 	errMsg   string // validation error message
+	refresh  key.Binding
 }
 
 // Model picker dialog dimension constants
@@ -80,9 +81,19 @@ var modelPickerLayout = pickerLayout{
 
 // NewModelPickerDialog creates a new model picker dialog.
 func NewModelPickerDialog(models []runtime.ModelChoice) Dialog {
+	return newModelPickerDialog(models, "")
+}
+
+// NewModelPickerDialogWithQuery creates a model picker and restores its filter.
+func NewModelPickerDialogWithQuery(models []runtime.ModelChoice, query string) Dialog {
+	return newModelPickerDialog(models, query)
+}
+
+func newModelPickerDialog(models []runtime.ModelChoice, query string) Dialog {
 	start := time.Now()
 	d := &modelPickerDialog{
 		pickerCore: newPickerCore(modelPickerLayout, "Type to search or enter custom model (provider/model)…"),
+		refresh:    key.NewBinding(key.WithKeys("ctrl+r"), key.WithHelp("ctrl+r", "refresh")),
 	}
 	d.textInput.CharLimit = 100
 
@@ -95,7 +106,7 @@ func NewModelPickerDialog(models []runtime.ModelChoice) Dialog {
 	sortDuration := time.Since(sortStart)
 	d.models = sortedModels
 	filterStart := time.Now()
-	d.filterModels()
+	d.setQuery(query)
 	slog.Debug("Model picker dialog constructed",
 		"duration", time.Since(start),
 		"sort_duration", sortDuration,
@@ -124,6 +135,11 @@ func modelSortKeys(m runtime.ModelChoice) pickerSortKeys {
 }
 
 func (d *modelPickerDialog) Init() tea.Cmd { return textinput.Blink }
+
+func (d *modelPickerDialog) setQuery(query string) {
+	d.textInput.SetValue(query)
+	d.filterModels()
+}
 
 func (d *modelPickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	// Scrollview handles mouse scrollbar, wheel, and pgup/pgdn/home/end.
@@ -163,8 +179,8 @@ func (d *modelPickerDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		case key.Matches(msg, d.keyMap.Enter):
 			cmd := d.handleSelection()
 			return d, cmd
-		case key.Matches(msg, key.NewBinding(key.WithKeys("ctrl+r"))):
-			return d, core.CmdHandler(messages.RefreshModelPickerMsg{})
+		case key.Matches(msg, d.refresh):
+			return d, core.CmdHandler(messages.RefreshModelPickerMsg{Query: d.textInput.Value()})
 		default:
 			cmd := d.handleInputChange(msg)
 			return d, cmd
@@ -386,7 +402,7 @@ func (d *modelPickerDialog) View() string {
 		AddSeparator().
 		AddContent(details).
 		AddSpace().
-		AddHelpKeys("↑/↓", "navigate", "enter", "select", "ctrl+r", "refresh", "esc", "cancel").
+		AddHelpKeys("↑/↓", "navigate", "enter", "select", d.refresh.Help().Key, d.refresh.Help().Desc, "esc", "cancel").
 		Build()
 	contentBuildDuration := time.Since(contentBuildStart)
 

--- a/pkg/tui/dialog/model_picker_test.go
+++ b/pkg/tui/dialog/model_picker_test.go
@@ -122,7 +122,8 @@ func TestModelPickerRefreshShortcut(t *testing.T) {
 
 	_, cmd := d.Update(tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
 	require.NotNil(t, cmd)
-	assert.IsType(t, messages.RefreshModelPickerMsg{}, cmd())
+	msg := cmd()
+	assert.Equal(t, messages.RefreshModelPickerMsg{}, msg)
 	assert.Empty(t, d.textInput.Value())
 	assert.Contains(t, d.View(), "refresh")
 }
@@ -155,7 +156,8 @@ func TestModelPickerRefreshShortcutWorksWithSearch(t *testing.T) {
 	_, cmd := d.Update(tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
 	assert.Equal(t, "m", d.textInput.Value())
 	require.NotNil(t, cmd)
-	assert.IsType(t, messages.RefreshModelPickerMsg{}, cmd())
+	msg := cmd()
+	assert.Equal(t, messages.RefreshModelPickerMsg{Query: "m"}, msg)
 }
 
 func TestModelPickerSorting(t *testing.T) {

--- a/pkg/tui/dialog/model_picker_test.go
+++ b/pkg/tui/dialog/model_picker_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/tui/messages"
 )
 
 func TestModelPickerNavigation(t *testing.T) {
@@ -108,6 +109,53 @@ func TestModelPickerCustomModel(t *testing.T) {
 	require.Len(t, d.filtered, 1, "should have 1 item (custom option)")
 	require.Equal(t, "Custom: openai/gpt-4", d.filtered[0].Name)
 	require.Equal(t, "openai/gpt-4", d.filtered[0].Ref)
+}
+
+func TestModelPickerRefreshShortcut(t *testing.T) {
+	t.Parallel()
+
+	d := NewModelPickerDialog([]runtime.ModelChoice{{
+		Name: "default_model", Ref: "default_model", Provider: "openai", Model: "gpt-4o", IsDefault: true,
+	}}).(*modelPickerDialog)
+	d.Init()
+	d.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
+	require.NotNil(t, cmd)
+	assert.IsType(t, messages.RefreshModelPickerMsg{}, cmd())
+	assert.Empty(t, d.textInput.Value())
+	assert.Contains(t, d.View(), "refresh")
+}
+
+func TestModelPickerRTypesIntoSearch(t *testing.T) {
+	t.Parallel()
+
+	d := NewModelPickerDialog([]runtime.ModelChoice{{
+		Name: "model_r", Ref: "model_r", Provider: "openai", Model: "gpt-4o",
+	}}).(*modelPickerDialog)
+	d.Init()
+	d.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
+
+	_, cmd := d.Update(tea.KeyPressMsg{Text: "r"})
+	assert.Equal(t, "r", d.textInput.Value())
+	assert.Nil(t, cmd)
+}
+
+func TestModelPickerRefreshShortcutWorksWithSearch(t *testing.T) {
+	t.Parallel()
+
+	d := NewModelPickerDialog([]runtime.ModelChoice{{
+		Name: "model_r", Ref: "model_r", Provider: "openai", Model: "gpt-4o",
+	}}).(*modelPickerDialog)
+	d.Init()
+	d.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
+
+	// Ctrl+R refreshes even when there is an active search.
+	d.Update(tea.KeyPressMsg{Text: "m"})
+	_, cmd := d.Update(tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
+	assert.Equal(t, "m", d.textInput.Value())
+	require.NotNil(t, cmd)
+	assert.IsType(t, messages.RefreshModelPickerMsg{}, cmd())
 }
 
 func TestModelPickerSorting(t *testing.T) {

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -586,6 +586,26 @@ func (m *appModel) handleOpenModelPicker() (tea.Model, tea.Cmd) {
 	})
 }
 
+func (m *appModel) handleRefreshModelPicker() (tea.Model, tea.Cmd) {
+	if err := m.application.RefreshModelsCatalog(m.ctx()); err != nil {
+		if !errors.Is(err, runtime.ErrUnsupported) {
+			return m, notification.ErrorCmd(fmt.Sprintf("Failed to refresh models catalog: %v", err))
+		}
+		// The runtime may discover models without models.dev (for example via a
+		// gateway); unsupported catalog refresh must not block that discovery.
+	}
+
+	models := m.application.AvailableModels(m.ctx())
+	if len(models) == 0 {
+		return m, notification.InfoCmd("No models available for selection")
+	}
+	modelDialog := dialog.NewModelPickerDialog(models)
+	return m, tea.Batch(
+		notification.SuccessCmd("Models refreshed"),
+		core.CmdHandler(dialog.OpenDialogMsg{Model: modelDialog}),
+	)
+}
+
 // handleCycleThinkingLevel advances the current agent's thinking-effort level
 // (shift+tab). On success the new level is reflected in the sidebar via the
 // re-emitted agent info; only failures surface a notification.

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -586,22 +586,47 @@ func (m *appModel) handleOpenModelPicker() (tea.Model, tea.Cmd) {
 	})
 }
 
-func (m *appModel) handleRefreshModelPicker() (tea.Model, tea.Cmd) {
-	if err := m.application.RefreshModelsCatalog(m.ctx()); err != nil {
-		if !errors.Is(err, runtime.ErrUnsupported) {
-			return m, notification.ErrorCmd(fmt.Sprintf("Failed to refresh models catalog: %v", err))
-		}
-		// The runtime may discover models without models.dev (for example via a
-		// gateway); unsupported catalog refresh must not block that discovery.
+func (m *appModel) handleRefreshModelPicker(query string) (tea.Model, tea.Cmd) {
+	if !m.application.SupportsModelSwitching() {
+		return m, notification.InfoCmd("Model switching is not supported with remote runtimes")
 	}
 
-	models := m.application.AvailableModels(m.ctx())
-	if len(models) == 0 {
+	ctx := m.ctx()
+	return m, tea.Batch(
+		notification.InfoCmd("Refreshing models…"),
+		func() tea.Msg {
+			err := m.application.RefreshModelsCatalog(ctx)
+			catalogRefreshed := err == nil
+			if errors.Is(err, runtime.ErrUnsupported) {
+				err = nil
+			}
+			if err != nil {
+				return messages.ModelPickerRefreshedMsg{Query: query, Err: err}
+			}
+			return messages.ModelPickerRefreshedMsg{
+				Models:           m.application.AvailableModels(ctx),
+				Query:            query,
+				CatalogRefreshed: catalogRefreshed,
+			}
+		},
+	)
+}
+
+func (m *appModel) handleModelPickerRefreshed(msg messages.ModelPickerRefreshedMsg) (tea.Model, tea.Cmd) {
+	if msg.Err != nil {
+		return m, notification.ErrorCmd(fmt.Sprintf("Failed to refresh models catalog: %v", msg.Err))
+	}
+	if len(msg.Models) == 0 {
 		return m, notification.InfoCmd("No models available for selection")
 	}
-	modelDialog := dialog.NewModelPickerDialog(models)
+
+	modelDialog := dialog.NewModelPickerDialogWithQuery(msg.Models, msg.Query)
+	toast := "Model list reloaded"
+	if msg.CatalogRefreshed {
+		toast = "Models refreshed"
+	}
 	return m, tea.Batch(
-		notification.SuccessCmd("Models refreshed"),
+		notification.SuccessCmd(toast),
 		core.CmdHandler(dialog.OpenDialogMsg{Model: modelDialog}),
 	)
 }

--- a/pkg/tui/messages/agent.go
+++ b/pkg/tui/messages/agent.go
@@ -1,5 +1,7 @@
 package messages
 
+import "github.com/docker/docker-agent/pkg/runtime"
+
 // Agent messages control agent switching, commands, and model selection.
 type (
 	// SwitchAgentMsg switches to a different agent.
@@ -17,7 +19,15 @@ type (
 
 	// RefreshModelPickerMsg forces a refresh of model discovery and reopens
 	// the model picker with the updated choices.
-	RefreshModelPickerMsg struct{}
+	RefreshModelPickerMsg struct{ Query string }
+
+	// ModelPickerRefreshedMsg carries the asynchronously refreshed choices.
+	ModelPickerRefreshedMsg struct {
+		Models           []runtime.ModelChoice
+		Query            string
+		Err              error
+		CatalogRefreshed bool
+	}
 
 	// ChangeModelMsg changes the model for the current agent.
 	ChangeModelMsg struct{ ModelRef string }

--- a/pkg/tui/messages/agent.go
+++ b/pkg/tui/messages/agent.go
@@ -15,6 +15,10 @@ type (
 	// OpenModelPickerMsg opens the model picker dialog.
 	OpenModelPickerMsg struct{}
 
+	// RefreshModelPickerMsg forces a refresh of model discovery and reopens
+	// the model picker with the updated choices.
+	RefreshModelPickerMsg struct{}
+
 	// ChangeModelMsg changes the model for the current agent.
 	ChangeModelMsg struct{ ModelRef string }
 

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1216,7 +1216,12 @@ func (m *appModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleOpenModelPicker()
 
 	case messages.RefreshModelPickerMsg:
-		return m.handleRefreshModelPicker()
+		_, closeCmd := m.dialogMgr.Update(dialog.CloseDialogMsg{})
+		model, refreshCmd := m.handleRefreshModelPicker(msg.Query)
+		return model, tea.Batch(closeCmd, refreshCmd)
+
+	case messages.ModelPickerRefreshedMsg:
+		return m.handleModelPickerRefreshed(msg)
 
 	case messages.ChangeModelMsg:
 		return m.handleChangeModel(msg.ModelRef)

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1215,6 +1215,9 @@ func (m *appModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case messages.OpenModelPickerMsg:
 		return m.handleOpenModelPicker()
 
+	case messages.RefreshModelPickerMsg:
+		return m.handleRefreshModelPicker()
+
 	case messages.ChangeModelMsg:
 		return m.handleChangeModel(msg.ModelRef)
 


### PR DESCRIPTION
The `/model` picker sources its list from models.dev, but that data is cached with a TTL — so newly added or changed models don't show up until the cache expires. There was no way for a user to force a fresh fetch without restarting the agent.

Pressing `Ctrl+R` in the model picker now bypasses the cache, re-fetches the models.dev catalog (and any in-memory model data), and reopens the picker with the updated choices. The current search query is preserved across the refresh so the user lands back in a filtered view rather than a blank one. Refreshes are serialized via a dedicated mutex so that rapid `Ctrl+R` presses don't stack concurrent fetches, and the store's read lock is never held during network I/O. Errors (including HTTP 304 not-modified and cache-still-valid cases) are handled gracefully and surfaced to the user rather than silently swallowed.

Tests cover cache bypass, 304/not-modified and error paths, concurrent refresh coalescing, query preservation, and the `Ctrl+R` key binding in the picker component.