### PR TITLE
fix(tui): show agent badge before reasoning

### DIFF
--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -1388,6 +1388,7 @@ func (m *model) LoadFromSession(sess *session.Session) tea.Cmd {
 
 		// Create new reasoning block
 		block := reasoningblock.New(nextBlockID(), agentName, m.sessionState)
+		block.SetShowAgentBadge(showReasoningAgentBadge(m.lastMessage(), agentName))
 		block.SetSize(m.contentWidth(), 0)
 
 		blockMsg := &types.Message{
@@ -1690,6 +1691,35 @@ func (m *model) AppendReasoning(agentName, content string) tea.Cmd {
 	return m.addReasoningBlock(agentName, content)
 }
 
+// lastMessage returns the most recently appended message, or nil when empty.
+func (m *model) lastMessage() *types.Message {
+	if len(m.messages) == 0 {
+		return nil
+	}
+	return m.messages[len(m.messages)-1]
+}
+
+// showReasoningAgentBadge reports whether a new reasoning block for agentName
+// should render its agent badge. Mirrors message.sameAgentAsPrevious: the
+// badge is hidden only when the block visually continues content from the
+// same agent (assistant text, reasoning, or tool activity). In particular, a
+// transfer_task tool call is sent by the parent agent, so reasoning from the
+// sub-agent that follows it shows the sub-agent's badge.
+func showReasoningAgentBadge(previous *types.Message, agentName string) bool {
+	if previous == nil || previous.Sender != agentName {
+		return true
+	}
+	switch previous.Type {
+	case types.MessageTypeAssistant,
+		types.MessageTypeAssistantReasoningBlock,
+		types.MessageTypeToolCall,
+		types.MessageTypeToolResult:
+		return false
+	default:
+		return true
+	}
+}
+
 // addReasoningBlock creates a new reasoning block message.
 //
 // Reasoning blocks routinely interleave with an actively streaming assistant
@@ -1710,6 +1740,7 @@ func (m *model) addReasoningBlock(agentName, content string) tea.Cmd {
 	}
 
 	block := reasoningblock.New(nextBlockID(), agentName, m.sessionState)
+	block.SetShowAgentBadge(showReasoningAgentBadge(m.lastMessage(), agentName))
 	block.SetReasoning(content)
 	block.SetSize(m.contentWidth(), 0)
 

--- a/pkg/tui/components/messages/messages_test.go
+++ b/pkg/tui/components/messages/messages_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/builtin/transfertask"
 	"github.com/docker/docker-agent/pkg/tui/animation"
 	"github.com/docker/docker-agent/pkg/tui/components/message"
 	"github.com/docker/docker-agent/pkg/tui/components/reasoningblock"
@@ -1238,6 +1239,159 @@ func TestAddOrUpdateToolCallFindsToolInNonActiveReasoningBlock(t *testing.T) {
 	require.True(t, ok)
 	assert.True(t, block.HasToolCall("call_1"))
 	assert.Equal(t, 1, block.ToolCount(), "reasoning block should still have exactly one tool call")
+}
+
+func TestAppendReasoningAfterTransferTaskShowsAgentBadge(t *testing.T) {
+	t.Parallel()
+
+	sessionState := &service.SessionState{}
+	m := NewScrollableView(80, 24, sessionState).(*model)
+	m.SetSize(80, 24)
+
+	// root delegates to developer: the transfer_task tool call is sent by the
+	// parent agent...
+	transferCall := tools.ToolCall{
+		ID:       "call_transfer",
+		Function: tools.FunctionCall{Name: transfertask.ToolNameTransferTask, Arguments: `{"agent":"developer","task":"fix it"}`},
+	}
+	m.AddOrUpdateToolCall("root", transferCall, tools.Tool{Name: transfertask.ToolNameTransferTask}, types.ToolStatusCompleted)
+
+	// ...and the sub-agent starts its turn with reasoning.
+	m.AppendReasoning("developer", "Analyzing the request...")
+
+	require.Len(t, m.messages, 2)
+	require.Equal(t, types.MessageTypeAssistantReasoningBlock, m.messages[1].Type)
+	block, ok := m.views[1].(*reasoningblock.Model)
+	require.True(t, ok)
+
+	view := ansi.Strip(block.View())
+	badgeIdx := strings.Index(view, "developer")
+	thinkingIdx := strings.Index(view, "Thinking")
+	require.GreaterOrEqual(t, badgeIdx, 0, "reasoning block should render the developer badge")
+	require.GreaterOrEqual(t, thinkingIdx, 0)
+	assert.Less(t, badgeIdx, thinkingIdx, "agent badge should render before the Thinking header")
+}
+
+func TestAppendReasoningContinuingSameAgentOmitsAgentBadge(t *testing.T) {
+	t.Parallel()
+
+	sessionState := &service.SessionState{}
+	m := NewScrollableView(80, 24, sessionState).(*model)
+	m.SetSize(80, 24)
+
+	m.AddUserMessage("hi")
+	m.AppendToLastMessage("developer", "Here is a first answer.")
+	m.AppendReasoning("developer", "Reconsidering the answer...")
+
+	require.Len(t, m.messages, 3)
+	require.Equal(t, types.MessageTypeAssistantReasoningBlock, m.messages[2].Type)
+	block, ok := m.views[2].(*reasoningblock.Model)
+	require.True(t, ok)
+
+	view := ansi.Strip(block.View())
+	assert.NotContains(t, view, "developer", "no badge when the block continues the same agent's content")
+	assert.Contains(t, view, "Thinking")
+}
+
+func TestLoadFromSessionReasoningBlockAgentBadges(t *testing.T) {
+	t.Parallel()
+
+	sessionState := &service.SessionState{}
+	m := NewScrollableView(80, 24, sessionState).(*model)
+	m.SetSize(80, 24)
+
+	sess := &session.Session{
+		ID: "test-session",
+		Messages: []session.Item{
+			session.NewMessageItem(&session.Message{
+				Message: chat.Message{Role: chat.MessageRoleUser, Content: "Hello"},
+			}),
+			session.NewMessageItem(&session.Message{
+				AgentName: "root",
+				Message: chat.Message{
+					Role:             chat.MessageRoleAssistant,
+					ReasoningContent: "First thoughts.",
+					Content:          "Answer one.",
+				},
+			}),
+			session.NewMessageItem(&session.Message{
+				AgentName: "root",
+				Message: chat.Message{
+					Role:             chat.MessageRoleAssistant,
+					ReasoningContent: "Second thoughts.",
+					Content:          "Answer two.",
+				},
+			}),
+		},
+	}
+
+	m.LoadFromSession(sess)
+
+	// user + (reasoning block + content) x 2
+	require.Len(t, m.messages, 5)
+
+	first, ok := m.views[1].(*reasoningblock.Model)
+	require.True(t, ok)
+	assert.Contains(t, ansi.Strip(first.View()), "root",
+		"the block starting the agent's turn should show its badge")
+
+	second, ok := m.views[3].(*reasoningblock.Model)
+	require.True(t, ok)
+	assert.NotContains(t, ansi.Strip(second.View()), "root",
+		"no badge when the block continues the same agent's content")
+}
+
+func TestLoadFromSessionReasoningAfterTransferTaskShowsAgentBadge(t *testing.T) {
+	t.Parallel()
+
+	sessionState := &service.SessionState{}
+	m := NewScrollableView(80, 24, sessionState).(*model)
+	m.SetSize(80, 24)
+
+	sess := &session.Session{
+		ID: "test-session",
+		Messages: []session.Item{
+			// root delegates to developer: the transfer_task tool call is
+			// sent by the parent agent...
+			session.NewMessageItem(&session.Message{
+				AgentName: "root",
+				Message: chat.Message{
+					Role: chat.MessageRoleAssistant,
+					ToolCalls: []tools.ToolCall{
+						{ID: "call_transfer", Function: tools.FunctionCall{Name: transfertask.ToolNameTransferTask, Arguments: `{"agent":"developer","task":"fix it"}`}},
+					},
+					ToolDefinitions: []tools.Tool{
+						{Name: transfertask.ToolNameTransferTask},
+					},
+				},
+			}),
+			// ...and the sub-agent starts its turn with reasoning.
+			session.NewMessageItem(&session.Message{
+				AgentName: "developer",
+				Message: chat.Message{
+					Role:             chat.MessageRoleAssistant,
+					ReasoningContent: "Analyzing the request...",
+				},
+			}),
+		},
+	}
+
+	m.LoadFromSession(sess)
+
+	// standalone transfer_task tool call + developer reasoning block
+	require.Len(t, m.messages, 2)
+	assert.Equal(t, types.MessageTypeToolCall, m.messages[0].Type)
+	assert.Equal(t, "root", m.messages[0].Sender)
+	require.Equal(t, types.MessageTypeAssistantReasoningBlock, m.messages[1].Type)
+	block, ok := m.views[1].(*reasoningblock.Model)
+	require.True(t, ok)
+
+	view := ansi.Strip(block.View())
+	badgeIdx := strings.Index(view, "developer")
+	thinkingIdx := strings.Index(view, "Thinking")
+	require.GreaterOrEqual(t, badgeIdx, 0, "reasoning block should render the developer badge")
+	require.GreaterOrEqual(t, thinkingIdx, 0)
+	assert.Less(t, badgeIdx, thinkingIdx, "agent badge should render before the Thinking header")
 }
 
 func TestBindingsExcludesEditKeyWhenAssistantMessageSelected(t *testing.T) {

--- a/pkg/tui/components/reasoningblock/reasoningblock.go
+++ b/pkg/tui/components/reasoningblock/reasoningblock.go
@@ -107,6 +107,7 @@ type expandedToolView interface {
 type Model struct {
 	id                  string
 	agentName           string
+	showAgentBadge      bool          // render the agent badge above the header
 	contentItems        []contentItem // Ordered sequence of reasoning and tool calls
 	toolEntries         []toolEntry   // All tool entries (referenced by contentItems)
 	expanded            bool
@@ -142,6 +143,15 @@ func (m *Model) ID() string {
 // AgentName returns the agent name for this block.
 func (m *Model) AgentName() string {
 	return m.agentName
+}
+
+// SetShowAgentBadge controls whether the block renders the agent badge above
+// the Thinking header. The messages list enables it when the block does not
+// visually continue content from the same agent (e.g. reasoning that starts a
+// sub-agent's turn right after a transfer_task), mirroring the sender prefix
+// on standard assistant messages.
+func (m *Model) SetShowAgentBadge(show bool) {
+	m.showAgentBadge = show
 }
 
 // SetReasoning sets reasoning content (replaces all content items with a single reasoning item).
@@ -461,10 +471,30 @@ func (m *Model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 
 // View renders the block.
 func (m *Model) View() string {
+	var content string
 	if m.expanded {
-		return m.renderExpanded()
+		content = m.renderExpanded()
+	} else {
+		content = m.renderCollapsed()
 	}
-	return m.renderCollapsed()
+	return m.agentBadgePrefix() + content
+}
+
+// rendersAgentBadge reports whether the agent badge actually renders: it
+// must be enabled and the agent name non-empty. Both rendering
+// (agentBadgePrefix) and hit-testing (headerLineIndex) rely on this single
+// condition so they can never diverge.
+func (m *Model) rendersAgentBadge() bool {
+	return m.showAgentBadge && m.agentName != ""
+}
+
+// agentBadgePrefix returns the agent badge line plus a blank separator when
+// enabled, using the same style and spacing as standard assistant messages.
+func (m *Model) agentBadgePrefix() string {
+	if !m.rendersAgentBadge() {
+		return ""
+	}
+	return styles.AgentBadgeStyleFor(m.agentName).MarginLeft(2).Render(m.agentName) + "\n\n"
 }
 
 // SetSize sets the component dimensions.
@@ -737,9 +767,18 @@ func (m *Model) StopAnimation() {
 	}
 }
 
-// IsHeaderLine returns true if the given line index is the header (line 0).
+// headerLineIndex returns the view line index of the Thinking header. The
+// agent badge, when shown, occupies two lines (badge + blank) above it.
+func (m *Model) headerLineIndex() int {
+	if m.rendersAgentBadge() {
+		return 2
+	}
+	return 0
+}
+
+// IsHeaderLine returns true if the given line index is the header line.
 func (m *Model) IsHeaderLine(lineIdx int) bool {
-	return lineIdx == 0
+	return lineIdx == m.headerLineIndex()
 }
 
 // IsToggleLine returns true if clicking this line should toggle the block.

--- a/pkg/tui/components/reasoningblock/reasoningblock_test.go
+++ b/pkg/tui/components/reasoningblock/reasoningblock_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -328,6 +329,38 @@ func TestReasoningBlockHeaderFooterLineDetection(t *testing.T) {
 	assert.True(t, block.IsHeaderLine(0))
 	assert.True(t, block.IsToggleLine(0))
 	assert.False(t, block.IsToggleLine(1)) // Body line
+}
+
+func TestReasoningBlockAgentBadge(t *testing.T) {
+	t.Parallel()
+
+	sessionState := &service.SessionState{}
+	block := New("test-badge", "developer", sessionState)
+	block.SetSize(80, 24)
+	block.SetReasoning("Working through the problem.")
+	// Expand so the header is toggleable regardless of extra content;
+	// otherwise IsToggleLine would be false everywhere and prove nothing.
+	block.SetExpanded(true)
+
+	// Badge is off by default: the header sits on line 0 and toggles there.
+	assert.NotContains(t, ansi.Strip(block.View()), "developer")
+	assert.True(t, block.IsHeaderLine(0))
+	assert.True(t, block.IsToggleLine(0))
+
+	block.SetShowAgentBadge(true)
+	stripped := ansi.Strip(block.View())
+	badgeIdx := strings.Index(stripped, "developer")
+	thinkingIdx := strings.Index(stripped, "Thinking")
+	require.GreaterOrEqual(t, badgeIdx, 0, "badge should be rendered")
+	require.GreaterOrEqual(t, thinkingIdx, 0)
+	assert.Less(t, badgeIdx, thinkingIdx, "badge should render before the Thinking header")
+
+	// The badge and its blank separator shift the header down by two lines,
+	// for hit-testing as well as rendering.
+	assert.False(t, block.IsHeaderLine(0))
+	assert.False(t, block.IsToggleLine(0))
+	assert.True(t, block.IsHeaderLine(2))
+	assert.True(t, block.IsToggleLine(2))
 }
 
 func TestReasoningBlockMultipleToolCalls(t *testing.T) {


### PR DESCRIPTION
## Summary

Display the active agent badge before a reasoning block when the block starts a new agent turn, including immediately after a `transfer_task`.

## Before

```text
root calls developer

✓ Fix the issue

Thinking
Analyzing the request...
```

## After

```text
root calls developer

✓ Fix the issue

developer

Thinking
Analyzing the request...
```

## Expected behavior

| Expectation | Implementation |
|---|---|
| Show the new agent after a handoff | The reasoning block renders the transferred agent badge before `Thinking` |
| Support reasoning as the first event | Both live streaming and restored sessions determine the badge when creating a reasoning block |
| Avoid redundant labels | The badge is omitted when reasoning continues content from the same agent |
| Preserve reasoning interactions | Header and toggle hit-testing account for the additional badge lines |

## Validation

| Check | Result |
|---|---|
| Build | passed |
| TUI test suite | passed |
| Lint | passed |
| Adversarial review | no blocker or major finding |
