### PR TITLE
feat(tui): add session path visibility setting

### DIFF
--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -382,7 +382,7 @@ The **Visuals** tab customizes the layout. It shows a live schematic preview of 
 
 - **Sidebar position**: `Right` (default), `Left`, `Top`, or `Bottom`. Left/right keep the full vertical sidebar next to the chat; top/bottom render it as a compact horizontal band above or below the chat (session title, working directory, usage, plus a one-line summary of the current agent, tools, and todos).
 - **Section spacing**: `Compact`, `Normal` (default), or `Relaxed`, the number of blank lines between the sidebar sections (1, 2, or 3).
-- **Sidebar sections**: toggle the visibility of the **Token usage**, **Agents**, **Tools**, and **Todos** sections. The session block (title and working directory) is always shown.
+- **Sidebar sections**: toggle the visibility of the **Session path** (the working directory line, including its git branch) and the **Token usage**, **Agents**, **Tools**, and **Todos** sections. The session title is always shown.
 
 The **Behavior** tab controls how messages are handled:
 
@@ -397,6 +397,7 @@ settings:
   layout:
     sidebar_position: left # right (default), left, top, bottom
     section_spacing: compact # normal (default), compact, relaxed
+    hide_session_path: false
     hide_usage: true
     hide_agents: false
     hide_tools: false

--- a/pkg/tui/components/sidebar/collapsed_view.go
+++ b/pkg/tui/components/sidebar/collapsed_view.go
@@ -30,10 +30,16 @@ func (vm CollapsedViewModel) LineCount() int {
 	lines := 1 // divider
 	lines += vm.titleSectionLines()
 
-	if vm.WdAndUsageOnOneLine {
+	// Path + usage metadata row. The two share one line only when both are
+	// present and fit; a missing part (e.g. hidden session path, no usage
+	// yet) is skipped so the row never renders blank.
+	switch {
+	case vm.WorkingDir != "" && vm.UsageSummary != "" && vm.WdAndUsageOnOneLine:
 		lines++
-	} else {
-		lines += linesNeeded(lipgloss.Width(vm.WorkingDir), vm.ContentWidth)
+	default:
+		if vm.WorkingDir != "" {
+			lines += linesNeeded(lipgloss.Width(vm.WorkingDir), vm.ContentWidth)
+		}
 		if vm.UsageSummary != "" {
 			lines += linesNeeded(lipgloss.Width(vm.UsageSummary), vm.ContentWidth)
 		}
@@ -84,11 +90,17 @@ func RenderCollapsedView(vm CollapsedViewModel) string {
 
 	// Working directory + usage line(s). WorkingDir arrives pre-styled
 	// (accent block + primary text) to match the vertical Session tab.
-	if vm.WdAndUsageOnOneLine {
+	// The two share one line only when both are present and fit; a missing
+	// part (e.g. hidden session path, no usage yet) is skipped so the row
+	// never renders blank. Mirrors LineCount.
+	switch {
+	case vm.WorkingDir != "" && vm.UsageSummary != "" && vm.WdAndUsageOnOneLine:
 		gap := vm.ContentWidth - lipgloss.Width(vm.WorkingDir) - lipgloss.Width(vm.UsageSummary)
 		lines = append(lines, fmt.Sprintf("%s%*s%s", vm.WorkingDir, gap, "", vm.UsageSummary))
-	} else {
-		lines = append(lines, vm.WorkingDir)
+	default:
+		if vm.WorkingDir != "" {
+			lines = append(lines, vm.WorkingDir)
+		}
 		if vm.UsageSummary != "" {
 			lines = append(lines, vm.UsageSummary)
 		}

--- a/pkg/tui/components/sidebar/section_visibility_test.go
+++ b/pkg/tui/components/sidebar/section_visibility_test.go
@@ -63,6 +63,30 @@ func TestRenderSections_HideTools(t *testing.T) {
 	assert.Contains(t, out, "Token Usage")
 }
 
+func TestRenderSections_HideSessionPath(t *testing.T) {
+	t.Parallel()
+
+	s := newVisibilityTestSidebar(t)
+	s.workingDirectory = "~/projects/myapp"
+	s.gitBranchName = "main"
+
+	out := renderedSections(s)
+	require.Contains(t, out, "~/projects/myapp (main)")
+	visibleLines := len(s.renderSections(40))
+
+	s.SetSectionVisibility(SectionVisibility{HideSessionPath: true})
+	out = renderedSections(s)
+
+	assert.NotContains(t, out, "~/projects/myapp")
+	assert.NotContains(t, out, "(main)", "the branch suffix goes with the path")
+	assert.Contains(t, out, "Session", "the session tab and title stay visible")
+	assert.Contains(t, out, "Token Usage", "other sections stay visible")
+
+	hiddenLines := len(s.renderSections(40))
+	assert.Equal(t, visibleLines-2, hiddenLines,
+		"hiding the path drops its line and separator without leaving a blank row")
+}
+
 func TestRenderSections_HideAgentsClearsClickZones(t *testing.T) {
 	t.Parallel()
 
@@ -89,6 +113,45 @@ func TestCollapsedViewModel_HideUsage(t *testing.T) {
 	s.SetSectionVisibility(SectionVisibility{HideUsage: true})
 	vm = s.computeCollapsedViewModel(60)
 	assert.Empty(t, vm.UsageSummary, "collapsed band omits usage when hidden")
+}
+
+func TestCollapsedViewModel_HideSessionPath(t *testing.T) {
+	t.Parallel()
+
+	s := newVisibilityTestSidebar(t)
+	s.workingDirectory = "~/projects/myapp"
+
+	vm := s.computeCollapsedViewModel(60)
+	require.NotEmpty(t, vm.WorkingDir)
+
+	s.SetSectionVisibility(SectionVisibility{HideSessionPath: true})
+	vm = s.computeCollapsedViewModel(60)
+	assert.Empty(t, vm.WorkingDir, "collapsed band omits the path when hidden")
+	require.NotEmpty(t, vm.UsageSummary)
+
+	rendered := ansi.Strip(RenderCollapsedView(vm))
+	assert.NotContains(t, rendered, "myapp")
+	assert.Contains(t, rendered, ansi.Strip(vm.UsageSummary), "usage keeps its band row")
+}
+
+func TestCollapsedView_HiddenPathLeavesNoBlankRow(t *testing.T) {
+	t.Parallel()
+
+	s := newVisibilityTestSidebar(t)
+	s.workingDirectory = "~/projects/myapp"
+	s.gitBranchName = ""
+
+	withPath := s.computeCollapsedViewModel(60).LineCount()
+
+	s.SetSectionVisibility(SectionVisibility{HideSessionPath: true, HideUsage: true})
+	vm := s.computeCollapsedViewModel(60)
+	assert.Equal(t, withPath-1, vm.LineCount(), "the path+usage row disappears entirely")
+
+	lines := strings.Split(RenderCollapsedView(vm), "\n")
+	assert.Len(t, lines, vm.LineCount()-1, "LineCount includes the divider, the render does not")
+	for _, line := range lines {
+		assert.NotEmpty(t, strings.TrimSpace(ansi.Strip(line)), "no blank metadata row may remain")
+	}
 }
 
 func TestCollapsedInfoLine_ShowsAgentsToolsTodos(t *testing.T) {

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -45,10 +45,11 @@ const (
 // SectionVisibility controls which optional sidebar sections are rendered.
 // The zero value shows everything.
 type SectionVisibility struct {
-	HideUsage  bool
-	HideAgents bool
-	HideTools  bool
-	HideTodos  bool
+	HideSessionPath bool
+	HideUsage       bool
+	HideAgents      bool
+	HideTools       bool
+	HideTodos       bool
 }
 
 // Model represents a sidebar component
@@ -763,10 +764,11 @@ func (m *model) HandleClickType(x, y int) (ClickResult, string) {
 		}
 
 		// In collapsed mode, working dir line follows the title section.
+		// A hidden session path renders no line and must not keep a hit target.
 		vm := m.computeCollapsedViewModel(m.contentWidth(false))
 		wdStartY := vm.titleSectionLines()
 		wdLines := linesNeeded(lipgloss.Width(vm.WorkingDir), vm.ContentWidth)
-		if m.workingDirectory != "" && y >= wdStartY && y < wdStartY+wdLines {
+		if m.workingDirectory != "" && !m.sectionVisibility.HideSessionPath && y >= wdStartY && y < wdStartY+wdLines {
 			return ClickWorkingDir, ""
 		}
 
@@ -790,8 +792,9 @@ func (m *model) HandleClickType(x, y int) (ClickResult, string) {
 		}
 	}
 
-	// Working dir is at: verticalStarY + titleLines (title) + 1 (empty separator)
-	if m.workingDirectory != "" && contentY == verticalStarY+titleLines+1 {
+	// Working dir is at: verticalStarY + titleLines (title) + 1 (empty separator).
+	// A hidden session path renders no line and must not keep a hit target.
+	if m.workingDirectory != "" && !m.sectionVisibility.HideSessionPath && contentY == verticalStarY+titleLines+1 {
 		return ClickWorkingDir, ""
 	}
 
@@ -1016,9 +1019,10 @@ func (m *model) workingDirWithBranch() string {
 }
 
 // workingDirLine renders the working directory with the sidebar's accent
-// block, shared by the vertical Session tab and the collapsed band.
+// block, shared by the vertical Session tab and the collapsed band. Empty
+// when the session path is hidden via section visibility.
 func (m *model) workingDirLine() string {
-	if m.workingDirectory == "" {
+	if m.workingDirectory == "" || m.sectionVisibility.HideSessionPath {
 		return ""
 	}
 	return styles.TabAccentStyle.Render("█") + styles.TabPrimaryStyle.Render(" "+m.workingDirWithBranch())
@@ -1740,13 +1744,12 @@ func (m *model) sessionInfo(contentWidth int) string {
 		titleLine = star + m.sessionTitle
 	}
 
-	lines := []string{
-		titleLine,
-		"",
-	}
+	lines := []string{titleLine}
 
-	if m.workingDirectory != "" {
-		lines = append(lines, m.workingDirLine())
+	// The separator only exists for the path line, so a hidden path leaves
+	// no blank row behind.
+	if wd := m.workingDirLine(); wd != "" {
+		lines = append(lines, "", wd)
 	}
 
 	return m.renderTab("Session", strings.Join(lines, "\n"), contentWidth)

--- a/pkg/tui/components/sidebar/title_edit_test.go
+++ b/pkg/tui/components/sidebar/title_edit_test.go
@@ -323,6 +323,59 @@ func TestSidebar_HandleClickType_WorkingDir_Collapsed(t *testing.T) {
 	assert.Equal(t, ClickTitle, result, "click on title should still return ClickTitle")
 }
 
+func TestSidebar_HandleClickType_HiddenPath_Vertical(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	sb := New(t.Context(), sessionState)
+
+	m := sb.(*model)
+	m.sessionHasContent = true
+	m.titleGenerated = true
+	m.mode = ModeVertical
+	m.width = 50
+	m.sessionTitle = "Hi"
+	m.workingDirectory = "~/projects/myapp"
+	m.SetSectionVisibility(SectionVisibility{HideSessionPath: true})
+
+	paddingLeft := m.layoutCfg.PaddingLeft
+	wdY := verticalStarY + m.titleLineCount() + 1
+
+	// The line where the path used to be must not keep a copyable hit target.
+	result, _ := sb.HandleClickType(paddingLeft+3, wdY)
+	assert.Equal(t, ClickNone, result, "a hidden path must not be clickable")
+
+	result, _ = sb.HandleClickType(paddingLeft+3, verticalStarY)
+	assert.Equal(t, ClickTitle, result, "the title stays clickable")
+}
+
+func TestSidebar_HandleClickType_HiddenPath_Collapsed(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	sb := New(t.Context(), sessionState)
+
+	m := sb.(*model)
+	m.sessionHasContent = true
+	m.titleGenerated = true
+	m.mode = ModeCollapsed
+	m.width = 50
+	m.sessionTitle = "Hi"
+	m.workingDirectory = "~/projects/myapp"
+	m.SetSectionVisibility(SectionVisibility{HideSessionPath: true})
+
+	paddingLeft := m.layoutCfg.PaddingLeft
+
+	// The row after the title must not keep a copyable hit target.
+	result, _ := sb.HandleClickType(paddingLeft+3, m.titleLineCount())
+	assert.Equal(t, ClickNone, result, "a hidden path must not be clickable")
+
+	result, _ = sb.HandleClickType(paddingLeft+3, 0)
+	assert.Equal(t, ClickTitle, result, "the title stays clickable")
+}
+
 func TestSidebar_WorkingDirectory(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/dialog/settings.go
+++ b/pkg/tui/dialog/settings.go
@@ -38,6 +38,7 @@ var settingsTabLabels = [tabCount]string{"Visuals", "Behavior"}
 const (
 	rowPosition = iota
 	rowSpacing
+	rowSessionPath
 	rowUsage
 	rowAgents
 	rowTools
@@ -224,6 +225,8 @@ func (d *settingsDialog) changeValue(delta int) tea.Cmd {
 		d.current.SidebarPosition = cycleValue(sidebarPositions, d.current.SidebarPosition, delta)
 	case rowSpacing:
 		d.current.SectionSpacing = cycleValue(sectionSpacings, d.current.SectionSpacing, delta)
+	case rowSessionPath:
+		d.current.HideSessionPath = !d.current.HideSessionPath
 	case rowUsage:
 		d.current.HideUsage = !d.current.HideUsage
 	case rowAgents:
@@ -335,6 +338,7 @@ func (d *settingsDialog) renderVisualsTab(content *Content, inner int) {
 		AddContent(d.renderSelectorRow(rowSpacing, "Section spacing", spacingLabels[d.current.SectionSpacing], inner)).
 		AddSpace().
 		AddContent(styles.MutedStyle.Render("Sidebar sections")).
+		AddContent(d.renderToggleRow(rowSessionPath, "Session path", d.current.HideSessionPath)).
 		AddContent(d.renderToggleRow(rowUsage, "Token usage", d.current.HideUsage)).
 		AddContent(d.renderToggleRow(rowAgents, "Agents", d.current.HideAgents)).
 		AddContent(d.renderToggleRow(rowTools, "Tools", d.current.HideTools)).
@@ -409,9 +413,15 @@ func (d *settingsDialog) renderToggleRow(row int, label string, hidden bool) str
 }
 
 // visibleSectionLabels returns the sidebar section labels that are visible
-// under the given settings. The session block is always shown.
+// under the given settings. The session block is always shown; its label
+// reads "session/path" while the session path is visible and "session" once
+// it is hidden.
 func visibleSectionLabels(s messages.LayoutSettings) []string {
-	labels := []string{"session"}
+	sessionLabel := "session/path"
+	if s.HideSessionPath {
+		sessionLabel = "session"
+	}
+	labels := []string{sessionLabel}
 	if !s.HideUsage {
 		labels = append(labels, "usage")
 	}

--- a/pkg/tui/dialog/settings_test.go
+++ b/pkg/tui/dialog/settings_test.go
@@ -44,6 +44,9 @@ func TestSettingsDialogNavigation(t *testing.T) {
 	require.Equal(t, rowSpacing, d.selected[tabVisuals])
 
 	d.Update(down)
+	require.Equal(t, rowSessionPath, d.selected[tabVisuals])
+
+	d.Update(down)
 	require.Equal(t, rowUsage, d.selected[tabVisuals])
 
 	for range 10 {
@@ -150,6 +153,23 @@ func TestSettingsDialogTogglesSection(t *testing.T) {
 
 	d.Update(tea.KeyPressMsg{Code: tea.KeySpace})
 	assert.False(t, d.current.HideUsage, "space must toggle back")
+}
+
+func TestSettingsDialogTogglesSessionPath(t *testing.T) {
+	t.Parallel()
+
+	d := newTestSettingsDialog(t, messages.LayoutSettings{})
+	d.selected[tabVisuals] = rowSessionPath
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+	msgs := collectMsgs(cmd)
+	require.Len(t, msgs, 1)
+	preview, ok := msgs[0].(messages.PreviewLayoutMsg)
+	require.True(t, ok, "toggling the session path must emit a live preview")
+	assert.True(t, preview.Layout.HideSessionPath, "space must hide the session path")
+
+	d.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+	assert.False(t, d.current.HideSessionPath, "space must toggle back")
 }
 
 func TestSettingsDialogTogglesSendModeWithoutPreview(t *testing.T) {
@@ -259,6 +279,7 @@ func TestSettingsDialogViewShowsVisualsRows(t *testing.T) {
 	assert.Contains(t, view, "Right")
 	assert.Contains(t, view, "Section spacing")
 	assert.Contains(t, view, "Normal")
+	assert.Contains(t, view, "Session path")
 	assert.Contains(t, view, "Token usage")
 	assert.Contains(t, view, "Agents")
 	assert.Contains(t, view, "Tools")
@@ -291,14 +312,17 @@ func TestRenderLayoutPreviewReflectsSections(t *testing.T) {
 	full := ansi.Strip(renderLayoutPreview(messages.LayoutSettings{}, previewMaxWidth))
 	assert.Contains(t, full, "chat")
 	assert.Contains(t, full, "input")
-	assert.Contains(t, full, "session")
+	assert.Contains(t, full, "session/path", "a visible session path shows in the session label")
 	assert.Contains(t, full, "usage")
 	assert.Contains(t, full, "todos")
 
 	trimmed := ansi.Strip(renderLayoutPreview(messages.LayoutSettings{
-		HideUsage: true,
-		HideTodos: true,
+		HideSessionPath: true,
+		HideUsage:       true,
+		HideTodos:       true,
 	}, previewMaxWidth))
+	assert.NotContains(t, trimmed, "session/path", "a hidden session path shortens the session label")
+	assert.Contains(t, trimmed, "session")
 	assert.NotContains(t, trimmed, "usage")
 	assert.NotContains(t, trimmed, "todos")
 	assert.Contains(t, trimmed, "agents")
@@ -313,9 +337,16 @@ func TestRenderLayoutPreviewPositions(t *testing.T) {
 		assert.Contains(t, preview, "session", "position %s", position)
 	}
 
-	// Band layouts list the sections on a single line.
+	// Band layouts list the sections on a single line; the full label is
+	// wider than the band and gets truncated at its tail.
 	band := ansi.Strip(renderLayoutPreview(messages.LayoutSettings{SidebarPosition: messages.SidebarTop}, previewMaxWidth))
-	assert.Contains(t, band, "session · usage · agents · tools · todos")
+	assert.Contains(t, band, "session/path · usage · agents · tools")
+
+	hidden := ansi.Strip(renderLayoutPreview(messages.LayoutSettings{
+		SidebarPosition: messages.SidebarTop,
+		HideSessionPath: true,
+	}, previewMaxWidth))
+	assert.Contains(t, hidden, "session · usage · agents · tools · todos")
 
 	// Narrow widths truncate the band list instead of overflowing.
 	narrow := ansi.Strip(renderLayoutPreview(messages.LayoutSettings{SidebarPosition: messages.SidebarTop}, previewMinWidth))

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -919,6 +919,7 @@ func layoutSettingsFromConfig(l userconfig.LayoutSettings) messages.LayoutSettin
 	return messages.LayoutSettings{
 		SidebarPosition: messages.ParseSidebarPosition(l.SidebarPosition),
 		SectionSpacing:  messages.ParseSectionSpacing(l.SectionSpacing),
+		HideSessionPath: l.HideSessionPath,
 		HideUsage:       l.HideUsage,
 		HideAgents:      l.HideAgents,
 		HideTools:       l.HideTools,
@@ -956,6 +957,7 @@ func saveSettingsToUserConfig(s messages.LayoutSettings, mode messages.SendMode)
 		cfg.Settings.Layout = &userconfig.LayoutSettings{
 			SidebarPosition: position,
 			SectionSpacing:  spacing,
+			HideSessionPath: s.HideSessionPath,
 			HideUsage:       s.HideUsage,
 			HideAgents:      s.HideAgents,
 			HideTools:       s.HideTools,

--- a/pkg/tui/messages/settings.go
+++ b/pkg/tui/messages/settings.go
@@ -72,6 +72,7 @@ func (s SectionSpacing) BlankLines() int {
 type LayoutSettings struct {
 	SidebarPosition SidebarPosition
 	SectionSpacing  SectionSpacing
+	HideSessionPath bool
 	HideUsage       bool
 	HideAgents      bool
 	HideTools       bool

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -407,10 +407,11 @@ func WithSendMode(mode msgtypes.SendMode) PageOption {
 // sectionVisibility maps layout settings to the sidebar's visibility config.
 func sectionVisibility(settings msgtypes.LayoutSettings) sidebar.SectionVisibility {
 	return sidebar.SectionVisibility{
-		HideUsage:  settings.HideUsage,
-		HideAgents: settings.HideAgents,
-		HideTools:  settings.HideTools,
-		HideTodos:  settings.HideTodos,
+		HideSessionPath: settings.HideSessionPath,
+		HideUsage:       settings.HideUsage,
+		HideAgents:      settings.HideAgents,
+		HideTools:       settings.HideTools,
+		HideTodos:       settings.HideTodos,
 	}
 }
 

--- a/pkg/tui/page/chat/layout_position_test.go
+++ b/pkg/tui/page/chat/layout_position_test.go
@@ -152,6 +152,27 @@ func TestSetLayoutSettingsForwardsVisibilityToSidebar(t *testing.T) {
 	assert.True(t, sl.sidebarOnLeft)
 }
 
+func TestSectionVisibilityMapsAllFields(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, sidebar.SectionVisibility{}, sectionVisibility(msgtypes.LayoutSettings{}),
+		"the default layout hides nothing")
+
+	assert.Equal(t, sidebar.SectionVisibility{
+		HideSessionPath: true,
+		HideUsage:       true,
+		HideAgents:      true,
+		HideTools:       true,
+		HideTodos:       true,
+	}, sectionVisibility(msgtypes.LayoutSettings{
+		HideSessionPath: true,
+		HideUsage:       true,
+		HideAgents:      true,
+		HideTools:       true,
+		HideTodos:       true,
+	}))
+}
+
 func TestSetLayoutSettingsBeforeSizingReturnsNil(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/settings_persistence_test.go
+++ b/pkg/tui/settings_persistence_test.go
@@ -35,6 +35,7 @@ func TestLayoutSettingsFromConfig(t *testing.T) {
 	got := layoutSettingsFromConfig(userconfig.LayoutSettings{
 		SidebarPosition: "bottom",
 		SectionSpacing:  "compact",
+		HideSessionPath: true,
 		HideUsage:       true,
 		HideAgents:      true,
 		HideTools:       true,
@@ -43,6 +44,7 @@ func TestLayoutSettingsFromConfig(t *testing.T) {
 	assert.Equal(t, messages.LayoutSettings{
 		SidebarPosition: messages.SidebarBottom,
 		SectionSpacing:  messages.SpacingCompact,
+		HideSessionPath: true,
 		HideUsage:       true,
 		HideAgents:      true,
 		HideTools:       true,
@@ -56,6 +58,7 @@ func TestSaveSettingsToUserConfig_RoundTrip(t *testing.T) {
 	saved := messages.LayoutSettings{
 		SidebarPosition: messages.SidebarLeft,
 		SectionSpacing:  messages.SpacingRelaxed,
+		HideSessionPath: true,
 		HideTools:       true,
 	}
 	require.NoError(t, saveSettingsToUserConfig(saved, messages.SendModeQueue))
@@ -97,4 +100,22 @@ func TestSaveSettingsToUserConfig_OmitsDefaultPosition(t *testing.T) {
 	assert.Empty(t, layout.SidebarPosition, "the default position is not written out")
 	assert.Empty(t, layout.SectionSpacing, "the default spacing is not written out")
 	assert.True(t, layout.HideUsage)
+}
+
+func TestSaveSettingsToUserConfig_HideSessionPathKeepsEntry(t *testing.T) {
+	setupSettingsConfigTest(t)
+
+	saved := messages.LayoutSettings{
+		SidebarPosition: messages.SidebarRight,
+		SectionSpacing:  messages.SpacingNormal,
+		HideSessionPath: true,
+	}
+	require.NoError(t, saveSettingsToUserConfig(saved, messages.SendModeSteer))
+
+	cfg, err := userconfig.Load()
+	require.NoError(t, err)
+	layout := cfg.GetSettings().Layout
+	require.NotNil(t, layout, "hide_session_path alone must keep the layout entry")
+	assert.True(t, layout.HideSessionPath)
+	assert.Equal(t, saved, layoutSettingsFromConfig(userconfig.Get().GetLayout()))
 }

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -114,6 +114,8 @@ type LayoutSettings struct {
 	// SectionSpacing controls the blank space between sidebar sections:
 	// "normal" (default), "compact", or "relaxed".
 	SectionSpacing string `yaml:"section_spacing,omitempty"`
+	// HideSessionPath hides the working directory (session path) line in the sidebar.
+	HideSessionPath bool `yaml:"hide_session_path,omitempty"`
 	// HideUsage hides the token usage section in the sidebar.
 	HideUsage bool `yaml:"hide_usage,omitempty"`
 	// HideAgents hides the agents section in the sidebar.

--- a/pkg/userconfig/userconfig_test.go
+++ b/pkg/userconfig/userconfig_test.go
@@ -235,6 +235,7 @@ func TestSettings_LayoutRoundTrip(t *testing.T) {
 			Layout: &LayoutSettings{
 				SidebarPosition: "left",
 				SectionSpacing:  "compact",
+				HideSessionPath: true,
 				HideUsage:       true,
 				HideTodos:       true,
 			},
@@ -243,12 +244,17 @@ func TestSettings_LayoutRoundTrip(t *testing.T) {
 
 	require.NoError(t, config.saveTo(configFile))
 
+	data, err := os.ReadFile(configFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "hide_session_path: true")
+
 	loaded, err := loadFrom(configFile, "")
 	require.NoError(t, err)
 
 	layout := loaded.GetSettings().GetLayout()
 	assert.Equal(t, "left", layout.SidebarPosition)
 	assert.Equal(t, "compact", layout.SectionSpacing)
+	assert.True(t, layout.HideSessionPath)
 	assert.True(t, layout.HideUsage)
 	assert.False(t, layout.HideAgents)
 	assert.False(t, layout.HideTools)


### PR DESCRIPTION
## Summary

Adds a persisted `/settings` option for controlling session path visibility in the TUI sidebar.

## Changes

- Adds a `Session path` checkbox to the Visuals settings.
- Hides the working directory and git branch in vertical and horizontal sidebar layouts.
- Keeps the session title visible and removes empty rows and inactive click targets.
- Persists the preference as `settings.layout.hide_session_path`.
- Updates documentation and test coverage.

## Validation

| Check | Result |
| --- | --- |
| Build | passed |
| Full test suite | passed |
| Lint | passed |
| Review | no findings |
