### PR TITLE
fix(toolexec): repair build after approvalMu removal

### DIFF
--- a/pkg/runtime/toolexec/dispatcher.go
+++ b/pkg/runtime/toolexec/dispatcher.go
@@ -494,22 +494,17 @@ func (c *call) autoApprovalAfterConfirmationWait() (PermissionDecision, bool) {
 // "mkdir x && rm -rf ~". Silencing a safety verdict demands the stricter
 // word-boundary, no-metacharacter reading — see shellGrantCoversCommand.
 func (c *call) sessionPermissionsAllow() bool {
-	c.d.approvalMu.Lock()
-	defer c.d.approvalMu.Unlock()
-	if c.sess.Permissions == nil {
+	perms := c.sess.ClonePermissions()
+	if perms == nil {
 		return false
 	}
 	args := ParseToolInput(c.tc.Function.Arguments)
-	checker := permissions.NewCheckerFromRules(
-		c.sess.Permissions.Allow,
-		c.sess.Permissions.Ask,
-		c.sess.Permissions.Deny,
-	)
+	checker := permissions.NewCheckerFromRules(perms.Allow, perms.Ask, perms.Deny)
 	if checker.CheckWithArgs(c.tc.Function.Name, args) != permissions.Allow {
 		return false
 	}
 	if c.tc.Function.Name == shellToolName {
-		return shellGrantCoversCommand(c.sess.Permissions.Allow, args)
+		return shellGrantCoversCommand(perms.Allow, args)
 	}
 	return true
 }


### PR DESCRIPTION
Main currently fails to compile due to a semantic merge conflict. PR #3490 removed `Dispatcher.approvalMu` and moved permission locking into the session package's own mutex, but an earlier commit (0a2dafdce) that fixed the preempt-yolo "always allow" path had already added `sessionPermissionsAllow()` in `pkg/runtime/toolexec/dispatcher.go` — a function that references `c.d.approvalMu`. Both changes merged cleanly at the text level, but the combined result references a field that no longer exists.

The fix rewrites `sessionPermissionsAllow` to use `sess.ClonePermissions()`, the thread-safe accessor that the new locking model exposes, eliminating the direct mutex reference on the dispatcher entirely. The behavior is identical: permissions are read under the session's own lock rather than a separate dispatcher-level one.

No API or behavior changes; this is a pure build fix.