### PR TITLE
chore(runtime): remove dead session event retry

### DIFF
--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -114,8 +114,6 @@ func NewClient(baseURL string, opts ...ClientOption) (*Client, error) {
 			"message_added":          func() Event { return &MessageAddedEvent{} },
 			"model_fallback":         func() Event { return &ModelFallbackEvent{} },
 			"sub_session_completed":  func() Event { return &SubSessionCompletedEvent{} },
-			"connection_lost":        func() Event { return &ConnectionLostEvent{} },
-			"connection_restored":    func() Event { return &ConnectionRestoredEvent{} },
 		},
 	}
 
@@ -722,80 +720,6 @@ func (c *Client) Ready(ctx context.Context) (*api.ReadyResponse, error) {
 		return nil, err
 	}
 	return &resp, nil
-}
-
-// StreamSessionEventsWithRetry streams events for a session with exponential backoff reconnection.
-// It emits ConnectionLostEvent and ConnectionRestoredEvent on connection changes.
-// Backs off exponentially between retries: 100ms, 200ms, 400ms, 800ms, 1600ms (max).
-func (c *Client) StreamSessionEventsWithRetry(ctx context.Context, sessionID string) (<-chan Event, error) {
-	output := make(chan Event, defaultEventChannelCapacity)
-
-	go func() {
-		defer close(output)
-		attempt := 0
-		const maxBackoff = 1600 * time.Millisecond
-		const initialBackoff = 100 * time.Millisecond
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-
-			attempt++
-			stream, err := c.StreamSessionEvents(ctx, sessionID)
-			if err != nil {
-				if attempt == 1 {
-					// First attempt failed; report and exit
-					return
-				}
-				// Emit connection lost event
-				select {
-				case output <- ConnectionLost(err.Error(), attempt):
-				case <-ctx.Done():
-					return
-				}
-
-				// Calculate backoff: 100ms, 200ms, 400ms, 800ms, 1600ms (max)
-				backoff := initialBackoff
-				if attempt > 1 {
-					backoff = initialBackoff * time.Duration(1<<uint(attempt-2))
-				}
-				if backoff > maxBackoff {
-					backoff = maxBackoff
-				}
-				select {
-				case <-time.After(backoff):
-					continue
-				case <-ctx.Done():
-					return
-				}
-			}
-
-			// Connection successful; emit restored event (if not first attempt)
-			if attempt > 1 {
-				select {
-				case output <- ConnectionRestored(attempt):
-				case <-ctx.Done():
-					return
-				}
-			}
-
-			// Stream events until error
-			for event := range stream {
-				select {
-				case output <- event:
-				case <-ctx.Done():
-					return
-				}
-			}
-
-			// Stream ended; will retry
-		}
-	}()
-
-	return output, nil
 }
 
 // GetSessionRecoveryData retrieves recovery data for a session in case of store failure

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -930,37 +930,3 @@ func SubSessionCompleted(parentSessionID string, subSession any, agentName strin
 		AgentContext:    newAgentContext(agentName),
 	}
 }
-
-// ConnectionLostEvent is emitted when the connection to the remote server is lost
-type ConnectionLostEvent struct {
-	AgentContext
-
-	Type    string `json:"type"`
-	Reason  string `json:"reason"`
-	Attempt int    `json:"attempt"`
-}
-
-func ConnectionLost(reason string, attempt int) Event {
-	return &ConnectionLostEvent{
-		Type:         "connection_lost",
-		Reason:       reason,
-		Attempt:      attempt,
-		AgentContext: newAgentContext(""),
-	}
-}
-
-// ConnectionRestoredEvent is emitted when the connection to the remote server is restored
-type ConnectionRestoredEvent struct {
-	AgentContext
-
-	Type    string `json:"type"`
-	Attempt int    `json:"attempt"`
-}
-
-func ConnectionRestored(attempt int) Event {
-	return &ConnectionRestoredEvent{
-		Type:         "connection_restored",
-		Attempt:      attempt,
-		AgentContext: newAgentContext(""),
-	}
-}


### PR DESCRIPTION
## Summary

- remove the unused `StreamSessionEventsWithRetry` runtime client method
- remove the orphaned connection lost and restored event types and constructors
- remove their event decoder registrations

## Issue expectations

| Expectation | Implementation |
|---|---|
| Remove `StreamSessionEventsWithRetry` | Removed from `pkg/runtime/client.go` |
| Remove orphaned connection events | Removed event types and constructors from `pkg/runtime/event.go` |
| Remove decoder/registration | Removed both event registry entries |
| Confirm no references remain | Repository-wide grep returns no matches |
| Build and checks remain green | Build, lint, and runtime tests pass |

## Validation

- `task build`
- `task lint`
- `go test ./pkg/runtime/...`
- `grep -RInE --exclude-dir=.git 'StreamSessionEventsWithRetry|ConnectionLost(Event)?|ConnectionRestored(Event)?|connection_lost|connection_restored' .` returns no matches

The full `task test` run still encounters pre-existing environment-dependent SSRF test failures in unrelated packages; the same failures reproduce on an unchanged `main` checkout.

Closes #3598
