### PR TITLE
feat(leantui): let embedders override the welcome banner

### DIFF
--- a/pkg/leantui/banner_test.go
+++ b/pkg/leantui/banner_test.go
@@ -32,3 +32,21 @@ func TestCommitWelcomePadsBanner(t *testing.T) {
 	helpLine := ansi.Strip(lines[len(lines)-1])
 	assert.True(t, strings.HasPrefix(helpLine, leftPad))
 }
+
+func TestCommitWelcomeUsesConfiguredBanner(t *testing.T) {
+	t.Parallel()
+	custom := []string{"custom banner line one", "custom banner line two"}
+	m := &model{screen: ui.NewScreen("", "", ""), banner: custom}
+	m.commitWelcome()
+
+	require.Equal(t, 1, m.screen.Transcript.BlockCount())
+	lines := m.screen.Transcript.BlockLines(0, 80)
+	require.GreaterOrEqual(t, len(lines), bannerTopPadding+len(custom))
+
+	leftPad := strings.Repeat(" ", bannerLeftPadding)
+	for i, want := range custom {
+		assert.Equal(t, leftPad+want, ansi.Strip(lines[bannerTopPadding+i]))
+	}
+	// The configured banner replaces the built-in art, it does not append to it.
+	assert.NotEqual(t, leftPad+bannerLines[0], ansi.Strip(lines[bannerTopPadding]))
+}

--- a/pkg/leantui/leantui.go
+++ b/pkg/leantui/leantui.go
@@ -27,6 +27,11 @@ type Config struct {
 
 	AppName          string
 	DisabledCommands []string
+
+	// Banner overrides the ASCII-art welcome banner. When nil the built-in
+	// bannerLines ("docker agent") is used; embedders set it to brand the lean
+	// TUI with their own art (each line ideally within 56 columns).
+	Banner []string
 }
 
 // Run drives the lean TUI until the user exits. It owns the terminal (raw
@@ -159,6 +164,7 @@ type model struct {
 
 	quitting         bool
 	appName          string
+	banner           []string
 	disabledCommands map[string]bool
 }
 
@@ -189,6 +195,7 @@ func newModel(term *ui.Terminal, cfg Config) *model {
 		sessionState:     sessionState,
 		usage:            ui.NewUsageTracker(),
 		appName:          appName,
+		banner:           cfg.Banner,
 		disabledCommands: disabled,
 	}
 }
@@ -208,14 +215,18 @@ func (m *model) renderFinal() {
 }
 
 func (m *model) commitWelcome() {
+	banner := m.banner
+	if len(banner) == 0 {
+		banner = bannerLines
+	}
 	m.screen.Transcript.AddBlock(func(int) []string {
-		lines := make([]string, 0, bannerTopPadding+len(bannerLines)+2)
+		lines := make([]string, 0, bannerTopPadding+len(banner)+2)
 		for range bannerTopPadding {
 			lines = append(lines, "")
 		}
 
 		leftPad := strings.Repeat(" ", bannerLeftPadding)
-		for _, l := range bannerLines {
+		for _, l := range banner {
 			lines = append(lines, ui.StAccent().Render(leftPad+l))
 		}
 		lines = append(lines,


### PR DESCRIPTION
## What

The lean TUI's welcome banner is hardcoded ASCII art ("docker agent")
and is not derived from `Config.AppName` (which is only used as a text
label elsewhere). Embedders that reuse the lean TUI therefore can't brand
the welcome screen with their own art.

This adds an optional `Config.Banner []string`:

- When unset (nil/empty), the built-in `bannerLines` art is used, so
  existing behavior is unchanged.
- When set, `commitWelcome` renders the provided lines in place of the
  built-in art, reusing the same top/left padding, accent styling, and
  help footer — so a custom banner looks native and the embedder only
  has to supply the raw art.

It's a `[]string` (pre-split lines) to match the existing `bannerLines`
shape and the per-line render loop; each line ideally fits within ~56
columns like the built-in art.

## Tests

Adds `TestCommitWelcomeUsesConfiguredBanner`, asserting a configured
banner renders at the correct padded offset and *replaces* (does not
append to) the built-in art.
