### PR TITLE
fix(eval): stop running containers on Ctrl-C

### DIFF
--- a/pkg/evaluation/eval.go
+++ b/pkg/evaluation/eval.go
@@ -467,6 +467,15 @@ func (r *Runner) runDockerAgentInContainer(ctx context.Context, imageID string, 
 
 	cmd := exec.CommandContext(ctx, "docker", args...)
 	cmd.Env = append(env, os.Environ()...)
+	// On cancellation send SIGINT instead of the default SIGKILL: the docker
+	// CLI proxies SIGINT to the container (SIGKILL is never proxied and would
+	// leave the container running daemon-side). The container's exit also
+	// triggers --rm removal. WaitDelay force-kills the CLI if the container
+	// doesn't stop in time.
+	cmd.Cancel = func() error {
+		return cmd.Process.Signal(os.Interrupt)
+	}
+	cmd.WaitDelay = 10 * time.Second
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, fmt.Errorf("creating stdout pipe: %w", err)


### PR DESCRIPTION
Interrupting `docker agent eval` with Ctrl-C leaves eval containers running. This regressed in 75654ed12 ("Remove useless code"), which removed the container tracker on the assumption that `exec.CommandContext` was sufficient. It isn't: on context cancellation, `exec.CommandContext`'s default `Cancel` sends SIGKILL to the `docker run` CLI process. SIGKILL cannot be caught, so the CLI never proxies the signal to the container — the container keeps running daemon-side, and `--rm` never fires because the container doesn't exit. In docker CLI plugin mode (`docker agent eval`), the nested CLI never sees the terminal SIGINT at all.

The fix overrides `cmd.Cancel` to send SIGINT instead of SIGKILL, letting the docker CLI proxy the signal to the container. The container stops, which also triggers daemon-side `--rm` removal, and the CLI exits gracefully with status 130. `cmd.WaitDelay` is set to 10 seconds as a backstop that force-kills the CLI if the container doesn't stop in time.

`--keep-containers` semantics are preserved: SIGINT stops the container but doesn't remove it when `--rm` isn't passed to `docker run`.