### PR TITLE
fix(tui): normalize pasted line endings

### DIFF
--- a/pkg/tui/components/editor/editor.go
+++ b/pkg/tui/components/editor/editor.go
@@ -682,9 +682,18 @@ func (e *editor) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		cmd := e.tickRecordingDots()
 		return e, cmd
 	case tea.PasteMsg:
-		if e.handlePaste(msg.Content) {
+		content, handled := e.handlePaste(msg.Content)
+		if handled {
 			return e, nil
 		}
+		// Forward the normalized content explicitly; falling through would
+		// hand the textarea the raw message, whose CR/CRLF line endings
+		// corrupt the rendered layout.
+		msg.Content = content
+		var cmd tea.Cmd
+		e.textarea, cmd = e.textarea.Update(msg)
+		e.refreshSuggestion()
+		return e, cmd
 	case tea.KeyboardEnhancementsMsg:
 		// Track keyboard enhancement support and configure newline keybinding accordingly
 		e.keyboardEnhancementsSupported = msg.Flags != 0 || termfeatures.SupportsModifiedEnter(os.Getenv)
@@ -939,10 +948,11 @@ func (e *editor) handleClipboardPaste() (layout.Model, tea.Cmd) {
 		return e, nil
 	}
 
-	// handlePaste returns true if content was buffered to disk (large paste),
-	// false if it's small enough for inline insertion.
-	if !e.handlePaste(content) {
-		e.textarea.InsertString(content)
+	// Insert the normalized content returned by handlePaste so the inserted
+	// text always matches what was classified.
+	normalized, handled := e.handlePaste(content)
+	if !handled {
+		e.textarea.InsertString(normalized)
 	}
 	return e, textarea.Blink
 }
@@ -1521,7 +1531,23 @@ func (e *editor) SendContent() tea.Cmd {
 	return e.resetAndSend(value)
 }
 
-func (e *editor) handlePaste(content string) bool {
+// normalizePasteNewlines converts CRLF and bare CR line endings to LF.
+// Pasted terminal output (e.g. Docker BuildKit logs) can separate records
+// with bare CRs, which would defeat line-based classification and let raw
+// CRs reach the textarea.
+func normalizePasteNewlines(content string) string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	return strings.ReplaceAll(content, "\r", "\n")
+}
+
+// handlePaste processes pasted content: file paths become attachments and
+// large text is buffered to a temp file attachment. It returns the
+// line-ending-normalized content and whether the paste was fully handled.
+// When handled is false the caller must insert the returned content, which
+// guarantees classification and insertion agree on the same string.
+func (e *editor) handlePaste(content string) (normalized string, handled bool) {
+	content = normalizePasteNewlines(content)
+
 	// First, try to parse as file paths (drag-and-drop)
 	filePaths := ParsePastedFiles(content)
 	if len(filePaths) > 0 {
@@ -1537,7 +1563,7 @@ func (e *editor) handlePaste(content string) bool {
 			attached++
 		}
 		if attached == len(filePaths) {
-			return true
+			return content, true
 		}
 		// Not all files could be attached; undo partial attachments and fall through to text paste
 		e.removeLastNAttachments(attached)
@@ -1552,22 +1578,22 @@ func (e *editor) handlePaste(content string) bool {
 
 	// Allow inline if within both limits
 	if lines <= maxInlinePasteLines && len(content) <= maxInlinePasteChars {
-		return false
+		return content, false
 	}
 
 	e.pasteCounter++
 	att, err := createPasteAttachment(content, e.pasteCounter)
 	if err != nil {
 		slog.Warn("failed to buffer paste", "error", err)
-		// Still return true to prevent the large paste from falling through
-		// to textarea.Update(), which would block the UI for seconds.
-		return true
+		// Still report handled to prevent the large paste from falling
+		// through to textarea.Update(), which would block the UI for seconds.
+		return content, true
 	}
 
 	e.textarea.InsertString(att.placeholder)
 	e.attachments = append(e.attachments, att)
 
-	return true
+	return content, true
 }
 
 // removeLastNAttachments removes the last n non-temp attachments and their

--- a/pkg/tui/components/editor/paste_test.go
+++ b/pkg/tui/components/editor/paste_test.go
@@ -8,9 +8,12 @@ import (
 	"testing"
 
 	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
 	"github.com/docker/go-units"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/paths"
 )
 
 func TestHandlePaste_SmallContent(t *testing.T) {
@@ -20,7 +23,7 @@ func TestHandlePaste_SmallContent(t *testing.T) {
 	// Content that's under both limits: few lines and few chars
 	smallContent := "line1\nline2\nline3"
 
-	handled := e.handlePaste(smallContent)
+	_, handled := e.handlePaste(smallContent)
 
 	assert.False(t, handled, "small content should not be handled (return false)")
 	assert.Empty(t, e.attachments, "no attachments should be created for small content")
@@ -37,7 +40,7 @@ func TestHandlePaste_AtLineLimitIsInline(t *testing.T) {
 	}
 	content := strings.Join(lines, "\n")
 
-	handled := e.handlePaste(content)
+	_, handled := e.handlePaste(content)
 
 	assert.False(t, handled, "content at line limit should be inline")
 }
@@ -49,9 +52,60 @@ func TestHandlePaste_AtCharLimitIsInline(t *testing.T) {
 	// Exactly at char limit and under line limit should be inline
 	content := strings.Repeat("x", maxInlinePasteChars)
 
-	handled := e.handlePaste(content)
+	_, handled := e.handlePaste(content)
 
 	assert.False(t, handled, "content at char limit should be inline")
+}
+
+func TestHandlePaste_ReturnsNormalizedContent(t *testing.T) {
+	t.Parallel()
+
+	e := &editor{}
+
+	normalized, handled := e.handlePaste("line1\r\nline2\rline3")
+
+	assert.False(t, handled, "small content should not be handled (return false)")
+	assert.Equal(t, "line1\nline2\nline3", normalized, "CRLF and bare CR should be normalized to LF")
+}
+
+func TestUpdate_PasteInsertsNormalizedLineEndings(t *testing.T) {
+	t.Parallel()
+
+	e := newPasteTestEditor()
+
+	_, _ = e.Update(tea.PasteMsg{Content: "line1\r\nline2\rline3"})
+
+	assert.Equal(t, "line1\nline2\nline3", e.textarea.Value())
+	assert.NotContains(t, e.textarea.Value(), "\r", "no raw CR should reach the textarea")
+	assert.Empty(t, e.attachments, "small paste should stay inline")
+}
+
+func TestUpdate_CRDelimitedPasteOverLineLimitBecomesAttachment(t *testing.T) {
+	// Not parallel: overrides the global data dir used by createPasteAttachment.
+	paths.SetDataDir(t.TempDir())
+	t.Cleanup(func() { paths.SetDataDir("") })
+
+	// BuildKit-style progress records separated by bare CRs, kept under the
+	// char limit so only line classification can collapse the paste.
+	records := make([]string, maxInlinePasteLines+1)
+	for i := range records {
+		records[i] = fmt.Sprintf("#1 record %d", i)
+	}
+	content := strings.Join(records, "\r")
+	require.LessOrEqual(t, len(content), maxInlinePasteChars)
+
+	e := newPasteTestEditor()
+	t.Cleanup(e.Cleanup)
+
+	_, _ = e.Update(tea.PasteMsg{Content: content})
+
+	require.Len(t, e.attachments, 1, "CR-delimited paste over the line limit should be buffered")
+	assert.Equal(t, "@paste-1", e.textarea.Value(), "only the placeholder should be inserted")
+
+	data, err := os.ReadFile(e.attachments[0].path)
+	require.NoError(t, err)
+	assert.Equal(t, strings.ReplaceAll(content, "\r", "\n"), string(data),
+		"attachment should keep every record, with normalized newlines")
 }
 
 func TestHandlePaste_ExceedsLineLimit(t *testing.T) {
@@ -492,7 +546,7 @@ func TestHandlePaste_DragDropSingleFile(t *testing.T) {
 	require.NoError(t, os.WriteFile(file, []byte("PNG"), 0o644))
 
 	e := newPasteTestEditor()
-	handled := e.handlePaste(file)
+	_, handled := e.handlePaste(file)
 
 	assert.True(t, handled, "valid file path should be handled as drag-and-drop")
 	assert.Len(t, e.attachments, 1)
@@ -509,7 +563,7 @@ func TestHandlePaste_DragDropMultipleFiles(t *testing.T) {
 	require.NoError(t, os.WriteFile(file2, []byte("JPG"), 0o644))
 
 	e := newPasteTestEditor()
-	handled := e.handlePaste(file1 + " " + file2)
+	_, handled := e.handlePaste(file1 + " " + file2)
 
 	assert.True(t, handled)
 	assert.Len(t, e.attachments, 2)
@@ -529,7 +583,7 @@ func TestHandlePaste_RollbackOnPartialFailure(t *testing.T) {
 	require.NoError(t, os.WriteFile(bigFile, make([]byte, 5*1024*1024), 0o644))
 
 	e := newPasteTestEditor()
-	handled := e.handlePaste(goodFile + " " + bigFile)
+	_, handled := e.handlePaste(goodFile + " " + bigFile)
 
 	assert.False(t, handled, "should fall through to text paste when any file fails")
 	assert.Empty(t, e.attachments, "partial attachments should be rolled back")
@@ -547,7 +601,7 @@ func TestHandlePaste_UnsupportedTypeRollback(t *testing.T) {
 	require.NoError(t, os.WriteFile(sh, []byte("#!/bin/sh"), 0o644))
 
 	e := newPasteTestEditor()
-	handled := e.handlePaste(png + " " + sh)
+	_, handled := e.handlePaste(png + " " + sh)
 
 	assert.False(t, handled, "unsupported file type should cause fallback to text")
 	assert.Empty(t, e.attachments, "no attachments when file type is unsupported")
@@ -564,7 +618,7 @@ func TestHandlePaste_SymlinkRejected(t *testing.T) {
 	require.NoError(t, os.Symlink(realFile, link))
 
 	e := newPasteTestEditor()
-	handled := e.handlePaste(link)
+	_, handled := e.handlePaste(link)
 
 	assert.False(t, handled, "symlink should be rejected")
 	assert.Empty(t, e.attachments)
@@ -574,7 +628,7 @@ func TestHandlePaste_PathTraversalRejected(t *testing.T) {
 	t.Parallel()
 
 	e := newPasteTestEditor()
-	handled := e.handlePaste("../../etc/passwd")
+	_, handled := e.handlePaste("../../etc/passwd")
 
 	assert.False(t, handled, "path traversal should be rejected")
 	assert.Empty(t, e.attachments)


### PR DESCRIPTION
## Summary

Normalize pasted line endings before editor classification and rendering to prevent carriage-return-delimited terminal logs from corrupting the TUI layout.

## Changes

- Normalize CRLF and bare CR line endings to LF at the editor paste boundary.
- Use the normalized content for bracketed paste and clipboard fallback paths.
- Correctly collapse large CR-delimited pastes into existing paste attachments.
- Add regression coverage for inline and large BuildKit-style pastes.

## Reported behavior mapping

| Expectation | Implementation |
|---|---|
| Pasting BuildKit logs must not corrupt the sidebar or TUI | Raw carriage returns no longer reach the textarea renderer |
| Progress records separated by bare CR must count as separate lines | Bare CR separators are normalized to LF before line classification |
| Large pastes must remain responsive | Content over the existing limits is buffered as a paste attachment |
| Pasted content must retain its line structure | CRLF and CR are converted to semantic LF line breaks |

## Validation

| Check | Result |
|---|---|
| `go test -race -count=1 ./pkg/tui/components/editor/...` | pass |
| `go test ./pkg/tui/...` | pass |
| `go build ./...` | pass |
| `golangci-lint run ./pkg/tui/components/editor/...` | pass |
| `go run ./lint .` | pass |
| `go mod tidy -diff` | clean |

`go test ./...` reaches an unrelated environmental failure in `pkg/teamloader`: `TestLoadExamples` attempts to pull `ai/qwen3`, and the Docker CDN returns HTTP 416.
