### PR TITLE
Fix openai 1password api key resolution

### DIFF
--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -86,8 +86,19 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			slog.DebugContext(ctx, "Custom provider with no token_key, sending requests without authentication",
 				"provider", cfg.Provider, "base_url", cfg.BaseURL)
 			clientOptions = append(clientOptions, option.WithAPIKey(""))
+		default:
+			// No token_key configured: resolve OPENAI_API_KEY through the
+			// environment provider chain instead of letting the SDK read it
+			// from the OS environment. The chain resolves secret references
+			// (e.g. "op://..." via the 1Password CLI) and consults extra
+			// sources (keychain, Docker Desktop, ...); the SDK's os.Getenv
+			// fallback would send the raw reference as the bearer token.
+			if authToken, _ := env.Get(ctx, "OPENAI_API_KEY"); authToken != "" {
+				clientOptions = append(clientOptions, option.WithAPIKey(authToken))
+			}
+			// Otherwise let the OpenAI SDK use its default behavior
+			// (OPENAI_API_KEY from the OS env).
 		}
-		// Otherwise let the OpenAI SDK use its default behavior (OPENAI_API_KEY from env)
 
 		if cfg.Provider == "azure" {
 			// Azure configuration

--- a/pkg/model/provider/openai/client_auth_test.go
+++ b/pkg/model/provider/openai/client_auth_test.go
@@ -1,0 +1,97 @@
+package openai
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+)
+
+// TestNewClient_NoTokenKeyUsesEnvProvider verifies that when no token_key is
+// configured, the API key is resolved through the environment provider chain
+// rather than the SDK's os.Getenv fallback. This matters when the OS env holds
+// a secret reference (e.g. "op://vault/item/field") that the provider chain
+// resolves: the SDK fallback would send the raw reference as the bearer token.
+func TestNewClient_NoTokenKeyUsesEnvProvider(t *testing.T) {
+	// Simulate an unresolved 1Password reference in the process environment.
+	t.Setenv("OPENAI_API_KEY", "op://vault/item/field")
+
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		writeSSEResponse(w)
+	}))
+	defer server.Close()
+
+	cfg := &latest.ModelConfig{
+		Provider: "openai",
+		Model:    "gpt-4o",
+		BaseURL:  server.URL,
+	}
+	// The provider chain resolves the reference to the actual secret.
+	env := environment.NewMapEnvProvider(map[string]string{
+		"OPENAI_API_KEY": "resolved-secret",
+	})
+
+	client, err := NewClient(t.Context(), cfg, env)
+	require.NoError(t, err)
+
+	stream, err := client.CreateChatCompletionStream(t.Context(), []chat.Message{
+		{Role: chat.MessageRoleUser, Content: "hello"},
+	}, nil)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	for {
+		if _, err := stream.Recv(); err != nil {
+			break
+		}
+	}
+
+	assert.Equal(t, "Bearer resolved-secret", gotAuth,
+		"API key must come from the environment provider chain, not os.Getenv")
+}
+
+// TestNewClient_NoTokenKeyFallsBackToOSEnv verifies that the SDK's default
+// OPENAI_API_KEY behavior is preserved when the environment provider chain
+// has no value for it.
+func TestNewClient_NoTokenKeyFallsBackToOSEnv(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "os-env-key")
+
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		writeSSEResponse(w)
+	}))
+	defer server.Close()
+
+	cfg := &latest.ModelConfig{
+		Provider: "openai",
+		Model:    "gpt-4o",
+		BaseURL:  server.URL,
+	}
+	env := environment.NewMapEnvProvider(map[string]string{})
+
+	client, err := NewClient(t.Context(), cfg, env)
+	require.NoError(t, err)
+
+	stream, err := client.CreateChatCompletionStream(t.Context(), []chat.Message{
+		{Role: chat.MessageRoleUser, Content: "hello"},
+	}, nil)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	for {
+		if _, err := stream.Recv(); err != nil {
+			break
+		}
+	}
+
+	assert.Equal(t, "Bearer os-env-key", gotAuth)
+}


### PR DESCRIPTION
avoids errors like this when using the 1password cli to resolve the openai api key

```
model failed: error receiving from stream: HTTP 401: Incorrect API key provided: op://******************. You can find your API key at https://platform.openai.com/account/api-keys.
```