### PR TITLE
docs: document agent delegation feedback UI (transfer and return animations)

### DIFF
--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -143,6 +143,36 @@ The **effort gauge** is a fixed-width six-cell indicator (`▰` filled, `▱` em
 
 Harness-backed agents (e.g. `claude-code`) show the harness type as their model and no thinking gauge. Press **Shift+Tab** to cycle the current model's thinking-effort level; a `✻ Thinking: <level>` toast confirms the change (useful when the sidebar is hidden).
 
+### Agent Delegation Feedback
+
+When a parent agent calls `transfer_task` to delegate work to a sub-agent, the TUI provides live visual feedback in both the sidebar and the chat.
+
+**Sidebar — Transfer box:** As soon as the delegation starts, an animated **Transfer** box appears below the agent roster, showing the direction of the handoff with a traveling dot:
+
+```
+┌ Transfer ─────────────────┐
+│  parent  ●──────►  child  │
+└───────────────────────────┘
+```
+
+The box stays visible for at least 1.5 seconds. Once the sub-agent produces its first message or tool output, the box hides (still honoring the minimum window) to keep the sidebar focused on the active agent. If the sub-agent is slow or silent, the box hides after a 3-second maximum cutoff. The header shows a `↔` marker while any delegation is still in flight, even after the box hides.
+
+**Sidebar — Return box:** When the sub-agent finishes and control returns to the parent, a brief **Return** box animates the reverse direction for up to 1.5 seconds, then disappears:
+
+```
+┌ Return ───────────────────┐
+│  child  ●──────►  parent  │
+└───────────────────────────┘
+```
+
+**Chat — return transition:** Alongside the sidebar Return animation, the chat shows a one-line static transition between the two agent badges:
+
+```
+[child]  returned control to  [parent]
+```
+
+This transition is not persisted — it does not reappear when you reload the session.
+
 ### Context-Usage Gauge
 
 The context percentage shown in the sidebar token-usage section, and the fill bar in the lean TUI status line, both color-escalate as the active session approaches the auto-compaction threshold:

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -150,19 +150,19 @@ When a parent agent calls `transfer_task` to delegate work to a sub-agent, the T
 **Sidebar — Transfer box:** As soon as the delegation starts, an animated **Transfer** box appears below the agent roster, showing the direction of the handoff with a traveling dot:
 
 ```
-┌ Transfer ─────────────────┐
-│  parent  ●──────►  child  │
-└───────────────────────────┘
+╭─ Transfer ─────────────────╮
+│  parent  ●──────►  child   │
+╰────────────────────────────╯
 ```
 
-The box stays visible for at least 1.5 seconds. Once the sub-agent produces its first message or tool output, the box hides (still honoring the minimum window) to keep the sidebar focused on the active agent. If the sub-agent is slow or silent, the box hides after a 3-second maximum cutoff. The header shows a `↔` marker while any delegation is still in flight, even after the box hides.
+The box stays visible for at least 1.5 seconds. Once the sub-agent produces its first message, reasoning, or tool output, the box hides (still honoring the minimum window) to keep the sidebar focused on the active agent. If the sub-agent is slow or silent, the box hides after a 3-second maximum cutoff. The header shows a `↔` marker while any delegation is still in flight, even after the box hides.
 
 **Sidebar — Return box:** When the sub-agent finishes and control returns to the parent, a brief **Return** box animates the reverse direction for up to 1.5 seconds, then disappears:
 
 ```
-┌ Return ───────────────────┐
-│  child  ●──────►  parent  │
-└───────────────────────────┘
+╭─ Return ───────────────────╮
+│  child  ●──────►  parent   │
+╰────────────────────────────╯
 ```
 
 **Chat — return transition:** Alongside the sidebar Return animation, the chat shows a one-line static transition between the two agent badges:

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -149,7 +149,7 @@ When a parent agent calls `transfer_task` to delegate work to a sub-agent, the T
 
 **Sidebar — Transfer box:** As soon as the delegation starts, an animated **Transfer** box appears below the agent roster, showing the direction of the handoff with a traveling dot:
 
-```
+```text
 ╭─ Transfer ─────────────────╮
 │  parent  ●──────►  child   │
 ╰────────────────────────────╯
@@ -159,7 +159,7 @@ The box stays visible for at least 1.5 seconds. Once the sub-agent produces its 
 
 **Sidebar — Return box:** When the sub-agent finishes and control returns to the parent, a brief **Return** box animates the reverse direction for up to 1.5 seconds, then disappears:
 
-```
+```text
 ╭─ Return ───────────────────╮
 │  child  ●──────►  parent   │
 ╰────────────────────────────╯
@@ -167,7 +167,7 @@ The box stays visible for at least 1.5 seconds. Once the sub-agent produces its 
 
 **Chat — return transition:** Alongside the sidebar Return animation, the chat shows a one-line static transition between the two agent badges:
 
-```
+```text
 [child]  returned control to  [parent]
 ```
 


### PR DESCRIPTION
Documents the new TUI delegation feedback introduced by #3582:

- **Transfer box**: animated sidebar box shown during `transfer_task` delegation — visible at least 1.5 s, hides when the sub-agent produces its first message/reasoning/tool output (after the minimum), or after a 3 s maximum
- **Return box**: brief (≤1.5 s) reverse-direction sidebar animation when control returns to the parent
- **Chat transition**: a non-persisted `[child] returned control to [parent]` line in the message stream

Added a new "Agent Delegation Feedback" subsection under the Agents Panel section in `docs/features/tui/index.md`.

**Testing:** docs-only; verified box corner characters and timing constants against the source code.