### PR TITLE
fix(cli): correct model setup documentation URL

### DIFF
--- a/pkg/environment/errors.go
+++ b/pkg/environment/errors.go
@@ -14,7 +14,7 @@ const SecretsDocsURL = "https://docs.docker.com/ai/docker-agent/guides/secrets/"
 
 // ModelSetupDocsURL is the step-by-step tutorial for making a model available,
 // covering both the cloud API-key path and the local Docker Model Runner path.
-const ModelSetupDocsURL = "https://docs.docker.com/ai/docker-agent/getting-started/set-up-a-model/"
+const ModelSetupDocsURL = "https://docker.github.io/docker-agent/getting-started/set-up-a-model/"
 
 type RequiredEnvError struct {
 	Missing []string

--- a/pkg/environment/errors_test.go
+++ b/pkg/environment/errors_test.go
@@ -49,4 +49,8 @@ func TestRequiredEnvError_SuggestsLocalModelForModelCredentials(t *testing.T) {
 	assert.Contains(t, msg, "docker model ls")
 	assert.Contains(t, msg, "docker agent setup")
 	assert.Contains(t, msg, ModelSetupDocsURL)
+
+	// Pin the exact published URL so an accidental change to the constant
+	// (e.g. back to the dead docs.docker.com path) fails loudly.
+	assert.Contains(t, msg, "https://docker.github.io/docker-agent/getting-started/set-up-a-model/")
 }


### PR DESCRIPTION
## Summary

- replace the broken model setup documentation URL with the published Docker Agent documentation page
- pin the exact URL in the environment error test to prevent regression

## Validation

| Check | Result |
| --- | --- |
| Published documentation URL | HTTP 200 |
| Targeted tests | pass |
| Build | pass |
| Lint | pass |
| Review | approved |
