### PR TITLE
feat(runtime): orchestrate targeted cross-agent compaction

### DIFF
--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -84,7 +84,7 @@ Type `/` during a session to see available commands, or press <kbd>Ctrl</kbd>+<k
 | `/attach`          | Attach a file to your message                                                        |
 | `/shell`           | Open a shell                                                                         |
 | `/star`            | Star/unstar the current session                                                      |
-| `/context`         | Show a context-window breakdown: estimated tokens per category (system prompt, tool definitions, prompt files, messages, tool results, compaction summary), plus a per-file inventory of attached files and prompt files. Select an attached file with the arrow keys and press <kbd>d</kbd> to drop it |
+| `/context`         | Show a context-window breakdown: estimated tokens per category (system prompt, tool definitions, prompt files, messages, tool results, compaction summary), a team-level **Live sessions** view (the current session plus every running sub-agent session with its agent, short session ID, and context budget), plus a per-file inventory of attached files and prompt files. Use the arrow keys to select a row: press <kbd>Enter</kbd> on a live session to explicitly compact it, or <kbd>d</kbd> on an attached file to drop it |
 | `/drop`            | Remove an attached file from the session context (`/drop <path>`, or `/drop` alone to review and drop from the `/context` dialog)  |
 | `/cost`            | Show cost breakdown for this session                                                 |
 | `/eval`            | Create an evaluation report                                                          |
@@ -205,6 +205,12 @@ Explain what the code in @pkg/agent/agent.go does
 The agent receives the full file contents in a structured `<attachments>` block, while the UI shows just the reference.
 
 Attached files are also recorded on the session so sub-agents spawned by task transfer can read them. To review what is attached, open `/context`: the dialog lists every attached file (and resolved prompt file) with a per-file token estimate. Use <kbd>↑</kbd>/<kbd>↓</kbd> to select an attached file and press <kbd>d</kbd> (or <kbd>x</kbd>/<kbd>Del</kbd>) to drop it, or run `/drop <path>` directly. Dropping stops sharing the file with sub-agents and skills; content already inlined in earlier messages stays in the conversation until compaction, and the file can always be re-attached with `@` or `/attach`.
+
+### Team Context Budgets and Targeted Compaction
+
+The `/context` dialog also shows a **Live sessions** section: the current session plus every currently running sub-agent session (foreground children spawned by task transfer and long-running `run_background_agent` tasks). Each row shows the agent name, a short session ID (so two concurrent runs of the same agent stay distinguishable), and that session's context budget: used tokens, context limit, and percentage, or an explicit "limit unknown" reading when the model's window cannot be resolved.
+
+Select a live session with <kbd>↑</kbd>/<kbd>↓</kbd> and press <kbd>Enter</kbd> to explicitly compact it. Cross-agent compaction happens only on this explicit request: no idle-triggered automatic compaction is added, and the existing automatic threshold and overflow-recovery compaction of sub-agent sessions is unchanged. The request is queued onto the target session's own run loop and executes at the next safe point between model turns, so it cannot corrupt an in-flight turn. The dialog closes and a notification confirms the request; a second notification reports the outcome (compacted, skipped, or failed) with the agent's name. Selecting the main row runs the same compaction as `/compact`. `/compact` itself keeps compacting the current root session. Remote runtimes do not expose live-session tracking, so the section is omitted there.
 
 ## Runtime Model Switching
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -988,6 +988,49 @@ func (a *App) ContextBreakdown(ctx context.Context) (*runtime.ContextBreakdown, 
 	return cp.ContextBreakdown(ctx, a.Session())
 }
 
+// liveSessionLister is an optional runtime capability: listing the current
+// root session plus every live sub-agent session for the /context team view.
+// Only the local runtime (which owns the RunStream registry) implements it;
+// remote runtimes degrade to a root-only view.
+type liveSessionLister interface {
+	LiveSessions(ctx context.Context, current *session.Session) []runtime.LiveSession
+}
+
+// LiveSessions returns the current root session plus every currently live
+// sub-agent session (foreground children and background agent tasks), or nil
+// when the runtime does not expose live-session tracking.
+func (a *App) LiveSessions(ctx context.Context) []runtime.LiveSession {
+	lister, ok := a.runtime.(liveSessionLister)
+	if !ok {
+		return nil
+	}
+	return lister.LiveSessions(ctx, a.Session())
+}
+
+// liveSessionCompactor is an optional runtime capability: queueing an
+// explicit compaction of one live session onto that session's own run loop.
+type liveSessionCompactor interface {
+	CompactLiveSession(ctx context.Context, sessionID, additionalPrompt string, events runtime.EventSink) error
+}
+
+// CompactLiveSession queues a manual compaction for the identified live
+// session and bridges the resulting compaction/usage events into the app's
+// event stream. The request executes on the target session's own run loop at
+// a safe iteration boundary; neither the root stream nor the target stream
+// is cancelled. Returns an error wrapping [runtime.ErrUnsupported] when the
+// runtime cannot target live sessions (e.g. remote runtimes), or the
+// runtime's rejection for unknown/finished sessions and duplicate requests.
+func (a *App) CompactLiveSession(ctx context.Context, sessionID, additionalPrompt string) error {
+	compactor, ok := a.runtime.(liveSessionCompactor)
+	if !ok {
+		return fmt.Errorf("targeted session compaction: %w", runtime.ErrUnsupported)
+	}
+	sink := runtime.EventSinkFunc(func(event runtime.Event) {
+		a.sendEvent(ctx, event)
+	})
+	return compactor.CompactLiveSession(ctx, sessionID, additionalPrompt, sink)
+}
+
 // DropAttachedFile removes a file from the current session's attached files
 // and returns the absolute path that was dropped. The path is resolved
 // against the session's attachment list: exact match first, then the

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -646,4 +647,90 @@ func TestResolveAttachedFile_RelativePath(t *testing.T) {
 	resolved, err := resolveAttachedFile([]string{abs}, "notes.md")
 	require.NoError(t, err)
 	assert.Equal(t, abs, resolved)
+}
+
+// liveSessionsMockRuntime layers the optional live-session capabilities
+// (LiveSessions, CompactLiveSession) over the base mock runtime.
+type liveSessionsMockRuntime struct {
+	mockRuntime
+
+	rows        []runtime.LiveSession
+	lastCurrent *session.Session
+	compactedID string
+	compactErr  error
+}
+
+func (m *liveSessionsMockRuntime) LiveSessions(_ context.Context, current *session.Session) []runtime.LiveSession {
+	m.lastCurrent = current
+	return m.rows
+}
+
+func (m *liveSessionsMockRuntime) CompactLiveSession(_ context.Context, sessionID, _ string, events runtime.EventSink) error {
+	if m.compactErr != nil {
+		return m.compactErr
+	}
+	m.compactedID = sessionID
+	events.Emit(runtime.SessionCompactionCompleted(sessionID, runtime.CompactionOutcomeApplied, "worker"))
+	return nil
+}
+
+func TestApp_LiveSessions_UnsupportedRuntime(t *testing.T) {
+	t.Parallel()
+
+	app := New(t.Context(), &mockRuntime{}, session.New())
+	assert.Nil(t, app.LiveSessions(t.Context()),
+		"runtimes without live-session tracking degrade to an empty team view")
+}
+
+func TestApp_CompactLiveSession_UnsupportedRuntime(t *testing.T) {
+	t.Parallel()
+
+	app := New(t.Context(), &mockRuntime{}, session.New())
+	err := app.CompactLiveSession(t.Context(), "some-session", "")
+	require.ErrorIs(t, err, runtime.ErrUnsupported)
+}
+
+func TestApp_LiveSessions_PassesCurrentSession(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	rt := &liveSessionsMockRuntime{rows: []runtime.LiveSession{
+		{SessionID: sess.ID, AgentName: "root", Current: true},
+		{SessionID: "child-1", AgentName: "worker"},
+	}}
+	app := New(t.Context(), rt, sess)
+
+	rows := app.LiveSessions(t.Context())
+	require.Len(t, rows, 2)
+	assert.Same(t, sess, rt.lastCurrent, "the app's current session drives the root row")
+}
+
+func TestApp_CompactLiveSession_BridgesEventsIntoStream(t *testing.T) {
+	t.Parallel()
+
+	rt := &liveSessionsMockRuntime{}
+	app := New(t.Context(), rt, session.New())
+
+	require.NoError(t, app.CompactLiveSession(t.Context(), "child-1", ""))
+	assert.Equal(t, "child-1", rt.compactedID)
+
+	select {
+	case msg := <-app.events:
+		evt, ok := msg.(*runtime.SessionCompactionEvent)
+		require.True(t, ok, "expected SessionCompactionEvent, got %T", msg)
+		assert.Equal(t, "child-1", evt.SessionID)
+		assert.Equal(t, "completed", evt.Status)
+	case <-time.After(time.Second):
+		t.Fatal("compaction event was not bridged into the app event stream")
+	}
+}
+
+func TestApp_CompactLiveSession_ForwardsRuntimeError(t *testing.T) {
+	t.Parallel()
+
+	rt := &liveSessionsMockRuntime{compactErr: errors.New("session x is not live")}
+	app := New(t.Context(), rt, session.New())
+
+	err := app.CompactLiveSession(t.Context(), "x", "")
+	require.ErrorContains(t, err, "not live")
 }

--- a/pkg/runtime/live_sessions.go
+++ b/pkg/runtime/live_sessions.go
@@ -1,0 +1,276 @@
+package runtime
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+// LiveSession is one row of the /context team view: a currently running
+// RunStream session (or the idle current root session) with its agent
+// identity, session identity and context budget. Token counts come from the
+// session's provider-reported cumulative usage; ContextLimit is 0 when the
+// effective model's window cannot be resolved (harness-backed agents, models
+// absent from the catalogue).
+type LiveSession struct {
+	SessionID    string `json:"session_id"`
+	AgentName    string `json:"agent_name"`
+	InputTokens  int64  `json:"input_tokens"`
+	OutputTokens int64  `json:"output_tokens"`
+	ContextLimit int64  `json:"context_limit"`
+	// Current marks the caller's current root session. It is listed even
+	// while idle (no active stream), unlike child rows which exist only
+	// while their RunStream is live.
+	Current bool `json:"current"`
+}
+
+// UsedTokens returns the session's current context occupancy estimate.
+func (s LiveSession) UsedTokens() int64 {
+	return s.InputTokens + s.OutputTokens
+}
+
+// ShortID returns the first 8 characters of the session ID, enough to
+// disambiguate concurrent runs of the same agent in UI listings.
+func (s LiveSession) ShortID() string {
+	if len(s.SessionID) <= 8 {
+		return s.SessionID
+	}
+	return s.SessionID[:8]
+}
+
+// liveCompactionRequest is one queued explicit compaction of a live session,
+// executed on that session's own run goroutine at a safe iteration boundary.
+type liveCompactionRequest struct {
+	additionalPrompt string
+	events           EventSink
+}
+
+// liveSessionEntry tracks one active RunStream in the live-session registry.
+type liveSessionEntry struct {
+	sess *session.Session
+	// agentName is resolved once at registration: exact for pinned
+	// sessions (background agents) and equal to the current agent at
+	// stream start otherwise (transfer_task swaps the current agent
+	// before starting the child stream).
+	agentName string
+	// treeRootID is the ID of the root session of sess's tree, cached at
+	// registration while the intermediate parents are still live.
+	// LiveSessions scopes by this cached identity instead of re-walking
+	// ParentID links through the registry, so a long-running nested
+	// background agent stays attributed to its root after its intermediate
+	// foreground parent finishes and unregisters. Immutable once the entry
+	// is published.
+	treeRootID string
+	// compactCh holds at most one pending explicit compaction request.
+	// Sends happen only under liveSessionsMu while the entry is still
+	// registered; the final drain runs after unregistration, so an
+	// accepted request can never be stranded.
+	compactCh chan liveCompactionRequest
+}
+
+// registerLiveSession adds sess to the live-session registry. Called by
+// RunStream before the run goroutine starts so the session is targetable for
+// the whole lifetime of its stream.
+func (r *LocalRuntime) registerLiveSession(sess *session.Session) *liveSessionEntry {
+	entry := &liveSessionEntry{
+		sess:      sess,
+		agentName: r.sessionAgentName(sess),
+		compactCh: make(chan liveCompactionRequest, 1),
+	}
+	r.liveSessionsMu.Lock()
+	defer r.liveSessionsMu.Unlock()
+	entry.treeRootID = r.treeRootIDLocked(sess)
+	r.liveSessions[sess.ID] = entry
+	return entry
+}
+
+// treeRootIDLocked resolves the tree root ID cached on a new entry; the
+// caller must hold liveSessionsMu so the resolution and the entry's
+// publication are one atomic step. A root session is its own root. A child
+// whose parent entry is registered inherits the parent's cached root; the
+// parent is live at this point in every real registration (transfer_task and
+// background tasks start child streams from within the parent's own stream),
+// which is what preserves nested lineage after the parent unregisters.
+// Otherwise the parent is an unregistered root (typically the idle current
+// session, which is only registered while its own stream runs) and the
+// parent ID itself is the root.
+func (r *LocalRuntime) treeRootIDLocked(sess *session.Session) string {
+	if sess.ParentID == "" {
+		return sess.ID
+	}
+	if parent, ok := r.liveSessions[sess.ParentID]; ok {
+		return parent.treeRootID
+	}
+	return sess.ParentID
+}
+
+// finishLiveSession removes entry from the registry and then executes any
+// already accepted compaction request. Removal happens under the registry
+// lock BEFORE the drain: afterwards CompactLiveSession can no longer enqueue
+// (it reports the session as not live), so everything the channel holds at
+// drain time is processed and a request is either rejected or executed,
+// never silently dropped.
+func (r *LocalRuntime) finishLiveSession(ctx context.Context, entry *liveSessionEntry) {
+	r.liveSessionsMu.Lock()
+	if r.liveSessions[entry.sess.ID] == entry {
+		delete(r.liveSessions, entry.sess.ID)
+	}
+	r.liveSessionsMu.Unlock()
+
+	for {
+		select {
+		case req := <-entry.compactCh:
+			r.runLiveCompactionRequest(ctx, entry.sess, req)
+		default:
+			return
+		}
+	}
+}
+
+// LiveSessions returns the caller's current root session followed by every
+// currently live RunStream session that descends from it (foreground
+// children and background agent tasks, nested sub-agents included). Descent
+// is decided by each entry's tree root ID, cached at registration, so a
+// nested background agent stays listed after its intermediate foreground
+// parent finished and unregistered. Live sessions rooted outside current's
+// tree (e.g. a stale root stream still draining after
+// App.NewSession/ReplaceSession swapped the current session, and its
+// descendants) are excluded. current may be nil, in which case every live
+// entry is listed. Child rows are stable-sorted by agent name then session
+// ID, so concurrent runs of the same agent stay distinct and the ordering is
+// deterministic. current is listed even while idle.
+func (r *LocalRuntime) LiveSessions(ctx context.Context, current *session.Session) []LiveSession {
+	r.liveSessionsMu.Lock()
+	entries := make([]*liveSessionEntry, 0, len(r.liveSessions))
+	for _, entry := range r.liveSessions {
+		if current != nil && (entry.sess.ID == current.ID || entry.treeRootID != current.ID) {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	r.liveSessionsMu.Unlock()
+
+	var rows []LiveSession
+	if current != nil {
+		rows = append(rows, r.liveSessionRow(ctx, current, r.sessionAgentName(current), true))
+	}
+
+	children := make([]LiveSession, 0, len(entries))
+	for _, entry := range entries {
+		children = append(children, r.liveSessionRow(ctx, entry.sess, entry.agentName, false))
+	}
+	slices.SortStableFunc(children, func(a, b LiveSession) int {
+		if c := cmp.Compare(a.AgentName, b.AgentName); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.SessionID, b.SessionID)
+	})
+	return append(rows, children...)
+}
+
+// liveSessionRow builds one team-view row from a session and its agent.
+func (r *LocalRuntime) liveSessionRow(ctx context.Context, sess *session.Session, agentName string, current bool) LiveSession {
+	input, output := sess.Usage()
+	row := LiveSession{
+		SessionID:    sess.ID,
+		AgentName:    agentName,
+		InputTokens:  input,
+		OutputTokens: output,
+		Current:      current,
+	}
+	if a, err := r.team.Agent(agentName); err == nil && a != nil && !a.HasHarness() {
+		row.ContextLimit = r.contextLimitForAgentModel(ctx, a, r.getEffectiveModelID(ctx, a))
+	}
+	return row
+}
+
+// CompactLiveSession queues an explicit manual compaction for the identified
+// live session. The request is accepted non-blockingly and executes on the
+// target session's own run goroutine at a safe iteration boundary (or during
+// its final teardown drain), so it can never interleave with an in-flight
+// model turn. Compaction and usage events are emitted to events; when hooks
+// veto the compaction before any terminal event, a completed/skipped event
+// is synthesized so the requester always observes a terminal signal.
+//
+// It returns an error when sessionID is not a live session (unknown or
+// already finished) or when a request is already pending for it.
+func (r *LocalRuntime) CompactLiveSession(_ context.Context, sessionID, additionalPrompt string, events EventSink) error {
+	if events == nil {
+		events = EventSinkFunc(func(Event) {})
+	}
+
+	r.liveSessionsMu.Lock()
+	defer r.liveSessionsMu.Unlock()
+	entry, ok := r.liveSessions[sessionID]
+	if !ok {
+		return fmt.Errorf("session %s is not live (unknown or already finished)", sessionID)
+	}
+	select {
+	case entry.compactCh <- liveCompactionRequest{additionalPrompt: additionalPrompt, events: events}:
+		return nil
+	default:
+		return fmt.Errorf("a compaction request is already pending for session %s", sessionID)
+	}
+}
+
+// runQueuedCompaction executes at most one pending explicit compaction
+// request for entry's session. It must only be called from the entry's own
+// run goroutine, at iteration boundaries, so the compaction snapshot cannot
+// race with messages appended by an active model turn. It drains exactly the
+// entry owned by that RunStream, never a registry lookup by session ID,
+// which under duplicate IDs would let an older stream steal a newer entry's
+// request and compact the wrong in-memory session.
+func (r *LocalRuntime) runQueuedCompaction(ctx context.Context, entry *liveSessionEntry) {
+	select {
+	case req := <-entry.compactCh:
+		r.runLiveCompactionRequest(ctx, entry.sess, req)
+	default:
+	}
+}
+
+// runLiveCompactionRequest performs one queued manual compaction, forwarding
+// all resulting events to the request's sink. When no terminal compaction
+// event was emitted (a pre_compact or before_compaction hook vetoed the run),
+// a completed/skipped event is synthesized, mirroring App.CompactSession's
+// behavior for the root /compact path.
+func (r *LocalRuntime) runLiveCompactionRequest(ctx context.Context, sess *session.Session, req liveCompactionRequest) {
+	// With ctx already cancelled (a teardown drain after Ctrl+C), attempting
+	// the compaction model call would fail immediately and emit a noisy
+	// started/failed pair. Consume the request and report a single terminal
+	// skipped event instead, so the requester still observes a terminal
+	// signal without a phantom failure.
+	if ctx.Err() != nil {
+		slog.InfoContext(ctx, "Skipping explicit compaction for live session: context already cancelled",
+			"session_id", sess.ID, "agent", r.sessionAgentName(sess))
+		req.events.Emit(SessionCompactionCompleted(sess.ID, CompactionOutcomeSkipped, r.sessionAgentName(sess)))
+		return
+	}
+
+	slog.InfoContext(ctx, "Running explicit compaction for live session",
+		"session_id", sess.ID, "agent", r.sessionAgentName(sess))
+
+	completed := false
+	sink := EventSinkFunc(func(event Event) {
+		if e, ok := event.(*SessionCompactionEvent); ok && e.Status == "completed" {
+			completed = true
+		}
+		req.events.Emit(event)
+	})
+	r.compactWithReason(ctx, sess, req.additionalPrompt, compactionReasonManual, sink)
+	if !completed {
+		req.events.Emit(SessionCompactionCompleted(sess.ID, CompactionOutcomeSkipped, r.sessionAgentName(sess)))
+	}
+}
+
+// sessionAgentName resolves the display agent name for sess, tolerating a
+// nil resolution (which resolveSessionAgent's contract makes unexpected).
+func (r *LocalRuntime) sessionAgentName(sess *session.Session) string {
+	if a := r.resolveSessionAgent(sess); a != nil {
+		return a.Name()
+	}
+	return ""
+}

--- a/pkg/runtime/live_sessions_test.go
+++ b/pkg/runtime/live_sessions_test.go
@@ -1,0 +1,627 @@
+package runtime
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/hooks"
+	"github.com/docker/docker-agent/pkg/model/provider/base"
+	"github.com/docker/docker-agent/pkg/modelsdev"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/team"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// providerStep is one scripted CreateChatCompletionStream call of a
+// stepProvider: the stream to serve, an optional started signal (closed when
+// the call begins) and an optional release gate (the call blocks until it is
+// closed), so tests can act while a model turn is verifiably in flight.
+type providerStep struct {
+	stream  chat.MessageStream
+	started chan struct{}
+	release <-chan struct{}
+}
+
+// stepProvider serves scripted steps in call order. Calls beyond the script
+// return an empty stream.
+type stepProvider struct {
+	id    string
+	mu    sync.Mutex
+	steps []providerStep
+}
+
+func (p *stepProvider) ID() modelsdev.ID { return modelsdev.ParseIDOrZero(p.id) }
+
+func (p *stepProvider) CreateChatCompletionStream(ctx context.Context, _ []chat.Message, _ []tools.Tool) (chat.MessageStream, error) {
+	p.mu.Lock()
+	var step providerStep
+	if len(p.steps) > 0 {
+		step = p.steps[0]
+		p.steps = p.steps[1:]
+	}
+	p.mu.Unlock()
+
+	if step.started != nil {
+		close(step.started)
+	}
+	if step.release != nil {
+		select {
+		case <-step.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if step.stream == nil {
+		return &mockStream{}, nil
+	}
+	return step.stream, nil
+}
+
+func (p *stepProvider) BaseConfig() base.Config { return base.Config{} }
+func (p *stepProvider) MaxTokens() int          { return 0 }
+
+// newLiveSessionsRuntime builds a runtime with a "root" agent and a "worker"
+// agent whose model is the supplied provider.
+func newLiveSessionsRuntime(t *testing.T, workerProvider *stepProvider, store ModelStore, workerOpts ...agent.Opt) *LocalRuntime {
+	t.Helper()
+
+	root := agent.New("root", "root agent", agent.WithModel(&mockProvider{id: "test/mock-model", stream: &mockStream{}}))
+	opts := append([]agent.Opt{agent.WithModel(workerProvider)}, workerOpts...)
+	worker := agent.New("worker", "worker agent", opts...)
+	tm := team.New(team.WithAgents(root, worker))
+
+	rt, err := NewLocalRuntime(t.Context(), tm,
+		WithSessionCompaction(false),
+		WithModelStore(store),
+	)
+	require.NoError(t, err)
+	return rt
+}
+
+// newWorkerSession builds a sub-session pinned to the worker agent.
+func newWorkerSession(id string) *session.Session {
+	return session.New(
+		session.WithID(id),
+		session.WithParentID("root-session"),
+		session.WithAgentName("worker"),
+		session.WithUserMessage("subtask"),
+	)
+}
+
+// drainStream consumes a RunStream channel until it closes, bounded by the
+// test's deadline through t.Context.
+func drainStream(t *testing.T, stream <-chan Event) {
+	t.Helper()
+	for {
+		select {
+		case _, ok := <-stream:
+			if !ok {
+				return
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out draining stream")
+		}
+	}
+}
+
+// waitClosed fails the test unless ch is closed within the timeout.
+func waitClosed(t *testing.T, ch <-chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("timed out waiting for %s", what)
+	}
+}
+
+func TestLiveSessions_ListsRootAndActiveChildren(t *testing.T) {
+	t.Parallel()
+
+	startedA := make(chan struct{})
+	startedB := make(chan struct{})
+	release := make(chan struct{})
+	prov := &stepProvider{id: "test/mock-model", steps: []providerStep{
+		{stream: newStreamBuilder().AddStopWithUsage(1, 1).Build(), started: startedA, release: release},
+		{stream: newStreamBuilder().AddStopWithUsage(1, 1).Build(), started: startedB, release: release},
+	}}
+	rt := newLiveSessionsRuntime(t, prov, mockModelStoreWithLimit{limit: 1000})
+
+	rootSess := session.New(session.WithID("root-session"), session.WithUserMessage("hi"))
+	rootSess.SetUsage(100, 50)
+
+	// Two concurrent runs of the SAME agent: they must both be listed,
+	// never collapsed by agent name.
+	childA := newWorkerSession("child-a")
+	childA.SetUsage(600, 100)
+	childB := newWorkerSession("child-b")
+	childB.SetUsage(10, 5)
+
+	streamA := rt.RunStream(t.Context(), childA)
+	streamB := rt.RunStream(t.Context(), childB)
+	waitClosed(t, startedA, "first child turn")
+	waitClosed(t, startedB, "second child turn")
+
+	rows := rt.LiveSessions(t.Context(), rootSess)
+	require.Len(t, rows, 3, "current root plus both live children")
+
+	assert.True(t, rows[0].Current)
+	assert.Equal(t, "root-session", rows[0].SessionID)
+	assert.Equal(t, "root", rows[0].AgentName)
+	assert.Equal(t, int64(150), rows[0].UsedTokens())
+	assert.Equal(t, int64(1000), rows[0].ContextLimit)
+
+	// Child rows are stable-sorted by agent name then session ID.
+	assert.Equal(t, "child-a", rows[1].SessionID)
+	assert.Equal(t, "worker", rows[1].AgentName)
+	assert.Equal(t, int64(700), rows[1].UsedTokens())
+	assert.Equal(t, int64(1000), rows[1].ContextLimit)
+	assert.False(t, rows[1].Current)
+
+	assert.Equal(t, "child-b", rows[2].SessionID)
+	assert.Equal(t, "worker", rows[2].AgentName)
+	assert.Equal(t, int64(15), rows[2].UsedTokens())
+
+	// Ordering is deterministic across calls.
+	assert.Equal(t, rows, rt.LiveSessions(t.Context(), rootSess))
+
+	close(release)
+	drainStream(t, streamA)
+	drainStream(t, streamB)
+
+	rows = rt.LiveSessions(t.Context(), rootSess)
+	require.Len(t, rows, 1, "finished children drop out of the view")
+	assert.True(t, rows[0].Current)
+}
+
+func TestLiveSessions_UnknownContextLimit(t *testing.T) {
+	t.Parallel()
+
+	prov := &stepProvider{id: "test/mock-model"}
+	rt := newLiveSessionsRuntime(t, prov, mockModelStore{})
+
+	rootSess := session.New(session.WithID("root-session"), session.WithUserMessage("hi"))
+	rootSess.SetUsage(42, 8)
+
+	rows := rt.LiveSessions(t.Context(), rootSess)
+	require.Len(t, rows, 1, "the idle current root is always listed")
+	assert.True(t, rows[0].Current)
+	assert.Equal(t, int64(50), rows[0].UsedTokens())
+	assert.Zero(t, rows[0].ContextLimit, "unresolvable model window reports an unknown limit")
+}
+
+// TestLiveSessions_ExcludesSessionsOutsideCurrentRootTree pins the team
+// scoping contract: only descendants of the current root are listed. A stale
+// root stream (the session App.NewSession/ReplaceSession swapped away from
+// before it fully unregistered) and its children stay out of the view, while
+// direct, duplicate same-agent, and nested descendants of current all remain.
+// With a nil current, every live entry is retained.
+func TestLiveSessions_ExcludesSessionsOutsideCurrentRootTree(t *testing.T) {
+	t.Parallel()
+
+	rt := newLiveSessionsRuntime(t, &stepProvider{id: "test/mock-model"}, mockModelStoreWithLimit{limit: 1000})
+
+	current := session.New(session.WithID("root-current"), session.WithUserMessage("hi"))
+
+	// Two concurrent same-agent children of current plus a nested sub-agent
+	// under the first child.
+	childA := session.New(session.WithID("child-a"), session.WithParentID("root-current"), session.WithAgentName("worker"))
+	childB := session.New(session.WithID("child-b"), session.WithParentID("root-current"), session.WithAgentName("worker"))
+	nested := session.New(session.WithID("nested-1"), session.WithParentID("child-a"), session.WithAgentName("worker"))
+
+	// An unrelated root still streaming, and its child.
+	staleRoot := session.New(session.WithID("root-stale"), session.WithUserMessage("old"))
+	staleChild := session.New(session.WithID("stale-child"), session.WithParentID("root-stale"), session.WithAgentName("worker"))
+
+	for _, sess := range []*session.Session{childA, childB, nested, staleRoot, staleChild} {
+		rt.registerLiveSession(sess)
+	}
+
+	rows := rt.LiveSessions(t.Context(), current)
+	require.Len(t, rows, 4, "current plus its direct and nested descendants only")
+	assert.True(t, rows[0].Current)
+	assert.Equal(t, "root-current", rows[0].SessionID)
+	assert.Equal(t, "child-a", rows[1].SessionID)
+	assert.Equal(t, "child-b", rows[2].SessionID)
+	assert.Equal(t, "nested-1", rows[3].SessionID)
+
+	rows = rt.LiveSessions(t.Context(), nil)
+	require.Len(t, rows, 5, "a nil current retains every live entry")
+	for _, row := range rows {
+		assert.False(t, row.Current)
+	}
+}
+
+// TestLiveSessions_KeepsNestedBackgroundAfterParentFinishes is the
+// regression test for cached tree-root ancestry: a nested background agent
+// (root R -> transfer child C -> background B started by C) must stay in
+// current R's view after its intermediate parent C finished and
+// unregistered, and after R's own stream finished too. Re-walking ParentID
+// links through live entries only would break B's lineage as soon as C left
+// the registry.
+func TestLiveSessions_KeepsNestedBackgroundAfterParentFinishes(t *testing.T) {
+	t.Parallel()
+
+	rt := newLiveSessionsRuntime(t, &stepProvider{id: "test/mock-model"}, mockModelStoreWithLimit{limit: 1000})
+
+	current := session.New(session.WithID("root-current"), session.WithUserMessage("hi"))
+	child := session.New(session.WithID("child-1"), session.WithParentID("root-current"), session.WithAgentName("worker"))
+	nested := session.New(session.WithID("nested-bg"), session.WithParentID("child-1"), session.WithAgentName("worker"))
+
+	// Registration order mirrors the real flow: each child stream starts
+	// from within its parent's still-live stream.
+	rootEntry := rt.registerLiveSession(current)
+	childEntry := rt.registerLiveSession(child)
+	rt.registerLiveSession(nested)
+
+	rows := rt.LiveSessions(t.Context(), current)
+	require.Len(t, rows, 3, "current plus both live descendants while everything runs")
+
+	// The intermediate parent finishes, then the root turn completes; the
+	// long-running background agent stays attributed to the current root.
+	rt.finishLiveSession(t.Context(), childEntry)
+	rt.finishLiveSession(t.Context(), rootEntry)
+
+	rows = rt.LiveSessions(t.Context(), current)
+	require.Len(t, rows, 2, "the nested background agent survives its parent's unregistration")
+	assert.True(t, rows[0].Current)
+	assert.Equal(t, "root-current", rows[0].SessionID)
+	assert.Equal(t, "nested-bg", rows[1].SessionID)
+	assert.False(t, rows[1].Current)
+}
+
+// TestLiveSessions_CachedRootFallbackForUnregisteredParents pins the
+// registration fallback for entries whose parent entry is not live: the
+// parent ID itself is cached as the tree root. An orphan pointing at an
+// unknown parent and a malformed ParentID cycle therefore resolve to roots
+// outside the current tree and are excluded from its view, while the orphan
+// is still attributed to its vanished parent's tree.
+func TestLiveSessions_CachedRootFallbackForUnregisteredParents(t *testing.T) {
+	t.Parallel()
+
+	rt := newLiveSessionsRuntime(t, &stepProvider{id: "test/mock-model"}, mockModelStoreWithLimit{limit: 1000})
+
+	current := session.New(session.WithID("root-current"), session.WithUserMessage("hi"))
+
+	orphan := session.New(session.WithID("orphan-1"), session.WithParentID("gone"), session.WithAgentName("worker"))
+	// cycle-a registers before cycle-b, so its unregistered parent cycle-b
+	// becomes the cached root, inherited by cycle-b in turn.
+	cycleA := session.New(session.WithID("cycle-a"), session.WithParentID("cycle-b"), session.WithAgentName("worker"))
+	cycleB := session.New(session.WithID("cycle-b"), session.WithParentID("cycle-a"), session.WithAgentName("worker"))
+
+	for _, sess := range []*session.Session{orphan, cycleA, cycleB} {
+		rt.registerLiveSession(sess)
+	}
+
+	rows := rt.LiveSessions(t.Context(), current)
+	require.Len(t, rows, 1, "entries rooted outside the current tree are excluded")
+	assert.True(t, rows[0].Current)
+
+	// The orphan's cached root is its vanished parent: were that parent the
+	// current session, the orphan would be listed under it.
+	gone := session.New(session.WithID("gone"), session.WithUserMessage("old"))
+	rows = rt.LiveSessions(t.Context(), gone)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "orphan-1", rows[1].SessionID)
+}
+
+func TestCompactLiveSession_UnknownSessionErrors(t *testing.T) {
+	t.Parallel()
+
+	rt := newLiveSessionsRuntime(t, &stepProvider{id: "test/mock-model"}, mockModelStoreWithLimit{limit: 1000})
+
+	err := rt.CompactLiveSession(t.Context(), "no-such-session", "", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not live")
+}
+
+func TestCompactLiveSession_ExecutesAtIterationBoundary(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	prov := &stepProvider{id: "test/mock-model", steps: []providerStep{
+		// Turn 1: content without a finish reason keeps the loop running,
+		// so the queued request executes at the next iteration boundary.
+		{stream: newStreamBuilder().AddContent("working on it").Build(), started: started, release: release},
+		// The compaction summary call.
+		{stream: newStreamBuilder().AddContent("a compact summary").AddStopWithUsage(10, 5).Build()},
+		// Turn 2: natural stop ends the stream.
+		{stream: newStreamBuilder().AddStopWithUsage(1, 1).Build()},
+	}}
+	rt := newLiveSessionsRuntime(t, prov, mockModelStoreWithLimit{limit: 100_000})
+
+	child := newWorkerSession("child-1")
+	stream := rt.RunStream(t.Context(), child)
+	waitClosed(t, started, "first child turn")
+
+	requestEvents := make(chan Event, 64)
+	require.NoError(t, rt.CompactLiveSession(t.Context(), "child-1", "", NewChannelSink(requestEvents)))
+
+	// A second request while one is pending is rejected clearly.
+	err := rt.CompactLiveSession(t.Context(), "child-1", "", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already pending")
+
+	close(release)
+	drainStream(t, stream)
+	close(requestEvents)
+
+	var kinds []string
+	for ev := range requestEvents {
+		switch e := ev.(type) {
+		case *SessionCompactionEvent:
+			assert.Equal(t, "child-1", e.SessionID)
+			assert.Equal(t, "worker", e.AgentName)
+			if e.Status == "completed" {
+				kinds = append(kinds, "completed:"+e.Outcome)
+			} else {
+				kinds = append(kinds, e.Status)
+			}
+		case *SessionSummaryEvent:
+			assert.Equal(t, "child-1", e.SessionID)
+			kinds = append(kinds, "summary")
+		case *TokenUsageEvent:
+			assert.Equal(t, "child-1", e.SessionID)
+			assert.Equal(t, "worker", e.AgentName)
+			kinds = append(kinds, "usage")
+		}
+	}
+	assert.Equal(t, []string{"started", "summary", "completed:applied", "usage"}, kinds)
+	assert.Equal(t, "a compact summary", child.LastSummary())
+}
+
+// TestCompactLiveSession_AcceptedRequestDrainedAtTeardown pins the shutdown
+// contract: a request accepted while the session's final turn is in flight
+// (so no further iteration boundary occurs) still executes during stream
+// teardown and emits a terminal event, instead of being silently dropped.
+func TestCompactLiveSession_AcceptedRequestDrainedAtTeardown(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	prov := &stepProvider{id: "test/mock-model", steps: []providerStep{
+		// The one and only turn: a natural stop, gated so the request can
+		// be enqueued mid-turn.
+		{stream: newStreamBuilder().AddContent("done").AddStopWithUsage(1, 1).Build(), started: started, release: release},
+		// The compaction summary call, issued from the teardown drain.
+		{stream: newStreamBuilder().AddContent("teardown summary").AddStopWithUsage(10, 5).Build()},
+	}}
+	rt := newLiveSessionsRuntime(t, prov, mockModelStoreWithLimit{limit: 100_000})
+
+	child := newWorkerSession("child-1")
+	stream := rt.RunStream(t.Context(), child)
+	waitClosed(t, started, "final child turn")
+
+	requestEvents := make(chan Event, 64)
+	require.NoError(t, rt.CompactLiveSession(t.Context(), "child-1", "", NewChannelSink(requestEvents)))
+
+	close(release)
+	drainStream(t, stream)
+
+	// The teardown drain executes before the stream channel closes, so the
+	// terminal compaction event is already buffered on the request sink.
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case ev := <-requestEvents:
+			if e, ok := ev.(*SessionCompactionEvent); ok && e.Status == "completed" {
+				assert.Equal(t, "child-1", e.SessionID)
+				assert.Equal(t, "worker", e.AgentName)
+				assert.Equal(t, CompactionOutcomeApplied, e.Outcome)
+				assert.Equal(t, "teardown summary", child.LastSummary())
+
+				// The session is gone from the registry: further requests
+				// are rejected instead of stranded.
+				err := rt.CompactLiveSession(t.Context(), "child-1", "", nil)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "not live")
+				return
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for the terminal compaction event")
+		}
+	}
+}
+
+// TestCompactLiveSession_DuplicateSessionIDsCompactOnlyTargetEntry is the
+// regression test for the boundary drain consuming the exact
+// *liveSessionEntry of its own RunStream: with two simultaneously registered
+// sessions sharing one ID, a request queued to the currently targetable
+// (latest) entry must not be consumed by the older stream's iteration
+// boundary or teardown drain, and must mutate only the newer in-memory
+// session.
+func TestCompactLiveSession_DuplicateSessionIDsCompactOnlyTargetEntry(t *testing.T) {
+	t.Parallel()
+
+	startedA := make(chan struct{})
+	releaseA := make(chan struct{})
+	startedB := make(chan struct{})
+	releaseB := make(chan struct{})
+	prov := &stepProvider{id: "test/mock-model", steps: []providerStep{
+		// Older stream turn 1: kept in flight while the newer stream
+		// registers under the same session ID.
+		{stream: newStreamBuilder().AddContent("older working").Build(), started: startedA, release: releaseA},
+		// Newer stream turn 1, gated so it stays live throughout.
+		{stream: newStreamBuilder().AddContent("newer working").Build(), started: startedB, release: releaseB},
+		// Older stream turn 2: natural stop. With the request left alone this
+		// is the older stream's next model call; stealing the request would
+		// consume this step as the compaction summary instead.
+		{stream: newStreamBuilder().AddStopWithUsage(1, 1).Build()},
+		// The compaction summary call, drained by the newer stream's own
+		// iteration boundary.
+		{stream: newStreamBuilder().AddContent("latest summary").AddStopWithUsage(10, 5).Build()},
+		// Newer stream turn 2: natural stop.
+		{stream: newStreamBuilder().AddStopWithUsage(1, 1).Build()},
+	}}
+	rt := newLiveSessionsRuntime(t, prov, mockModelStoreWithLimit{limit: 100_000})
+
+	older := newWorkerSession("dup-id")
+	newer := newWorkerSession("dup-id")
+
+	streamA := rt.RunStream(t.Context(), older)
+	waitClosed(t, startedA, "older stream turn")
+	streamB := rt.RunStream(t.Context(), newer)
+	waitClosed(t, startedB, "newer stream turn")
+
+	// The registry now maps dup-id to the newer entry, so the request is
+	// queued there.
+	requestEvents := make(chan Event, 64)
+	require.NoError(t, rt.CompactLiveSession(t.Context(), "dup-id", "", NewChannelSink(requestEvents)))
+
+	// Run the older stream to completion (iteration boundary plus teardown
+	// drain) while the request is still pending for the newer entry.
+	close(releaseA)
+	drainStream(t, streamA)
+
+	assert.Empty(t, older.LastSummary(), "the older stream must not execute the newer entry's request")
+	err := rt.CompactLiveSession(t.Context(), "dup-id", "", nil)
+	require.Error(t, err, "the queued request must survive the older stream's boundary and teardown")
+	assert.Contains(t, err.Error(), "already pending")
+
+	close(releaseB)
+	drainStream(t, streamB)
+	close(requestEvents)
+
+	var outcomes []string
+	for ev := range requestEvents {
+		if e, ok := ev.(*SessionCompactionEvent); ok && e.Status == "completed" {
+			outcomes = append(outcomes, e.Outcome)
+		}
+	}
+	assert.Equal(t, []string{CompactionOutcomeApplied}, outcomes)
+	assert.Equal(t, "latest summary", newer.LastSummary(), "the request must compact the newer in-memory session")
+	assert.Empty(t, older.LastSummary())
+}
+
+// TestCompactLiveSession_CancelledStreamEmitsSingleSkippedEvent pins the
+// cancellation contract: a request accepted before the stream's context is
+// cancelled is still consumed, but reports exactly one terminal
+// completed/skipped event with the target's identity instead of attempting
+// the compaction model call (which would emit a noisy started/failed pair).
+func TestCompactLiveSession_CancelledStreamEmitsSingleSkippedEvent(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	prov := &stepProvider{id: "test/mock-model", steps: []providerStep{
+		// The one and only turn, blocked until the context is cancelled.
+		{stream: newStreamBuilder().AddStopWithUsage(1, 1).Build(), started: started, release: make(chan struct{})},
+	}}
+	rt := newLiveSessionsRuntime(t, prov, mockModelStoreWithLimit{limit: 100_000})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	child := newWorkerSession("child-1")
+	stream := rt.RunStream(ctx, child)
+	waitClosed(t, started, "child turn")
+
+	requestEvents := make(chan Event, 64)
+	require.NoError(t, rt.CompactLiveSession(t.Context(), "child-1", "", NewChannelSink(requestEvents)))
+
+	cancel()
+	drainStream(t, stream)
+	close(requestEvents)
+
+	var kinds []string
+	for ev := range requestEvents {
+		if e, ok := ev.(*SessionCompactionEvent); ok {
+			assert.Equal(t, "child-1", e.SessionID)
+			assert.Equal(t, "worker", e.AgentName)
+			kinds = append(kinds, e.Status+":"+e.Outcome)
+		}
+	}
+	assert.Equal(t, []string{"completed:" + CompactionOutcomeSkipped}, kinds,
+		"a cancelled target must consume the request and emit exactly one terminal skipped event")
+	assert.Empty(t, child.LastSummary(), "no compaction must run against a cancelled stream")
+}
+
+// TestCompactLiveSession_HookVetoSynthesizesSkipped verifies that when a
+// pre_compact hook vetoes the compaction (so no started/completed pair is
+// emitted), the requester still observes a synthesized completed/skipped
+// terminal event, mirroring App.CompactSession's root /compact behavior.
+func TestCompactLiveSession_HookVetoSynthesizesSkipped(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	prov := &stepProvider{id: "test/mock-model", steps: []providerStep{
+		{stream: newStreamBuilder().AddContent("working on it").Build(), started: started, release: release},
+		{stream: newStreamBuilder().AddStopWithUsage(1, 1).Build()},
+	}}
+	rt := newLiveSessionsRuntime(t, prov, mockModelStoreWithLimit{limit: 100_000},
+		agent.WithHooks(&latest.HooksConfig{
+			PreCompact: []latest.HookDefinition{{Type: "builtin", Command: "test-veto-compact"}},
+		}),
+	)
+	require.NoError(t, rt.hooksRegistry.RegisterBuiltin(
+		"test-veto-compact",
+		func(context.Context, *hooks.Input, []string) (*hooks.Output, error) {
+			return &hooks.Output{Decision: hooks.DecisionBlockValue, Reason: "vetoed"}, nil
+		},
+	))
+
+	child := newWorkerSession("child-1")
+	stream := rt.RunStream(t.Context(), child)
+	waitClosed(t, started, "first child turn")
+
+	requestEvents := make(chan Event, 64)
+	require.NoError(t, rt.CompactLiveSession(t.Context(), "child-1", "", NewChannelSink(requestEvents)))
+
+	close(release)
+	drainStream(t, stream)
+	close(requestEvents)
+
+	var statuses []string
+	for ev := range requestEvents {
+		if e, ok := ev.(*SessionCompactionEvent); ok {
+			statuses = append(statuses, e.Status+":"+e.Outcome)
+		}
+	}
+	assert.Equal(t, []string{"completed:" + CompactionOutcomeSkipped}, statuses,
+		"a vetoed request must synthesize the terminal skipped event, with no started pair")
+	assert.Empty(t, child.LastSummary(), "a vetoed compaction must not modify the session")
+}
+
+// TestLiveSessions_ConcurrentAccess exercises the registry under -race:
+// listings and rejected targeting requests race with stream registration and
+// teardown.
+func TestLiveSessions_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	prov := &stepProvider{id: "test/mock-model", steps: []providerStep{
+		{stream: newStreamBuilder().AddStopWithUsage(1, 1).Build(), release: release},
+	}}
+	rt := newLiveSessionsRuntime(t, prov, mockModelStoreWithLimit{limit: 1000})
+	rootSess := session.New(session.WithID("root-session"), session.WithUserMessage("hi"))
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Go(func() {
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					rt.LiveSessions(t.Context(), rootSess)
+					_ = rt.CompactLiveSession(t.Context(), "unknown", "", nil)
+				}
+			}
+		})
+	}
+
+	child := newWorkerSession("child-1")
+	stream := rt.RunStream(t.Context(), child)
+	close(release)
+	drainStream(t, stream)
+
+	close(done)
+	wg.Wait()
+}

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -230,11 +230,16 @@ func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-c
 		r.activeRootStreams.Add(1)
 	}
 
+	// Register before the run goroutine starts so the session is listed in
+	// the /context team view (and targetable for explicit compaction) for
+	// the whole lifetime of its stream.
+	entry := r.registerLiveSession(sess)
+
 	go func() {
 		if rootStream {
 			defer r.activeRootStreams.Add(-1)
 		}
-		r.runStreamLoop(ctx, sess, events)
+		r.runStreamLoop(ctx, sess, entry, events)
 	}()
 	return r.observe(ctx, sess, events)
 }
@@ -242,7 +247,7 @@ func (r *LocalRuntime) RunStream(ctx context.Context, sess *session.Session) <-c
 // runStreamLoop is the body of RunStream. Pulled out of the anonymous
 // goroutine so it has a real name in stack traces and is easier to navigate
 // in editors.
-func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session, events chan Event) {
+func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session, liveEntry *liveSessionEntry, events chan Event) {
 	sink := &channelSink{ch: events}
 
 	// Seed the cagent session ID at the run-loop boundary so any
@@ -316,6 +321,13 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 	defer func() {
 		r.finalizeEventChannel(ctx, sess, streamReason, prevElicitationCh, events)
 	}()
+
+	// Unregister from the live-session registry and execute any accepted
+	// explicit-compaction request before the stream lifecycle closes.
+	// Registered after the finalize defer so it runs first (LIFO): an
+	// accepted request is processed before StreamStopped is emitted and
+	// the events channel closes, so it can never be stranded.
+	defer r.finishLiveSession(ctx, liveEntry)
 
 	a := r.resolveSessionAgent(sess)
 
@@ -417,6 +429,12 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 				return
 			}
 		}
+
+		// Execute any explicitly requested (/context) compaction for this
+		// session now, at the iteration boundary: no model turn is in flight,
+		// so the compaction snapshot cannot race with messages being appended
+		// between the snapshot and ApplyCompaction.
+		r.runQueuedCompaction(ctx, liveEntry)
 
 		a = r.resolveSessionAgent(sess)
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -290,6 +290,13 @@ type LocalRuntime struct {
 	// stream has gone idle.
 	activeRootStreams atomic.Int32
 
+	// liveSessions is the registry of sessions with an active RunStream,
+	// keyed by session ID. It backs the /context team view (LiveSessions)
+	// and targeted manual compaction (CompactLiveSession). Guarded by
+	// liveSessionsMu; see live_sessions.go for the enqueue/drain contract.
+	liveSessionsMu sync.Mutex
+	liveSessions   map[string]*liveSessionEntry
+
 	// recallHandler wakes embedders (TUI/App) when a tool recall arrives after
 	// the active RunStream has gone idle. Protected by recallMu because tool
 	// callbacks can fire from background goroutines.
@@ -599,6 +606,7 @@ func NewLocalRuntime(ctx context.Context, agents *team.Team, opts ...Opt) (*Loca
 	r := &LocalRuntime{
 		ctx:                    func() context.Context { return context.WithoutCancel(ctx) },
 		toolMap:                make(map[string]ToolHandlerFunc),
+		liveSessions:           make(map[string]*liveSessionEntry),
 		team:                   agents,
 		agents:                 newAgentRouter(agents, defaultAgent.Name()),
 		resumeChan:             make(chan ResumeRequest),

--- a/pkg/tui/compact_routing_test.go
+++ b/pkg/tui/compact_routing_test.go
@@ -1,0 +1,198 @@
+package tui
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/app"
+	"github.com/docker/docker-agent/pkg/effort"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/sessiontitle"
+	"github.com/docker/docker-agent/pkg/tools"
+	skillstool "github.com/docker/docker-agent/pkg/tools/builtin/skills"
+	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
+	"github.com/docker/docker-agent/pkg/tui/components/notification"
+	"github.com/docker/docker-agent/pkg/tui/messages"
+)
+
+// stubRuntime is a no-op runtime.Runtime for wiring an *app.App into
+// appModel handler tests. It deliberately does NOT implement the optional
+// live-session capabilities.
+type stubRuntime struct{}
+
+func (stubRuntime) CurrentAgentInfo(context.Context) runtime.CurrentAgentInfo {
+	return runtime.CurrentAgentInfo{}
+}
+func (stubRuntime) CurrentAgentName(context.Context) string                 { return "root" }
+func (stubRuntime) SetCurrentAgent(context.Context, string) error           { return nil }
+func (stubRuntime) CurrentAgentTools(context.Context) ([]tools.Tool, error) { return nil, nil }
+func (stubRuntime) CurrentAgentToolsetStatuses() []tools.ToolsetStatus      { return nil }
+func (stubRuntime) RestartToolset(context.Context, string) error            { return nil }
+func (stubRuntime) EmitStartupInfo(context.Context, *session.Session, runtime.EventSink) {
+}
+func (stubRuntime) EmitAgentInfo(context.Context, runtime.EventSink) {}
+func (stubRuntime) ResetStartupInfo()                                {}
+func (stubRuntime) RunStream(context.Context, *session.Session) <-chan runtime.Event {
+	ch := make(chan runtime.Event)
+	close(ch)
+	return ch
+}
+
+func (stubRuntime) Run(context.Context, *session.Session) ([]session.Message, error) {
+	return nil, nil
+}
+func (stubRuntime) Resume(context.Context, runtime.ResumeRequest) {}
+func (stubRuntime) ResumeElicitation(context.Context, tools.ElicitationAction, map[string]any) error {
+	return nil
+}
+func (stubRuntime) SessionStore() session.Store { return nil }
+func (stubRuntime) Summarize(context.Context, *session.Session, string, runtime.EventSink) {
+}
+func (stubRuntime) PermissionsInfo() *runtime.PermissionsInfo      { return nil }
+func (stubRuntime) CurrentAgentSkillsToolset() *skillstool.ToolSet { return nil }
+
+func (stubRuntime) RunSkillFork(context.Context, *session.Session, skillstool.RunSkillArgs, runtime.EventSink) (*tools.ToolCallResult, error) {
+	return nil, nil
+}
+
+func (stubRuntime) CurrentMCPPrompts(context.Context) map[string]mcptools.PromptInfo { return nil }
+
+func (stubRuntime) ExecuteMCPPrompt(context.Context, string, map[string]string) (string, error) {
+	return "", nil
+}
+
+func (stubRuntime) UpdateSessionTitle(context.Context, *session.Session, string) error {
+	return nil
+}
+func (stubRuntime) TitleGenerator(context.Context) *sessiontitle.Generator { return nil }
+func (stubRuntime) Steer(context.Context, runtime.QueuedMessage) error     { return nil }
+func (stubRuntime) FollowUp(context.Context, runtime.QueuedMessage) error  { return nil }
+func (stubRuntime) SetAgentModel(context.Context, string, string) error    { return nil }
+func (stubRuntime) CycleAgentThinkingLevel(context.Context, string) (effort.Level, error) {
+	return "", runtime.ErrUnsupported
+}
+
+func (stubRuntime) SetAgentThinkingLevel(context.Context, string, effort.Level) (effort.Level, error) {
+	return "", runtime.ErrUnsupported
+}
+func (stubRuntime) AvailableModels(context.Context) []runtime.ModelChoice { return nil }
+func (stubRuntime) SupportsModelSwitching() bool                          { return false }
+func (stubRuntime) OnToolsChanged(func(runtime.Event))                    {}
+func (stubRuntime) OnBackgroundEvent(func(runtime.Event))                 {}
+func (stubRuntime) QueueStatus() runtime.QueueStatus                      { return runtime.QueueStatus{} }
+func (stubRuntime) TogglePause(context.Context) (bool, error)             { return false, nil }
+func (stubRuntime) Close() error                                          { return nil }
+
+var _ runtime.Runtime = stubRuntime{}
+
+// liveCompactRuntime adds the optional targeted-compaction capability.
+type liveCompactRuntime struct {
+	stubRuntime
+
+	compacted  []string
+	compactErr error
+}
+
+func (r *liveCompactRuntime) CompactLiveSession(_ context.Context, sessionID, _ string, _ runtime.EventSink) error {
+	if r.compactErr != nil {
+		return r.compactErr
+	}
+	r.compacted = append(r.compacted, sessionID)
+	return nil
+}
+
+// newCompactTestModel wires a minimal appModel around rt and sess.
+func newCompactTestModel(t *testing.T, rt runtime.Runtime, sess *session.Session) (*appModel, *mockChatPage) {
+	t.Helper()
+	m, _ := newTestModel(t)
+	m.application = app.New(t.Context(), rt, sess)
+	page := m.chatPage.(*mockChatPage)
+	return m, page
+}
+
+func TestHandleCompactSession_EmptyTargetUsesRootPath(t *testing.T) {
+	t.Parallel()
+
+	rt := &liveCompactRuntime{}
+	m, page := newCompactTestModel(t, rt, session.New())
+
+	_, _ = m.Update(messages.CompactSessionMsg{AdditionalPrompt: "focus on code"})
+
+	assert.Equal(t, []string{"focus on code"}, page.compactCalls,
+		"/compact routes through the chat page's root compaction")
+	assert.Empty(t, rt.compacted, "the targeted API must not be used for the root session")
+}
+
+func TestHandleCompactSession_RootSessionIDUsesRootPath(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	rt := &liveCompactRuntime{}
+	m, page := newCompactTestModel(t, rt, sess)
+
+	_, _ = m.Update(messages.CompactSessionMsg{SessionID: sess.ID, AgentName: "root"})
+
+	assert.Len(t, page.compactCalls, 1, "the main /context row routes through the root compaction path")
+	assert.Empty(t, rt.compacted)
+}
+
+func TestHandleCompactSession_SubSessionUsesTargetedPath(t *testing.T) {
+	t.Parallel()
+
+	rt := &liveCompactRuntime{}
+	m, page := newCompactTestModel(t, rt, session.New())
+
+	_, cmd := m.Update(messages.CompactSessionMsg{SessionID: "child-1", AgentName: "worker"})
+
+	assert.Empty(t, page.compactCalls, "a targeted request must not cancel or restart the root stream")
+	assert.Equal(t, []string{"child-1"}, rt.compacted)
+
+	require.NotNil(t, cmd)
+	msgs := collectMsgs(cmd)
+	require.Len(t, msgs, 1)
+	note, ok := msgs[0].(notification.ShowMsg)
+	require.True(t, ok, "expected a notification, got %T", msgs[0])
+	assert.Equal(t, notification.TypeInfo, note.Type)
+	assert.Contains(t, note.Text, "worker")
+	assert.Contains(t, note.Text, "child-1")
+}
+
+func TestHandleCompactSession_TargetedErrorNotifies(t *testing.T) {
+	t.Parallel()
+
+	rt := &liveCompactRuntime{compactErr: errors.New("session child-1 is not live")}
+	m, page := newCompactTestModel(t, rt, session.New())
+
+	_, cmd := m.Update(messages.CompactSessionMsg{SessionID: "child-1"})
+
+	assert.Empty(t, page.compactCalls)
+	require.NotNil(t, cmd)
+	msgs := collectMsgs(cmd)
+	require.Len(t, msgs, 1)
+	note, ok := msgs[0].(notification.ShowMsg)
+	require.True(t, ok, "expected a notification, got %T", msgs[0])
+	assert.Equal(t, notification.TypeError, note.Type)
+	assert.Contains(t, note.Text, "not live")
+}
+
+func TestHandleCompactSession_UnsupportedRuntimeNotifies(t *testing.T) {
+	t.Parallel()
+
+	m, page := newCompactTestModel(t, stubRuntime{}, session.New())
+
+	_, cmd := m.Update(messages.CompactSessionMsg{SessionID: "child-1"})
+
+	assert.Empty(t, page.compactCalls)
+	require.NotNil(t, cmd)
+	msgs := collectMsgs(cmd)
+	require.Len(t, msgs, 1)
+	note, ok := msgs[0].(notification.ShowMsg)
+	require.True(t, ok, "expected a notification, got %T", msgs[0])
+	assert.Equal(t, notification.TypeError, note.Type)
+	assert.Contains(t, note.Text, "not supported")
+}

--- a/pkg/tui/components/sidebar/context_gauge_test.go
+++ b/pkg/tui/components/sidebar/context_gauge_test.go
@@ -107,3 +107,41 @@ func TestStreamCancelClearsCompacting(t *testing.T) {
 
 	assert.False(t, m.compacting, "ESC cancel must not leave the gauge stuck on compacting…")
 }
+
+// TestCompactingGaugeIgnoresOtherSessions pins the #3439 sidebar contract:
+// the "compacting…" gauge describes the displayed session only, so a
+// targeted compaction of a session that is not displayed (e.g. an idle
+// background agent session) must not flip it in either direction.
+func TestCompactingGaugeIgnoresOtherSessions(t *testing.T) {
+	t.Parallel()
+
+	m := newTestSidebar(t)
+	m.startStream("session-1", "root")
+	m.spinnerActive = true
+
+	m.Update(&runtime.SessionCompactionEvent{SessionID: "background-1", Status: "started"})
+	assert.False(t, m.compacting, "another session's compaction must not show the root gauge as compacting")
+
+	m.Update(&runtime.SessionCompactionEvent{SessionID: "session-1", Status: "started"})
+	assert.True(t, m.compacting, "the displayed session's compaction still drives the gauge")
+
+	m.Update(&runtime.SessionCompactionEvent{SessionID: "background-1", Status: "completed", Outcome: runtime.CompactionOutcomeApplied})
+	assert.True(t, m.compacting, "another session's completion must not clear the running gauge")
+
+	m.Update(&runtime.SessionCompactionEvent{SessionID: "session-1", Status: "completed", Outcome: runtime.CompactionOutcomeApplied})
+	assert.False(t, m.compacting)
+}
+
+// TestCompactingGaugeBeforeAnySessionKnown keeps the legacy behavior when no
+// session has been recorded yet (fresh session, /compact before any stream):
+// the event is applied rather than dropped.
+func TestCompactingGaugeBeforeAnySessionKnown(t *testing.T) {
+	t.Parallel()
+
+	m := newTestSidebar(t)
+	m.workingAgent = "root" // keep needsSpinner true so Update never touches the coordinator
+	m.spinnerActive = true
+
+	m.Update(&runtime.SessionCompactionEvent{SessionID: "session-1", Status: "started"})
+	assert.True(t, m.compacting)
+}

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -724,6 +724,14 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		m.SetTokenUsage(msg)
 		return m, nil
 	case *runtime.SessionCompactionEvent:
+		// The "compacting…" gauge describes the displayed session only: a
+		// targeted compaction of a session that is not currently shown
+		// (e.g. an idle background agent session) must not flip it. Events
+		// without a session ID, or arriving before any session is known,
+		// keep the legacy behavior.
+		if active := m.activeSessionID(); active != "" && msg.SessionID != "" && msg.SessionID != active {
+			return m, nil
+		}
 		m.compacting = msg.Status == "started"
 		m.invalidateCache()
 		if m.compacting {

--- a/pkg/tui/dialog/context.go
+++ b/pkg/tui/dialog/context.go
@@ -29,49 +29,78 @@ import (
 type contextDialog struct {
 	BaseDialog
 
-	breakdown  *runtime.ContextBreakdown
-	keyMap     contextDialogKeyMap
-	scrollview *scrollview.Model
+	breakdown    *runtime.ContextBreakdown
+	liveSessions []runtime.LiveSession
+	keyMap       contextDialogKeyMap
+	scrollview   *scrollview.Model
 
-	// selected indexes breakdown.AttachedFiles; -1 when the inventory has
-	// nothing to select.
+	// selected indexes the combined selectable rows: live sessions first
+	// (0..len(liveSessions)-1), then breakdown.AttachedFiles; -1 when there
+	// is nothing to select.
 	selected int
-	// attachedLines maps each attached file to its line index in the
-	// scrollable content region. Rebuilt on every render and used to keep
-	// the selection visible while navigating.
-	attachedLines []int
+	// rowLines maps each selectable row (same order as the selection index)
+	// to its line index in the scrollable content region. Rebuilt on every
+	// render and used to keep the selection visible while navigating.
+	rowLines []int
 }
 
 type contextDialogKeyMap struct {
-	Close, Copy, Up, Down, Drop key.Binding
+	Close, Copy, Up, Down, Drop, Compact key.Binding
 }
 
 // NewContextDialog creates the /context dialog showing the estimated
-// context-window composition by category, plus the per-file inventory of
-// attached files (droppable) and prompt files.
-func NewContextDialog(breakdown *runtime.ContextBreakdown) Dialog {
+// context-window composition by category, the live-session team view
+// (explicitly compactable), plus the per-file inventory of attached files
+// (droppable) and prompt files.
+func NewContextDialog(breakdown *runtime.ContextBreakdown, liveSessions ...runtime.LiveSession) Dialog {
 	if breakdown == nil {
 		breakdown = &runtime.ContextBreakdown{}
 	}
 	d := &contextDialog{
-		breakdown: breakdown,
-		selected:  -1,
+		breakdown:    breakdown,
+		liveSessions: liveSessions,
+		selected:     -1,
 		scrollview: scrollview.New(
 			scrollview.WithKeyMap(scrollview.ReadOnlyScrollKeyMap()),
 			scrollview.WithReserveScrollbarSpace(true),
 		),
 		keyMap: contextDialogKeyMap{
-			Close: key.NewBinding(key.WithKeys("esc", "enter", "q"), key.WithHelp("Esc", "close")),
-			Copy:  key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "copy")),
-			Up:    key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("↑", "select")),
-			Down:  key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓", "select")),
-			Drop:  key.NewBinding(key.WithKeys("d", "x", "backspace", "delete"), key.WithHelp("d", "drop")),
+			Close:   key.NewBinding(key.WithKeys("esc", "q"), key.WithHelp("Esc", "close")),
+			Copy:    key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "copy")),
+			Up:      key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("↑", "select")),
+			Down:    key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓", "select")),
+			Drop:    key.NewBinding(key.WithKeys("d", "x", "backspace", "delete"), key.WithHelp("d", "drop")),
+			Compact: key.NewBinding(key.WithKeys("enter"), key.WithHelp("Enter", "compact")),
 		},
 	}
-	if len(breakdown.AttachedFiles) > 0 {
+	if d.selectableCount() > 0 {
 		d.selected = 0
 	}
 	return d
+}
+
+// selectableCount returns the number of selectable rows: live sessions plus
+// attached files.
+func (d *contextDialog) selectableCount() int {
+	return len(d.liveSessions) + len(d.breakdown.AttachedFiles)
+}
+
+// selectedLiveSession returns the live-session row under the selection.
+func (d *contextDialog) selectedLiveSession() (runtime.LiveSession, bool) {
+	if d.selected >= 0 && d.selected < len(d.liveSessions) {
+		return d.liveSessions[d.selected], true
+	}
+	return runtime.LiveSession{}, false
+}
+
+// selectedAttachedIndex returns the breakdown.AttachedFiles index under the
+// selection.
+func (d *contextDialog) selectedAttachedIndex() (int, bool) {
+	idx := d.selected - len(d.liveSessions)
+	if d.selected >= len(d.liveSessions) && idx >= 0 && idx < len(d.breakdown.AttachedFiles) {
+		return idx, true
+	}
+	return -1, false
 }
 
 func (d *contextDialog) Init() tea.Cmd { return nil }
@@ -93,54 +122,73 @@ func (d *contextDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 }
 
 // handleKey processes dialog-level keys. Up/Down are claimed for selection
-// only while attached files are listed; without them the keys fall through
-// to the scrollview and keep their plain scrolling behavior.
+// only while selectable rows (live sessions, attached files) are listed;
+// without them the keys fall through to the scrollview and keep their plain
+// scrolling behavior.
 func (d *contextDialog) handleKey(msg tea.KeyPressMsg) (tea.Cmd, bool) {
-	hasAttached := len(d.breakdown.AttachedFiles) > 0
+	selectable := d.selectableCount() > 0
 	switch {
 	case key.Matches(msg, d.keyMap.Close):
 		return core.CmdHandler(CloseDialogMsg{}), true
 	case key.Matches(msg, d.keyMap.Copy):
 		_ = clipboard.WriteAll(d.renderPlainText())
 		return notification.SuccessCmd("Context breakdown copied to clipboard."), true
-	case key.Matches(msg, d.keyMap.Up) && hasAttached:
+	case key.Matches(msg, d.keyMap.Up) && selectable:
 		d.moveSelection(-1)
 		return nil, true
-	case key.Matches(msg, d.keyMap.Down) && hasAttached:
+	case key.Matches(msg, d.keyMap.Down) && selectable:
 		d.moveSelection(1)
 		return nil, true
-	case key.Matches(msg, d.keyMap.Drop) && hasAttached:
-		return d.dropSelected(), true
+	case key.Matches(msg, d.keyMap.Compact) && len(d.liveSessions) > 0:
+		return d.compactSelected(), true
+	case key.Matches(msg, d.keyMap.Drop):
+		if idx, ok := d.selectedAttachedIndex(); ok {
+			return d.dropSelected(idx), true
+		}
 	}
 	return nil, false
 }
 
-// moveSelection moves the attached-file selection by delta, clamped to the
-// list bounds, and scrolls the selected row into view.
+// moveSelection moves the selection by delta across the combined rows (live
+// sessions, then attached files), clamped to the list bounds, and scrolls
+// the selected row into view.
 func (d *contextDialog) moveSelection(delta int) {
-	n := len(d.breakdown.AttachedFiles)
+	n := d.selectableCount()
 	if n == 0 {
 		return
 	}
 	d.selected = min(max(d.selected+delta, 0), n-1)
-	if d.selected < len(d.attachedLines) {
-		d.scrollview.EnsureLineVisible(d.attachedLines[d.selected])
+	if d.selected < len(d.rowLines) {
+		d.scrollview.EnsureLineVisible(d.rowLines[d.selected])
 	}
 }
 
-// dropSelected removes the selected attached file from the local inventory
+// compactSelected requests an explicit compaction of the selected live
+// session and closes the dialog. The row's SessionID and AgentName travel on
+// the message so the handler can route the current root session through the
+// classic /compact path and live sub-agent sessions through the targeted
+// runtime API.
+func (d *contextDialog) compactSelected() tea.Cmd {
+	row, ok := d.selectedLiveSession()
+	if !ok {
+		return nil
+	}
+	return tea.Sequence(
+		core.CmdHandler(CloseDialogMsg{}),
+		core.CmdHandler(messages.CompactSessionMsg{SessionID: row.SessionID, AgentName: row.AgentName}),
+	)
+}
+
+// dropSelected removes the attached file at idx from the local inventory
 // and asks the app to drop it from the session. The local removal is
 // optimistic, mirroring the session-browser delete flow; the handler reports
 // success or failure through a notification.
-func (d *contextDialog) dropSelected() tea.Cmd {
+func (d *contextDialog) dropSelected(idx int) tea.Cmd {
 	files := d.breakdown.AttachedFiles
-	if d.selected < 0 || d.selected >= len(files) {
-		return nil
-	}
-	path := files[d.selected].Path
-	d.breakdown.AttachedFiles = slices.Delete(files, d.selected, d.selected+1)
-	if d.selected >= len(d.breakdown.AttachedFiles) {
-		d.selected = len(d.breakdown.AttachedFiles) - 1
+	path := files[idx].Path
+	d.breakdown.AttachedFiles = slices.Delete(files, idx, idx+1)
+	if n := d.selectableCount(); d.selected >= n {
+		d.selected = n - 1
 	}
 	return core.CmdHandler(messages.DropAttachedFileMsg{Path: path})
 }
@@ -254,6 +302,11 @@ const contextEstimateNote = "Token counts are estimates; the provider's tokenize
 // stops being shared forward, but past messages keep their inlined copy.
 const contextDropNote = "Dropping a file removes it from the session's attachment list (sub-agents and skills stop receiving it); content already inlined in past messages stays until compaction."
 
+// contextCompactNote explains the live-session rows: Enter queues an
+// explicit compaction that executes on the selected session's own run loop
+// at a safe point, so it never interrupts an in-flight model turn.
+const contextCompactNote = "Press Enter to compact the selected live session; sub-agent compactions run at the session's next safe point."
+
 // categoryColors returns the per-category accent colors, aligned with the
 // order of contextRows. Hues are used categorically (Error's rose tint
 // carries no alarm semantics here); each maps to a distinct color in the
@@ -294,15 +347,83 @@ func (d *contextDialog) renderContent(contentWidth, maxHeight int) string {
 		lines = append(lines, renderContextRow(&row, scale, labelWidth, markerColor(i, row, colors)))
 	}
 
+	d.rowLines = d.rowLines[:0]
+	lines = d.appendLiveSessions(lines)
 	lines = d.appendInventory(lines, scale, contentWidth)
 
 	lines = append(lines, "")
 	lines = append(lines, wrapMutedLines(contextEstimateNote, contentWidth)...)
+	if len(d.liveSessions) > 0 {
+		lines = append(lines, wrapMutedLines(contextCompactNote, contentWidth)...)
+	}
 	if len(b.AttachedFiles) > 0 {
 		lines = append(lines, wrapMutedLines(contextDropNote, contentWidth)...)
 	}
 
 	return d.applyScrolling(lines, contentWidth, maxHeight)
+}
+
+// appendLiveSessions renders the team view: one selectable row per live
+// session (the current root first, then every running sub-agent session)
+// with its agent identity, short session ID and context budget. Omitted when
+// the runtime does not expose live-session tracking.
+func (d *contextDialog) appendLiveSessions(lines []string) []string {
+	if len(d.liveSessions) == 0 {
+		return lines
+	}
+	lines = append(lines, "", sectionStyle().Render("Live sessions"))
+	labelWidth := liveAgentLabelWidth(d.liveSessions)
+	for i := range d.liveSessions {
+		d.rowLines = append(d.rowLines, len(lines)-contextHeaderLines)
+		lines = append(lines, renderLiveSessionRow(&d.liveSessions[i], labelWidth, i == d.selected))
+	}
+	return lines
+}
+
+// liveAgentLabelWidth returns the display width of the agent-name column,
+// clamped so one long name cannot push the budget columns off screen.
+func liveAgentLabelWidth(rows []runtime.LiveSession) int {
+	width := 0
+	for i := range rows {
+		width = max(width, lipgloss.Width(rows[i].AgentName))
+	}
+	return min(max(width, 4), 24)
+}
+
+// renderLiveSessionRow renders one team row:
+// "▶ developer  0f9e8d7c  55.1K of 200.0K (28%)".
+func renderLiveSessionRow(row *runtime.LiveSession, labelWidth int, selected bool) string {
+	prefix := "  "
+	nameStyle := labelStyle()
+	if selected {
+		prefix = accentStyle().Render("▶ ")
+		nameStyle = nameStyle.Foreground(styles.Highlight)
+	}
+	name := truncateName(row.AgentName, labelWidth)
+	pad := strings.Repeat(" ", max(0, labelWidth-lipgloss.Width(name)))
+	line := fmt.Sprintf("%s%s%s  %s  %s",
+		prefix,
+		nameStyle.Render(name),
+		pad,
+		styles.MutedStyle.Render(row.ShortID()),
+		valueStyle().Render(liveSessionBudget(row)))
+	if row.Current {
+		line += "  " + styles.MutedStyle.Render("(current)")
+	}
+	return line
+}
+
+// liveSessionBudget formats a live session's context budget: used tokens,
+// window and percentage, or an explicit unknown-limit reading.
+func liveSessionBudget(row *runtime.LiveSession) string {
+	used := row.UsedTokens()
+	if row.ContextLimit <= 0 {
+		return formatTokenCount(used) + " tokens, limit unknown"
+	}
+	return fmt.Sprintf("%s of %s (%s)",
+		formatTokenCount(used),
+		formatTokenCount(row.ContextLimit),
+		percentLabel(used, row.ContextLimit))
 }
 
 // appendInventory renders the per-file inventory under the category rows:
@@ -311,15 +432,14 @@ func (d *contextDialog) renderContent(contentWidth, maxHeight int) string {
 // content-region line index of every attached row is recorded so navigation
 // can keep the selection visible.
 func (d *contextDialog) appendInventory(lines []string, scale int64, contentWidth int) []string {
-	d.attachedLines = d.attachedLines[:0]
 	b := d.breakdown
 	labelWidth := fileLabelWidth(b)
 
 	if len(b.AttachedFiles) > 0 {
 		lines = append(lines, "", sectionStyle().Render("Attached files"))
 		for i := range b.AttachedFiles {
-			d.attachedLines = append(d.attachedLines, len(lines)-contextHeaderLines)
-			lines = append(lines, renderContextFileRow(&b.AttachedFiles[i], scale, labelWidth, contentWidth, i == d.selected))
+			d.rowLines = append(d.rowLines, len(lines)-contextHeaderLines)
+			lines = append(lines, renderContextFileRow(&b.AttachedFiles[i], scale, labelWidth, contentWidth, len(d.liveSessions)+i == d.selected))
 		}
 	}
 	if len(b.PromptFileItems) > 0 {
@@ -530,13 +650,21 @@ func (d *contextDialog) applyScrolling(allLines []string, contentWidth, maxHeigh
 	return lipgloss.JoinVertical(lipgloss.Left, parts...)
 }
 
-// helpKeys returns the footer bindings; the selection/drop pair appears
-// only while attached files are listed.
+// helpKeys returns the footer bindings; the selection pair appears while
+// selectable rows are listed, the compact key while live sessions are
+// listed, and the drop key while attached files are listed.
 func (d *contextDialog) helpKeys() []string {
-	if len(d.breakdown.AttachedFiles) > 0 {
-		return []string{"↑↓", "select", "d", "drop", "c", "copy", "Esc", "close"}
+	keys := []string{"↑↓", "scroll"}
+	if d.selectableCount() > 0 {
+		keys = []string{"↑↓", "select"}
 	}
-	return []string{"↑↓", "scroll", "c", "copy", "Esc", "close"}
+	if len(d.liveSessions) > 0 {
+		keys = append(keys, "Enter", "compact")
+	}
+	if len(d.breakdown.AttachedFiles) > 0 {
+		keys = append(keys, "d", "drop")
+	}
+	return append(keys, "c", "copy", "Esc", "close")
 }
 
 // ---------------------------------------------------------------------------
@@ -566,6 +694,13 @@ func (d *contextDialog) renderPlainText() string {
 		lines = append(lines, line)
 	}
 
+	if len(d.liveSessions) > 0 {
+		lines = append(lines, "", "Live sessions")
+		for i := range d.liveSessions {
+			lines = append(lines, plainLiveSessionLine(&d.liveSessions[i]))
+		}
+	}
+
 	if len(b.AttachedFiles) > 0 {
 		lines = append(lines, "", "Attached files")
 		for i := range b.AttachedFiles {
@@ -588,6 +723,15 @@ func plainFileLine(file *runtime.ContextFile, scale int64) string {
 	line := fmt.Sprintf("%-8s %4s  %s", fileTokensLabel(file), percentLabel(file.Tokens, scale), file.Path)
 	if file.Missing {
 		line += " (missing)"
+	}
+	return line
+}
+
+// plainLiveSessionLine formats one live-session row for the clipboard copy.
+func plainLiveSessionLine(row *runtime.LiveSession) string {
+	line := fmt.Sprintf("%s  %s  %s", row.AgentName, row.ShortID(), liveSessionBudget(row))
+	if row.Current {
+		line += " (current)"
 	}
 	return line
 }

--- a/pkg/tui/dialog/context_test.go
+++ b/pkg/tui/dialog/context_test.go
@@ -320,3 +320,172 @@ func TestFileLabelWidthClamped(t *testing.T) {
 	b = &runtime.ContextBreakdown{AttachedFiles: []runtime.ContextFile{{Path: "/p/a.go"}}}
 	assert.Equal(t, 4, fileLabelWidth(b))
 }
+
+// ---------------------------------------------------------------------------
+// Live sessions (team view, targeted compaction)
+// ---------------------------------------------------------------------------
+
+func testLiveSessions() []runtime.LiveSession {
+	return []runtime.LiveSession{
+		{SessionID: "root-session-1234", AgentName: "root", InputTokens: 20_000, OutputTokens: 5_400, ContextLimit: 128_000, Current: true},
+		// Two concurrent runs of the SAME agent: rows must stay distinct.
+		{SessionID: "aaaa1111-e89b-12d3", AgentName: "developer", InputTokens: 50_000, OutputTokens: 5_100, ContextLimit: 200_000},
+		{SessionID: "bbbb2222-e89b-12d3", AgentName: "developer", InputTokens: 1_000, OutputTokens: 200},
+	}
+}
+
+func TestContextDialogLiveSessionsView(t *testing.T) {
+	t.Parallel()
+
+	dialog := NewContextDialog(testBreakdown(), testLiveSessions()...)
+	dialog.SetSize(120, 50)
+	view := dialog.View()
+
+	assert.Contains(t, view, "Live sessions")
+	assert.Contains(t, view, "root")
+	assert.Contains(t, view, "(current)")
+	assert.Contains(t, view, "developer")
+
+	// Short session IDs disambiguate duplicate same-agent rows.
+	assert.Contains(t, view, "aaaa1111")
+	assert.Contains(t, view, "bbbb2222")
+
+	// Budgets: used of limit with percentage, or the unknown-limit reading.
+	assert.Contains(t, view, "55.1K of 200.0K (28%)")
+	assert.Contains(t, view, "1.2K tokens, limit unknown")
+
+	assert.Contains(t, view, "compact", "help must advertise the compact key")
+}
+
+func TestContextDialogNoLiveSessions(t *testing.T) {
+	t.Parallel()
+
+	dialog := NewContextDialog(testBreakdown())
+	dialog.SetSize(100, 50)
+	view := dialog.View()
+
+	assert.NotContains(t, view, "Live sessions")
+	assert.NotContains(t, view, "compact")
+}
+
+func TestContextDialogEnterCompactsSelectedLiveSession(t *testing.T) {
+	t.Parallel()
+
+	d := NewContextDialog(testBreakdown(), testLiveSessions()...).(*contextDialog)
+	d.SetSize(120, 50)
+	d.View()
+
+	require.Equal(t, 0, d.selected, "selection starts on the first live session")
+
+	// Select the second developer row and request its compaction.
+	d.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	d.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.NotNil(t, cmd)
+
+	msgs := collectMsgs(cmd)
+	require.Len(t, msgs, 2)
+	assert.IsType(t, CloseDialogMsg{}, msgs[0], "the dialog closes after requesting a compaction")
+	compactMsg, ok := msgs[1].(messages.CompactSessionMsg)
+	require.True(t, ok, "expected CompactSessionMsg, got %T", msgs[1])
+	assert.Equal(t, "bbbb2222-e89b-12d3", compactMsg.SessionID)
+	assert.Equal(t, "developer", compactMsg.AgentName)
+	assert.Empty(t, compactMsg.AdditionalPrompt)
+}
+
+func TestContextDialogEnterOnMainRowTargetsRootSession(t *testing.T) {
+	t.Parallel()
+
+	d := NewContextDialog(testBreakdown(), testLiveSessions()...).(*contextDialog)
+	d.SetSize(120, 50)
+	d.View()
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.NotNil(t, cmd)
+
+	msgs := collectMsgs(cmd)
+	require.Len(t, msgs, 2)
+	compactMsg, ok := msgs[1].(messages.CompactSessionMsg)
+	require.True(t, ok, "expected CompactSessionMsg, got %T", msgs[1])
+	assert.Equal(t, "root-session-1234", compactMsg.SessionID,
+		"the main row carries the root session ID; the handler routes it through the classic /compact path")
+}
+
+func TestContextDialogCombinedSelection(t *testing.T) {
+	t.Parallel()
+
+	d := NewContextDialog(testBreakdownWithFiles(), testLiveSessions()...).(*contextDialog)
+	d.SetSize(120, 50)
+	d.View()
+
+	// 3 live sessions + 3 attached files = 6 selectable rows.
+	require.Equal(t, 6, d.selectableCount())
+
+	// Walk from the live rows into the attached rows.
+	for range 3 {
+		d.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	}
+	assert.Equal(t, 3, d.selected)
+	idx, ok := d.selectedAttachedIndex()
+	require.True(t, ok)
+	assert.Equal(t, 0, idx)
+
+	// Enter on an attached row is inert: no compaction, no close.
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	assert.Nil(t, cmd)
+
+	// Dropping works from the combined selection and targets the right file.
+	_, cmd = d.Update(keyPress('d'))
+	require.NotNil(t, cmd)
+	dropMsg, ok := cmd().(messages.DropAttachedFileMsg)
+	require.True(t, ok)
+	assert.Equal(t, "/proj/main.go", dropMsg.Path)
+	require.Len(t, d.breakdown.AttachedFiles, 2)
+
+	// Selection clamps within the combined bounds after drops.
+	d.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	d.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	d.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	assert.Equal(t, 4, d.selected)
+
+	// The drop keys are inert while a live-session row is selected.
+	for range 6 {
+		d.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+	}
+	require.Equal(t, 0, d.selected)
+	_, cmd = d.Update(keyPress('d'))
+	assert.Nil(t, cmd)
+	require.Len(t, d.breakdown.AttachedFiles, 2, "drop on a live row must not remove attachments")
+}
+
+func TestContextDialogEnterDoesNotClose(t *testing.T) {
+	t.Parallel()
+
+	// Without live sessions Enter is unbound: neither close nor compact.
+	d := NewContextDialog(testBreakdown()).(*contextDialog)
+	d.SetSize(100, 50)
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	assert.Nil(t, cmd)
+
+	// Esc and q still close.
+	_, cmd = d.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	require.NotNil(t, cmd)
+	assert.IsType(t, CloseDialogMsg{}, cmd())
+	_, cmd = d.Update(keyPress('q'))
+	require.NotNil(t, cmd)
+	assert.IsType(t, CloseDialogMsg{}, cmd())
+}
+
+func TestContextDialogPlainTextLiveSessions(t *testing.T) {
+	t.Parallel()
+
+	d := &contextDialog{breakdown: testBreakdown(), liveSessions: testLiveSessions()}
+	text := d.renderPlainText()
+
+	assert.Contains(t, text, "Live sessions")
+	assert.Contains(t, text, "root  root-ses")
+	assert.Contains(t, text, "(current)")
+	assert.Contains(t, text, "developer  aaaa1111  55.1K of 200.0K (28%)")
+	assert.Contains(t, text, "developer  bbbb2222  1.2K tokens, limit unknown")
+	assert.NotContains(t, text, "\x1b[", "plain text must carry no ANSI escapes")
+}

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -224,8 +224,41 @@ func (m *appModel) handleExportSession(filename string) (tea.Model, tea.Cmd) {
 	return m, notification.SuccessCmd("Session exported to " + exportFile)
 }
 
-func (m *appModel) handleCompactSession(additionalPrompt string) (tea.Model, tea.Cmd) {
-	return m, m.chatPage.CompactSession(additionalPrompt)
+func (m *appModel) handleCompactSession(msg messages.CompactSessionMsg) (tea.Model, tea.Cmd) {
+	if compactTargetsCurrentSession(msg, m.application.Session()) {
+		return m, m.chatPage.CompactSession(msg.AdditionalPrompt)
+	}
+	// Targeted compaction of a live sub-agent session: queued onto the
+	// target session's own run loop, so neither the root stream nor the
+	// target stream is cancelled.
+	if err := m.application.CompactLiveSession(m.ctx(), msg.SessionID, msg.AdditionalPrompt); err != nil {
+		return m, notification.ErrorCmd(fmt.Sprintf("Compaction request failed: %v", err))
+	}
+	return m, notification.InfoCmd(fmt.Sprintf(
+		"Compaction requested for %s; it runs at the session's next safe point.",
+		compactTargetLabel(msg)))
+}
+
+// compactTargetsCurrentSession reports whether msg addresses the current
+// root session: an empty target (the /compact command) or the root's own
+// session ID (the main row of the /context team view). Both route through
+// the existing root compaction path.
+func compactTargetsCurrentSession(msg messages.CompactSessionMsg, current *session.Session) bool {
+	return msg.SessionID == "" || (current != nil && msg.SessionID == current.ID)
+}
+
+// compactTargetLabel names the target of a targeted compaction request for
+// notifications: "agent (session 0f9e8d7c)", or just the short session ID
+// when the agent name is unknown.
+func compactTargetLabel(msg messages.CompactSessionMsg) string {
+	shortID := msg.SessionID
+	if len(shortID) > 8 {
+		shortID = shortID[:8]
+	}
+	if msg.AgentName == "" {
+		return "session " + shortID
+	}
+	return fmt.Sprintf("%s (session %s)", msg.AgentName, shortID)
 }
 
 func (m *appModel) handleCopySessionToClipboard() (tea.Model, tea.Cmd) {
@@ -455,7 +488,8 @@ func (m *appModel) handleShowCostDialog() (tea.Model, tea.Cmd) {
 // goroutine: the computation lists the agent's tools, which may start
 // not-yet-started toolsets (e.g. MCP servers) and block for a while, so it
 // must not run inside the Update loop. The dialog opens when the data is
-// ready.
+// ready, together with the live-session team view (current root plus every
+// running sub-agent session; empty for runtimes without live tracking).
 func (m *appModel) handleShowContextDialog() (tea.Model, tea.Cmd) {
 	appRef := m.application
 	ctx := m.ctx()
@@ -473,7 +507,7 @@ func (m *appModel) handleShowContextDialog() (tea.Model, tea.Cmd) {
 				Type: notification.TypeError,
 			}
 		}
-		return dialog.OpenDialogMsg{Model: dialog.NewContextDialog(breakdown)}
+		return dialog.OpenDialogMsg{Model: dialog.NewContextDialog(breakdown, appRef.LiveSessions(ctx)...)}
 	}
 }
 

--- a/pkg/tui/messages/session.go
+++ b/pkg/tui/messages/session.go
@@ -39,7 +39,15 @@ type (
 	EvalSessionMsg struct{ Filename string }
 
 	// CompactSessionMsg generates a summary and compacts session history.
-	CompactSessionMsg struct{ AdditionalPrompt string }
+	// SessionID selects the target: empty (or the current root session's ID)
+	// compacts the root session via the classic /compact path, any other ID
+	// requests a targeted compaction of that live sub-agent session.
+	// AgentName is carried along for user-facing feedback only.
+	CompactSessionMsg struct {
+		AdditionalPrompt string
+		SessionID        string
+		AgentName        string
+	}
 
 	// CopySessionToClipboardMsg copies the entire conversation to clipboard.
 	CopySessionToClipboardMsg struct{}

--- a/pkg/tui/page/chat/compaction_events_test.go
+++ b/pkg/tui/page/chat/compaction_events_test.go
@@ -1,0 +1,95 @@
+package chat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/app"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tui/service"
+)
+
+// subCompactionEvent builds a completed compaction event for the given session.
+func subCompactionEvent(sessionID, outcome string) *runtime.SessionCompactionEvent {
+	return &runtime.SessionCompactionEvent{
+		Type:         "session_compaction",
+		SessionID:    sessionID,
+		Status:       "completed",
+		Outcome:      outcome,
+		AgentContext: runtime.AgentContext{AgentName: "worker"},
+	}
+}
+
+// TestSubSessionCompactionKeepsRootWorkState pins the #3439 event-routing
+// contract: a sub-agent session finishing a compaction must not flip the
+// root chat idle, clear its stream cancel func, or process root queues.
+func TestSubSessionCompactionKeepsRootWorkState(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	p := New(t.Context(), app.New(t.Context(), queueTestRuntime{}, sess), service.NewSessionState(sess)).(*chatPage)
+
+	_, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	p.msgCancel = cancel
+	p.working = true
+	p.messageQueue = []queuedMessage{{content: "queued while working"}}
+
+	handled, _ := p.handleRuntimeEvent(subCompactionEvent("sub-session-1", runtime.CompactionOutcomeApplied))
+	require.True(t, handled)
+
+	assert.True(t, p.working, "a sub-session compaction must not mark the root chat idle")
+	assert.NotNil(t, p.msgCancel, "the root stream cancel func must stay intact")
+	assert.Len(t, p.messageQueue, 1, "root queued messages must not be processed")
+}
+
+// TestRootSessionCompactionResetsWorkState pins the complementary root path:
+// the root session's own compaction completion still cleans up.
+func TestRootSessionCompactionResetsWorkState(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	p := New(t.Context(), app.New(t.Context(), queueTestRuntime{}, sess), service.NewSessionState(sess)).(*chatPage)
+
+	_, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	p.msgCancel = cancel
+	p.working = true
+
+	handled, _ := p.handleRuntimeEvent(subCompactionEvent(sess.ID, runtime.CompactionOutcomeApplied))
+	require.True(t, handled)
+
+	assert.False(t, p.working, "the root compaction completion marks the chat idle")
+	assert.Nil(t, p.msgCancel)
+}
+
+// TestSubSessionCompactionNotice verifies the agent-scoped feedback for each
+// terminal outcome and the silence of non-terminal events.
+func TestSubSessionCompactionNotice(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, subSessionCompactionNotice(&runtime.SessionCompactionEvent{Status: "started"}),
+		"the request was already announced; started stays silent")
+
+	for _, outcome := range []string{"", runtime.CompactionOutcomeApplied, runtime.CompactionOutcomeSkipped, runtime.CompactionOutcomeFailed} {
+		assert.NotNil(t, subSessionCompactionNotice(subCompactionEvent("sub-1", outcome)),
+			"outcome %q must produce user feedback", outcome)
+	}
+}
+
+// TestIsSubSessionEvent covers the root/sub classification, including the
+// empty-session-ID backward-compatibility case.
+func TestIsSubSessionEvent(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	p := New(t.Context(), app.New(t.Context(), queueTestRuntime{}, sess), service.NewSessionState(sess)).(*chatPage)
+
+	assert.False(t, p.isSubSessionEvent(""), "events without a session ID belong to the root")
+	assert.False(t, p.isSubSessionEvent(sess.ID))
+	assert.True(t, p.isSubSessionEvent("some-other-session"))
+}

--- a/pkg/tui/page/chat/runtime_events.go
+++ b/pkg/tui/page/chat/runtime_events.go
@@ -133,8 +133,16 @@ func (p *chatPage) handleRuntimeEvent(msg tea.Msg) (bool, tea.Cmd) {
 
 	case *runtime.SessionCompactionEvent:
 		// The sidebar tracks the started/completed pair to drive its
-		// "compacting…" gauge state.
+		// "compacting…" gauge state (it ignores sessions it is not
+		// currently displaying).
 		sidebarCmd := p.forwardToSidebar(msg)
+		if p.isSubSessionEvent(msg.SessionID) {
+			// A sub-agent session compacting (threshold-triggered on a
+			// foreground child, or an explicit /context request on a live
+			// session) must not touch the root chat's work state: no
+			// clearing of msgCancel, no spinner flip, no queue processing.
+			return true, tea.Batch(sidebarCmd, subSessionCompactionNotice(msg))
+		}
 		if msg.Status == "completed" {
 			p.msgCancel = nil
 			cmds := []tea.Cmd{
@@ -182,6 +190,39 @@ func (p *chatPage) forwardToSidebar(msg tea.Msg) tea.Cmd {
 	model, cmd := p.sidebar.Update(msg)
 	p.sidebar = model.(sidebar.Model)
 	return cmd
+}
+
+// isSubSessionEvent reports whether sessionID identifies a session other
+// than the page's root session. Events without a session ID are treated as
+// root events for backward compatibility.
+func (p *chatPage) isSubSessionEvent(sessionID string) bool {
+	if sessionID == "" || p.app == nil {
+		return false
+	}
+	sess := p.app.Session()
+	return sess != nil && sessionID != sess.ID
+}
+
+// subSessionCompactionNotice builds the agent-scoped feedback for a
+// sub-agent session's compaction: success, skipped or failed on the terminal
+// event, silence while it runs (the request itself was already announced).
+func subSessionCompactionNotice(msg *runtime.SessionCompactionEvent) tea.Cmd {
+	if msg.Status != "completed" {
+		return nil
+	}
+	agentLabel := msg.AgentName
+	if agentLabel == "" {
+		agentLabel = "sub-agent"
+	}
+	switch msg.Outcome {
+	case "", runtime.CompactionOutcomeApplied:
+		return notification.SuccessCmd(fmt.Sprintf("Compacted %s's session.", agentLabel))
+	case runtime.CompactionOutcomeSkipped:
+		return notification.InfoCmd(fmt.Sprintf("Compaction skipped for %s's session.", agentLabel))
+	case runtime.CompactionOutcomeFailed:
+		return notification.ErrorCmd(fmt.Sprintf("Compaction failed for %s's session.", agentLabel))
+	}
+	return nil
 }
 
 // handleTokenUsage updates sidebar and session with token usage data.

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1140,7 +1140,7 @@ func (m *appModel) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.forwardChat(msg)
 
 	case messages.CompactSessionMsg:
-		return m.handleCompactSession(msg.AdditionalPrompt)
+		return m.handleCompactSession(msg)
 
 	case messages.CopySessionToClipboardMsg:
 		return m.handleCopySessionToClipboard()

--- a/pkg/tui/tui_exit_test.go
+++ b/pkg/tui/tui_exit_test.go
@@ -29,13 +29,18 @@ import (
 )
 
 // mockChatPage implements chat.Page for testing.
-type mockChatPage struct{}
+type mockChatPage struct {
+	compactCalls []string // AdditionalPrompt of each CompactSession call
+}
 
-func (m *mockChatPage) Init() tea.Cmd                            { return nil }
-func (m *mockChatPage) Update(tea.Msg) (layout.Model, tea.Cmd)   { return m, nil }
-func (m *mockChatPage) View() string                             { return "" }
-func (m *mockChatPage) SetSize(int, int) tea.Cmd                 { return nil }
-func (m *mockChatPage) CompactSession(string) tea.Cmd            { return nil }
+func (m *mockChatPage) Init() tea.Cmd                          { return nil }
+func (m *mockChatPage) Update(tea.Msg) (layout.Model, tea.Cmd) { return m, nil }
+func (m *mockChatPage) View() string                           { return "" }
+func (m *mockChatPage) SetSize(int, int) tea.Cmd               { return nil }
+func (m *mockChatPage) CompactSession(prompt string) tea.Cmd {
+	m.compactCalls = append(m.compactCalls, prompt)
+	return nil
+}
 func (m *mockChatPage) SetSessionStarred(bool)                   {}
 func (m *mockChatPage) SetTitleRegenerating(bool) tea.Cmd        { return nil }
 func (m *mockChatPage) ScrollToBottom() tea.Cmd                  { return nil }


### PR DESCRIPTION
Closes #3439

## Summary

Adds a team-level live-session view to `/context` and explicit compaction targeting for individual sub-agent sessions.

The runtime tracks active `RunStream` sessions, including foreground delegation and `run_background_agent` work. Targeted requests are queued onto the selected session's own run loop and execute between model turns, preventing compaction from racing an in-flight turn.

## Issue expectations

| Expectation | Implementation |
| --- | --- |
| Team-level `/context` view | Lists the current root session and every live descendant session |
| Context budget per session | Shows used tokens, context limit, and percentage, with an unknown-limit fallback |
| Target a named sub-agent | Live rows show agent name and short session ID; Enter targets the exact session |
| Background-agent support | Every active `RunStream`, including `run_background_agent`, is registered |
| Explicit user action | Cross-agent targeting occurs only after selecting a row and pressing Enter |
| No idle auto-compaction | No idle-triggered policy was added; existing threshold and overflow recovery behavior is unchanged |
| Safe event forwarding | Sub-session compaction events do not cancel, idle, or drain queues for the root TUI session |

## Runtime flow

```text
/context
  -> LiveSessions(current root)
  -> select live row
  -> CompactLiveSession(session ID)
  -> bounded request queue on target live-session entry
  -> target RunStream reaches a safe iteration boundary
  -> manual compaction events return through the App event stream
```

Accepted requests are drained before stream teardown. Requests on already-cancelled streams complete as skipped, avoiding a misleading started/failed sequence. Cached root-tree identity keeps long-running nested background sessions visible after an intermediate foreground parent finishes, while excluding stale sessions from a replaced root.

## TUI behavior

- Up/Down moves across live-session and attached-file rows.
- Enter compacts a selected live session.
- `d`, `x`, or Delete still drops a selected attachment.
- The current/root row preserves the existing `/compact` path.
- Targeted child compaction does not cancel the root stream or alter its working state.
- The sidebar compaction indicator only follows the session currently displayed.

## Design decisions and residual scope

- Live-session listing and targeting are optional local-runtime capabilities, matching the existing optional context-breakdown pattern. Remote runtimes omit the live-session section and report targeted compaction as unsupported.
- Harness-backed sessions have no regular model-loop iteration boundaries and no known context limit. An accepted request is therefore handled during teardown rather than interrupting harness execution.
- Existing proactive threshold and overflow-recovery compaction remain active for sub-agent sessions. This change only adds explicit cross-agent orchestration.

## Validation

| Check | Result |
| --- | --- |
| `task build` | pass |
| `task --force lint` | pass, 0 issues |
| Relevant package tests | pass |
| Race tests for runtime, App, dialog, chat, sidebar, and TUI | pass |
| Full `task test` | pass with proxy variables unset, isolated Docker config, and Docker Model Runner marked unavailable |
| Adversarial review | two cycles completed; blocking findings resolved |
