### PR TITLE
fix(toolexec): honor session "always allow" grant under preempt_yolo hooks

### DIFF
--- a/pkg/permissions/permissions.go
+++ b/pkg/permissions/permissions.go
@@ -60,6 +60,19 @@ func NewChecker(cfg *latest.PermissionsConfig) *Checker {
 	}
 }
 
+// NewCheckerFromRules builds a Checker directly from allow/ask/deny
+// pattern slices, for callers that hold the rules outside a
+// [latest.PermissionsConfig] (e.g. session-scoped permissions whose
+// config type lives in the session package). Semantics are identical
+// to [NewChecker].
+func NewCheckerFromRules(allow, ask, deny []string) *Checker {
+	return &Checker{
+		allowPatterns: allow,
+		askPatterns:   ask,
+		denyPatterns:  deny,
+	}
+}
+
 // Check evaluates the permission for a given tool name without arguments.
 // This is a convenience method that calls CheckWithArgs with nil arguments.
 // Evaluation order: Deny (checked first), then Allow, then Ask (default)

--- a/pkg/runtime/toolexec/dispatcher.go
+++ b/pkg/runtime/toolexec/dispatcher.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/hooks"
+	"github.com/docker/docker-agent/pkg/permissions"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/telemetry"
 	"github.com/docker/docker-agent/pkg/telemetry/genai"
@@ -392,6 +393,18 @@ func (c *call) approveAndRun(ctx context.Context, runTool func() CallOutcome) Ca
 			c.errorResponse(ctx, rejectMsg)
 			return CallOutcome{}
 		case hooks.DecisionAsk:
+			// A session-scoped allow grant (the interactive "T = always
+			// allow this tool" decision, stored in sess.Permissions) is an
+			// informed opt-in the user made in response to this very safety
+			// prompt. Honor it instead of asking again, otherwise "always
+			// allow" would re-prompt on every matching call. The blanket
+			// --yolo and the team/config permission layer stay subordinate
+			// to the preempt-yolo verdict — see [call.sessionPermissionsAllow].
+			if c.sessionPermissionsAllow() {
+				slog.DebugContext(ctx, "preempt-yolo Ask overridden by session permission allow", "tool", c.tc.Function.Name, "session_id", c.sess.ID)
+				c.notifyApproval(ctx, ApprovalDecisionAllow, ApprovalSourceSessionPermissionsAllow)
+				return runTool()
+			}
 			return c.askUser(ctx, runTool)
 		}
 		// DecisionAllow / "" → advisory; fall through to Decide().
@@ -452,10 +465,48 @@ func (c *call) permissionDecision(readOnlyHint bool) PermissionDecision {
 
 func (c *call) autoApprovalAfterConfirmationWait() (PermissionDecision, bool) {
 	if c.preYoloResult != nil && c.preYoloResult.Decision == hooks.DecisionAsk {
+		// Even under a preempt-yolo Ask, a session-scoped allow grant that
+		// landed while we were blocked on the resume channel (e.g. a
+		// concurrent "always allow this tool" decision) is an informed
+		// opt-in and takes effect. Mirrors approveAndRun's Stage 0: the
+		// blanket --yolo and the team/config layer stay subordinate.
+		if c.sessionPermissionsAllow() {
+			return PermissionDecision{Outcome: OutcomeAllow, Reason: ReasonChecker, Source: sessionPermissionsSource}, true
+		}
 		return PermissionDecision{}, false
 	}
 	decision := c.permissionDecision(c.tool.Annotations.ReadOnlyHint)
 	return decision, decision.Outcome == OutcomeAllow
+}
+
+// sessionPermissionsAllow reports whether the session-scoped permission
+// layer explicitly allows this call. That layer (sess.Permissions) is
+// populated by the interactive "T = always allow this tool" grant and the
+// session-permissions API/template — informed, session-scoped opt-ins —
+// as opposed to the team/config layer (global settings + agent YAML) and
+// the blanket --yolo, both of which the preempt-yolo lane must keep
+// guarding.
+//
+// It is consulted when the preempt-yolo pre_tool_use lane wants to Ask so
+// that a grant the user made in response to that safety prompt actually
+// takes effect. Deny/Ask patterns in the same layer are honored via
+// [permissions.Checker.CheckWithArgs] ordering (Deny > Allow > Ask), so a
+// session-level Deny or explicit Ask never yields an allow here.
+func (c *call) sessionPermissionsAllow() bool {
+	c.d.approvalMu.Lock()
+	defer c.d.approvalMu.Unlock()
+	if c.sess.Permissions == nil {
+		return false
+	}
+	checker := permissions.NewCheckerFromRules(
+		c.sess.Permissions.Allow,
+		c.sess.Permissions.Ask,
+		c.sess.Permissions.Deny,
+	)
+	return checker.CheckWithArgs(
+		c.tc.Function.Name,
+		ParseToolInput(c.tc.Function.Arguments),
+	) == permissions.Allow
 }
 
 func (c *call) cancellationMessage(ctx context.Context) string {
@@ -608,11 +659,17 @@ func allowSourceForDecision(d PermissionDecision) string {
 	return allowSourceForChecker(d.Source)
 }
 
+// sessionPermissionsSource is the checker source label the runtime
+// attaches to the session-scoped permission checker (see
+// pkg/runtime.permissionCheckers). It distinguishes interactive /
+// session-scoped grants from the team/config layer.
+const sessionPermissionsSource = "session permissions"
+
 // allowSourceForChecker maps a checker source label ("session permissions"
 // or "permissions configuration") onto the corresponding ApprovalSource*
 // allow constant.
 func allowSourceForChecker(checkerSource string) string {
-	if checkerSource == "session permissions" {
+	if checkerSource == sessionPermissionsSource {
 		return ApprovalSourceSessionPermissionsAllow
 	}
 	return ApprovalSourceTeamPermissionsAllow
@@ -620,7 +677,7 @@ func allowSourceForChecker(checkerSource string) string {
 
 // denySourceForChecker mirrors allowSourceForChecker for the deny path.
 func denySourceForChecker(checkerSource string) string {
-	if checkerSource == "session permissions" {
+	if checkerSource == sessionPermissionsSource {
 		return ApprovalSourceSessionPermissionsDeny
 	}
 	return ApprovalSourceTeamPermissionsDeny

--- a/pkg/runtime/toolexec/dispatcher_test.go
+++ b/pkg/runtime/toolexec/dispatcher_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/hooks"
+	"github.com/docker/docker-agent/pkg/permissions"
 	"github.com/docker/docker-agent/pkg/runtime/toolexec"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tools"
@@ -846,6 +847,113 @@ func TestDispatcher_PreToolUsePreYoloAskPreemptsYolo(t *testing.T) {
 	require.Len(t, em.responses, 1)
 	assert.True(t, em.responses[0].IsError)
 	assert.Contains(t, em.responses[0].Output, "canceled by the user")
+}
+
+// TestDispatcher_PreToolUsePreYoloAskHonorsSessionAllow pins the fix
+// for the "always allow this tool" grant being ignored under a
+// preempt-yolo hook: a session-scoped allow pattern (the interactive
+// "T" decision, stored in sess.Permissions) must auto-run a matching
+// call even when the preempt-yolo lane returns Ask. Without this the
+// user is re-prompted on every matching call despite having chosen
+// "always allow".
+func TestDispatcher_PreToolUsePreYoloAskHonorsSessionAllow(t *testing.T) {
+	t.Parallel()
+
+	a := newAgent()
+	sess := session.New()
+	// The exact pattern BuildPermissionPattern produces for a "T" grant
+	// on `mkdir foo`.
+	sess.Permissions = &session.PermissionsConfig{Allow: []string{"shell:cmd=mkdir*"}}
+
+	ran := false
+	tool := tools.Tool{
+		Name: "shell",
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
+			ran = true
+			return tools.ResultSuccess("ok"), nil
+		},
+	}
+
+	hd := &stubHookDispatcher{
+		on: map[hooks.EventType]*hooks.Result{
+			hooks.EventPreToolUsePreYolo: {
+				Allowed:        true,
+				Decision:       hooks.DecisionAsk,
+				DecisionReason: "unknown command",
+			},
+		},
+	}
+
+	d := &toolexec.Dispatcher{
+		AgentFor: func(*session.Session) *agent.Agent { return a },
+		Hooks:    hd,
+	}
+	em := &captureEmitter{}
+
+	d.Process(t.Context(), sess, []tools.ToolCall{{
+		ID:       "x",
+		Function: tools.FunctionCall{Name: "shell", Arguments: `{"cmd":"mkdir bar"}`},
+	}}, []tools.Tool{tool}, em)
+
+	assert.True(t, ran, "session allow grant must auto-run despite preempt-yolo Ask")
+	assert.Empty(t, em.confirmations, "an informed 'always allow' grant must not re-prompt")
+}
+
+// TestDispatcher_PreToolUsePreYoloAskGuardsTeamAllow pins the boundary
+// of the fix: a matching allow pattern in the TEAM/config layer (the
+// dispatcher's Permissions checker, e.g. global settings or agent YAML)
+// must NOT override a preempt-yolo Ask — that ahead-of-time,
+// non-interactive layer is exactly what the safety lane keeps guarding.
+// Only the session-scoped layer (interactive grants) overrides.
+func TestDispatcher_PreToolUsePreYoloAskGuardsTeamAllow(t *testing.T) {
+	t.Parallel()
+
+	a := newAgent()
+	sess := session.New() // no session-scoped permissions
+
+	tool := tools.Tool{
+		Name: "shell",
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
+			panic("must not run: team allow must stay subordinate to preempt-yolo")
+		},
+	}
+
+	hd := &stubHookDispatcher{
+		on: map[hooks.EventType]*hooks.Result{
+			hooks.EventPreToolUsePreYolo: {
+				Allowed:        true,
+				Decision:       hooks.DecisionAsk,
+				DecisionReason: "unknown command",
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	d := &toolexec.Dispatcher{
+		AgentFor: func(*session.Session) *agent.Agent { return a },
+		Hooks:    hd,
+		// A team/config-layer allow that matches the call. It must be
+		// ignored on the preempt-yolo Ask path.
+		Permissions: func(*session.Session) []toolexec.NamedChecker {
+			return []toolexec.NamedChecker{{
+				Checker: permissions.NewCheckerFromRules([]string{"shell:cmd=mkdir*"}, nil, nil),
+				Source:  "permissions configuration",
+			}}
+		},
+	}
+	em := &captureEmitter{confirmed: make(chan struct{})}
+	go func() {
+		<-em.confirmed
+		cancel()
+	}()
+
+	d.Process(ctx, sess, []tools.ToolCall{{
+		ID:       "x",
+		Function: tools.FunctionCall{Name: "shell", Arguments: `{"cmd":"mkdir bar"}`},
+	}}, []tools.Tool{tool}, em)
+
+	require.Len(t, em.confirmations, 1, "team/config allow must not override preempt-yolo Ask")
 }
 
 // TestDispatcher_PreToolUsePreYoloDenyShortCircuits pins the Deny


### PR DESCRIPTION
## What

Makes the **"T — always allow this tool"** confirmation choice actually stick when a `preempt_yolo` pre_tool_use hook (e.g. the `safer_shell` builtin) is active.

Fixes #3569.

## Why

Pressing **T** stores a session-scoped allow pattern (e.g. `shell:cmd=mkdir*`) in `sess.Permissions.Allow`. But the `preempt_yolo` lane runs at **Stage 0** of `approveAndRun`, before `Decide()` — and on an `Ask` verdict it jumps straight to `askUser`, so the stored grant is never consulted. Result: the dialog offers a T button that the very hook which raised the dialog then ignores, and the user is re-prompted on every matching call.

Without a `preempt_yolo` hook, T works correctly — the bug is specific to that lane.

## How

The `preempt_yolo` lane must keep overriding *blanket, ahead-of-time* approvals (`--yolo`/`ToolsApproved` and team/config allow-lists) — that's its purpose. But an **interactive, informed, session-scoped** grant, made *in response to* the safety prompt, should be honored. The architecture already separates these: interactive grants live in `sess.Permissions`; ahead-of-time config lives in the separate team checker.

- **`pkg/permissions`**: add `NewCheckerFromRules(allow, ask, deny)` so `toolexec` can build a session-scoped checker without depending on `config/latest`.
- **`pkg/runtime/toolexec/dispatcher.go`**:
  - add `call.sessionPermissionsAllow()` — checks **only** `sess.Permissions`, with `Deny > Allow > Ask` ordering preserved within that layer.
  - consult it in Stage 0's `Ask` branch and in `autoApprovalAfterConfirmationWait()` (concurrent-grant race).
  - extract the `"session permissions"` source label into a const.

### Boundaries preserved
- `--yolo` / "approve all" (`ToolsApproved`) → still guarded (not a session allow *pattern*).
- Team/config allow-lists (global settings, agent YAML) → still guarded (separate checker).
- Only the interactive session-scoped allow overrides the preempt-yolo `Ask`.

## Tests

- `TestDispatcher_PreToolUsePreYoloAskHonorsSessionAllow` — session allow grant auto-runs a matching call under a preempt-yolo `Ask` (the fix).
- `TestDispatcher_PreToolUsePreYoloAskGuardsTeamAllow` — a matching *team/config* allow does **not** override the `Ask` (the safety boundary).
- Existing `TestDispatcher_PreToolUsePreYoloAskPreemptsYolo` still passes (`--yolo` stays subordinate).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/runtime/toolexec/ ./pkg/permissions/`
- [x] `go test ./pkg/runtime/... ./pkg/permissions/...`
