### PR TITLE
feat(tui): improve agent transfer feedback

### DIFF
--- a/pkg/tui/components/message/message.go
+++ b/pkg/tui/components/message/message.go
@@ -362,6 +362,8 @@ func (mv *messageModel) render(width int) string {
 		return msg.Content
 	case types.MessageTypeCancelled:
 		return styles.WarningStyle.Render("⚠ stream cancelled ⚠")
+	case types.MessageTypeAgentReturn:
+		return renderAgentReturn(msg.Sender, msg.Content, width)
 	case types.MessageTypeWelcome:
 		messageStyle := styles.WelcomeMessageStyle
 		// Convert explicit newlines to markdown hard line breaks (two trailing spaces)
@@ -449,6 +451,26 @@ func (mv *messageModel) senderPrefix(sender string) string {
 		return ""
 	}
 	return styles.AgentBadgeStyleFor(sender).MarginLeft(2).Render(sender) + "\n\n"
+}
+
+// renderAgentReturn renders the delegation-return transition: the returning
+// child's badge, a muted "returned control to" connector, and the parent's
+// badge — the same visual language as the transfer_task/handoff headers, kept
+// visually light. The line is word-wrapped to the width and each wrapped line
+// hard-capped, so narrow chat columns never overflow (the cap only ever trims
+// trailing wrap spaces).
+func renderAgentReturn(fromAgent, toAgent string, width int) string {
+	line := styles.AgentBadgeStyleFor(fromAgent).MarginLeft(2).Render(fromAgent) +
+		styles.MutedStyle.Render(" "+types.AgentReturnLabel+" ") +
+		styles.AgentBadgeStyleFor(toAgent).Render(toAgent)
+	if width <= 0 {
+		return line
+	}
+	lines := strings.Split(ansi.Wrap(line, width, ""), "\n")
+	for i, l := range lines {
+		lines[i] = ansi.Truncate(l, width, "")
+	}
+	return strings.Join(lines, "\n")
 }
 
 // sameAgentAsPrevious returns true if the previous message was from the same agent

--- a/pkg/tui/components/message/message_test.go
+++ b/pkg/tui/components/message/message_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -356,5 +357,43 @@ func TestUserMessageHoverKeepsHeightAtNarrowWidth(t *testing.T) {
 		h := mv.Height(width)
 		mv.SetHovered(true)
 		assert.Equal(t, h, mv.Height(width), "hover must not change height at width %d", width)
+	}
+}
+
+// TestAgentReturnRendersBadgesAndLabel covers the delegation-return
+// transition: both agent badges render around the "returned control to"
+// connector, and the view is a plain static line — not spinner-driven, and
+// distinct from assistant markdown (no action row, no copy affordance).
+func TestAgentReturnRendersBadgesAndLabel(t *testing.T) {
+	t.Parallel()
+
+	mv := New(types.AgentReturn("researcher", "root"), nil)
+	mv.SetSize(80, 0)
+
+	assert.False(t, mv.isSpinnerDriven(), "the transition is static")
+
+	out := stripANSI(mv.View())
+	assert.Contains(t, out, "researcher", "the child badge names the returning agent")
+	assert.Contains(t, out, "root", "the parent badge names the agent receiving control")
+	assert.Contains(t, out, types.AgentReturnLabel)
+	assert.NotContains(t, out, types.MessageCopyLabel, "the transition carries no copy affordance")
+
+	mv.SetHovered(true)
+	assert.Equal(t, out, stripANSI(mv.View()), "hovering an agent-return changes nothing")
+}
+
+// TestAgentReturnRespectsNarrowWidths verifies the transition wraps instead of
+// overflowing when the chat column is narrow.
+func TestAgentReturnRespectsNarrowWidths(t *testing.T) {
+	t.Parallel()
+
+	msg := types.AgentReturn("delegation-orchestrator", "implementation-reviewer")
+	for _, width := range []int{10, 16, 24, 40} {
+		mv := New(msg, nil)
+		mv.SetSize(width, 0)
+		for i, line := range strings.Split(mv.View(), "\n") {
+			assert.LessOrEqualf(t, ansi.StringWidth(line), width,
+				"width %d: line %d must not overflow", width, i)
+		}
 	}
 }

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -73,6 +73,10 @@ type Model interface {
 	AppendToLastMessage(agentName, content string) tea.Cmd
 	AppendReasoning(agentName, content string) tea.Cmd
 	AddShellOutputMessage(content string) tea.Cmd
+	// AddAgentReturn appends the UI-only "child returned control to parent"
+	// delegation transition. It is never persisted, so it does not reappear
+	// when the session is reloaded.
+	AddAgentReturn(fromAgent, toAgent string) tea.Cmd
 	LoadFromSession(sess *session.Session) tea.Cmd
 
 	RemoveSpinner()
@@ -1309,6 +1313,26 @@ func (m *model) AddErrorMessage(content string) tea.Cmd {
 
 func (m *model) AddShellOutputMessage(content string) tea.Cmd {
 	return m.addMessage(types.ShellOutput(content))
+}
+
+// AddAgentReturn appends the delegation-return transition. A pending-response
+// spinner pinned at the tail is re-added (with its label) after the
+// transition so the "spinner is always last" invariant — relied on by
+// RemoveSpinner — keeps holding.
+func (m *model) AddAgentReturn(fromAgent, toAgent string) tea.Cmd {
+	if fromAgent == "" || toAgent == "" {
+		return nil
+	}
+	var trailingSpinner *types.Message
+	if last := m.lastMessage(); last != nil && last.Type == types.MessageTypeSpinner {
+		trailingSpinner = last
+		m.removeSpinner()
+	}
+	cmds := []tea.Cmd{m.addMessage(types.AgentReturn(fromAgent, toAgent))}
+	if trailingSpinner != nil {
+		cmds = append(cmds, m.addMessage(types.SpinnerLabeled(trailingSpinner.Sender, trailingSpinner.Content)))
+	}
+	return tea.Batch(cmds...)
 }
 
 func (m *model) AddAssistantMessage(sender, label string) tea.Cmd {

--- a/pkg/tui/components/messages/messages_test.go
+++ b/pkg/tui/components/messages/messages_test.go
@@ -1644,3 +1644,68 @@ func TestEditLabelInContentIsNotClickable(t *testing.T) {
 	_, cmd = m.handleMouseClick(tea.MouseClickMsg{X: ansi.StringWidth(before), Y: contentLine, Button: tea.MouseLeft})
 	assert.Nil(t, cmd, "edit label text inside message content must not be clickable")
 }
+
+// TestAddAgentReturnKeepsSpinnerLast verifies the delegation-return transition
+// slips in before a trailing pending-response spinner (whose label survives),
+// preserving the "spinner is always last" invariant RemoveSpinner relies on.
+func TestAddAgentReturnKeepsSpinnerLast(t *testing.T) {
+	t.Parallel()
+
+	m := NewScrollableView(80, 24, &service.SessionState{}).(*model)
+	m.AddAssistantMessage("researcher", "root → researcher")
+	require.Equal(t, types.MessageTypeSpinner, m.messages[len(m.messages)-1].Type)
+
+	cmd := m.AddAgentReturn("researcher", "root")
+	require.NotNil(t, cmd)
+
+	require.Len(t, m.messages, 2)
+	assert.Equal(t, types.MessageTypeAgentReturn, m.messages[0].Type)
+	assert.Equal(t, "researcher", m.messages[0].Sender)
+	assert.Equal(t, "root", m.messages[0].Content)
+	last := m.messages[1]
+	assert.Equal(t, types.MessageTypeSpinner, last.Type, "the spinner stays at the tail")
+	assert.Equal(t, "researcher", last.Sender, "the re-added spinner keeps its sender")
+	assert.Equal(t, "root → researcher", last.Content, "the re-added spinner keeps its label")
+
+	m.RemoveSpinner()
+	require.Len(t, m.messages, 1, "the tail spinner is still removable")
+	assert.Equal(t, types.MessageTypeAgentReturn, m.messages[0].Type)
+}
+
+// TestAddAgentReturnWithoutSpinnerAppends verifies the transition simply
+// appends when no spinner is pending, and that empty names are a no-op.
+func TestAddAgentReturnWithoutSpinnerAppends(t *testing.T) {
+	t.Parallel()
+
+	m := NewScrollableView(80, 24, &service.SessionState{}).(*model)
+	m.AddUserMessage("go")
+
+	require.NotNil(t, m.AddAgentReturn("researcher", "root"))
+	require.Len(t, m.messages, 2)
+	assert.Equal(t, types.MessageTypeAgentReturn, m.messages[1].Type)
+
+	assert.Nil(t, m.AddAgentReturn("", "root"))
+	assert.Nil(t, m.AddAgentReturn("researcher", ""))
+	assert.Len(t, m.messages, 2, "empty agent names add nothing")
+}
+
+// TestAgentReturnIsInertInList verifies the transition is neither selectable
+// nor hoverable-for-copy nor animated: it must not be treated like assistant
+// or tool content by the list machinery.
+func TestAgentReturnIsInertInList(t *testing.T) {
+	t.Parallel()
+
+	m := NewScrollableView(80, 24, &service.SessionState{}).(*model)
+	m.AddAgentReturn("researcher", "root")
+
+	require.Len(t, m.messages, 1)
+	assert.False(t, m.isSelectableMessage(0), "the transition is not selectable")
+	assert.False(t, m.shouldCacheMessage(0))
+	assert.False(t, m.hasAnimatedContent(), "the transition needs no animation ticks")
+	assert.Equal(t, -1, m.findLastAssistantMessage(), "the transition is not assistant content")
+
+	out := ansi.Strip(m.View())
+	assert.Contains(t, out, "researcher")
+	assert.Contains(t, out, types.AgentReturnLabel)
+	assert.NotContains(t, out, types.MessageCopyLabel)
+}

--- a/pkg/tui/components/sidebar/agent_transfer_test.go
+++ b/pkg/tui/components/sidebar/agent_transfer_test.go
@@ -38,6 +38,43 @@ func transferRelationIndex(m *model) int {
 	return -1
 }
 
+// visibleBoxTitle renders the panel and returns the title embedded in the
+// visible transfer box's top border ("Transfer" or "Return"), or "" when no
+// box renders.
+func visibleBoxTitle(m *model) string {
+	idx := transferRelationIndex(m)
+	if idx <= 0 {
+		return ""
+	}
+	top := agentBody(m)[idx-1]
+	for _, title := range []string{transferBoxTitle, transferReturnBoxTitle} {
+		if strings.Contains(top, " "+title+" ") {
+			return title
+		}
+	}
+	return ""
+}
+
+// fireHopTimer fires the tokenized min or max presentation timer of the live
+// hop identified by from→to.
+func fireHopTimer(t *testing.T, m *model, from, to string, kind transferTimerKind) {
+	t.Helper()
+	for _, hop := range m.agentTransfers {
+		if hop.from == from && hop.to == to {
+			_, _ = m.Update(transferTimerMsg{gen: hop.gen, kind: kind})
+			return
+		}
+	}
+	t.Fatalf("no live hop %s→%s", from, to)
+}
+
+// expireReturn fires the live Return presentation's timer.
+func expireReturn(t *testing.T, m *model) {
+	t.Helper()
+	require.NotNil(t, m.agentReturn, "a Return presentation should be live")
+	_, _ = m.Update(transferTimerMsg{gen: m.agentReturn.gen, kind: transferTimerReturn})
+}
+
 // TestTransferPanelContentAndPlacement verifies the in-flight transfer renders
 // as a compact three-line box — muted bordered title, source ─●─► destination
 // relation — below the whole roster after a blank breathing line, all unowned
@@ -257,10 +294,67 @@ func TestTransferPanelPathologicalWidths(t *testing.T) {
 	m := newAgentPanelSidebar(t, 40, transferRoster()...)
 	m.SetAgentSwitching(true, "Scout", "Coder")
 
+	pres, ok := m.visibleTransfer()
+	require.True(t, ok)
 	for width := 1; width <= 16; width++ {
-		for _, line := range m.renderTransferPanel(m.agentTransfers[0], width) {
+		for _, line := range m.renderTransferPanel(pres, width) {
 			assert.LessOrEqualf(t, lipgloss.Width(line), width, "box line must fit width %d", width)
 		}
+	}
+}
+
+// TestTransferCollapsedSummaryFitsNarrowWidths verifies the collapsed band's
+// transfer summary is budgeted to the content width — long and wide (CJK)
+// names are truncated, never overflowing — so the band's height estimate
+// cannot be undercut by an over-wide info line.
+func TestTransferCollapsedSummaryFitsNarrowWidths(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		from, to string
+	}{
+		{"long ascii", "delegation-orchestrator", "implementation-reviewer"},
+		{"wide cjk", "调度协调器智能体", "代码实现者智能体"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := newAgentPanelSidebar(t, MinWidth,
+				runtime.AgentDetails{Name: tc.from, Provider: "openai", Model: "gpt-5.4", Thinking: "off"},
+				runtime.AgentDetails{Name: tc.to, Provider: "anthropic", Model: "claude-sonnet-4-6", Thinking: "high"},
+			)
+			m.SetMode(ModeCollapsed)
+			// Isolate the info line to the transfer summary (no agent entry,
+			// no working dir) so the width/height assertions are exact.
+			m.sessionState.SetCurrentAgentName("")
+			m.workingDirectory = ""
+			m.SetAgentSwitching(true, tc.from, tc.to)
+
+			for width := 1; width <= 30; width++ {
+				summary := m.transferSummaryCollapsed(width)
+				assert.LessOrEqualf(t, lipgloss.Width(summary), width,
+					"summary must fit content width %d", width)
+			}
+
+			contentWidth := m.contentWidth(false)
+			summary := ansi.Strip(m.transferSummaryCollapsed(contentWidth))
+			assert.Contains(t, summary, transferArrowHead, "the rail survives truncation")
+			assert.Contains(t, summary, "…", "overflowing names are truncated with ellipses")
+
+			// With every band line fitting the content width, the terminal
+			// wraps nothing, so the height estimate covers the actual lines
+			// (CollapsedHeight additionally counts the divider).
+			vm := m.computeCollapsedViewModel(contentWidth)
+			rendered := strings.Split(RenderCollapsedView(vm), "\n")
+			for i, line := range rendered {
+				assert.LessOrEqualf(t, lipgloss.Width(line), contentWidth,
+					"collapsed band line %d must fit the content width", i)
+			}
+			assert.GreaterOrEqual(t, m.CollapsedHeight(m.width), len(rendered)+1,
+				"the height estimate is not under-evaluated")
+		})
 	}
 }
 
@@ -317,9 +411,10 @@ func TestTransferAnimationTickKeepsLayoutClean(t *testing.T) {
 }
 
 // TestTransferStackNestedRestore replays nested transfers: A→B then B→C shows
-// B→C with the dot restarted on the left; when C returns to B the outer A→B
-// box reappears, again from the left; when B returns to A nothing is left, the
-// subscription ends and the ↔ header marker goes away.
+// B→C with the dot restarted on the left; when C returns to B a transient
+// Return box shows first, then the outer A→B box (still inside its window)
+// reappears, again from the left; when B returns to A the final Return expires
+// into nothing, the subscription ends and the ↔ header marker goes away.
 func TestTransferStackNestedRestore(t *testing.T) {
 	t.Parallel()
 
@@ -345,21 +440,31 @@ func TestTransferStackNestedRestore(t *testing.T) {
 		_, _ = m.Update(animation.TickMsg{Frame: frame})
 	}
 	m.SetAgentSwitching(false, "C", "B") // stop of B→C carries the inverse pair
-	assert.Zero(t, m.transferAnimationFrame, "restoring the parent restarts the dot on the left")
-	assert.True(t, m.transferAnimation.IsActive(), "the animation keeps running for the parent hop")
+	assert.Zero(t, m.transferAnimationFrame, "the Return restarts the dot on the left")
+	assert.True(t, m.transferAnimation.IsActive(), "the animation keeps running for the Return")
+	assert.Equal(t, transferReturnBoxTitle, visibleBoxTitle(m), "the stop presents a Return box first")
+	idx = transferRelationIndex(m)
+	require.GreaterOrEqual(t, idx, 0)
+	assert.Contains(t, agentBody(m)[idx], "C ●──► B", "the Return shows child → parent")
+
+	expireReturn(t, m)
+	assert.Equal(t, transferBoxTitle, visibleBoxTitle(m), "the unacknowledged outer hop resumes after the Return")
 	idx = transferRelationIndex(m)
 	require.GreaterOrEqual(t, idx, 0)
 	assert.Contains(t, agentBody(m)[idx], "A ●──► B", "the outer hop's box reappears")
+	assert.True(t, m.transferAnimation.IsActive())
 
 	m.SetAgentSwitching(false, "B", "A")
+	assert.Equal(t, transferReturnBoxTitle, visibleBoxTitle(m))
+	expireReturn(t, m)
 	assert.Equal(t, -1, transferRelationIndex(m), "no box once all hops returned")
-	assert.False(t, m.transferAnimation.IsActive(), "the last stop ends the animation subscription")
+	assert.False(t, m.transferAnimation.IsActive(), "the final Return's expiry ends the animation subscription")
 	assert.NotContains(t, renderAgentPanel(m)[0], "↔", "the header marker clears with the stack")
 }
 
 // TestTransferStackOutOfOrderStop verifies a stop pops its matching hop (the
-// inverse pair of its start), not blindly the top of the stack, and that the
-// still-visible hop keeps its animation phase.
+// inverse pair of its start), not blindly the top of the stack: after that
+// stop's Return expires, the unmatched inner hop is what resumes.
 func TestTransferStackOutOfOrderStop(t *testing.T) {
 	t.Parallel()
 
@@ -372,43 +477,113 @@ func TestTransferStackOutOfOrderStop(t *testing.T) {
 	m.SetAgentSwitching(true, "A", "B")
 	m.SetAgentSwitching(true, "B", "C")
 	_, _ = m.Update(animation.TickMsg{Frame: 1})
-	frame := m.transferAnimationFrame
-	require.NotZero(t, frame)
 
 	m.SetAgentSwitching(false, "B", "A") // the outer stop arrives first
+	require.Len(t, m.agentTransfers, 1)
+	assert.Equal(t, "B", m.agentTransfers[0].from, "the matching outer hop was removed, not the top")
+	assert.Equal(t, "C", m.agentTransfers[0].to)
+	assert.Equal(t, transferReturnBoxTitle, visibleBoxTitle(m), "the stop presents its Return")
+
+	expireReturn(t, m)
 	idx := transferRelationIndex(m)
 	require.GreaterOrEqual(t, idx, 0)
-	assert.Contains(t, agentBody(m)[idx], "B ●──► C", "the unmatched inner hop stays on top")
-	assert.Equal(t, frame, m.transferAnimationFrame, "the visible hop is unchanged, so the phase is preserved")
+	assert.Contains(t, agentBody(m)[idx], "B ●──► C", "the unmatched inner hop resumes")
 	assert.True(t, m.transferAnimation.IsActive())
 
 	m.SetAgentSwitching(false, "C", "B")
+	expireReturn(t, m)
 	assert.Equal(t, -1, transferRelationIndex(m))
 	assert.False(t, m.transferAnimation.IsActive())
 }
 
-// TestTransferStopFallbackPop verifies a stop that matches no recorded hop
-// still pops the innermost one (stopping the animation with the emptied
-// stack), and a stop on an empty stack is a no-op.
+// TestTransferStopFallbackPop verifies a legacy nameless stop still pops the
+// innermost hop — without presenting a Return — and a stop on an empty stack
+// is a no-op. Named stops that match no hop are covered by
+// TestTransferStaleNamedStopIsNoOp.
 func TestTransferStopFallbackPop(t *testing.T) {
 	t.Parallel()
 
 	m := newAgentPanelSidebar(t, 40, transferRoster()...)
 
 	m.SetAgentSwitching(true, "Scout", "Coder")
-	m.SetAgentSwitching(false, "", "")
-	assert.Empty(t, m.agentTransfers, "an unmatched stop pops the innermost hop")
+	res := m.SetAgentSwitching(false, "", "")
+	assert.False(t, res.Accepted, "a nameless stop is never accepted")
+	assert.Empty(t, res.Timers, "a nameless stop arms no Return timer")
+	assert.Empty(t, m.agentTransfers, "a nameless stop pops the innermost hop")
+	assert.Nil(t, m.agentReturn, "a nameless stop presents no Return")
 	assert.False(t, m.transferAnimation.IsActive(), "an emptied stack stops the animation")
 	assert.Zero(t, m.transferAnimationFrame)
 
-	m.SetAgentSwitching(false, "Coder", "Scout")
+	res = m.SetAgentSwitching(false, "Coder", "Scout")
+	assert.False(t, res.Accepted)
 	assert.Empty(t, m.agentTransfers, "a stop on an empty stack is a no-op")
+	assert.Nil(t, m.agentReturn, "a stop on an empty stack (e.g. after a cancel) presents no Return")
 	assert.False(t, m.transferAnimation.IsActive())
 }
 
+// TestTransferStaleNamedStopIsNoOp verifies a named stop that closes no
+// recorded hop is a complete no-op: it can neither steal a live hop of
+// another delegation nor present a bogus Return.
+func TestTransferStaleNamedStopIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+
+	// A hop completes, then a new one starts; its stale duplicate stop
+	// arrives late (e.g. it raced a retry) and must not touch the new hop.
+	m.SetAgentSwitching(true, "Scout", "Coder")
+	res := m.SetAgentSwitching(false, "Coder", "Scout")
+	require.True(t, res.Accepted)
+	expireReturn(t, m)
+
+	m.SetAgentSwitching(true, "Scout", "root")
+	res = m.SetAgentSwitching(false, "Coder", "Scout")
+	assert.False(t, res.Accepted, "the duplicate stop matches no live hop")
+	assert.Nil(t, res.Cmd)
+	assert.Empty(t, res.Timers)
+	require.Len(t, m.agentTransfers, 1, "the live hop is not stolen")
+	assert.Equal(t, "root", m.agentTransfers[0].to)
+	assert.Nil(t, m.agentReturn, "no Return is presented for a stale stop")
+	assert.Equal(t, transferBoxTitle, visibleBoxTitle(m), "the live hop's box stays up")
+
+	// A stop from an unrelated pair is equally ignored.
+	res = m.SetAgentSwitching(false, "root", "Coder")
+	assert.False(t, res.Accepted)
+	require.Len(t, m.agentTransfers, 1)
+	assert.Nil(t, m.agentReturn)
+}
+
+// TestTransferBoundariesIgnoredWhileCancelled verifies hop boundaries
+// arriving between an ESC cancel and the next stream start are dropped — no
+// box, no Return — and that a new stream start restores normal handling.
+func TestTransferBoundariesIgnoredWhileCancelled(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+
+	m.SetAgentSwitching(true, "Scout", "Coder")
+	_, _ = m.Update(messages.StreamCancelledMsg{})
+
+	res := m.SetAgentSwitching(false, "Coder", "Scout")
+	assert.False(t, res.Accepted, "a stop of the dying stream is dropped")
+	assert.Nil(t, m.agentReturn)
+
+	res = m.SetAgentSwitching(true, "Scout", "Coder")
+	assert.False(t, res.Accepted, "a late start of the dying stream is dropped")
+	assert.Empty(t, m.agentTransfers)
+	assert.Equal(t, -1, transferRelationIndex(m), "no box reappears after the cancel")
+	assert.False(t, m.transferAnimation.IsActive())
+
+	// The next stream start clears the flag: delegation works again.
+	_, _ = m.Update(runtime.StreamStarted("root-session", "root"))
+	res = m.SetAgentSwitching(true, "Scout", "Coder")
+	assert.True(t, res.Accepted, "a new stream reactivates transfer tracking")
+	assert.Equal(t, transferBoxTitle, visibleBoxTitle(m))
+}
+
 // TestTransferSubscriptionLifecycle verifies the single animation subscription
-// starts with the first hop, is shared by nested hops (never double-registered)
-// and ends with the last stop.
+// starts with the first hop, is shared by nested hops and the Return boxes
+// (never double-registered) and ends when the last Return expires.
 func TestTransferSubscriptionLifecycle(t *testing.T) {
 	t.Parallel()
 
@@ -422,15 +597,22 @@ func TestTransferSubscriptionLifecycle(t *testing.T) {
 	assert.True(t, m.transferAnimation.IsActive(), "a nested hop reuses the single subscription")
 
 	m.SetAgentSwitching(false, "root", "Coder")
-	assert.True(t, m.transferAnimation.IsActive(), "the subscription survives while hops remain")
+	assert.True(t, m.transferAnimation.IsActive(), "the subscription survives for the Return and the remaining hop")
+
+	expireReturn(t, m)
+	assert.True(t, m.transferAnimation.IsActive(), "the outer hop is still inside its own window")
 
 	m.SetAgentSwitching(false, "Coder", "Scout")
-	assert.False(t, m.transferAnimation.IsActive(), "the last stop ends the subscription")
+	assert.True(t, m.transferAnimation.IsActive(), "the last stop still animates its Return")
+
+	expireReturn(t, m)
+	assert.False(t, m.transferAnimation.IsActive(), "the last Return's expiry ends the subscription")
 }
 
 // TestTransferClearedOnCancelResetAndLoad verifies a stream cancel, a
-// stream-tracking reset and a session load all drop any in-flight transfer —
-// no ghost box, subscription stopped, phase back to zero.
+// stream-tracking reset and a session load all drop any in-flight transfer
+// and Return — no ghost box, subscription stopped, phase back to zero — and
+// that the stale presentation timers of the cleared state reactivate nothing.
 func TestTransferClearedOnCancelResetAndLoad(t *testing.T) {
 	t.Parallel()
 
@@ -439,24 +621,45 @@ func TestTransferClearedOnCancelResetAndLoad(t *testing.T) {
 	assertCleared := func(context string) {
 		t.Helper()
 		assert.Empty(t, m.agentTransfers, context)
+		assert.Nil(t, m.agentReturn, context)
 		assert.Equal(t, -1, transferRelationIndex(m), context)
 		assert.False(t, m.transferAnimation.IsActive(), context)
 		assert.Zero(t, m.transferAnimationFrame, context)
 	}
 
+	// The timers armed before each clear must be stale afterwards.
+	fireStaleTimers := func(gen int64) {
+		t.Helper()
+		for _, kind := range []transferTimerKind{transferTimerMin, transferTimerMax, transferTimerReturn} {
+			_, _ = m.Update(transferTimerMsg{gen: gen, kind: kind})
+		}
+	}
+
 	m.SetAgentSwitching(true, "Scout", "Coder")
+	hopGen := m.agentTransfers[0].gen
 	_, _ = m.Update(animation.TickMsg{Frame: 1})
 	require.GreaterOrEqual(t, transferRelationIndex(m), 0)
 	_, _ = m.Update(messages.StreamCancelledMsg{})
 	assertCleared("cancel clears the box and stops the animation")
+	fireStaleTimers(hopGen)
+	assertCleared("stale timers after a cancel reactivate nothing")
 
+	// A new stream start lifts the cancel guard for the next scenarios.
+	_, _ = m.Update(runtime.StreamStarted("root-session", "root"))
 	m.SetAgentSwitching(true, "Scout", "Coder")
+	m.SetAgentSwitching(false, "Coder", "Scout") // leaves a live Return
+	returnGen := m.agentReturn.gen
 	m.ResetStreamTracking()
 	assertCleared("a new top-level run clears the box and stops the animation")
+	fireStaleTimers(returnGen)
+	assertCleared("stale timers after a reset reactivate nothing")
 
 	m.SetAgentSwitching(true, "Scout", "Coder")
+	hopGen = m.agentTransfers[0].gen
 	m.LoadFromSession(session.New())
 	assertCleared("loading a session starts from a clean slate")
+	fireStaleTimers(hopGen)
+	assertCleared("stale timers after a load reactivate nothing")
 }
 
 // TestNoTransferPanelWhenIdle verifies no box (and no header marker) renders

--- a/pkg/tui/components/sidebar/agent_transfer_window_test.go
+++ b/pkg/tui/components/sidebar/agent_transfer_window_test.go
@@ -1,0 +1,263 @@
+package sidebar
+
+import (
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+)
+
+// The tests in this file pin the transfer box's presentation windows: the
+// outbound box shows at least the minimum window, hides on the destination's
+// first useful activity, and never outlives the maximum cutoff; the stop-side
+// Return box shows briefly and never restores an acknowledged outer hop. All
+// timers are tokenized messages fired explicitly, so no test ever sleeps.
+
+// TestTransferOutboundStaysUntilMinDespiteEarlyActivity verifies early child
+// activity does not cut the box short: it stays visible until the minimum
+// window elapses, then hides while the hop stays tracked logically.
+func TestTransferOutboundStaysUntilMinDespiteEarlyActivity(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+	m.SetAgentSwitching(true, "Scout", "Coder")
+	require.GreaterOrEqual(t, transferRelationIndex(m), 0, "the box shows as soon as the hop starts")
+
+	m.SetAgentActivity("Coder")
+	assert.GreaterOrEqual(t, transferRelationIndex(m), 0, "early activity keeps the box perceptible until the minimum window")
+	assert.True(t, m.transferAnimation.IsActive())
+
+	fireHopTimer(t, m, "Scout", "Coder", transferTimerMin)
+	assert.Equal(t, -1, transferRelationIndex(m), "the minimum window hides the box once activity was seen")
+	assert.False(t, m.transferAnimation.IsActive(), "nothing animated is left once the box hid")
+	require.Len(t, m.agentTransfers, 1, "the logical hop survives its hidden box")
+	assert.Contains(t, renderAgentPanel(m)[0], "↔", "the header keeps hinting at the in-flight delegation")
+
+	// The max cutoff of the acknowledged hop is a no-op.
+	fireHopTimer(t, m, "Scout", "Coder", transferTimerMax)
+	assert.Equal(t, -1, transferRelationIndex(m))
+	assert.False(t, m.transferAnimation.IsActive())
+}
+
+// TestTransferOutboundNoActivityHidesAtMax verifies a silent/slow destination
+// keeps the box up past the minimum window, until the max cutoff clears it.
+func TestTransferOutboundNoActivityHidesAtMax(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+	m.SetAgentSwitching(true, "Scout", "Coder")
+
+	fireHopTimer(t, m, "Scout", "Coder", transferTimerMin)
+	assert.GreaterOrEqual(t, transferRelationIndex(m), 0, "without activity the box outlives the minimum window")
+	assert.True(t, m.transferAnimation.IsActive())
+
+	fireHopTimer(t, m, "Scout", "Coder", transferTimerMax)
+	assert.Equal(t, -1, transferRelationIndex(m), "the max cutoff hides the box for silent destinations")
+	assert.False(t, m.transferAnimation.IsActive())
+	assert.Len(t, m.agentTransfers, 1, "the logical hop survives the cutoff")
+}
+
+// TestTransferOutboundActivityAfterMinHidesImmediately verifies activity
+// arriving after the minimum window hides the box right away.
+func TestTransferOutboundActivityAfterMinHidesImmediately(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+	m.SetAgentSwitching(true, "Scout", "Coder")
+	fireHopTimer(t, m, "Scout", "Coder", transferTimerMin)
+	require.GreaterOrEqual(t, transferRelationIndex(m), 0)
+
+	m.SetAgentActivity("Coder")
+	assert.Equal(t, -1, transferRelationIndex(m), "post-min activity hides the box immediately")
+	assert.False(t, m.transferAnimation.IsActive())
+}
+
+// TestTransferActivityForOtherAgentIgnored verifies only the destination
+// agent's activity acknowledges a hop: the source (or an unrelated agent)
+// changes nothing.
+func TestTransferActivityForOtherAgentIgnored(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+	m.SetAgentSwitching(true, "Scout", "Coder")
+	fireHopTimer(t, m, "Scout", "Coder", transferTimerMin)
+
+	m.SetAgentActivity("Scout")
+	m.SetAgentActivity("root")
+	m.SetAgentActivity("")
+	assert.GreaterOrEqual(t, transferRelationIndex(m), 0, "non-destination activity does not acknowledge the hop")
+	assert.False(t, m.agentTransfers[0].activity)
+}
+
+// TestTransferStaleTimersOfPreviousHopIgnored verifies a dismissed hop's
+// timers cannot affect whatever replaced it: neither the live Return nor a
+// newly started hop.
+func TestTransferStaleTimersOfPreviousHopIgnored(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+	m.SetAgentSwitching(true, "Scout", "Coder")
+	staleGen := m.agentTransfers[0].gen
+	m.SetAgentSwitching(false, "Coder", "Scout") // hop removed, Return live
+	require.Equal(t, transferReturnBoxTitle, visibleBoxTitle(m))
+
+	_, _ = m.Update(transferTimerMsg{gen: staleGen, kind: transferTimerMin})
+	_, _ = m.Update(transferTimerMsg{gen: staleGen, kind: transferTimerMax})
+	assert.Equal(t, transferReturnBoxTitle, visibleBoxTitle(m), "the dismissed hop's timers do not touch the Return")
+
+	staleReturnGen := m.agentReturn.gen
+	m.SetAgentSwitching(true, "Scout", "Coder")
+	require.Equal(t, transferBoxTitle, visibleBoxTitle(m), "a new hop supersedes the Return")
+
+	_, _ = m.Update(transferTimerMsg{gen: staleReturnGen, kind: transferTimerReturn})
+	_, _ = m.Update(transferTimerMsg{gen: staleGen, kind: transferTimerMax})
+	assert.Equal(t, transferBoxTitle, visibleBoxTitle(m), "stale timers do not touch the new hop")
+	assert.True(t, m.transferAnimation.IsActive())
+}
+
+// TestTransferReturnPresentationAndExpiry verifies a stop presents the
+// child ●──► parent relation under the Return title — even when the outbound
+// box was still up (immediate return) — and clears after its own window.
+func TestTransferReturnPresentationAndExpiry(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+	m.SetAgentSwitching(true, "Scout", "Coder")
+	m.SetAgentSwitching(false, "Coder", "Scout") // immediate return, min never elapsed
+
+	assert.Empty(t, m.agentTransfers, "the stop removes the logical hop")
+	assert.Equal(t, transferReturnBoxTitle, visibleBoxTitle(m), "the Return box carries its own title")
+	idx := transferRelationIndex(m)
+	require.GreaterOrEqual(t, idx, 0, "an immediate return still shows the Return box")
+	assert.Contains(t, agentBody(m)[idx], "Coder ●──► Scout", "the relation reads child → parent, dot on the left")
+	assert.True(t, m.transferAnimation.IsActive())
+
+	expireReturn(t, m)
+	assert.Equal(t, -1, transferRelationIndex(m), "the Return expires on its own window")
+	assert.False(t, m.transferAnimation.IsActive(), "the subscription ends when nothing is animated")
+	assert.NotContains(t, renderAgentPanel(m)[0], "↔", "no delegation is left in flight")
+}
+
+// TestTransferReturnDoesNotRestoreAckedOuter verifies an outer hop whose box
+// was already acknowledged stays hidden after a nested Return expires.
+func TestTransferReturnDoesNotRestoreAckedOuter(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+	m.SetAgentSwitching(true, "root", "Scout")
+	fireHopTimer(t, m, "root", "Scout", transferTimerMax) // outer box acknowledged by the cutoff
+	require.Equal(t, -1, transferRelationIndex(m))
+
+	m.SetAgentSwitching(true, "Scout", "Coder")
+	require.Equal(t, transferBoxTitle, visibleBoxTitle(m))
+	m.SetAgentSwitching(false, "Coder", "Scout")
+	require.Equal(t, transferReturnBoxTitle, visibleBoxTitle(m))
+
+	expireReturn(t, m)
+	assert.Equal(t, -1, transferRelationIndex(m), "the acknowledged outer hop is not restored")
+	assert.False(t, m.transferAnimation.IsActive())
+	require.Len(t, m.agentTransfers, 1, "the outer hop is still tracked logically")
+	assert.Contains(t, renderAgentPanel(m)[0], "↔", "the header still hints at the outer delegation")
+}
+
+// TestTransferCollapsedSummaryShowsRelation verifies the collapsed band's info
+// line carries the visible relation (with the Transfer/Return state) and drops
+// it once the box acknowledged.
+func TestTransferCollapsedSummaryShowsRelation(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+	width := m.contentWidth(false)
+
+	assert.Empty(t, m.transferSummaryCollapsed(width), "no relation renders while idle")
+
+	m.SetAgentSwitching(true, "Scout", "Coder")
+	line := ansi.Strip(m.collapsedInfoLine(width))
+	assert.Contains(t, line, transferBoxTitle)
+	assert.Contains(t, line, "Scout")
+	assert.Contains(t, line, "Coder")
+	assert.Contains(t, line, transferArrowHead)
+
+	m.SetAgentActivity("Coder")
+	fireHopTimer(t, m, "Scout", "Coder", transferTimerMin)
+	assert.Empty(t, m.transferSummaryCollapsed(width), "the acknowledged box leaves the band")
+	assert.NotContains(t, ansi.Strip(m.collapsedInfoLine(width)), transferArrowHead)
+
+	m.SetAgentSwitching(false, "Coder", "Scout")
+	line = ansi.Strip(m.collapsedInfoLine(width))
+	assert.Contains(t, line, transferReturnBoxTitle, "the Return state is named in the band")
+	assert.Contains(t, line, "Coder "+transferDot)
+
+	expireReturn(t, m)
+	assert.Empty(t, m.transferSummaryCollapsed(width))
+}
+
+// TestTransferSwitchResultTimers verifies SetAgentSwitching returns the
+// documented presentation windows as timer descriptors whose payloads drive
+// this sidebar's Update: min elapsing without activity keeps the box, max
+// hides it, and an accepted stop's Return timer clears the Return box.
+func TestTransferSwitchResultTimers(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+
+	res := m.SetAgentSwitching(true, "Scout", "Coder")
+	require.True(t, res.Accepted)
+	require.Len(t, res.Timers, 2, "a start arms the min and max windows")
+	assert.Equal(t, transferMinVisible, res.Timers[0].Duration)
+	assert.Equal(t, transferMaxVisible, res.Timers[1].Duration)
+
+	_, _ = m.Update(res.Timers[0].Msg)
+	assert.GreaterOrEqual(t, transferRelationIndex(m), 0, "min elapsing without activity keeps the box")
+	_, _ = m.Update(res.Timers[1].Msg)
+	assert.Equal(t, -1, transferRelationIndex(m), "the max payload hides the box")
+
+	stop := m.SetAgentSwitching(false, "Coder", "Scout")
+	require.True(t, stop.Accepted)
+	require.Len(t, stop.Timers, 1, "an accepted stop arms the Return window")
+	assert.Equal(t, transferReturnVisible, stop.Timers[0].Duration)
+	require.Equal(t, transferReturnBoxTitle, visibleBoxTitle(m))
+	_, _ = m.Update(stop.Timers[0].Msg)
+	assert.Equal(t, -1, transferRelationIndex(m), "the Return payload clears the Return box")
+	assert.False(t, m.transferAnimation.IsActive())
+}
+
+// TestTransferTimerCmdDeliversPayload executes a real scheduled timer command
+// (with a synthetic short duration) and verifies the tick delivers the
+// descriptor's payload unchanged.
+func TestTransferTimerCmdDeliversPayload(t *testing.T) {
+	t.Parallel()
+
+	payload := transferTimerMsg{gen: 7, kind: transferTimerMax}
+	timer := TransferTimer{Duration: time.Millisecond, Msg: payload}
+	assert.Equal(t, payload, timer.Cmd()())
+}
+
+// TestTransferClearedWhenOutermostStreamStops verifies the safety net for
+// pages whose timer commands are discarded (background tabs): a nested stream
+// stop leaves the presentation alone, while the outermost stop drops whatever
+// outlasted its timers so nothing leaks past the run.
+func TestTransferClearedWhenOutermostStreamStops(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, transferRoster()...)
+	_, _ = m.Update(runtime.StreamStarted("root-session", "Scout"))
+	m.SetAgentSwitching(true, "Scout", "Coder")
+	_, _ = m.Update(runtime.StreamStarted("sub-session", "Coder"))
+	require.GreaterOrEqual(t, transferRelationIndex(m), 0)
+
+	_, _ = m.Update(runtime.StreamStopped("sub-session", "Coder", ""))
+	assert.GreaterOrEqual(t, transferRelationIndex(m), 0, "a nested stop leaves the presentation alone")
+	assert.True(t, m.transferAnimation.IsActive())
+
+	m.SetAgentSwitching(false, "Coder", "Scout") // Return would normally expire on its timer
+	_, _ = m.Update(runtime.StreamStopped("root-session", "Scout", ""))
+	assert.Equal(t, -1, transferRelationIndex(m), "the outermost stop clears any lingering presentation")
+	assert.Empty(t, m.agentTransfers)
+	assert.Nil(t, m.agentReturn)
+	assert.False(t, m.transferAnimation.IsActive(), "no animation survives the run")
+}

--- a/pkg/tui/components/sidebar/section_visibility_test.go
+++ b/pkg/tui/components/sidebar/section_visibility_test.go
@@ -100,7 +100,7 @@ func TestCollapsedInfoLine_ShowsAgentsToolsTodos(t *testing.T) {
 		{Description: "second", Status: "pending"},
 	}}))
 
-	info := ansi.Strip(s.collapsedInfoLine())
+	info := ansi.Strip(s.collapsedInfoLine(60))
 	assert.Contains(t, info, "▶ root")
 	assert.Contains(t, info, "12 tools")
 	assert.Contains(t, info, "1/2 todos")
@@ -118,13 +118,13 @@ func TestCollapsedInfoLine_HonorsVisibility(t *testing.T) {
 	}}))
 
 	s.SetSectionVisibility(SectionVisibility{HideAgents: true, HideTodos: true})
-	info := ansi.Strip(s.collapsedInfoLine())
+	info := ansi.Strip(s.collapsedInfoLine(60))
 	assert.NotContains(t, info, "▶ root")
 	assert.NotContains(t, info, "todos")
 	assert.Contains(t, info, "12 tools", "tools stay visible")
 
 	s.SetSectionVisibility(SectionVisibility{HideAgents: true, HideTools: true, HideTodos: true})
-	assert.Empty(t, s.collapsedInfoLine(), "hiding every section removes the line")
+	assert.Empty(t, s.collapsedInfoLine(60), "hiding every section removes the line")
 }
 
 func TestCollapsedLineCount_GrowsWithInfoLine(t *testing.T) {

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"charm.land/bubbles/v2/textinput"
@@ -66,10 +67,20 @@ type Model interface {
 	SetTeamInfo(availableAgents []runtime.AgentDetails)
 	// SetAgentSwitching records the start (switching=true) or end of a
 	// transfer_task hop between fromAgent and toAgent. Stops carry the
-	// inverse pair of their start (start A→B is closed by stop B→A). The
-	// returned command starts the transfer-box animation tick when the first
-	// hop begins; callers must dispatch it.
-	SetAgentSwitching(switching bool, fromAgent, toAgent string) tea.Cmd
+	// inverse pair of their start (start A→B is closed by stop B→A) and are
+	// only accepted when that exact hop is live. A start presents the
+	// outbound transfer box for a bounded window (≥ ~1.5s, until the
+	// destination's first useful activity, ≤ ~3s); an accepted stop replaces
+	// it with a transient child→parent Return box shown for up to ~1.5s —
+	// it may disappear earlier when the enclosing turn/stream ends, since
+	// the outermost StreamStopped intentionally clears any leftover
+	// presentation. Callers must dispatch the result's Cmd and schedule its
+	// Timers (see AgentSwitchResult).
+	SetAgentSwitching(switching bool, fromAgent, toAgent string) AgentSwitchResult
+	// SetAgentActivity records the first useful activity (reasoning, content
+	// or a tool call) attributed to agentName, acknowledging the outbound
+	// transfer box of the innermost hop targeting that agent.
+	SetAgentActivity(agentName string) tea.Cmd
 	SetToolsetInfo(availableTools int, loading bool)
 	SetSkillsInfo(availableSkills int)
 	SetSessionStarred(starred bool)
@@ -131,12 +142,113 @@ type ragIndexingState struct {
 	spinner spinner.Spinner
 }
 
-// agentTransfer is one in-flight transfer_task hop. The sidebar keeps a stack
-// of them: the innermost hop renders as a compact box below the whole agent
-// roster (see renderTransferPanel), and popping it restores the enclosing
-// hop's box with its rail dot back on the left.
+// agentTransfer is one logical transfer_task hop. The sidebar keeps a stack
+// of them for the lifetime of the delegations (so nested starts/stops and the
+// return transition stay correct), while the compact box below the agent
+// roster (see renderTransferPanel) is only presented for a bounded window:
+// at least transferMinVisible, until the destination agent shows its first
+// useful activity, and never past the transferMaxVisible cutoff.
 type agentTransfer struct {
 	from, to string
+	// gen tokens this hop's presentation timers: a timer message carrying a
+	// generation that no longer matches any live hop is stale and ignored.
+	gen int64
+	// minElapsed is set when the minimum-visibility window has passed.
+	minElapsed bool
+	// activity is set on the destination agent's first useful event
+	// (reasoning, content, or a tool call).
+	activity bool
+	// acked hides the hop's box: the child proved it took over (activity
+	// after the minimum window) or the maximum window elapsed.
+	acked bool
+}
+
+// agentReturnState is the transient child→parent "Return" presentation shown
+// briefly (transferReturnVisible) when a transfer_task hop completes.
+type agentReturnState struct {
+	from, to string
+	gen      int64
+}
+
+// transferPresentation is what the transfer panel currently displays: a
+// from→to relation and the box title distinguishing an outbound Transfer
+// from a Return. gen makes distinct presentations of the same relation
+// comparable, so a phase reset can be detected reliably.
+type transferPresentation struct {
+	from, to string
+	title    string
+	gen      int64
+}
+
+// transferTimerKind selects which presentation window elapsed.
+type transferTimerKind int
+
+const (
+	transferTimerMin transferTimerKind = iota
+	transferTimerMax
+	transferTimerReturn
+)
+
+// transferTimerMsg is the tokenized tea.Tick payload driving the transfer
+// presentation windows. gen identifies the hop (or Return) the timer was
+// armed for, so timers of dismissed or replaced presentations are ignored.
+type transferTimerMsg struct {
+	gen  int64
+	kind transferTimerKind
+}
+
+// transferGenCounter issues process-unique generations for the presentation
+// timers. Uniqueness across sidebar instances matters: a misrouted timer
+// message must never accidentally identify another sidebar's hop.
+var transferGenCounter atomic.Int64
+
+// TransferTimer is a one-shot presentation-window timer the sidebar asks its
+// owner to schedule: after Duration, Msg must be delivered back to this
+// sidebar's Update. Descriptors are returned instead of pre-built tick
+// commands so the owning page can address the expiry to itself (wrapping Msg
+// in a routed envelope); a deadline armed on one tab is then neither lost
+// nor applied to whichever tab happens to be active when it fires.
+type TransferTimer struct {
+	Duration time.Duration
+	Msg      tea.Msg
+}
+
+// Cmd schedules the timer as a plain tick delivered to the active page —
+// sufficient for single-page setups; multi-tab owners wrap Msg in their own
+// routed envelope instead.
+func (t TransferTimer) Cmd() tea.Cmd {
+	return tea.Tick(t.Duration, func(time.Time) tea.Msg { return t.Msg })
+}
+
+// AgentSwitchResult is the outcome of SetAgentSwitching. Cmd carries the
+// animation-subscription command and must be dispatched; Timers are the
+// presentation-window timers armed by the boundary and must be scheduled by
+// the owner (see TransferTimer). Accepted reports whether the boundary
+// matched the sidebar's delegation state — a recorded start, or a stop that
+// closed its exact inverse hop; only an accepted stop presents a Return, so
+// callers gate their own return feedback on it.
+type AgentSwitchResult struct {
+	Cmd      tea.Cmd
+	Timers   []TransferTimer
+	Accepted bool
+}
+
+// Transfer presentation windows.
+const (
+	// transferMinVisible is the floor under the outbound box: even when the
+	// destination agent acts immediately, the box stays perceptible this long.
+	transferMinVisible = 1500 * time.Millisecond
+	// transferMaxVisible is the cutoff for silent or slow destinations: the
+	// box clears at this point even without any child activity.
+	transferMaxVisible = 3 * time.Second
+	// transferReturnVisible is how long the child→parent Return box shows.
+	transferReturnVisible = 1500 * time.Millisecond
+)
+
+// transferTimer builds the tokenized descriptor of one presentation-window
+// timer.
+func transferTimer(d time.Duration, gen int64, kind transferTimerKind) TransferTimer {
+	return TransferTimer{Duration: d, Msg: transferTimerMsg{gen: gen, kind: kind}}
 }
 
 // model implements Model
@@ -159,7 +271,8 @@ type model struct {
 	agentModel         string
 	agentDescription   string
 	availableAgents    []runtime.AgentDetails
-	agentTransfers     []agentTransfer // in-flight transfer_task hops (stack; top = innermost)
+	agentTransfers     []agentTransfer   // logical transfer_task hops (stack; top = innermost)
+	agentReturn        *agentReturnState // transient child→parent Return presentation, nil when none
 	availableTools     int
 	availableSkills    int
 	toolsLoading       bool // true when more tools may still be loading
@@ -355,53 +468,187 @@ func (m *model) SetTeamInfo(availableAgents []runtime.AgentDetails) {
 	m.invalidateCache()
 }
 
-// SetAgentSwitching tracks the in-flight transfer_task hops. A start
-// (switching=true) pushes the fromAgent→toAgent hop; a stop pops it. Stops
-// carry the inverse pair of their start (start A→B is closed by stop B→A), so
-// the matching entry is removed even when nested stops arrive out of order;
-// when no entry matches, the innermost hop is popped.
+// SetAgentSwitching tracks the transfer_task hops. A start (switching=true)
+// pushes the fromAgent→toAgent hop and presents its box. A stop is matched
+// strictly: stops carry the inverse pair of their start (start A→B is closed
+// by stop B→A), so only the exact inverse hop is removed — and a transient
+// child→parent Return box presented — even when nested stops arrive out of
+// order. A named stop matching no live hop is stale (its start was already
+// cleared, or it belongs to another run) and is a complete no-op, so it can
+// neither steal a live hop nor present a bogus Return. A legacy nameless
+// stop still drops the innermost hop so old emitters cannot leak the stack,
+// but never presents a Return. Boundaries arriving after an ESC cancel are
+// dropped until the next stream start resets the flag.
 //
-// The first hop starts the transfer-box animation subscription (the returned
-// command primes the shared tick); the last stop ends it. Whenever the visible
-// (innermost) hop changes, the rail phase restarts on the left.
-func (m *model) SetAgentSwitching(switching bool, fromAgent, toAgent string) tea.Cmd {
+// Presentation windows are driven by tokenized timers (see transferTimerMsg):
+// the outbound box hides at min(first useful child activity, max cutoff) but
+// never before the minimum window; the Return box hides after its own window
+// without restoring an already-acknowledged outer hop. The shared animation
+// subscription runs exactly while a box is visible.
+func (m *model) SetAgentSwitching(switching bool, fromAgent, toAgent string) AgentSwitchResult {
+	if m.streamCancelled {
+		// The cancel already tore the presentation down; hops of the dying
+		// stream must not repaint it. StreamStartedEvent clears the flag.
+		return AgentSwitchResult{}
+	}
+	prev, prevOK := m.visibleTransfer()
 	if switching {
-		// The new hop becomes the visible top of the stack.
-		m.agentTransfers = append(m.agentTransfers, agentTransfer{from: fromAgent, to: toAgent})
-		m.transferAnimationFrame = 0
-		m.invalidateCache()
-		return m.transferAnimation.Start()
+		gen := transferGenCounter.Add(1)
+		m.agentTransfers = append(m.agentTransfers, agentTransfer{from: fromAgent, to: toAgent, gen: gen})
+		// A new outbound hop supersedes any transient Return.
+		m.agentReturn = nil
+		return AgentSwitchResult{
+			Cmd: m.resyncTransferPresentation(prev, prevOK),
+			Timers: []TransferTimer{
+				transferTimer(transferMinVisible, gen, transferTimerMin),
+				transferTimer(transferMaxVisible, gen, transferTimerMax),
+			},
+			Accepted: true,
+		}
 	}
 	n := len(m.agentTransfers)
 	if n == 0 {
-		return nil
+		// Nothing in flight (e.g. cancel/reset already cleared the stack):
+		// a late stop must not present a Return.
+		return AgentSwitchResult{}
 	}
-	idx := n - 1
+	if fromAgent == "" && toAgent == "" {
+		// Legacy nameless stop: pop the innermost hop, present nothing.
+		m.agentTransfers = slices.Delete(m.agentTransfers, n-1, n)
+		return AgentSwitchResult{Cmd: m.resyncTransferPresentation(prev, prevOK)}
+	}
+	idx := -1
 	for i := n - 1; i >= 0; i-- {
-		if m.agentTransfers[i] == (agentTransfer{from: toAgent, to: fromAgent}) {
+		if m.agentTransfers[i].from == toAgent && m.agentTransfers[i].to == fromAgent {
 			idx = i
 			break
 		}
 	}
+	if idx < 0 {
+		// Stale named stop: no live hop to close — full no-op.
+		return AgentSwitchResult{}
+	}
 	m.agentTransfers = slices.Delete(m.agentTransfers, idx, idx+1)
-	if idx == len(m.agentTransfers) {
-		// The innermost hop was popped: the restored parent (if any) restarts
-		// its dot on the left. Out-of-order pops keep the visible hop's phase.
-		m.transferAnimationFrame = 0
+	gen := transferGenCounter.Add(1)
+	m.agentReturn = &agentReturnState{from: fromAgent, to: toAgent, gen: gen}
+	return AgentSwitchResult{
+		Cmd:      m.resyncTransferPresentation(prev, prevOK),
+		Timers:   []TransferTimer{transferTimer(transferReturnVisible, gen, transferTimerReturn)},
+		Accepted: true,
 	}
-	if len(m.agentTransfers) == 0 {
-		m.transferAnimation.Stop()
+}
+
+// SetAgentActivity records the first useful activity attributed to agentName
+// and acknowledges the innermost hop targeting that agent: immediately when
+// the minimum-visibility window has already elapsed, otherwise the pending
+// minimum timer performs the hide so the box stays perceptible.
+func (m *model) SetAgentActivity(agentName string) tea.Cmd {
+	if agentName == "" {
+		return nil
 	}
-	m.invalidateCache()
+	for i := range slices.Backward(m.agentTransfers) {
+		hop := &m.agentTransfers[i]
+		if hop.to != agentName || hop.acked {
+			continue
+		}
+		hop.activity = true
+		if !hop.minElapsed {
+			return nil
+		}
+		prev, prevOK := m.visibleTransfer()
+		hop.acked = true
+		return m.resyncTransferPresentation(prev, prevOK)
+	}
 	return nil
 }
 
-// activeTransfer returns the innermost in-flight transfer hop, if any.
-func (m *model) activeTransfer() (agentTransfer, bool) {
-	if n := len(m.agentTransfers); n > 0 {
-		return m.agentTransfers[n-1], true
+// handleTransferTimer applies an elapsed presentation window. Timers are
+// tokenized by generation: a message whose generation matches no live hop
+// (nor the live Return) is stale — its presentation was already dismissed,
+// replaced, or cleared by cancel/reset/load — and is dropped.
+func (m *model) handleTransferTimer(msg transferTimerMsg) tea.Cmd {
+	if msg.kind == transferTimerReturn {
+		if m.agentReturn == nil || m.agentReturn.gen != msg.gen {
+			return nil
+		}
+		prev, prevOK := m.visibleTransfer()
+		m.agentReturn = nil
+		return m.resyncTransferPresentation(prev, prevOK)
 	}
-	return agentTransfer{}, false
+	for i := range m.agentTransfers {
+		hop := &m.agentTransfers[i]
+		if hop.gen != msg.gen {
+			continue
+		}
+		if msg.kind == transferTimerMin {
+			hop.minElapsed = true
+			if !hop.activity {
+				// No useful child activity yet: keep the box up until the
+				// activity arrives or the max cutoff fires.
+				return nil
+			}
+		}
+		if hop.acked {
+			return nil
+		}
+		prev, prevOK := m.visibleTransfer()
+		hop.acked = true
+		return m.resyncTransferPresentation(prev, prevOK)
+	}
+	return nil
+}
+
+// visibleTransfer returns the relation the transfer panel should currently
+// present, if any: the transient Return takes precedence (it is always the
+// most recent event), then the innermost not-yet-acknowledged hop — so an
+// acknowledged outer hop is never restored, while one still inside its
+// presentation window resumes after the Return.
+func (m *model) visibleTransfer() (transferPresentation, bool) {
+	if r := m.agentReturn; r != nil {
+		return transferPresentation{from: r.from, to: r.to, title: transferReturnBoxTitle, gen: r.gen}, true
+	}
+	for _, hop := range slices.Backward(m.agentTransfers) {
+		if !hop.acked {
+			return transferPresentation{from: hop.from, to: hop.to, title: transferBoxTitle, gen: hop.gen}, true
+		}
+	}
+	return transferPresentation{}, false
+}
+
+// resyncTransferPresentation reconciles the rail phase and the animation
+// subscription after a transfer-state mutation. prev is the presentation that
+// was visible before the mutation: when the visible relation changed, the dot
+// restarts on the left; the shared subscription runs exactly while a box is
+// visible so an idle panel never keeps the coordinator ticking.
+func (m *model) resyncTransferPresentation(prev transferPresentation, prevOK bool) tea.Cmd {
+	m.invalidateCache()
+	cur, ok := m.visibleTransfer()
+	if !ok {
+		m.transferAnimationFrame = 0
+		m.transferAnimation.Stop()
+		return nil
+	}
+	if !prevOK || cur != prev {
+		m.transferAnimationFrame = 0
+	}
+	return m.transferAnimation.Start()
+}
+
+// delegationInFlight reports whether any transfer_task hop is still running
+// or a Return is being presented; it drives the Agents header's ↔ marker so
+// the relation stays hinted even after the box acknowledged.
+func (m *model) delegationInFlight() bool {
+	return len(m.agentTransfers) > 0 || m.agentReturn != nil
+}
+
+// clearTransferPresentation drops all transfer state — the logical hops, the
+// transient Return and the rail phase — and stops the animation subscription.
+// Pending presentation timers become stale and are ignored when they fire.
+func (m *model) clearTransferPresentation() {
+	m.agentTransfers = nil
+	m.agentReturn = nil
+	m.transferAnimation.Stop()
+	m.transferAnimationFrame = 0
 }
 
 // SetToolsetInfo sets the number of available tools and loading state
@@ -597,9 +844,7 @@ func (m *model) LoadFromSession(sess *session.Session) {
 	// stack entries.
 	m.rootSessionID = sess.ID
 	m.sessionStack = nil
-	m.agentTransfers = nil
-	m.transferAnimation.Stop()
-	m.transferAnimationFrame = 0
+	m.clearTransferPresentation()
 
 	// Load session title
 	if sess.Title != "" {
@@ -629,13 +874,11 @@ func (m *model) LoadFromSession(sess *session.Session) {
 // transfer box cannot survive into the new run. rootSessionID is
 // preserved so the idle display stays valid until the next stream starts.
 func (m *model) ResetStreamTracking() {
-	if len(m.sessionStack) == 0 && len(m.agentTransfers) == 0 {
+	if len(m.sessionStack) == 0 && len(m.agentTransfers) == 0 && m.agentReturn == nil {
 		return
 	}
 	m.sessionStack = nil
-	m.agentTransfers = nil
-	m.transferAnimation.Stop()
-	m.transferAnimationFrame = 0
+	m.clearTransferPresentation()
 	m.invalidateCache()
 }
 
@@ -851,8 +1094,12 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 			m.workingAgent = msg.AgentName
 			m.invalidateCache()
 		}
+		// A tool call is useful activity: it acknowledges the outbound
+		// transfer box of the hop targeting this agent (models may call a
+		// tool without emitting any text first).
+		activityCmd := m.SetAgentActivity(msg.AgentName)
 		cmd := m.startSpinner()
-		return m, cmd
+		return m, tea.Batch(cmd, activityCmd)
 	case *runtime.ToolCallResponseEvent:
 		// Tool response received - ensure working agent is set (in case stream events were missed)
 		if msg.AgentName != "" {
@@ -897,6 +1144,12 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		if n := len(m.sessionStack); n > 0 {
 			m.sessionStack = m.sessionStack[:n-1]
 		}
+		if len(m.sessionStack) == 0 {
+			// The outermost stream ended: no delegation can outlive it. Drop
+			// any presentation that outlasted its timers — e.g. on a
+			// background tab whose tick commands were discarded.
+			m.clearTransferPresentation()
+		}
 		m.invalidateCache()
 		m.stopSpinner() // Will only stop if no other state needs it
 		return m, nil
@@ -907,7 +1160,18 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		m.SetTeamInfo(msg.AvailableAgents)
 		return m, nil
 	case *runtime.AgentSwitchingEvent:
-		cmd := m.SetAgentSwitching(msg.Switching, msg.FromAgent, msg.ToAgent)
+		// Standalone dispatch: no routing identity exists at this level, so
+		// the presentation timers fire as plain ticks — correct for a
+		// single-page setup. The multi-tab chat page intercepts this event
+		// and routes the timers to its own tab instead.
+		res := m.SetAgentSwitching(msg.Switching, msg.FromAgent, msg.ToAgent)
+		cmds := []tea.Cmd{res.Cmd}
+		for _, timer := range res.Timers {
+			cmds = append(cmds, timer.Cmd())
+		}
+		return m, tea.Batch(cmds...)
+	case transferTimerMsg:
+		cmd := m.handleTransferTimer(msg)
 		return m, cmd
 	case *runtime.ToolsetInfoEvent:
 		// Ignore loading state if stream was cancelled (stale event from before cancellation)
@@ -926,9 +1190,7 @@ func (m *model) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		m.streamCancelled = true
 		m.workingAgent = ""
 		m.sessionStack = nil
-		m.agentTransfers = nil
-		m.transferAnimation.Stop()
-		m.transferAnimationFrame = 0
+		m.clearTransferPresentation()
 		m.toolsLoading = false
 		m.titleRegenerating = false
 		m.compacting = false
@@ -1064,7 +1326,7 @@ func (m *model) computeCollapsedViewModel(contentWidth int) CollapsedViewModel {
 		TitleWithStar:    titleWithStar,
 		WorkingIndicator: m.workingIndicatorCollapsed(),
 		WorkingDir:       m.workingDirLine(),
-		InfoLine:         m.collapsedInfoLine(),
+		InfoLine:         m.collapsedInfoLine(contentWidth),
 		ContentWidth:     contentWidth,
 	}
 	if !m.sectionVisibility.HideUsage {
@@ -1096,7 +1358,7 @@ func (m *model) CollapsedHeight(outerWidth int) int {
 
 // collapsedInfoLine returns a one-line summary of the agents, tools, and
 // todos sections for the collapsed band, honoring section visibility.
-func (m *model) collapsedInfoLine() string {
+func (m *model) collapsedInfoLine(contentWidth int) string {
 	var parts []string
 	appendPart := func(part string) {
 		if part != "" {
@@ -1106,6 +1368,7 @@ func (m *model) collapsedInfoLine() string {
 
 	if !m.sectionVisibility.HideAgents {
 		appendPart(m.agentSummaryCollapsed())
+		appendPart(m.transferSummaryCollapsed(contentWidth))
 	}
 	if !m.sectionVisibility.HideTools {
 		appendPart(m.toolsSummaryCollapsed())
@@ -1133,6 +1396,26 @@ func (m *model) agentSummaryCollapsed() string {
 		summary += styles.MutedStyle.Render(fmt.Sprintf(" +%d", n-1))
 	}
 	return summary
+}
+
+// transferSummaryCollapsed renders the visible transfer presentation for the
+// collapsed band: the box title (Transfer/Return) in muted style followed by
+// the same animated from ─●─► to relation as the vertical box. The whole
+// summary is budgeted to contentWidth — overflowing names are truncated by
+// the shared relation renderer — so the band's height estimate stays honest
+// even with long or wide (CJK) agent names.
+func (m *model) transferSummaryCollapsed(contentWidth int) string {
+	pres, ok := m.visibleTransfer()
+	if !ok {
+		return ""
+	}
+	title := pres.title + " "
+	avail := contentWidth - lipgloss.Width(title)
+	if avail < transferRailCells+1 {
+		// No room for even the bare rail after the title: drop the title.
+		return m.transferRelationLine(pres, max(0, contentWidth))
+	}
+	return styles.MutedStyle.Render(title) + m.transferRelationLine(pres, avail)
 }
 
 // toolsSummaryCollapsed renders the tools/skills counts with the sidebar's
@@ -1524,7 +1807,7 @@ func (m *model) agentInfo(contentWidth int) string {
 	if len(m.availableAgents) > 1 {
 		agentTitle = "Agents"
 	}
-	if len(m.agentTransfers) > 0 {
+	if m.delegationInFlight() {
 		agentTitle += " ↔"
 	}
 
@@ -1551,12 +1834,12 @@ func (m *model) agentInfo(contentWidth int) string {
 			add(line, agent.Name)
 		}
 	}
-	// The innermost in-flight transfer renders as a compact box below the whole
-	// roster, after a blank breathing line; every one of its lines is unowned so
-	// the box stays unclickable.
-	if transfer, ok := m.activeTransfer(); ok {
+	// The visible transfer presentation renders as a compact box below the
+	// whole roster, after a blank breathing line; every one of its lines is
+	// unowned so the box stays unclickable.
+	if pres, ok := m.visibleTransfer(); ok {
 		add("", "")
-		for _, line := range m.renderTransferPanel(transfer, contentWidth) {
+		for _, line := range m.renderTransferPanel(pres, contentWidth) {
 			add(line, "")
 		}
 	}
@@ -1731,11 +2014,12 @@ func (m *model) renderAgentLine(agent runtime.AgentDetails, index, contentWidth,
 // language. The rail is the fixed three-cell track the bright dot travels
 // before the arrow head (●──►, ─●─►, ──●►).
 const (
-	transferBoxTitle  = "Transfer"
-	transferTrack     = "─"
-	transferDot       = "●"
-	transferArrowHead = "►"
-	transferRailCells = 3
+	transferBoxTitle       = "Transfer"
+	transferReturnBoxTitle = "Return"
+	transferTrack          = "─"
+	transferDot            = "●"
+	transferArrowHead      = "►"
+	transferRailCells      = 3
 
 	// transferFramesPerStep divides the shared 14 FPS animation tick down to
 	// a sober ~7 FPS dot movement.
@@ -1767,12 +2051,19 @@ func (m *model) transferRailView() string {
 }
 
 // renderTransferRelation renders the box's content — "Scout ─●─► Coder" —
-// fitted to exactly width cells (space-padded on the right). The agent names
-// use their accent styles and share the room left by the fixed rail: when they
-// overflow, a short name donates its surplus to the long one and both are
-// truncated with ellipses. Widths too small for names degrade to the animated
-// rail alone, then to a bare muted track; the result never exceeds width.
-func (m *model) renderTransferRelation(t agentTransfer, width int) string {
+// fitted to exactly width cells (space-padded on the right by way of
+// transferRelationLine, which does the fitting).
+func (m *model) renderTransferRelation(t transferPresentation, width int) string {
+	return padRight(m.transferRelationLine(t, width), width)
+}
+
+// transferRelationLine renders the relation fitted to at most width cells,
+// without trailing padding. The agent names use their accent styles and
+// share the room left by the fixed rail: when they overflow, a short name
+// donates its surplus to the long one and both are truncated with ellipses.
+// Widths too small for names degrade to the animated rail alone, then to a
+// bare muted track; the result never exceeds width.
+func (m *model) transferRelationLine(t transferPresentation, width int) string {
 	const railWidth = transferRailCells + 1 // track cells + arrow head
 	if width < railWidth {
 		return styles.MutedStyle.Render(strings.Repeat(transferTrack, max(0, width)))
@@ -1780,7 +2071,7 @@ func (m *model) renderTransferRelation(t agentTransfer, width int) string {
 
 	nameAvail := width - railWidth - 2 // one space on each side of the rail
 	if nameAvail < 2 {
-		return padRight(m.transferRailView(), width)
+		return m.transferRailView()
 	}
 
 	fromWidth, toWidth := lipgloss.Width(t.from), lipgloss.Width(t.to)
@@ -1797,24 +2088,37 @@ func (m *model) renderTransferRelation(t agentTransfer, width int) string {
 		}
 	}
 
-	line := styles.AgentAccentStyleFor(t.from).Render(toolcommon.TruncateText(t.from, fromBudget)) +
+	line := styles.AgentAccentStyleFor(t.from).Render(truncateAgentName(t.from, fromBudget)) +
 		" " + m.transferRailView() + " " +
-		styles.AgentAccentStyleFor(t.to).Render(toolcommon.TruncateText(t.to, toBudget))
-	return padRight(line, width)
+		styles.AgentAccentStyleFor(t.to).Render(truncateAgentName(t.to, toBudget))
+	return line
 }
 
-// renderTransferPanel renders the in-flight transfer hop as a compact
+// truncateAgentName truncates an agent name to budget cells for the transfer
+// relation. TruncateText can overflow the budget by one cell when it
+// force-takes a wide (CJK) rune at tiny budgets; degrade to a bare ellipsis
+// in that case so the relation never exceeds its width.
+func truncateAgentName(name string, budget int) string {
+	s := toolcommon.TruncateText(name, budget)
+	if lipgloss.Width(s) > budget {
+		return "…"
+	}
+	return s
+}
+
+// renderTransferPanel renders the visible transfer presentation as a compact
 // three-line box spanning the full content width:
 //
 //	╭─ Transfer ────────╮
 //	│ Scout ─●─► Coder  │
 //	╰───────────────────╯
 //
-// The border and embedded title are muted; the content line is built by
+// The embedded title distinguishes the outbound Transfer from the transient
+// Return. The border and title are muted; the content line is built by
 // renderTransferRelation. As the sidebar narrows the title is dropped first,
 // then the inner margins; pathologically small widths fall back to the bare
 // relation so no line ever exceeds contentWidth.
-func (m *model) renderTransferPanel(t agentTransfer, contentWidth int) []string {
+func (m *model) renderTransferPanel(t transferPresentation, contentWidth int) []string {
 	border := lipgloss.RoundedBorder()
 	inner := contentWidth - 2 // room between the border columns
 	if inner < transferRailCells+1 {
@@ -1822,7 +2126,7 @@ func (m *model) renderTransferPanel(t agentTransfer, contentWidth int) []string 
 	}
 
 	top := border.TopLeft + strings.Repeat(border.Top, inner) + border.TopRight
-	head := border.TopLeft + border.Top + " " + transferBoxTitle + " "
+	head := border.TopLeft + border.Top + " " + t.title + " "
 	if headWidth := lipgloss.Width(head); headWidth+1 <= contentWidth {
 		top = head + strings.Repeat(border.Top, contentWidth-headWidth-1) + border.TopRight
 	}

--- a/pkg/tui/page/chat/agent_switching_test.go
+++ b/pkg/tui/page/chat/agent_switching_test.go
@@ -1,0 +1,309 @@
+package chat
+
+import (
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/app"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tui/components/sidebar"
+	msgtypes "github.com/docker/docker-agent/pkg/tui/messages"
+	"github.com/docker/docker-agent/pkg/tui/service"
+	"github.com/docker/docker-agent/pkg/tui/types"
+)
+
+// agentSwitchCall records one SetAgentSwitching invocation on the sidebar.
+type agentSwitchCall struct {
+	switching bool
+	from, to  string
+}
+
+// recordingSidebar wraps the real sidebar to record the delegation-related
+// calls the chat page makes on it (and the results the sidebar returned). It
+// only survives handlers that do not forward events through sidebar.Update
+// (which replaces p.sidebar with the unwrapped model), which is exactly the
+// set under test here.
+type recordingSidebar struct {
+	sidebar.Model
+
+	switching []agentSwitchCall
+	results   []sidebar.AgentSwitchResult
+	activity  []string
+}
+
+func (r *recordingSidebar) SetAgentSwitching(switching bool, fromAgent, toAgent string) sidebar.AgentSwitchResult {
+	r.switching = append(r.switching, agentSwitchCall{switching: switching, from: fromAgent, to: toAgent})
+	res := r.Model.SetAgentSwitching(switching, fromAgent, toAgent)
+	r.results = append(r.results, res)
+	return res
+}
+
+func (r *recordingSidebar) SetAgentActivity(agentName string) tea.Cmd {
+	r.activity = append(r.activity, agentName)
+	return r.Model.SetAgentActivity(agentName)
+}
+
+// newSwitchingTestPage builds a chat page whose sidebar records delegation
+// calls.
+func newSwitchingTestPage(t *testing.T) (*chatPage, *recordingSidebar) {
+	t.Helper()
+	sess := session.New()
+	p := New(t.Context(), app.New(t.Context(), queueTestRuntime{}, sess), service.NewSessionState(sess)).(*chatPage)
+	rec := &recordingSidebar{Model: p.sidebar}
+	p.sidebar = rec
+	// Tests start transfers without always stopping them; the cancel clears
+	// the sidebar's animation subscription so no registration leaks on the
+	// global coordinator. Sending through p.sidebar reaches the real model
+	// even while it is still the wrapper (Update is promoted from the
+	// embedded Model) and after a handler unwrapped it.
+	t.Cleanup(func() {
+		_, _ = p.sidebar.Update(msgtypes.StreamCancelledMsg{})
+	})
+	return p, rec
+}
+
+// TestAgentSwitchingReturnAddsTransition verifies the end of a transfer_task
+// hop — matching its recorded start — adds the "child returned control to
+// parent" transition to the chat and reaches the sidebar's return
+// presentation.
+func TestAgentSwitchingReturnAddsTransition(t *testing.T) {
+	t.Parallel()
+
+	p, rec := newSwitchingTestPage(t)
+
+	handled, _ := p.handleRuntimeEvent(runtime.AgentSwitching(true, "root", "researcher"))
+	require.True(t, handled)
+
+	handled, cmd := p.handleRuntimeEvent(runtime.AgentSwitching(false, "researcher", "root"))
+	require.True(t, handled)
+	require.NotNil(t, cmd)
+
+	out := ansi.Strip(p.messages.View())
+	assert.Contains(t, out, "researcher")
+	assert.Contains(t, out, "root")
+	assert.Contains(t, out, types.AgentReturnLabel)
+
+	require.Len(t, rec.switching, 2, "the sidebar sees both hop boundaries")
+	assert.Equal(t, agentSwitchCall{switching: false, from: "researcher", to: "root"}, rec.switching[1])
+	assert.True(t, rec.results[1].Accepted, "the stop closed its recorded start")
+}
+
+// TestAgentSwitchingStartAddsNoTransition verifies the start of a hop adds no
+// return transition (the transfer_task tool call already narrates it) while
+// still reaching the sidebar.
+func TestAgentSwitchingStartAddsNoTransition(t *testing.T) {
+	t.Parallel()
+
+	p, rec := newSwitchingTestPage(t)
+
+	handled, _ := p.handleRuntimeEvent(runtime.AgentSwitching(true, "root", "researcher"))
+	require.True(t, handled)
+
+	assert.NotContains(t, ansi.Strip(p.messages.View()), types.AgentReturnLabel)
+	require.Len(t, rec.switching, 1)
+	assert.Equal(t, agentSwitchCall{switching: true, from: "root", to: "researcher"}, rec.switching[0])
+}
+
+// TestAgentSwitchingStaleStopAddsNothing verifies a stop the sidebar did not
+// accept — no recorded start to close — adds no transition: an empty stack
+// stays empty and a stale stop cannot steal a different in-flight hop.
+func TestAgentSwitchingStaleStopAddsNothing(t *testing.T) {
+	t.Parallel()
+
+	p, rec := newSwitchingTestPage(t)
+
+	// Stop on an empty stack: no label.
+	handled, _ := p.handleRuntimeEvent(runtime.AgentSwitching(false, "researcher", "root"))
+	require.True(t, handled)
+	assert.NotContains(t, ansi.Strip(p.messages.View()), types.AgentReturnLabel)
+	require.Len(t, rec.results, 1)
+	assert.False(t, rec.results[0].Accepted)
+
+	// A different hop is in flight; the stale stop must not pop it nor label.
+	handled, _ = p.handleRuntimeEvent(runtime.AgentSwitching(true, "root", "coder"))
+	require.True(t, handled)
+	handled, _ = p.handleRuntimeEvent(runtime.AgentSwitching(false, "researcher", "root"))
+	require.True(t, handled)
+	assert.NotContains(t, ansi.Strip(p.messages.View()), types.AgentReturnLabel)
+	require.Len(t, rec.results, 3)
+	assert.False(t, rec.results[2].Accepted, "the stale stop must not match the root→coder hop")
+
+	// The genuine stop still labels.
+	handled, _ = p.handleRuntimeEvent(runtime.AgentSwitching(false, "coder", "root"))
+	require.True(t, handled)
+	assert.Contains(t, ansi.Strip(p.messages.View()), types.AgentReturnLabel)
+}
+
+// TestAgentSwitchingReturnAfterCancelStaysSilent verifies hop boundaries
+// unwinding after the user cancelled the stream are dropped entirely: the
+// delegation they belong to was already torn down visually.
+func TestAgentSwitchingReturnAfterCancelStaysSilent(t *testing.T) {
+	t.Parallel()
+
+	p, rec := newSwitchingTestPage(t)
+
+	// The hop started before the cancel; its end races the cancel teardown.
+	handled, _ := p.handleRuntimeEvent(runtime.AgentSwitching(true, "root", "researcher"))
+	require.True(t, handled)
+	p.streamCancelled = true
+
+	handled, cmd := p.handleRuntimeEvent(runtime.AgentSwitching(false, "researcher", "root"))
+	require.True(t, handled)
+	assert.Nil(t, cmd)
+	assert.NotContains(t, ansi.Strip(p.messages.View()), types.AgentReturnLabel)
+	assert.Len(t, rec.switching, 1, "the sidebar sees no boundary after the cancel")
+}
+
+// TestChildActivityEventsAckSidebar verifies the child-activity signals —
+// reasoning, content, and (partial) tool calls, which models may emit without
+// any text — all acknowledge the sidebar's outbound transfer presentation.
+func TestChildActivityEventsAckSidebar(t *testing.T) {
+	t.Parallel()
+
+	p, rec := newSwitchingTestPage(t)
+	p.handleRuntimeEvent(runtime.AgentSwitching(true, "root", "researcher"))
+
+	events := []tea.Msg{
+		runtime.AgentChoiceReasoning("researcher", "s1", "thinking…"),
+		runtime.AgentChoice("researcher", "s1", "found it"),
+		runtime.PartialToolCall(tools.ToolCall{ID: "t1"}, tools.Tool{Name: "shell"}, "researcher"),
+	}
+	for _, evt := range events {
+		handled, _ := p.handleRuntimeEvent(evt)
+		require.Truef(t, handled, "%T must be handled", evt)
+	}
+
+	assert.Equal(t, []string{"researcher", "researcher", "researcher"}, rec.activity,
+		"each useful child event acknowledges the transfer")
+}
+
+// TestChildActivityIgnoredAfterCancel verifies content events of a cancelled
+// stream do not reach the sidebar's activity tracking.
+func TestChildActivityIgnoredAfterCancel(t *testing.T) {
+	t.Parallel()
+
+	p, rec := newSwitchingTestPage(t)
+	p.streamCancelled = true
+
+	handled, _ := p.handleRuntimeEvent(runtime.AgentChoice("researcher", "s1", "late chunk"))
+	require.True(t, handled)
+	assert.Empty(t, rec.activity)
+}
+
+// TestScheduleTransferTimersWrapsInRoutedMsg executes the real timer command
+// produced for a routed page (with a synthetic short duration) and verifies
+// the expiry is wrapped in a messages.RoutedMsg addressed to the page's tab,
+// while a page without a routing identity delivers the raw payload.
+func TestScheduleTransferTimersWrapsInRoutedMsg(t *testing.T) {
+	t.Parallel()
+
+	type payload struct{ n int }
+
+	p, _ := newSwitchingTestPage(t)
+	p.SetRoutingID("tab-1")
+	cmd := p.scheduleTransferTimers([]sidebar.TransferTimer{{Duration: time.Millisecond, Msg: payload{n: 42}}})
+	require.NotNil(t, cmd)
+
+	msgs := runTimerCmd(t, cmd)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, msgtypes.RoutedMsg{SessionID: "tab-1", Inner: payload{n: 42}}, msgs[0],
+		"the expiry is addressed to the owning tab")
+
+	p.pendingTimers = nil
+	p.SetRoutingID("")
+	cmd = p.scheduleTransferTimers([]sidebar.TransferTimer{{Duration: time.Millisecond, Msg: payload{n: 7}}})
+	msgs = runTimerCmd(t, cmd)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, payload{n: 7}, msgs[0], "standalone pages deliver the raw payload")
+}
+
+// runTimerCmd executes a (possibly batched) command, following nested batches,
+// and returns the messages it produces.
+func runTimerCmd(t *testing.T, cmd tea.Cmd) []tea.Msg {
+	t.Helper()
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var msgs []tea.Msg
+		for _, inner := range batch {
+			msgs = append(msgs, runTimerCmd(t, inner)...)
+		}
+		return msgs
+	}
+	return []tea.Msg{msg}
+}
+
+// TestAgentSwitchingArmsRoutedTimersForBackgroundDispatch verifies a hop
+// boundary records its routed timer commands so TakeRoutedTimers can hand
+// them to the appModel when the page is hidden (its regular command is
+// discarded there), and that the collection drains exactly once.
+func TestAgentSwitchingArmsRoutedTimersForBackgroundDispatch(t *testing.T) {
+	t.Parallel()
+
+	p, _ := newSwitchingTestPage(t)
+	p.SetRoutingID("tab-1")
+
+	model, _ := p.Update(runtime.AgentSwitching(true, "root", "researcher"))
+	page := model.(*chatPage)
+
+	timers := page.TakeRoutedTimers()
+	require.NotNil(t, timers, "a start's min/max timers are collectable for background dispatch")
+	assert.Nil(t, page.TakeRoutedTimers(), "the collection drains once")
+
+	// The next Update clears leftovers so a later drain cannot re-arm
+	// timers that the active path already dispatched.
+	model, _ = page.Update(runtime.AgentSwitching(false, "researcher", "root"))
+	page = model.(*chatPage)
+	require.NotNil(t, page.TakeRoutedTimers(), "an accepted stop arms the Return timer")
+
+	model, _ = page.Update(msgtypes.StreamCancelledMsg{})
+	page = model.(*chatPage)
+	assert.Nil(t, page.TakeRoutedTimers(), "updates without boundaries arm nothing")
+}
+
+// TestRoutedTimerExpiryDrivesSidebarOnOwnerPage chains the real pieces: the
+// hop boundary's timers are wrapped for the page's tab, and delivering their
+// inner payloads back to the page (as the appModel's routing does) drives the
+// sidebar's presentation windows.
+func TestRoutedTimerExpiryDrivesSidebarOnOwnerPage(t *testing.T) {
+	t.Parallel()
+
+	p, rec := newSwitchingTestPage(t)
+	p.SetRoutingID("tab-1")
+	p.sessionState.SetCurrentAgentName("root")
+
+	handled, _ := p.handleRuntimeEvent(runtime.AgentSwitching(true, "root", "researcher"))
+	require.True(t, handled)
+	require.Contains(t, ansi.Strip(p.sidebar.View()), transferBoxMarker, "the outbound box shows on the hop start")
+	require.Len(t, rec.results, 1)
+	timers := rec.results[0].Timers
+	require.Len(t, timers, 2)
+
+	// Rewrap each real payload through the page's routed tick (short
+	// duration), check the envelope targets this tab, and deliver the
+	// unwrapped payload to the page as handleRoutedMsg does.
+	for _, timer := range timers {
+		msg := p.routedTimerCmd(sidebar.TransferTimer{Duration: time.Millisecond, Msg: timer.Msg})()
+		routed, ok := msg.(msgtypes.RoutedMsg)
+		require.True(t, ok)
+		assert.Equal(t, "tab-1", routed.SessionID)
+
+		_, _ = p.Update(routed.Inner)
+	}
+
+	// Min then max elapsed without activity: the outbound box is gone.
+	assert.NotContains(t, ansi.Strip(p.sidebar.View()), transferBoxMarker)
+}
+
+// transferBoxMarker is the visible marker of the sidebar transfer box (the
+// box title embedded in the rounded top border).
+const transferBoxMarker = "─ Transfer "

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -155,6 +155,19 @@ type Page interface {
 	// SetSendMode sets what happens to messages sent while the agent is
 	// working: steer into the ongoing stream or queue until the turn ends.
 	SetSendMode(mode msgtypes.SendMode)
+	// SetRoutingID records the tab identity used to address this page's
+	// one-shot UI timers back to it (messages.RoutedMsg.SessionID). The
+	// appModel keys its chat pages — and the supervisor its event routing —
+	// by this ID, which is the tab's initial session ID and may diverge from
+	// the current app.Session().ID after a session restore or in-place
+	// replace.
+	SetRoutingID(id string)
+	// TakeRoutedTimers returns and clears the routed one-shot timer commands
+	// armed by the most recent Update. The active page's Update already
+	// returns them inside its regular command; the appModel calls this for
+	// background pages — whose regular commands are discarded — so
+	// presentation deadlines keep running while a tab is hidden.
+	TakeRoutedTimers() tea.Cmd
 }
 
 // queuedMessage represents a message waiting to be sent to the agent
@@ -188,6 +201,15 @@ type chatPage struct {
 	streamDepth     int      // nesting depth of active streams (incremented on StreamStarted, decremented on StreamStopped)
 	agentStack      []string // agent per active stream level; len(agentStack)==streamDepth
 	streamStartTime time.Time
+
+	// routingID is the tab identity this page's routed UI timers are
+	// addressed to; empty for standalone pages (timers then fire unrouted,
+	// which is correct when this is the only page).
+	routingID string
+	// pendingTimers holds the routed timer commands armed by the current
+	// Update, so they can be re-collected via TakeRoutedTimers when the
+	// regular command is discarded (background tabs).
+	pendingTimers []tea.Cmd
 
 	// Track whether we've received content from an assistant response
 	// Used by --exit-after-response to ensure we don't exit before receiving content
@@ -414,6 +436,10 @@ func (p *chatPage) Init() tea.Cmd {
 
 // Update handles messages and updates the page state
 func (p *chatPage) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
+	// Timers armed by a previous Update were dispatched by its caller (either
+	// through the returned command or via TakeRoutedTimers); only this
+	// update's timers may be collected after it.
+	p.pendingTimers = nil
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		cmd := p.SetSize(msg.Width, msg.Height)
@@ -1209,6 +1235,56 @@ func (p *chatPage) SetLayoutSettings(settings msgtypes.LayoutSettings) tea.Cmd {
 // SetSendMode sets the behavior of messages sent while the agent is working.
 func (p *chatPage) SetSendMode(mode msgtypes.SendMode) {
 	p.sendMode = mode
+}
+
+// SetRoutingID records the tab identity this page's routed UI timers are
+// addressed to. See Page.SetRoutingID.
+func (p *chatPage) SetRoutingID(id string) {
+	p.routingID = id
+}
+
+// TakeRoutedTimers returns and clears the routed timer commands armed by the
+// most recent Update. See Page.TakeRoutedTimers.
+func (p *chatPage) TakeRoutedTimers() tea.Cmd {
+	if len(p.pendingTimers) == 0 {
+		return nil
+	}
+	cmd := tea.Batch(p.pendingTimers...)
+	p.pendingTimers = nil
+	return cmd
+}
+
+// scheduleTransferTimers arms the sidebar's one-shot presentation timers,
+// addressed to this page: with a routing identity each expiry is wrapped in
+// a messages.RoutedMsg so it lands on this page's tab even when another tab
+// is active (or this one is hidden) by then; without one (standalone pages)
+// the raw payload goes to the single active page. The commands are also
+// recorded for TakeRoutedTimers so an update on a hidden page keeps its
+// deadlines armed.
+func (p *chatPage) scheduleTransferTimers(timers []sidebar.TransferTimer) tea.Cmd {
+	if len(timers) == 0 {
+		return nil
+	}
+	cmds := make([]tea.Cmd, 0, len(timers))
+	for _, timer := range timers {
+		cmds = append(cmds, p.routedTimerCmd(timer))
+	}
+	cmd := tea.Batch(cmds...)
+	p.pendingTimers = append(p.pendingTimers, cmd)
+	return cmd
+}
+
+// routedTimerCmd schedules one timer, wrapping its payload in the page's
+// routing envelope. The routing ID is captured by value: the command runs on
+// a background goroutine and must not read page state later.
+func (p *chatPage) routedTimerCmd(timer sidebar.TransferTimer) tea.Cmd {
+	routingID := p.routingID
+	if routingID == "" {
+		return timer.Cmd()
+	}
+	return tea.Tick(timer.Duration, func(time.Time) tea.Msg {
+		return msgtypes.RoutedMsg{SessionID: routingID, Inner: timer.Msg}
+	})
 }
 
 // handleSidebarClickType checks what was clicked in the sidebar area.

--- a/pkg/tui/page/chat/runtime_events.go
+++ b/pkg/tui/page/chat/runtime_events.go
@@ -121,7 +121,7 @@ func (p *chatPage) handleRuntimeEvent(msg tea.Msg) (bool, tea.Cmd) {
 		return true, nil
 
 	case *runtime.AgentSwitchingEvent:
-		return true, p.sidebar.SetAgentSwitching(msg.Switching, msg.FromAgent, msg.ToAgent)
+		return true, p.handleAgentSwitching(msg)
 
 	case *runtime.ToolsetInfoEvent:
 		p.sidebar.SetSkillsInfo(len(p.app.CurrentAgentSkills()))
@@ -273,7 +273,10 @@ func (p *chatPage) handleAgentChoice(msg *runtime.AgentChoiceEvent) tea.Cmd {
 	p.hasReceivedAssistantContent = true
 	// Clear pending response indicator - first chunk has arrived
 	p.setPendingResponse(false)
-	return p.messages.AppendToLastMessage(msg.AgentName, msg.Content)
+	// Content is useful activity: acknowledge the sidebar's outbound transfer
+	// box when this agent is a delegation target.
+	activityCmd := p.sidebar.SetAgentActivity(msg.AgentName)
+	return tea.Batch(activityCmd, p.messages.AppendToLastMessage(msg.AgentName, msg.Content))
 }
 
 func (p *chatPage) handleAgentChoiceReasoning(msg *runtime.AgentChoiceReasoningEvent) tea.Cmd {
@@ -281,7 +284,31 @@ func (p *chatPage) handleAgentChoiceReasoning(msg *runtime.AgentChoiceReasoningE
 		return nil
 	}
 	p.setPendingResponse(false)
-	return p.messages.AppendReasoning(msg.AgentName, msg.Content)
+	activityCmd := p.sidebar.SetAgentActivity(msg.AgentName)
+	return tea.Batch(activityCmd, p.messages.AppendReasoning(msg.AgentName, msg.Content))
+}
+
+// handleAgentSwitching forwards transfer_task hop boundaries to the sidebar
+// and schedules the presentation timers it arms, routed back to this page so
+// they expire on their owner even after a tab switch. A stop the sidebar
+// accepted (it closed the exact inverse hop of a recorded start) additionally
+// adds the delegation-return transition to the chat ("child returned control
+// to parent"); a stale stop — no matching hop — stays silent everywhere, and
+// a start adds nothing to the chat: the transfer_task tool call already
+// narrates the outbound direction. Boundaries arriving after the user
+// cancelled the stream are dropped entirely: the delegation they belong to
+// was already torn down visually.
+func (p *chatPage) handleAgentSwitching(msg *runtime.AgentSwitchingEvent) tea.Cmd {
+	if p.streamCancelled {
+		return nil
+	}
+	res := p.sidebar.SetAgentSwitching(msg.Switching, msg.FromAgent, msg.ToAgent)
+	cmd := tea.Batch(res.Cmd, p.scheduleTransferTimers(res.Timers))
+	if msg.Switching || !res.Accepted {
+		return cmd
+	}
+	returnCmd := p.messages.AddAgentReturn(msg.FromAgent, msg.ToAgent)
+	return tea.Batch(cmd, returnCmd, p.messages.ScrollToBottom())
 }
 
 func (p *chatPage) handleStreamStopped(msg *runtime.StreamStoppedEvent) tea.Cmd {
@@ -354,8 +381,11 @@ func (p *chatPage) handlePartialToolCall(msg *runtime.PartialToolCallEvent) tea.
 	if msg.ToolDefinition != nil {
 		toolDef = *msg.ToolDefinition
 	}
+	// A tool call is useful activity even without any streamed text:
+	// acknowledge the sidebar's outbound transfer box.
+	activityCmd := p.sidebar.SetAgentActivity(msg.AgentName)
 	toolCmd := p.messages.AddOrUpdateToolCall(msg.AgentName, msg.ToolCall, toolDef, types.ToolStatusPending)
-	return tea.Batch(toolCmd, p.messages.ScrollToBottom())
+	return tea.Batch(activityCmd, toolCmd, p.messages.ScrollToBottom())
 }
 
 func (p *chatPage) handleToolCallConfirmation(msg *runtime.ToolCallConfirmationEvent) tea.Cmd {

--- a/pkg/tui/routed_timer_test.go
+++ b/pkg/tui/routed_timer_test.go
@@ -1,0 +1,142 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/app"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tui/core/layout"
+	"github.com/docker/docker-agent/pkg/tui/messages"
+	"github.com/docker/docker-agent/pkg/tui/page/chat"
+	"github.com/docker/docker-agent/pkg/tui/service"
+	"github.com/docker/docker-agent/pkg/tui/service/supervisor"
+)
+
+// timerRecordingPage scripts a chat.Page for the handleRoutedMsg contract:
+// it records the messages it was updated with and hands out canned commands
+// for the regular (UI) and routed-timer channels.
+type timerRecordingPage struct {
+	mockChatPage
+
+	updates  []tea.Msg
+	uiCmd    tea.Cmd
+	timerCmd tea.Cmd
+}
+
+func (p *timerRecordingPage) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
+	p.updates = append(p.updates, msg)
+	return p, p.uiCmd
+}
+
+func (p *timerRecordingPage) TakeRoutedTimers() tea.Cmd {
+	cmd := p.timerCmd
+	p.timerCmd = nil
+	return cmd
+}
+
+type (
+	uiMarkerMsg    struct{}
+	timerMarkerMsg struct{}
+)
+
+// newRoutedTestModel wires an appModel around a real supervisor holding two
+// sessions (the first added is active) with one chat page each, built by
+// makePage.
+func newRoutedTestModel(t *testing.T, makePage func(sess *session.Session, routingID string) chat.Page) (m *appModel, activeID, backgroundID string) {
+	t.Helper()
+	m, _ = newTestModel(t)
+
+	sv := supervisor.New(nil)
+	sessA, sessB := session.New(), session.New()
+	activeID = sv.AddSession(t.Context(), nil, sessA, "", nil)
+	backgroundID = sv.AddSession(t.Context(), nil, sessB, "", nil)
+	m.supervisor = sv
+	require.Equal(t, activeID, sv.ActiveID())
+
+	m.chatPages[activeID] = makePage(sessA, activeID)
+	m.chatPages[backgroundID] = makePage(sessB, backgroundID)
+	m.chatPage = m.chatPages[activeID]
+	m.sessionStates[activeID] = service.NewSessionState(sessA)
+	m.sessionStates[backgroundID] = service.NewSessionState(sessB)
+	return m, activeID, backgroundID
+}
+
+// TestHandleRoutedMsg_InactiveTabKeepsRoutedTimers verifies the routing
+// contract for hidden tabs: the inner message is applied to the owning page,
+// its UI-only command is discarded, and its routed one-shot timers are the
+// command handleRoutedMsg returns — so presentation deadlines keep running
+// while the tab is hidden.
+func TestHandleRoutedMsg_InactiveTabKeepsRoutedTimers(t *testing.T) {
+	t.Parallel()
+
+	m, _, backgroundID := newRoutedTestModel(t, func(*session.Session, string) chat.Page {
+		return &timerRecordingPage{
+			uiCmd:    func() tea.Msg { return uiMarkerMsg{} },
+			timerCmd: func() tea.Msg { return timerMarkerMsg{} },
+		}
+	})
+	background := m.chatPages[backgroundID].(*timerRecordingPage)
+
+	inner := runtime.AgentSwitching(true, "root", "scout")
+	_, cmd := m.Update(messages.RoutedMsg{SessionID: backgroundID, Inner: inner})
+
+	require.Len(t, background.updates, 1, "the inner message reaches the owning page")
+	assert.Same(t, inner, background.updates[0])
+
+	msgs := collectMsgs(cmd)
+	assert.True(t, hasMsg[timerMarkerMsg](msgs), "the page's routed timers are dispatched")
+	assert.False(t, hasMsg[uiMarkerMsg](msgs), "UI-only cmds of hidden pages stay discarded")
+
+	// A routed message for an unknown (closed) tab is dropped entirely.
+	_, cmd = m.Update(messages.RoutedMsg{SessionID: "gone", Inner: inner})
+	assert.Nil(t, cmd)
+	assert.Len(t, background.updates, 1)
+}
+
+// newRealChatPage builds a real chat page bound to a fresh app around sess,
+// with its routing identity set and sized so its sidebar renders. The stream
+// cancel on cleanup stops any animations a test started (e.g. a transfer's
+// rail), so no registration leaks on the global animation coordinator.
+func newRealChatPage(t *testing.T, sess *session.Session, routingID string) chat.Page {
+	t.Helper()
+	ss := service.NewSessionState(sess)
+	ss.SetCurrentAgentName("root")
+	page := chat.New(t.Context(), app.New(t.Context(), stubRuntime{}, sess), ss)
+	page.SetRoutingID(routingID)
+	_ = page.SetSize(140, 40)
+	t.Cleanup(func() {
+		_, _ = page.Update(messages.StreamCancelledMsg{})
+	})
+	return page
+}
+
+// TestHandleRoutedMsg_TransferOnHiddenTabArmsTimersAndStaysLocal exercises
+// the real pieces end to end: a transfer_task start routed to a hidden tab
+// shows the transfer box on that tab only (never on the active one) and
+// still arms the presentation timers — the command handleRoutedMsg returns —
+// even though the page's regular command is discarded.
+func TestHandleRoutedMsg_TransferOnHiddenTabArmsTimersAndStaysLocal(t *testing.T) {
+	t.Parallel()
+
+	m, activeID, backgroundID := newRoutedTestModel(t, func(sess *session.Session, routingID string) chat.Page {
+		return newRealChatPage(t, sess, routingID)
+	})
+
+	const transferBoxMarker = "─ Transfer "
+	_, cmd := m.Update(messages.RoutedMsg{
+		SessionID: backgroundID,
+		Inner:     runtime.AgentSwitching(true, "root", "scout"),
+	})
+
+	assert.NotNil(t, cmd, "the hidden tab's presentation timers survive the UI-cmd discard")
+	assert.Contains(t, ansi.Strip(m.chatPages[backgroundID].View()), transferBoxMarker,
+		"the hop's box shows on its owning tab")
+	assert.NotContains(t, ansi.Strip(m.chatPages[activeID].View()), transferBoxMarker,
+		"the active tab shows nothing for another tab's hop")
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -487,6 +487,7 @@ func New(ctx context.Context, spawner SessionSpawner, initialApp *app.App, initi
 
 	// Create initial chat page (after options are applied so leanMode is set)
 	initialChatPage := chat.New(m.ctx(), initialApp, initialSessionState, m.chatPageOpts()...)
+	initialChatPage.SetRoutingID(sessID)
 	m.chatPages[sessID] = initialChatPage
 	m.chatPage = initialChatPage
 
@@ -628,6 +629,7 @@ func (m *appModel) editorOpts() []editor.Option {
 func (m *appModel) initSessionComponents(tabID string, a *app.App, sess *session.Session) {
 	ss := service.NewSessionState(sess)
 	cp := chat.New(m.ctx(), a, ss, m.chatPageOpts()...)
+	cp.SetRoutingID(tabID)
 	ed := editor.New(m.history, m.editorOpts()...)
 
 	m.chatPages[tabID] = cp
@@ -1366,10 +1368,14 @@ func (m *appModel) handleRoutedMsg(msg messages.RoutedMsg) (tea.Model, tea.Cmd) 
 		}
 	}
 
-	// Update the inactive chat page (discard cmds — UI effects aren't needed for hidden pages)
+	// Update the inactive chat page (discard cmds — UI effects aren't needed for hidden pages),
+	// except its routed one-shot timers: presentation deadlines (e.g. the sidebar's transfer box)
+	// must keep running while the tab is hidden, and their expiry lands back here as a RoutedMsg
+	// for this page. Applying such a timer arms no new ones, so this cannot loop.
 	updated, _ := chatPage.Update(msg.Inner)
-	m.chatPages[msg.SessionID] = updated.(chat.Page)
-	return m, nil
+	page := updated.(chat.Page)
+	m.chatPages[msg.SessionID] = page
+	return m, page.TakeRoutedTimers()
 }
 
 // applyPauseEvent advances a session's pause indicator in response to runtime

--- a/pkg/tui/tui_exit_test.go
+++ b/pkg/tui/tui_exit_test.go
@@ -57,6 +57,8 @@ func (m *mockChatPage) SetLayoutSettings(messages.LayoutSettings) tea.Cmd {
 	return nil
 }
 func (m *mockChatPage) SetSendMode(messages.SendMode) {}
+func (m *mockChatPage) SetRoutingID(string)           {}
+func (m *mockChatPage) TakeRoutedTimers() tea.Cmd     { return nil }
 func (m *mockChatPage) Bindings() []key.Binding       { return nil }
 func (m *mockChatPage) Help() help.KeyMap             { return nil }
 

--- a/pkg/tui/types/types.go
+++ b/pkg/tui/types/types.go
@@ -22,12 +22,20 @@ const (
 	MessageTypeToolResult
 	MessageTypeWelcome
 	MessageTypeLoading
+	// MessageTypeAgentReturn is the UI-only delegation-return transition shown
+	// when a sub-agent hands control back to its parent. It is live feedback
+	// for the AgentSwitching runtime event, which is not persisted to the
+	// session, so it never reappears when a session is reloaded.
+	MessageTypeAgentReturn
 )
 
 const (
 	UserMessageEditLabel = "✎ edit"
 	MessageCopyLabel     = "⎘ copy"
 	ErrorRetryLabel      = "↻ retry"
+	// AgentReturnLabel is the connector between the child and parent badges
+	// of a delegation-return transition (see AgentReturn).
+	AgentReturnLabel = "returned control to"
 	// MessageActionSeparator joins adjacent action labels (e.g. edit + copy)
 	// on a message's hover-action row.
 	MessageActionSeparator = "  "
@@ -115,6 +123,19 @@ func User(content string) *Message {
 func Cancelled() *Message {
 	return &Message{
 		Type: MessageTypeCancelled,
+	}
+}
+
+// AgentReturn is the delegation-return transition: fromAgent (the child)
+// returned control to toAgent (the parent). Sender carries the child so the
+// accent/badge machinery colors it like any other agent attribution; Content
+// carries the parent name rather than copyable text — the message type is
+// UI-only and is neither selectable nor copyable.
+func AgentReturn(fromAgent, toAgent string) *Message {
+	return &Message{
+		Type:    MessageTypeAgentReturn,
+		Sender:  fromAgent,
+		Content: toAgent,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Bound outbound agent-transfer animations to a short, perceptible window.
- Show an explicit chat transition and sidebar animation when control returns to the parent agent.
- Preserve correct behavior across nested transfers, cancellations, stale events, and inactive tabs.

## Expectations

| Expectation | Implementation |
|---|---|
| Transfer feedback must not remain during the full sub-agent run | The outbound animation remains visible for at least 1.5 seconds, stops after useful child activity, and has a 3-second maximum |
| Models without reasoning must be supported | Content and tool-call events also count as activity; the maximum timeout covers silent models |
| Returning control must be visible in chat | A live, non-persisted `child returned control to parent` transition uses the existing agent badges |
| Returning control must be visible in the sidebar | A short `Return` animation displays the child-to-parent relation |
| Nested transfers must remain correct | Logical transfer hops are tracked independently from their transient presentation |
| Inactive tabs must retain correct deadlines | Timer messages are routed to their owning tab |
| Stale events must not corrupt a newer transfer | Named returns only close an exact matching transfer hop |
| Narrow and collapsed layouts must remain valid | Transfer relations are width-bounded, including long and CJK agent names |

## Validation

| Check | Result |
|---|---|
| `go build ./...` | pass |
| `go vet ./...` | pass |
| `golangci-lint run` | pass |
| `go test ./pkg/tui/...` | pass |
| Focused TUI race tests | pass |
| Adversarial review | pass, no blockers |

## Design notes

- Return transitions are live UI feedback and are not restored from persisted sessions.
- The sidebar Return animation lasts up to 1.5 seconds and may clear earlier when the enclosing stream finishes.
- A full local `go test ./...` encountered environment-dependent failures unrelated to this change: a DMR model pull returned HTTP 416, and local proxy behavior affected existing SSRF tests in the API, fetch, and OpenAPI packages.
