### PR TITLE
docs: sandbox template contents and config version hint

### DIFF
--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -19,7 +19,7 @@ A docker-agent config has these main sections:
 
 ```bash
 # 1. Version — configuration schema version (optional but recommended)
-version: 10
+version: 12
 
 # 2. Metadata — optional agent metadata for distribution
 metadata:
@@ -294,10 +294,10 @@ For YAML editor autocompletion and validation, use the [Docker Agent JSON Schema
 
 ## Config Versioning
 
-docker-agent configs are versioned. The current version is `10`. Add the version at the top of your config:
+docker-agent configs are versioned. The current version is `12`. Add the version at the top of your config:
 
 ```yaml
-version: 10
+version: 12
 
 agents:
   root:
@@ -306,6 +306,14 @@ agents:
 ```
 
 When you load an older config, docker-agent automatically migrates it to the latest schema. It's recommended to include the version to ensure consistent behavior.
+
+If you use a config key that requires a newer schema version, docker-agent will fail with a strict-parse error and include a hint like:
+
+```
+hint: this key is supported by config version 12; update the top-level 'version' field (currently 11)
+```
+
+Bump the `version` field as directed to enable the new key.
 
 ## Metadata Section
 

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -307,7 +307,7 @@ agents:
 
 When you load an older config, docker-agent automatically migrates it to the latest schema. It's recommended to include the version to ensure consistent behavior.
 
-If you use a config key that requires a newer schema version, docker-agent will fail with a strict-parse error and include a hint like:
+If you use a config key that requires a newer schema version, Docker Agent will fail with a strict-parse error and include a hint like:
 
 ```
 hint: this key is supported by config version 12; update the top-level 'version' field (currently 11)

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -309,7 +309,7 @@ When you load an older config, docker-agent automatically migrates it to the lat
 
 If you use a config key that requires a newer schema version, Docker Agent will fail with a strict-parse error and include a hint like:
 
-```
+```text
 hint: this key is supported by config version 12; update the top-level 'version' field (currently 11)
 ```
 

--- a/docs/configuration/sandbox/index.md
+++ b/docs/configuration/sandbox/index.md
@@ -166,6 +166,12 @@ docker agent run --sandbox agent.yaml
 6. All tools (shell, filesystem, background jobs, etc.) run inside the VM.
 7. When the session ends, docker-agent exits but does not stop or remove the sandbox VM; both the VM and the kit are kept around so subsequent runs from the same workspace can reuse them. A fresh sandbox is created only when the mount set has changed.
 
+### What the default template includes
+
+The default template (`docker/sandbox-templates:docker-agent`) ships with:
+
+- **`docker-mcp`** CLI plugin — installed at `~/.docker/cli-plugins/docker-mcp`, available out of the box so agents can invoke `docker mcp` commands inside the sandbox without any additional setup.
+
 ## Auto-Kit
 
 The sandbox VM has its own filesystem and `$HOME` — none of the host's `~/.agents/skills/`, `~/.claude/skills/`, project-level `.agents/skills/`, or prompt files like `AGENTS.md` and `CLAUDE.md` are visible inside it. To bridge that gap, docker-agent automatically builds a **kit**: a self-contained directory staged on the host before the sandbox starts and bind-mounted read-only into the VM at the same path.


### PR DESCRIPTION
Documents user-visible changes from PRs merged in the last 36 hours.

**PR #3545** — install docker-mcp plugin in sbx template:
Added a "What the default template includes" subsection to `docs/configuration/sandbox/index.md` noting that `docker-mcp` is pre-installed in the default sandbox template, so agents can invoke `docker mcp` commands inside the sandbox without additional setup.

**PR #3550** — config key requires newer schema version hint:
- Updated the config version in `docs/configuration/overview/index.md` from `10` to `12` (current schema, confirmed by `agent-schema.json`).
- Added a short paragraph explaining that Docker Agent appends a helpful hint to strict-parse errors pointing users to the minimum required schema version.

**PRs already self-documented** (included docs changes in their own commits):
- #3558 (custom provider setup): `docs/providers/custom/index.md` global providers section
- #3556 (board columns): `docs/features/board/index.md`
- #3555 (skills .github/skills): `docs/features/skills/index.md`, `docs/configuration/sandbox/index.md`
- #3553 (steer/settings): `docs/features/tui/index.md`
- #3559 (hover copy/edit): `docs/features/tui/index.md`
- #3546 (single-mapping hooks): `docs/configuration/hooks/index.md`