### PR TITLE
fix(permissions): match glob wildcards across path separators

### DIFF
--- a/pkg/permissions/permissions.go
+++ b/pkg/permissions/permissions.go
@@ -4,7 +4,7 @@ package permissions
 
 import (
 	"fmt"
-	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/docker/docker-agent/pkg/config/latest"
@@ -239,17 +239,18 @@ func argToString(v any) string {
 }
 
 // matchGlob checks if a value matches a glob pattern.
-// Supports glob-style patterns using filepath.Match semantics:
-// - "*" matches any sequence of characters within a path segment
+// Supports glob-style patterns:
+// - "*" matches any sequence of characters (including path separators and spaces)
 // - "?" matches any single character
 // - "[...]" matches character classes
 //
 // Matching is case-insensitive.
 //
-// Note: filepath.Match's "*" stops at path separators, but for argument
-// matching we want "*" to match any characters including spaces.
-// We handle trailing wildcards specially to support patterns like "sudo*"
-// matching "sudo rm -rf /".
+// Note: filepath.Match's "*"/"?" stop at path separators ("/", or "\" on
+// Windows), but argument values (shell commands, file paths, URLs) routinely
+// contain "/", so matching must not depend on it. We therefore translate the
+// glob to an anchored regexp instead of using filepath.Match. Trailing
+// wildcards keep a plain prefix-match fast path (e.g. "sudo*").
 func matchGlob(pattern, value string) bool {
 	// Normalize both to lowercase for case-insensitive matching
 	pattern = strings.ToLower(pattern)
@@ -266,7 +267,70 @@ func matchGlob(pattern, value string) bool {
 		}
 	}
 
-	// Try glob pattern match (also handles exact matches)
-	matched, err := filepath.Match(pattern, value)
-	return err == nil && matched
+	// Full glob match (also handles exact matches). Unlike filepath.Match, the
+	// translated "*"/"?" span any character, so patterns match values that
+	// contain path separators.
+	re, err := globToRegexp(pattern)
+	if err != nil {
+		return false
+	}
+	return re.MatchString(value)
+}
+
+// globToRegexp translates a filepath.Match-style glob into an anchored regular
+// expression. Unlike filepath.Match, the resulting "*" and "?" match any
+// character, including path separators — argument values such as shell commands,
+// file paths and URLs routinely contain "/", and permission patterns must match
+// them regardless. Character classes ("[...]"), whose bracket syntax glob and
+// regexp share, are copied through verbatim; every other character is matched literally.
+func globToRegexp(pattern string) (*regexp.Regexp, error) {
+	var b strings.Builder
+	b.WriteString(`\A`)
+	for i := 0; i < len(pattern); {
+		switch c := pattern[i]; c {
+		case '*':
+			b.WriteString(`.*`)
+			i++
+		case '?':
+			b.WriteByte('.')
+			i++
+		case '[':
+			if end := classEnd(pattern, i); end > 0 {
+				b.WriteString(pattern[i : end+1])
+				i = end + 1
+				continue
+			}
+			// Unterminated class: match "[" literally.
+			b.WriteString(regexp.QuoteMeta("["))
+			i++
+		default:
+			b.WriteString(regexp.QuoteMeta(string(c)))
+			i++
+		}
+	}
+	b.WriteString(`\z`)
+	return regexp.Compile(b.String())
+}
+
+// classEnd returns the index of the "]" closing the character class opened at
+// start, or -1 if the class is unterminated. A "]" in the first position
+// (optionally after a leading "^" negation) is treated as a literal member,
+// matching glob semantics.
+func classEnd(pattern string, start int) int {
+	i := start + 1
+	if i < len(pattern) && pattern[i] == '^' {
+		i++
+	}
+	if i < len(pattern) && pattern[i] == ']' {
+		i++
+	}
+	for ; i < len(pattern); i++ {
+		switch pattern[i] {
+		case '\\':
+			i++
+		case ']':
+			return i
+		}
+	}
+	return -1
 }

--- a/pkg/permissions/permissions.go
+++ b/pkg/permissions/permissions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/docker/docker-agent/pkg/config/latest"
 )
@@ -240,17 +241,23 @@ func argToString(v any) string {
 
 // matchGlob checks if a value matches a glob pattern.
 // Supports glob-style patterns:
-// - "*" matches any sequence of characters (including path separators and spaces)
-// - "?" matches any single character
+// - "*" matches any sequence of characters, path separators and newlines included
+// - "?" matches any single character, path separator or newline included
 // - "[...]" matches character classes
+// - "\x" matches the literal character x
 //
 // Matching is case-insensitive.
 //
 // Note: filepath.Match's "*"/"?" stop at path separators ("/", or "\" on
-// Windows), but argument values (shell commands, file paths, URLs) routinely
-// contain "/", so matching must not depend on it. We therefore translate the
-// glob to an anchored regexp instead of using filepath.Match. Trailing
-// wildcards keep a plain prefix-match fast path (e.g. "sudo*").
+// Windows), but argument values are shell commands, file paths and URLs: they
+// routinely contain "/" and are often multi-line (heredocs, "&&" chains), so
+// matching must not depend on either. We therefore translate the glob to an
+// anchored regexp rather than using filepath.Match. Trailing wildcards keep a
+// plain prefix-match fast path (e.g. "sudo*").
+//
+// One deliberate divergence from filepath.Match: "\" escapes the next character
+// on every platform (filepath.Match treats it as a literal on Windows), and it
+// does so both inside and outside character classes.
 func matchGlob(pattern, value string) bool {
 	// Normalize both to lowercase for case-insensitive matching
 	pattern = strings.ToLower(pattern)
@@ -267,67 +274,141 @@ func matchGlob(pattern, value string) bool {
 		}
 	}
 
-	// Full glob match (also handles exact matches). Unlike filepath.Match, the
-	// translated "*"/"?" span any character, so patterns match values that
-	// contain path separators.
-	re, err := globToRegexp(pattern)
+	// Full glob match (also handles exact matches).
+	re, err := compileGlob(pattern)
 	if err != nil {
 		return false
 	}
 	return re.MatchString(value)
 }
 
-// globToRegexp translates a filepath.Match-style glob into an anchored regular
-// expression. Unlike filepath.Match, the resulting "*" and "?" match any
-// character, including path separators — argument values such as shell commands,
-// file paths and URLs routinely contain "/", and permission patterns must match
-// them regardless. Character classes ("[...]"), whose bracket syntax glob and
-// regexp share, are copied through verbatim; every other character is matched literally.
+// globCache memoizes compiled glob patterns. Patterns come from configuration
+// and are stable for the lifetime of a Checker, so the cache is bounded by the
+// number of configured rules.
+var globCache sync.Map // map[string]*regexp.Regexp
+
+// compileGlob returns the compiled form of pattern, translating it on first use.
+func compileGlob(pattern string) (*regexp.Regexp, error) {
+	if cached, ok := globCache.Load(pattern); ok {
+		return cached.(*regexp.Regexp), nil
+	}
+	re, err := globToRegexp(pattern)
+	if err != nil {
+		return nil, err
+	}
+	globCache.Store(pattern, re)
+	return re, nil
+}
+
+// globToRegexp translates a glob into an anchored regular expression whose "*"
+// and "?" match any character, path separators and newlines included.
+//
+// Literal runs are quoted as whole substrings rather than byte by byte, so
+// multi-byte UTF-8 runes survive the translation. Scanning bytes is safe
+// regardless: every glob metacharacter is ASCII, and UTF-8 continuation bytes
+// are always >= 0x80.
 func globToRegexp(pattern string) (*regexp.Regexp, error) {
 	var b strings.Builder
-	b.WriteString(`\A`)
+
+	// (?s) makes "." match "\n" as well. Without it the wildcards would stop at
+	// a line break the same way filepath.Match's stopped at a path separator.
+	b.WriteString(`(?s)\A`)
+
+	lit := 0 // start of the literal run pending emission
+	flush := func(end int) {
+		if lit < end {
+			b.WriteString(regexp.QuoteMeta(pattern[lit:end]))
+		}
+	}
+
 	for i := 0; i < len(pattern); {
-		switch c := pattern[i]; c {
+		switch pattern[i] {
 		case '*':
+			flush(i)
 			b.WriteString(`.*`)
 			i++
+			lit = i
 		case '?':
+			flush(i)
 			b.WriteByte('.')
 			i++
-		case '[':
-			if end := classEnd(pattern, i); end > 0 {
-				b.WriteString(pattern[i : end+1])
-				i = end + 1
+			lit = i
+		case '\\':
+			if i+1 == len(pattern) {
+				i++ // trailing "\": nothing to escape, keep it in the literal run
 				continue
 			}
-			// Unterminated class: match "[" literally.
-			b.WriteString(regexp.QuoteMeta("["))
-			i++
+			flush(i)
+			// Drop the backslash and start a literal run at the escaped
+			// character. Any UTF-8 continuation bytes fall through to default
+			// and join that run.
+			i += 2
+			lit = i - 1
+		case '[':
+			end := classEnd(pattern, i)
+			if end < 0 {
+				i++ // unterminated class: "[" stays in the literal run
+				continue
+			}
+			flush(i)
+			writeClass(&b, pattern[i:end+1])
+			i = end + 1
+			lit = i
 		default:
-			b.WriteString(regexp.QuoteMeta(string(c)))
 			i++
 		}
 	}
+	flush(len(pattern))
+
 	b.WriteString(`\z`)
 	return regexp.Compile(b.String())
 }
 
+// writeClass translates a glob character class (brackets included) into a
+// regexp character class. Glob "\x" escapes are resolved to the literal x and
+// the remaining members are escaped, so regexp's Perl and POSIX classes cannot
+// leak into glob syntax: "[\d]" stays the literal "d", as it was under
+// filepath.Match. "-" is passed through so that ranges keep working.
+func writeClass(b *strings.Builder, class string) {
+	body := class[1 : len(class)-1]
+
+	b.WriteByte('[')
+	if strings.HasPrefix(body, "^") {
+		b.WriteByte('^')
+		body = body[1:]
+	}
+	for i := 0; i < len(body); i++ {
+		switch c := body[i]; {
+		case c == '\\' && i+1 < len(body):
+			i++
+			writeClassByte(b, body[i])
+		case c == '-':
+			b.WriteByte('-') // range separator
+		default:
+			writeClassByte(b, c)
+		}
+	}
+	b.WriteByte(']')
+}
+
+// writeClassByte writes one literal byte of a character class, escaping the
+// characters regexp treats as special inside "[...]".
+func writeClassByte(b *strings.Builder, c byte) {
+	if strings.IndexByte(`\]^-[`, c) >= 0 {
+		b.WriteByte('\\')
+	}
+	b.WriteByte(c)
+}
+
 // classEnd returns the index of the "]" closing the character class opened at
-// start, or -1 if the class is unterminated. A "]" in the first position
-// (optionally after a leading "^" negation) is treated as a literal member,
-// matching glob semantics.
+// start, or -1 if the class is unterminated. As with filepath.Match, a "]" in
+// the first position closes an empty class rather than being a literal member;
+// the class then fails to compile and, like ErrBadPattern, matches nothing.
 func classEnd(pattern string, start int) int {
-	i := start + 1
-	if i < len(pattern) && pattern[i] == '^' {
-		i++
-	}
-	if i < len(pattern) && pattern[i] == ']' {
-		i++
-	}
-	for ; i < len(pattern); i++ {
+	for i := start + 1; i < len(pattern); i++ {
 		switch pattern[i] {
 		case '\\':
-			i++
+			i++ // skip the escaped character
 		case ']':
 			return i
 		}

--- a/pkg/permissions/permissions_test.go
+++ b/pkg/permissions/permissions_test.go
@@ -599,6 +599,63 @@ func TestDenyGlobCrossesPathSeparator(t *testing.T) {
 		"deny rule must also block a multi-line command")
 }
 
+// TestDenyNeverDegradesToAllowOrAsk is an invariant: whatever shape the argument
+// value takes — path separators either way, quoting, chained commands — a
+// matching deny rule must win over an overlapping allow or ask rule. Deny is the
+// operator's explicit guardrail, so anything less than Deny here is fail-open.
+//
+// This is the Checker-level invariant. It deliberately says nothing about --yolo,
+// which short-circuits the checker pipeline entirely in toolexec.Decide.
+func TestDenyNeverDegradesToAllowOrAsk(t *testing.T) {
+	t.Parallel()
+
+	commands := []string{
+		"rm -rf tmp",          // no separator at all
+		"rm -rf /",            // bare separator
+		"sudo rm -rf /etc",    // separator mid-value
+		"echo hi && rm -rf /", // chained with &&
+		"echo hi; rm -rf /",   // chained with ;
+		"echo hi\nrm -rf /",   // chained with a newline
+		`rm -rf "/my dir"`,    // double-quoted, with a separator
+		`rm -rf 'some path'`,  // single-quoted
+		`rm -rf $(pwd)/build`, // command substitution
+	}
+
+	for _, cmd := range commands {
+		t.Run(cmd, func(t *testing.T) {
+			t.Parallel()
+			// The deny rule overlaps both an allow and an ask rule that would
+			// otherwise resolve the call; deny must still win.
+			checker := NewCheckerFromRules(
+				[]string{"shell"},
+				[]string{"shell"},
+				[]string{"shell:cmd=*rm -rf*"},
+			)
+			assert.Equal(t, Deny,
+				checker.CheckWithArgs("shell", map[string]any{"cmd": cmd}),
+				"deny must win over allow/ask for %q", cmd)
+		})
+	}
+}
+
+// TestDenyMatchesBackslashPaths covers the backslash case. "\" is an escape in a
+// glob, so a literal backslash in a pattern is written "\\"; a deny rule spelled
+// that way must match a Windows-style path in the value, and must not be
+// defeated by an overlapping allow rule.
+func TestDenyMatchesBackslashPaths(t *testing.T) {
+	t.Parallel()
+
+	checker := NewCheckerFromRules(
+		[]string{"shell"},
+		nil,
+		[]string{`shell:cmd=*windows\\system32*`},
+	)
+
+	assert.Equal(t, Deny, checker.CheckWithArgs("shell",
+		map[string]any{"cmd": `rd /s /q c:\windows\system32`}),
+		`deny rule "*windows\\system32*" must block a backslash path`)
+}
+
 func TestArgToString(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/permissions/permissions_test.go
+++ b/pkg/permissions/permissions_test.go
@@ -544,6 +544,12 @@ func TestMatchGlob(t *testing.T) {
 		{"mcp:*", "mcp:github:create_issue", true}, // * matches everything including :
 		{"mcp:github:*", "mcp:github:create_issue", true},
 		{"mcp:github:create_*", "mcp:github:create_issue", true},
+
+		// "*" and "?" span path separators. Argument values (shell commands,
+		// paths, URLs) routinely contain "/", so wildcards must not stop at it.
+		{"*rm -rf*", "rm -rf /", true},
+		{"*/etc/*", "cat /etc/passwd", true},
+		{"a?c", "a/c", true},
 	}
 
 	for _, tt := range tests {
@@ -553,6 +559,25 @@ func TestMatchGlob(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestDenyGlobCrossesPathSeparator guards against a deny rule failing open.
+//
+// A deny pattern with a non-trailing wildcard (e.g. "*rm -rf*") must match the
+// same command whether or not the argument value contains a path separator.
+// Previously it fell through to filepath.Match, whose "*" stops at "/", so the
+// rule fired for "rm -rf tmp" but silently returned Ask for "rm -rf /".
+func TestDenyGlobCrossesPathSeparator(t *testing.T) {
+	t.Parallel()
+
+	checker := NewCheckerFromRules(nil, nil, []string{"shell:cmd=*rm -rf*"})
+
+	assert.Equal(t, Deny, checker.CheckWithArgs("shell",
+		map[string]any{"cmd": "rm -rf tmp"}),
+		"deny rule should block 'rm -rf tmp'")
+	assert.Equal(t, Deny, checker.CheckWithArgs("shell",
+		map[string]any{"cmd": "rm -rf /"}),
+		"deny rule must also block 'rm -rf /'")
 }
 
 func TestArgToString(t *testing.T) {

--- a/pkg/permissions/permissions_test.go
+++ b/pkg/permissions/permissions_test.go
@@ -550,6 +550,22 @@ func TestMatchGlob(t *testing.T) {
 		{"*rm -rf*", "rm -rf /", true},
 		{"*/etc/*", "cat /etc/passwd", true},
 		{"a?c", "a/c", true},
+
+		// ...and they span newlines too: shell commands are often multi-line
+		// (heredocs, "&&" chains).
+		{"*rm -rf*", "echo hi\nrm -rf /", true},
+		{"*b*", "a\nb", true},
+		{"a?b", "a\nb", true},
+
+		// Multi-byte UTF-8 in patterns keeps matching literally.
+		{"café", "café", true},
+		{"*café*", "xx café yy", true},
+
+		// "\" escapes the next character, inside and outside classes.
+		{`foo\*`, "foo*", true},
+		{`foo\*`, "foobar", false},
+		{`[\d]`, "d", true}, // literal "d", not regexp's digit class
+		{`[\d]`, "5", false},
 	}
 
 	for _, tt := range tests {
@@ -578,6 +594,9 @@ func TestDenyGlobCrossesPathSeparator(t *testing.T) {
 	assert.Equal(t, Deny, checker.CheckWithArgs("shell",
 		map[string]any{"cmd": "rm -rf /"}),
 		"deny rule must also block 'rm -rf /'")
+	assert.Equal(t, Deny, checker.CheckWithArgs("shell",
+		map[string]any{"cmd": "echo hi\nrm -rf /"}),
+		"deny rule must also block a multi-line command")
 }
 
 func TestArgToString(t *testing.T) {


### PR DESCRIPTION
## Closes #3604

## What

`matchGlob` in `pkg/permissions` falls back to `filepath.Match` for any pattern that isn't a plain trailing
wildcard. `filepath.Match`'s `*` and `?` match only **non-separator** characters, so they stop at `/` (and at
`\` on Windows). This translates the glob to an anchored regexp whose `*`/`?` span **any** character instead.

## Why

Permission patterns match argument *values* — shell commands, file paths, URLs — which routinely contain `/`.
Because of the separator boundary, a rule with a **non-trailing** wildcard silently fails to match once the
value contains a `/`:

```yaml
permissions:
  deny:
    - "shell:cmd=*rm -rf*"
```

- `shell` with `cmd = "rm -rf tmp"` → denied ✅
- `shell` with `cmd = "rm -rf /"`   → **not** denied (falls through to `Ask`) ❌

For a `deny` rule this is the unsafe direction — it **fails open**. In an interactive session the fall-through
to `Ask` still prompts, so the practical exposure is a degraded control; it becomes a real bypass under
`--yolo`, non-interactive / auto-approval runs, or when an overlapping `allow` rule is present. The same
boundary also silently breaks `allow` rules, though those fail closed.

The existing docstring already stated the intent — *"for argument matching we want `*` to match any characters
including spaces"* — but that only held for the trailing-wildcard fast path (`sudo*`), which is why casual
testing with trailing-only patterns never surfaced this.

## How

- Replace the `filepath.Match` fallback in `matchGlob` with `globToRegexp` + `regexp.MatchString`.
- `globToRegexp` translates a `filepath.Match`-style glob into an anchored regexp: `*` → `.*`, `?` → `.`,
  character classes (`[...]`) copied through (bracket syntax is shared with regexp), everything else matched
  literally via `regexp.QuoteMeta`.
- The trailing-`*` prefix-match fast path and the case-insensitive lowercasing are unchanged.
- No new dependencies (`regexp` is stdlib; `path/filepath` import dropped).

This keeps all existing `matchGlob` semantics (`*`, `?`, `[...]`, case-insensitivity) — only the separator
boundary changes.

## Tests

- New `TestDenyGlobCrossesPathSeparator`: end-to-end via `CheckWithArgs`, asserting a `*rm -rf*` deny rule
  blocks both `rm -rf tmp` and `rm -rf /`.
- Extended the `TestMatchGlob` table with separator-crossing cases (`*rm -rf*`, `*/etc/*`, `a?c` vs `a/c`).

These fail on `main` and pass with the fix. Full `pkg/permissions` suite, `go vet`, `gofmt`, and
`golangci-lint` are all green (Go 1.26.4).

```
--- PASS: TestDenyGlobCrossesPathSeparator (0.00s)
--- PASS: TestMatchGlob (0.00s)
ok  	github.com/docker/docker-agent/pkg/permissions
```