### PR TITLE
feat(tui): show animated agent transfers

### DIFF
--- a/pkg/tui/components/sidebar/agent_panel_test.go
+++ b/pkg/tui/components/sidebar/agent_panel_test.go
@@ -16,6 +16,9 @@ import (
 
 // newAgentPanelSidebar builds a sidebar whose current agent is "root" and whose
 // roster is set, ready to render the Agents panel at the given outer width.
+// The transfer-box animation is always stopped on cleanup so tests that start
+// it (via SetAgentSwitching) cannot leak a registration on the global
+// animation coordinator into parallel tests.
 func newAgentPanelSidebar(t *testing.T, width int, agents ...runtime.AgentDetails) *model {
 	t.Helper()
 	sess := session.New()
@@ -29,6 +32,7 @@ func newAgentPanelSidebar(t *testing.T, width int, agents ...runtime.AgentDetail
 	m.availableAgents = agents
 	m.width = width
 	m.height = 200
+	t.Cleanup(m.transferAnimation.Stop)
 	return m
 }
 

--- a/pkg/tui/components/sidebar/agent_transfer_test.go
+++ b/pkg/tui/components/sidebar/agent_transfer_test.go
@@ -1,0 +1,474 @@
+package sidebar
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tui/animation"
+	"github.com/docker/docker-agent/pkg/tui/components/spinner"
+	"github.com/docker/docker-agent/pkg/tui/messages"
+)
+
+// transferRoster is a 3-agent roster whose current agent is "root" (set by
+// newAgentPanelSidebar), used across the transfer box tests.
+func transferRoster() []runtime.AgentDetails {
+	return []runtime.AgentDetails{
+		{Name: "root", Provider: "anthropic", Model: "opus", Thinking: "high"},
+		{Name: "Scout", Provider: "openai", Model: "gpt-5.4-mini", Thinking: "off"},
+		{Name: "Coder", Provider: "anthropic", Model: "claude-sonnet-4-6", Thinking: "high"},
+	}
+}
+
+// transferRelationIndex renders the panel and returns the body-line index of
+// the transfer box's relation line (the line carrying the ► arrow head), or
+// -1 when absent.
+func transferRelationIndex(m *model) int {
+	for j, line := range agentBody(m) {
+		if strings.Contains(line, transferArrowHead) {
+			return j
+		}
+	}
+	return -1
+}
+
+// TestTransferPanelContentAndPlacement verifies the in-flight transfer renders
+// as a compact three-line box — muted bordered title, source ─●─► destination
+// relation — below the whole roster after a blank breathing line, all unowned
+// so it stays unclickable, and that the Agents header keeps its ↔ marker.
+func TestTransferPanelContentAndPlacement(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+	m.SetAgentSwitching(true, "Scout", "Coder")
+
+	body := agentBody(m)
+	idx := transferRelationIndex(m)
+	require.GreaterOrEqual(t, idx, 0, "a transfer relation line should render")
+
+	// The roster stays uninterrupted: each agent keeps its two lines and the
+	// blank separators, then the breathing line and the three box lines follow.
+	assert.Equal(t, []string{
+		"root", "root", "", "Scout", "Scout", "", "Coder", "Coder",
+		"", "", "", "",
+	}, m.agentLineOwners)
+	require.Len(t, body, 12)
+	assert.Equal(t, len(body)-2, idx, "the relation line is the box's middle line")
+	assert.Empty(t, strings.TrimSpace(body[len(body)-4]), "a blank breathing line precedes the box")
+
+	top, relation, bottom := body[idx-1], body[idx], body[idx+1]
+	assert.True(t, strings.HasPrefix(top, "╭─ "+transferBoxTitle+" "), "the top border embeds the title")
+	assert.True(t, strings.HasSuffix(top, "╮"))
+	assert.True(t, strings.HasPrefix(relation, "│ "), "the relation line sits inside the border")
+	assert.True(t, strings.HasSuffix(relation, " │"))
+	assert.Contains(t, relation, "Scout", "the relation shows the source")
+	assert.Contains(t, relation, "Coder", "the relation shows the destination")
+	assert.Contains(t, relation, transferDot, "the relation carries the rail dot")
+	assert.True(t, strings.HasPrefix(bottom, "╰"))
+	assert.True(t, strings.HasSuffix(bottom, "╯"))
+
+	contentWidth := m.contentWidth(false)
+	for _, line := range []string{top, relation, bottom} {
+		assert.Equal(t, contentWidth, lipgloss.Width(line), "the box spans the full content width")
+	}
+
+	title := renderAgentPanel(m)[0]
+	assert.Contains(t, title, "Agents ↔", "the header keeps its switching marker")
+}
+
+// TestTransferPanelBelowRosterAnyOrder verifies the box always sits below the
+// whole roster regardless of where source and destination appear in it —
+// destination first, source last — and that exactly one relation line renders.
+func TestTransferPanelBelowRosterAnyOrder(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40,
+		runtime.AgentDetails{Name: "Coder", Provider: "anthropic", Model: "claude-sonnet-4-6", Thinking: "high"},
+		runtime.AgentDetails{Name: "middle", Provider: "google", Model: "gemini-flash", Thinking: "off"},
+		runtime.AgentDetails{Name: "Scout", Provider: "openai", Model: "gpt-5.4-mini", Thinking: "off"},
+	)
+	m.SetAgentSwitching(true, "Scout", "Coder")
+
+	body := agentBody(m)
+	idx := transferRelationIndex(m)
+	require.GreaterOrEqual(t, idx, 0)
+
+	assert.Equal(t, []string{
+		"Coder", "Coder", "", "middle", "middle", "", "Scout", "Scout",
+		"", "", "", "",
+	}, m.agentLineOwners, "nothing is inserted inside the roster")
+	assert.Equal(t, len(body)-2, idx, "the box stays at the bottom of the panel body")
+
+	count := 0
+	for _, l := range body {
+		if strings.Contains(l, transferArrowHead) {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "only one relation line renders")
+}
+
+// TestTransferPanelKeepsRosterMarkers verifies the box neither replaces nor
+// masks the destination's own marker: the ▶ (or the native spinner while the
+// destination works) stays on the roster entry and never leaks into the box.
+func TestTransferPanelKeepsRosterMarkers(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+	m.sessionState.SetCurrentAgentName("Coder")
+	m.SetAgentSwitching(true, "Scout", "Coder")
+
+	idx := transferRelationIndex(m)
+	require.GreaterOrEqual(t, idx, 0)
+	line1, _ := agentLines(m, "Coder")
+	assert.Contains(t, line1, "▶", "the destination keeps its current-agent marker")
+
+	m.workingAgent = "Coder"
+	line1, _ = agentLines(m, "Coder")
+	assert.Contains(t, line1, m.spinner.RawFrame(), "the working destination keeps the native spinner")
+
+	box := strings.Join(agentBody(m)[idx-1:idx+2], "\n")
+	assert.NotContains(t, box, "▶", "the box carries no current-agent marker")
+	for i := range 10 {
+		assert.NotContains(t, box, spinner.Frame(i), "the box carries no spinner")
+	}
+}
+
+// TestTransferPanelNotClickable verifies through the full view that clicking
+// the box (or its breathing line) hits nothing while the surrounding agent
+// lines stay clickable.
+func TestTransferPanelNotClickable(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+	m.SetAgentSwitching(true, "Scout", "Coder")
+
+	_ = m.View()
+
+	relationY := -1
+	for y, l := range m.cachedLines {
+		if strings.Contains(ansi.Strip(l), transferArrowHead) {
+			relationY = y
+			break
+		}
+	}
+	require.GreaterOrEqual(t, relationY, 0, "the box renders in the full view")
+
+	x := m.layoutCfg.PaddingLeft + 2
+	for _, y := range []int{relationY - 2, relationY - 1, relationY, relationY + 1} {
+		result, name := m.HandleClickType(x, y)
+		assert.Equalf(t, ClickNone, result, "box line at offset %d is not clickable", y-relationY)
+		assert.Empty(t, name)
+	}
+
+	clicked := map[string]bool{}
+	for y := range len(m.cachedLines) {
+		if r, n := m.HandleClickType(x, y); r == ClickAgent {
+			clicked[n] = true
+		}
+	}
+	assert.True(t, clicked["Scout"], "the source's own lines stay clickable")
+	assert.True(t, clicked["Coder"], "the destination's own lines stay clickable")
+}
+
+// TestTransferPanelAtMinWidth verifies that at the narrowest expanded sidebar
+// both names remain visible (the longer side truncated with an ellipsis), the
+// rail and arrow survive, and no body line exceeds the content width.
+func TestTransferPanelAtMinWidth(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, MinWidth, transferRoster()...)
+	m.SetAgentSwitching(true, "Scout", "Coder")
+
+	contentWidth := m.contentWidth(false)
+	body := agentBody(m)
+	idx := transferRelationIndex(m)
+	require.GreaterOrEqual(t, idx, 0)
+
+	for j, l := range body {
+		assert.LessOrEqualf(t, lipgloss.Width(l), contentWidth, "body line %d must fit the content width", j)
+	}
+	relation := body[idx]
+	assert.Contains(t, relation, transferArrowHead, "the arrow survives at MinWidth")
+	assert.Contains(t, relation, transferDot, "the rail dot survives at MinWidth")
+	assert.Contains(t, relation, "Coder", "the destination stays readable")
+	assert.Contains(t, relation, "Sco…", "the source is truncated with an ellipsis, not dropped")
+}
+
+// TestTransferPanelTruncatesLongNames verifies both names are truncated with
+// ellipses when they overflow the shared name budget, still within width.
+func TestTransferPanelTruncatesLongNames(t *testing.T) {
+	t.Parallel()
+
+	const from = "delegation-orchestrator"
+	const to = "implementation-reviewer"
+	m := newAgentPanelSidebar(t, MinWidth,
+		runtime.AgentDetails{Name: from, Provider: "openai", Model: "gpt-5.4", Thinking: "off"},
+		runtime.AgentDetails{Name: to, Provider: "anthropic", Model: "claude-sonnet-4-6", Thinking: "high"},
+	)
+	m.SetAgentSwitching(true, from, to)
+
+	contentWidth := m.contentWidth(false)
+	body := agentBody(m)
+	idx := transferRelationIndex(m)
+	require.GreaterOrEqual(t, idx, 0)
+
+	for j, l := range body {
+		assert.LessOrEqualf(t, lipgloss.Width(l), contentWidth, "body line %d must fit the content width", j)
+	}
+	relation := body[idx]
+	assert.Contains(t, relation, transferArrowHead, "the arrow survives truncation")
+	assert.Contains(t, relation, "…", "overflowing names are truncated with ellipses")
+}
+
+// TestTransferPanelWideUnicodeNames verifies wide (CJK) agent names never push
+// a box line past the content width.
+func TestTransferPanelWideUnicodeNames(t *testing.T) {
+	t.Parallel()
+
+	const from = "调度协调器智能体"
+	const to = "代码实现者智能体"
+	m := newAgentPanelSidebar(t, MinWidth,
+		runtime.AgentDetails{Name: from, Provider: "openai", Model: "gpt-5.4", Thinking: "off"},
+		runtime.AgentDetails{Name: to, Provider: "anthropic", Model: "claude-sonnet-4-6", Thinking: "high"},
+	)
+	m.SetAgentSwitching(true, from, to)
+
+	contentWidth := m.contentWidth(false)
+	idx := transferRelationIndex(m)
+	require.GreaterOrEqual(t, idx, 0)
+	for j, l := range agentBody(m) {
+		assert.LessOrEqualf(t, lipgloss.Width(l), contentWidth, "body line %d must fit the content width", j)
+	}
+	assert.Contains(t, agentBody(m)[idx], transferArrowHead)
+}
+
+// TestTransferPanelPathologicalWidths verifies the box degrades gracefully at
+// arbitrarily small widths: no panic and no line ever wider than requested.
+func TestTransferPanelPathologicalWidths(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+	m.SetAgentSwitching(true, "Scout", "Coder")
+
+	for width := 1; width <= 16; width++ {
+		for _, line := range m.renderTransferPanel(m.agentTransfers[0], width) {
+			assert.LessOrEqualf(t, lipgloss.Width(line), width, "box line must fit width %d", width)
+		}
+	}
+}
+
+// TestTransferAnimationAdvancesAcrossTicks verifies the rail dot travels
+// across shared animation ticks: at least three distinct positions appear
+// while the names, the arrow and the line width stay constant.
+func TestTransferAnimationAdvancesAcrossTicks(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+	m.SetAgentSwitching(true, "Scout", "Coder")
+
+	snapshot := func() string {
+		idx := transferRelationIndex(m)
+		require.GreaterOrEqual(t, idx, 0)
+		relation := agentBody(m)[idx]
+		assert.Contains(t, relation, "Scout", "the source stays readable on every frame")
+		assert.Contains(t, relation, "Coder", "the destination stays readable on every frame")
+		assert.Contains(t, relation, transferArrowHead, "the arrow stays visible on every frame")
+		return relation
+	}
+
+	first := snapshot()
+	width := lipgloss.Width(first)
+	positions := map[string]bool{first: true}
+	for frame := 1; frame <= 2*transferFramesPerStep*transferRailCells; frame++ {
+		_, _ = m.Update(animation.TickMsg{Frame: frame})
+		relation := snapshot()
+		assert.Equal(t, width, lipgloss.Width(relation), "the width is constant across frames")
+		positions[relation] = true
+	}
+	assert.GreaterOrEqual(t, len(positions), 3, "the dot visits at least three distinct positions")
+}
+
+// TestTransferAnimationTickKeepsLayoutClean verifies an animation tick takes
+// the animation-only render path: the cache is refreshed but the layout stays
+// clean and the rendered line count is unchanged.
+func TestTransferAnimationTickKeepsLayoutClean(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+	m.SetAgentSwitching(true, "Scout", "Coder")
+
+	_ = m.View() // settle the cache and the scrollbar probe
+	require.False(t, m.layoutDirty)
+	linesBefore := len(m.cachedLines)
+
+	_, _ = m.Update(animation.TickMsg{Frame: 1})
+	assert.True(t, m.cacheDirty, "a tick refreshes the rendered frame")
+	assert.False(t, m.layoutDirty, "a tick is animation-only and keeps the layout clean")
+
+	_ = m.View()
+	assert.Len(t, m.cachedLines, linesBefore, "the line count is constant across frames")
+}
+
+// TestTransferStackNestedRestore replays nested transfers: A→B then B→C shows
+// B→C with the dot restarted on the left; when C returns to B the outer A→B
+// box reappears, again from the left; when B returns to A nothing is left, the
+// subscription ends and the ↔ header marker goes away.
+func TestTransferStackNestedRestore(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40,
+		runtime.AgentDetails{Name: "A", Provider: "openai", Model: "gpt-5.4", Thinking: "off"},
+		runtime.AgentDetails{Name: "B", Provider: "anthropic", Model: "opus", Thinking: "high"},
+		runtime.AgentDetails{Name: "C", Provider: "google", Model: "gemini-flash", Thinking: "off"},
+	)
+
+	m.SetAgentSwitching(true, "A", "B")
+	for frame := 1; frame <= transferFramesPerStep; frame++ {
+		_, _ = m.Update(animation.TickMsg{Frame: frame})
+	}
+	require.NotZero(t, m.transferAnimationFrame)
+
+	m.SetAgentSwitching(true, "B", "C")
+	assert.Zero(t, m.transferAnimationFrame, "a nested hop restarts the dot on the left")
+	idx := transferRelationIndex(m)
+	require.GreaterOrEqual(t, idx, 0)
+	assert.Contains(t, agentBody(m)[idx], "B ●──► C", "the innermost hop is shown, dot on the left")
+
+	for frame := 1; frame <= transferFramesPerStep; frame++ {
+		_, _ = m.Update(animation.TickMsg{Frame: frame})
+	}
+	m.SetAgentSwitching(false, "C", "B") // stop of B→C carries the inverse pair
+	assert.Zero(t, m.transferAnimationFrame, "restoring the parent restarts the dot on the left")
+	assert.True(t, m.transferAnimation.IsActive(), "the animation keeps running for the parent hop")
+	idx = transferRelationIndex(m)
+	require.GreaterOrEqual(t, idx, 0)
+	assert.Contains(t, agentBody(m)[idx], "A ●──► B", "the outer hop's box reappears")
+
+	m.SetAgentSwitching(false, "B", "A")
+	assert.Equal(t, -1, transferRelationIndex(m), "no box once all hops returned")
+	assert.False(t, m.transferAnimation.IsActive(), "the last stop ends the animation subscription")
+	assert.NotContains(t, renderAgentPanel(m)[0], "↔", "the header marker clears with the stack")
+}
+
+// TestTransferStackOutOfOrderStop verifies a stop pops its matching hop (the
+// inverse pair of its start), not blindly the top of the stack, and that the
+// still-visible hop keeps its animation phase.
+func TestTransferStackOutOfOrderStop(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40,
+		runtime.AgentDetails{Name: "A", Provider: "openai", Model: "gpt-5.4", Thinking: "off"},
+		runtime.AgentDetails{Name: "B", Provider: "anthropic", Model: "opus", Thinking: "high"},
+		runtime.AgentDetails{Name: "C", Provider: "google", Model: "gemini-flash", Thinking: "off"},
+	)
+
+	m.SetAgentSwitching(true, "A", "B")
+	m.SetAgentSwitching(true, "B", "C")
+	_, _ = m.Update(animation.TickMsg{Frame: 1})
+	frame := m.transferAnimationFrame
+	require.NotZero(t, frame)
+
+	m.SetAgentSwitching(false, "B", "A") // the outer stop arrives first
+	idx := transferRelationIndex(m)
+	require.GreaterOrEqual(t, idx, 0)
+	assert.Contains(t, agentBody(m)[idx], "B ●──► C", "the unmatched inner hop stays on top")
+	assert.Equal(t, frame, m.transferAnimationFrame, "the visible hop is unchanged, so the phase is preserved")
+	assert.True(t, m.transferAnimation.IsActive())
+
+	m.SetAgentSwitching(false, "C", "B")
+	assert.Equal(t, -1, transferRelationIndex(m))
+	assert.False(t, m.transferAnimation.IsActive())
+}
+
+// TestTransferStopFallbackPop verifies a stop that matches no recorded hop
+// still pops the innermost one (stopping the animation with the emptied
+// stack), and a stop on an empty stack is a no-op.
+func TestTransferStopFallbackPop(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+
+	m.SetAgentSwitching(true, "Scout", "Coder")
+	m.SetAgentSwitching(false, "", "")
+	assert.Empty(t, m.agentTransfers, "an unmatched stop pops the innermost hop")
+	assert.False(t, m.transferAnimation.IsActive(), "an emptied stack stops the animation")
+	assert.Zero(t, m.transferAnimationFrame)
+
+	m.SetAgentSwitching(false, "Coder", "Scout")
+	assert.Empty(t, m.agentTransfers, "a stop on an empty stack is a no-op")
+	assert.False(t, m.transferAnimation.IsActive())
+}
+
+// TestTransferSubscriptionLifecycle verifies the single animation subscription
+// starts with the first hop, is shared by nested hops (never double-registered)
+// and ends with the last stop.
+func TestTransferSubscriptionLifecycle(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+	require.False(t, m.transferAnimation.IsActive())
+
+	m.SetAgentSwitching(true, "Scout", "Coder")
+	assert.True(t, m.transferAnimation.IsActive(), "the first hop starts the subscription")
+
+	m.SetAgentSwitching(true, "Coder", "root")
+	assert.True(t, m.transferAnimation.IsActive(), "a nested hop reuses the single subscription")
+
+	m.SetAgentSwitching(false, "root", "Coder")
+	assert.True(t, m.transferAnimation.IsActive(), "the subscription survives while hops remain")
+
+	m.SetAgentSwitching(false, "Coder", "Scout")
+	assert.False(t, m.transferAnimation.IsActive(), "the last stop ends the subscription")
+}
+
+// TestTransferClearedOnCancelResetAndLoad verifies a stream cancel, a
+// stream-tracking reset and a session load all drop any in-flight transfer —
+// no ghost box, subscription stopped, phase back to zero.
+func TestTransferClearedOnCancelResetAndLoad(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+
+	assertCleared := func(context string) {
+		t.Helper()
+		assert.Empty(t, m.agentTransfers, context)
+		assert.Equal(t, -1, transferRelationIndex(m), context)
+		assert.False(t, m.transferAnimation.IsActive(), context)
+		assert.Zero(t, m.transferAnimationFrame, context)
+	}
+
+	m.SetAgentSwitching(true, "Scout", "Coder")
+	_, _ = m.Update(animation.TickMsg{Frame: 1})
+	require.GreaterOrEqual(t, transferRelationIndex(m), 0)
+	_, _ = m.Update(messages.StreamCancelledMsg{})
+	assertCleared("cancel clears the box and stops the animation")
+
+	m.SetAgentSwitching(true, "Scout", "Coder")
+	m.ResetStreamTracking()
+	assertCleared("a new top-level run clears the box and stops the animation")
+
+	m.SetAgentSwitching(true, "Scout", "Coder")
+	m.LoadFromSession(session.New())
+	assertCleared("loading a session starts from a clean slate")
+}
+
+// TestNoTransferPanelWhenIdle verifies no box (and no header marker) renders
+// while no transfer is in flight.
+func TestNoTransferPanelWhenIdle(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+
+	assert.Equal(t, -1, transferRelationIndex(m))
+	body := strings.Join(agentBody(m), "\n")
+	assert.NotContains(t, body, transferBoxTitle)
+	assert.NotContains(t, body, "╭")
+	assert.NotContains(t, renderAgentPanel(m)[0], "↔")
+}

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tui/animation"
 	"github.com/docker/docker-agent/pkg/tui/components/scrollbar"
 	"github.com/docker/docker-agent/pkg/tui/components/scrollview"
 	"github.com/docker/docker-agent/pkg/tui/components/spinner"
@@ -63,7 +64,12 @@ type Model interface {
 	SetMirroredPadding(mirrored bool)
 	SetAgentInfo(agentName, model, description string) tea.Cmd
 	SetTeamInfo(availableAgents []runtime.AgentDetails)
-	SetAgentSwitching(switching bool)
+	// SetAgentSwitching records the start (switching=true) or end of a
+	// transfer_task hop between fromAgent and toAgent. Stops carry the
+	// inverse pair of their start (start A→B is closed by stop B→A). The
+	// returned command starts the transfer-box animation tick when the first
+	// hop begins; callers must dispatch it.
+	SetAgentSwitching(switching bool, fromAgent, toAgent string) tea.Cmd
 	SetToolsetInfo(availableTools int, loading bool)
 	SetSkillsInfo(availableSkills int)
 	SetSessionStarred(starred bool)
@@ -125,6 +131,14 @@ type ragIndexingState struct {
 	spinner spinner.Spinner
 }
 
+// agentTransfer is one in-flight transfer_task hop. The sidebar keeps a stack
+// of them: the innermost hop renders as a compact box below the whole agent
+// roster (see renderTransferPanel), and popping it restores the enclosing
+// hop's box with its rail dot back on the left.
+type agentTransfer struct {
+	from, to string
+}
+
 // model implements Model
 type model struct {
 	width              int
@@ -145,7 +159,7 @@ type model struct {
 	agentModel         string
 	agentDescription   string
 	availableAgents    []runtime.AgentDetails
-	agentSwitching     bool
+	agentTransfers     []agentTransfer // in-flight transfer_task hops (stack; top = innermost)
 	availableTools     int
 	availableSkills    int
 	toolsLoading       bool // true when more tools may still be loading
@@ -168,6 +182,13 @@ type model struct {
 	lastTitleClickTime time.Time         // for double-click detection on title
 	sectionVisibility  SectionVisibility // which optional sections are rendered
 	sectionGap         int               // blank lines between sections in vertical mode
+
+	// Transfer-box animation: a single animation.Subscription drives the rail
+	// dot while any transfer_task hop is in flight. The frame counts shared
+	// coordinator ticks since the visible (innermost) hop appeared and is
+	// divided down to the rail phase (see transferPhase).
+	transferAnimation      animation.Subscription
+	transferAnimationFrame int
 
 	ctx func() context.Context
 
@@ -264,9 +285,10 @@ func (m *model) invalidateCache() {
 }
 
 // invalidateAnimation marks the cache dirty for an animation-only change, i.e. a
-// spinner advancing one frame. Spinner glyphs are fixed (single-cell) width, so
-// the line count and scrollbar visibility cannot change; the next View() can
-// therefore skip the scrollbar-probe pass and render the sections only once.
+// spinner or the transfer-box rail advancing one frame. Those glyph swaps keep
+// every line's width and the line count constant, so scrollbar visibility cannot
+// change; the next View() can therefore skip the scrollbar-probe pass and render
+// the sections only once.
 func (m *model) invalidateAnimation() {
 	m.cacheDirty = true
 }
@@ -333,10 +355,53 @@ func (m *model) SetTeamInfo(availableAgents []runtime.AgentDetails) {
 	m.invalidateCache()
 }
 
-// SetAgentSwitching sets whether an agent switch is in progress
-func (m *model) SetAgentSwitching(switching bool) {
-	m.agentSwitching = switching
+// SetAgentSwitching tracks the in-flight transfer_task hops. A start
+// (switching=true) pushes the fromAgent→toAgent hop; a stop pops it. Stops
+// carry the inverse pair of their start (start A→B is closed by stop B→A), so
+// the matching entry is removed even when nested stops arrive out of order;
+// when no entry matches, the innermost hop is popped.
+//
+// The first hop starts the transfer-box animation subscription (the returned
+// command primes the shared tick); the last stop ends it. Whenever the visible
+// (innermost) hop changes, the rail phase restarts on the left.
+func (m *model) SetAgentSwitching(switching bool, fromAgent, toAgent string) tea.Cmd {
+	if switching {
+		// The new hop becomes the visible top of the stack.
+		m.agentTransfers = append(m.agentTransfers, agentTransfer{from: fromAgent, to: toAgent})
+		m.transferAnimationFrame = 0
+		m.invalidateCache()
+		return m.transferAnimation.Start()
+	}
+	n := len(m.agentTransfers)
+	if n == 0 {
+		return nil
+	}
+	idx := n - 1
+	for i := n - 1; i >= 0; i-- {
+		if m.agentTransfers[i] == (agentTransfer{from: toAgent, to: fromAgent}) {
+			idx = i
+			break
+		}
+	}
+	m.agentTransfers = slices.Delete(m.agentTransfers, idx, idx+1)
+	if idx == len(m.agentTransfers) {
+		// The innermost hop was popped: the restored parent (if any) restarts
+		// its dot on the left. Out-of-order pops keep the visible hop's phase.
+		m.transferAnimationFrame = 0
+	}
+	if len(m.agentTransfers) == 0 {
+		m.transferAnimation.Stop()
+	}
 	m.invalidateCache()
+	return nil
+}
+
+// activeTransfer returns the innermost in-flight transfer hop, if any.
+func (m *model) activeTransfer() (agentTransfer, bool) {
+	if n := len(m.agentTransfers); n > 0 {
+		return m.agentTransfers[n-1], true
+	}
+	return agentTransfer{}, false
 }
 
 // SetToolsetInfo sets the number of available tools and loading state
@@ -528,9 +593,13 @@ func (m *model) LoadFromSession(sess *session.Session) {
 	}
 
 	// The restored session is the main session until a stream starts. A freshly
-	// loaded session has no in-flight streams, so clear any stale stack entries.
+	// loaded session has no in-flight streams or transfers, so clear any stale
+	// stack entries.
 	m.rootSessionID = sess.ID
 	m.sessionStack = nil
+	m.agentTransfers = nil
+	m.transferAnimation.Stop()
+	m.transferAnimationFrame = 0
 
 	// Load session title
 	if sess.Title != "" {
@@ -556,13 +625,17 @@ func (m *model) LoadFromSession(sess *session.Session) {
 // top-level run begins so leaked entries from a previous run that ended without
 // a balanced StreamStoppedEvent (e.g. a context cancel without a
 // StreamCancelledMsg) cannot pile up and pin the panel to a stale sub-session.
-// rootSessionID is preserved so the idle display stays valid until the next
-// stream starts.
+// The in-flight transfer stack is dropped for the same reason, so a ghost
+// transfer box cannot survive into the new run. rootSessionID is
+// preserved so the idle display stays valid until the next stream starts.
 func (m *model) ResetStreamTracking() {
-	if len(m.sessionStack) == 0 {
+	if len(m.sessionStack) == 0 && len(m.agentTransfers) == 0 {
 		return
 	}
 	m.sessionStack = nil
+	m.agentTransfers = nil
+	m.transferAnimation.Stop()
+	m.transferAnimationFrame = 0
 	m.invalidateCache()
 }
 
@@ -826,8 +899,8 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		m.SetTeamInfo(msg.AvailableAgents)
 		return m, nil
 	case *runtime.AgentSwitchingEvent:
-		m.SetAgentSwitching(msg.Switching)
-		return m, nil
+		cmd := m.SetAgentSwitching(msg.Switching, msg.FromAgent, msg.ToAgent)
+		return m, cmd
 	case *runtime.ToolsetInfoEvent:
 		// Ignore loading state if stream was cancelled (stale event from before cancellation)
 		if m.streamCancelled && msg.Loading {
@@ -845,6 +918,9 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		m.streamCancelled = true
 		m.workingAgent = ""
 		m.sessionStack = nil
+		m.agentTransfers = nil
+		m.transferAnimation.Stop()
+		m.transferAnimationFrame = 0
 		m.toolsLoading = false
 		m.titleRegenerating = false
 		m.compacting = false
@@ -894,6 +970,14 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		var cmds []tea.Cmd
 		needsInvalidate := false
 
+		// Advance the transfer-box rail on the shared animation tick while a
+		// transfer is in flight; the phase math divides the coordinator's
+		// 14 FPS down to a sober dot movement (see transferPhase).
+		if _, isTick := msg.(animation.TickMsg); isTick && m.transferAnimation.IsActive() {
+			m.transferAnimationFrame++
+			needsInvalidate = true
+		}
+
 		// Update main spinner when tools are loading, agent is working, or title is regenerating
 		if m.toolsLoading || m.workingAgent != "" || m.titleRegenerating {
 			model, cmd := m.spinner.Update(msg)
@@ -910,8 +994,9 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 			needsInvalidate = true
 		}
 
-		// Invalidate cache when spinners update to show new animation frames.
-		// This is animation-only (fixed-width glyph swap), so the cheaper path is used.
+		// Invalidate cache when animations advance to show their new frames.
+		// These are animation-only changes (fixed-width glyph swaps), so the
+		// cheaper path is used.
 		if needsInvalidate {
 			m.invalidateAnimation()
 		}
@@ -1413,9 +1498,12 @@ func (m *model) queueSection(contentWidth int) string {
 // the agent's latest context usage percentage right-aligned once known. The
 // current agent is marked with ▶ (or the spinner while it works); the other
 // agents pad that marker column so their names stay aligned. Descriptions are
-// deliberately omitted. Each content line is owned by its agent (agentLineOwners)
-// so click zones can be registered explicitly (see buildAgentClickZones) and a
-// click on either line switches to that agent; separators carry an empty owner
+// deliberately omitted. While a transfer_task runs, the innermost hop renders
+// as a compact box below the whole roster — after a blank breathing line — so
+// the roster itself stays uninterrupted (see renderTransferPanel). Each
+// content line is owned by its agent (agentLineOwners) so click zones can be
+// registered explicitly (see buildAgentClickZones) and a click on either line
+// switches to that agent; separators and the transfer box carry an empty owner
 // so they stay unclickable.
 func (m *model) agentInfo(contentWidth int) string {
 	// Read current agent from session state so sidebar updates when agent is switched
@@ -1428,7 +1516,7 @@ func (m *model) agentInfo(contentWidth int) string {
 	if len(m.availableAgents) > 1 {
 		agentTitle = "Agents"
 	}
-	if m.agentSwitching {
+	if len(m.agentTransfers) > 0 {
 		agentTitle += " ↔"
 	}
 
@@ -1453,6 +1541,15 @@ func (m *model) agentInfo(contentWidth int) string {
 		current := agent.Name == currentAgent
 		for _, line := range m.renderAgentLine(agent, i, contentWidth, nameWidth, badgeWidth, glyphOnly, current) {
 			add(line, agent.Name)
+		}
+	}
+	// The innermost in-flight transfer renders as a compact box below the whole
+	// roster, after a blank breathing line; every one of its lines is unowned so
+	// the box stays unclickable.
+	if transfer, ok := m.activeTransfer(); ok {
+		add("", "")
+		for _, line := range m.renderTransferPanel(transfer, contentWidth) {
+			add(line, "")
 		}
 	}
 	m.agentLineOwners = owners
@@ -1619,6 +1716,124 @@ func (m *model) renderAgentLine(agent runtime.AgentDetails, index, contentWidth,
 	}
 
 	return []string{line1, line2}
+}
+
+// Transfer-box vocabulary: the arrow head matches the handoff tool's
+// "Sender ─► Agent" glyph so the roster and the transcript share one visual
+// language. The rail is the fixed three-cell track the bright dot travels
+// before the arrow head (●──►, ─●─►, ──●►).
+const (
+	transferBoxTitle  = "Transfer"
+	transferTrack     = "─"
+	transferDot       = "●"
+	transferArrowHead = "►"
+	transferRailCells = 3
+
+	// transferFramesPerStep divides the shared 14 FPS animation tick down to
+	// a sober ~7 FPS dot movement.
+	transferFramesPerStep = 2
+)
+
+// transferPhase returns the rail cell currently occupied by the dot.
+func (m *model) transferPhase() int {
+	return m.transferAnimationFrame / transferFramesPerStep % transferRailCells
+}
+
+// transferRailView renders the animated rail: three track cells with the
+// bright dot at the current phase, then the arrow head. The track and dot swap
+// cell by cell, so the rail's width is constant across frames — ticks can take
+// the animation-only render path. The arrow head is left unstyled so the tab
+// body's primary style keeps it clearly visible.
+func (m *model) transferRailView() string {
+	phase := m.transferPhase()
+	var rail strings.Builder
+	for i := range transferRailCells {
+		if i == phase {
+			rail.WriteString(styles.SpinnerDotsHighlightStyle.Render(transferDot))
+		} else {
+			rail.WriteString(styles.MutedStyle.Render(transferTrack))
+		}
+	}
+	rail.WriteString(transferArrowHead)
+	return rail.String()
+}
+
+// renderTransferRelation renders the box's content — "Scout ─●─► Coder" —
+// fitted to exactly width cells (space-padded on the right). The agent names
+// use their accent styles and share the room left by the fixed rail: when they
+// overflow, a short name donates its surplus to the long one and both are
+// truncated with ellipses. Widths too small for names degrade to the animated
+// rail alone, then to a bare muted track; the result never exceeds width.
+func (m *model) renderTransferRelation(t agentTransfer, width int) string {
+	const railWidth = transferRailCells + 1 // track cells + arrow head
+	if width < railWidth {
+		return styles.MutedStyle.Render(strings.Repeat(transferTrack, max(0, width)))
+	}
+
+	nameAvail := width - railWidth - 2 // one space on each side of the rail
+	if nameAvail < 2 {
+		return padRight(m.transferRailView(), width)
+	}
+
+	fromWidth, toWidth := lipgloss.Width(t.from), lipgloss.Width(t.to)
+	fromBudget, toBudget := fromWidth, toWidth
+	if fromWidth+toWidth > nameAvail {
+		half := nameAvail / 2
+		switch {
+		case fromWidth <= half:
+			toBudget = nameAvail - fromWidth
+		case toWidth <= nameAvail-half:
+			fromBudget = nameAvail - toWidth
+		default:
+			fromBudget, toBudget = half, nameAvail-half
+		}
+	}
+
+	line := styles.AgentAccentStyleFor(t.from).Render(toolcommon.TruncateText(t.from, fromBudget)) +
+		" " + m.transferRailView() + " " +
+		styles.AgentAccentStyleFor(t.to).Render(toolcommon.TruncateText(t.to, toBudget))
+	return padRight(line, width)
+}
+
+// renderTransferPanel renders the in-flight transfer hop as a compact
+// three-line box spanning the full content width:
+//
+//	╭─ Transfer ────────╮
+//	│ Scout ─●─► Coder  │
+//	╰───────────────────╯
+//
+// The border and embedded title are muted; the content line is built by
+// renderTransferRelation. As the sidebar narrows the title is dropped first,
+// then the inner margins; pathologically small widths fall back to the bare
+// relation so no line ever exceeds contentWidth.
+func (m *model) renderTransferPanel(t agentTransfer, contentWidth int) []string {
+	border := lipgloss.RoundedBorder()
+	inner := contentWidth - 2 // room between the border columns
+	if inner < transferRailCells+1 {
+		return []string{m.renderTransferRelation(t, contentWidth)}
+	}
+
+	top := border.TopLeft + strings.Repeat(border.Top, inner) + border.TopRight
+	head := border.TopLeft + border.Top + " " + transferBoxTitle + " "
+	if headWidth := lipgloss.Width(head); headWidth+1 <= contentWidth {
+		top = head + strings.Repeat(border.Top, contentWidth-headWidth-1) + border.TopRight
+	}
+
+	relWidth, margin := inner, ""
+	if inner >= transferRailCells+1+2 {
+		relWidth, margin = inner-2, " "
+	}
+	middle := styles.MutedStyle.Render(border.Left) + margin +
+		m.renderTransferRelation(t, relWidth) + margin +
+		styles.MutedStyle.Render(border.Right)
+
+	bottom := border.BottomLeft + strings.Repeat(border.Bottom, inner) + border.BottomRight
+
+	return []string{
+		styles.MutedStyle.Render(top),
+		middle,
+		styles.MutedStyle.Render(bottom),
+	}
 }
 
 // buildAgentClickZones populates agentClickZones from the explicit per-line

--- a/pkg/tui/components/sidebar/title_edit_test.go
+++ b/pkg/tui/components/sidebar/title_edit_test.go
@@ -134,15 +134,18 @@ func TestSidebar_TitleRegenerating(t *testing.T) {
 	assert.False(t, m.titleRegenerating, "should not be regenerating initially")
 	assert.False(t, m.needsSpinner(), "should not need spinner initially")
 
-	// Start regenerating
-	cmd := sb.SetTitleRegenerating(true)
+	// Start regenerating. The spinner registers with the shared animation
+	// coordinator; the returned command carries the first global tick only
+	// when no other animation is running, so assert on the model-local
+	// registration instead: parallel tests may hold coordinator
+	// registrations of their own.
+	_ = sb.SetTitleRegenerating(true)
 	assert.True(t, m.titleRegenerating, "should be regenerating after SetTitleRegenerating(true)")
 	assert.True(t, m.needsSpinner(), "should need spinner when regenerating")
-	// The returned command starts the spinner animation
-	assert.NotNil(t, cmd, "should return a command to start the spinner")
+	assert.True(t, m.spinnerActive, "should register the spinner")
 
 	// Stop regenerating
-	cmd = sb.SetTitleRegenerating(false)
+	cmd := sb.SetTitleRegenerating(false)
 	assert.False(t, m.titleRegenerating, "should not be regenerating after SetTitleRegenerating(false)")
 	assert.False(t, m.needsSpinner(), "should not need spinner after stopping regeneration")
 	assert.Nil(t, cmd, "should return nil command when stopping")

--- a/pkg/tui/page/chat/runtime_events.go
+++ b/pkg/tui/page/chat/runtime_events.go
@@ -121,8 +121,7 @@ func (p *chatPage) handleRuntimeEvent(msg tea.Msg) (bool, tea.Cmd) {
 		return true, nil
 
 	case *runtime.AgentSwitchingEvent:
-		p.sidebar.SetAgentSwitching(msg.Switching)
-		return true, nil
+		return true, p.sidebar.SetAgentSwitching(msg.Switching, msg.FromAgent, msg.ToAgent)
 
 	case *runtime.ToolsetInfoEvent:
 		p.sidebar.SetSkillsInfo(len(p.app.CurrentAgentSkills()))


### PR DESCRIPTION
## Summary

Display active `transfer_task` handoffs in a dedicated animated panel below the Agents roster.

The roster remains uninterrupted, the destination agent keeps its native activity marker, and the transfer panel stays non-clickable.

## Behavior

| State | Behavior |
|---|---|
| Active transfer | Shows the source and destination in a `Transfer` panel below the roster |
| Animation | Moves a highlighted dot toward the destination using the shared animation coordinator |
| Narrow sidebar | Truncates long names while preserving the direction indicator |
| Nested transfer | Shows the innermost transfer and restores its parent when complete |
| Stop or cancellation | Removes the panel and stops its animation subscription |
| Mouse interaction | Keeps the panel non-clickable |

## Implementation

- Reuses `runtime.AgentSwitchingEvent` source and destination metadata.
- Drives the transfer rail through the existing global animation tick, without a dedicated timer.
- Preserves the destination agent spinner on the normal roster entry.
- Clears transfer state on completion, cancellation, stream reset, and session load.
- Keeps all panel lines within the available sidebar width, including long and wide Unicode names.

## Validation

- `task build`
- `task lint`
- `go test ./...`
- `go vet ./pkg/tui/components/sidebar ./pkg/tui/page/chat`
- `git diff --check`
