### PR TITLE
fix(tui): queue pending attention events FIFO instead of a single slot (#3584)

### DIFF
--- a/pkg/tui/service/supervisor/supervisor.go
+++ b/pkg/tui/service/supervisor/supervisor.go
@@ -19,15 +19,21 @@ import (
 
 // SessionRunner represents a running session.
 type SessionRunner struct {
-	ID           string
-	App          *app.App
-	WorkingDir   string
-	Title        string
-	IsRunning    bool    // True when stream is active
-	NeedsAttn    bool    // True when user attention is needed
-	PendingEvent tea.Msg // Event that triggered attention (for replay on tab switch)
-	cancel       context.CancelFunc
-	cleanup      func()
+	ID         string
+	App        *app.App
+	WorkingDir string
+	Title      string
+	IsRunning  bool // True when stream is active
+	NeedsAttn  bool // True when user attention is needed
+	// PendingEvents queues attention events (tool confirmation, max
+	// iterations, elicitation) that arrived while this tab was inactive, in
+	// arrival order, for replay when the user switches to it. A single slot
+	// used to overwrite an earlier event with a later one, silently dropping
+	// it (#3584) — e.g. two concurrent background-job elicitations on the
+	// same unfocused tab would leave only the second visible.
+	PendingEvents []tea.Msg
+	cancel        context.CancelFunc
+	cleanup       func()
 }
 
 // SessionSpawner is a function that creates new sessions.
@@ -179,14 +185,14 @@ func (s *Supervisor) handleRuntimeEvent(sessionID string, msg tea.Msg) {
 	case *runtime.StreamStartedEvent:
 		if isTopLevelStream(runner.ID, ev.SessionID) {
 			runner.IsRunning = true
-			runner.PendingEvent = nil // New top-level stream supersedes any stale pending event
+			runner.PendingEvents = nil // New top-level stream supersedes any stale pending events
 			s.notifyTabsUpdated()
 		}
 
 	case *runtime.StreamStoppedEvent:
 		if isTopLevelStream(runner.ID, ev.SessionID) {
 			runner.IsRunning = false
-			runner.PendingEvent = nil // Clear any pending attention event since the top-level stream ended
+			runner.PendingEvents = nil // Clear any pending attention events since the top-level stream ended
 			runner.NeedsAttn = false
 			s.notifyTabsUpdated()
 		}
@@ -199,7 +205,7 @@ func (s *Supervisor) handleRuntimeEvent(sessionID string, msg tea.Msg) {
 		// These require user attention
 		if sessionID != s.activeID {
 			runner.NeedsAttn = true
-			runner.PendingEvent = msg
+			runner.PendingEvents = append(runner.PendingEvents, msg)
 			s.notifyTabsUpdated()
 			// Ring the terminal bell to alert the user
 			if p := s.program; p != nil {
@@ -274,24 +280,25 @@ func (s *Supervisor) SwitchTo(sessionID string) *SessionRunner {
 	return runner
 }
 
-// ConsumePendingEvent returns and clears the pending event for the given session.
-// Returns nil if no event is pending.
+// ConsumePendingEvent pops and returns the oldest pending event for the given
+// session (FIFO). Returns nil if none is pending.
 func (s *Supervisor) ConsumePendingEvent(sessionID string) tea.Msg {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	runner, ok := s.runners[sessionID]
-	if !ok || runner.PendingEvent == nil {
+	if !ok || len(runner.PendingEvents) == 0 {
 		return nil
 	}
 
-	event := runner.PendingEvent
-	runner.PendingEvent = nil
+	event := runner.PendingEvents[0]
+	runner.PendingEvents = runner.PendingEvents[1:]
 	return event
 }
 
-// SetPendingEvent stores an attention event for the given session so it can
-// be replayed when the user later switches to that tab. Used to re-stash a
+// SetPendingEvent re-queues an attention event at the FRONT of the given
+// session's pending queue, ahead of anything queued behind it, so it can be
+// replayed when the user later switches to that tab. Used to re-stash a
 // background dialog's originating event when the user navigates away from
 // the tab that opened it.
 //
@@ -303,7 +310,7 @@ func (s *Supervisor) SetPendingEvent(sessionID string, event tea.Msg) {
 	defer s.mu.Unlock()
 
 	if runner, ok := s.runners[sessionID]; ok {
-		runner.PendingEvent = event
+		runner.PendingEvents = append([]tea.Msg{event}, runner.PendingEvents...)
 	}
 }
 

--- a/pkg/tui/service/supervisor/supervisor_test.go
+++ b/pkg/tui/service/supervisor/supervisor_test.go
@@ -3,6 +3,7 @@ package supervisor
 import (
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -118,12 +119,36 @@ func TestSetPendingEvent_RoundTrip(t *testing.T) {
 
 	s.SetPendingEvent("A", event)
 
-	assert.Equal(t, event, s.runners["A"].PendingEvent, "event is stored on the runner")
+	assert.Equal(t, []tea.Msg{event}, s.runners["A"].PendingEvents, "event is stored on the runner")
 	assert.False(t, s.runners["A"].NeedsAttn, "SetPendingEvent must NOT raise NeedsAttn (the user is already aware)")
 
 	got := s.ConsumePendingEvent("A")
 	assert.Equal(t, event, got)
-	assert.Nil(t, s.runners["A"].PendingEvent, "event is cleared after consumption")
+	assert.Empty(t, s.runners["A"].PendingEvents, "event is cleared after consumption")
+}
+
+// TestSetPendingEvent_Queue verifies that multiple events queued for the same
+// inactive session are replayed in FIFO order and that SetPendingEvent
+// re-queues at the front, ahead of anything queued behind it (#3584).
+func TestSetPendingEvent_Queue(t *testing.T) {
+	t.Parallel()
+	s := newTestSupervisor([]string{"A"}, "B")
+
+	type fakeEvent struct{ id int }
+	first := &fakeEvent{id: 1}
+	second := &fakeEvent{id: 2}
+
+	s.runners["A"].PendingEvents = []tea.Msg{first, second}
+
+	// Re-stash a third event (e.g. the live dialog instance for the event the
+	// user was looking at) ahead of the two already queued.
+	stashed := &fakeEvent{id: 0}
+	s.SetPendingEvent("A", stashed)
+
+	assert.Equal(t, stashed, s.ConsumePendingEvent("A"))
+	assert.Equal(t, first, s.ConsumePendingEvent("A"))
+	assert.Equal(t, second, s.ConsumePendingEvent("A"))
+	assert.Nil(t, s.ConsumePendingEvent("A"), "queue is drained")
 }
 
 // TestSetPendingEvent_UnknownSession is a no-op (and must not panic).
@@ -133,7 +158,7 @@ func TestSetPendingEvent_UnknownSession(t *testing.T) {
 
 	s.SetPendingEvent("does-not-exist", "payload")
 
-	assert.Nil(t, s.runners["A"].PendingEvent, "unrelated runner is untouched")
+	assert.Empty(t, s.runners["A"].PendingEvents, "unrelated runner is untouched")
 }
 
 // --- #3217: session-aware stream lifecycle tests ---
@@ -167,7 +192,7 @@ func TestStreamStarted_SubSessionDoesNotDropPendingEvent(t *testing.T) {
 	s := newTestSupervisor([]string{"sess-A", "sess-B"}, "sess-B") // sess-A is background
 
 	elicitation := runtime.ElicitationRequest("confirm?", "form", nil, "", "eid-1", nil, "agent")
-	s.runners["sess-A"].PendingEvent = elicitation
+	s.runners["sess-A"].PendingEvents = []tea.Msg{elicitation}
 	s.runners["sess-A"].NeedsAttn = true
 	s.runners["sess-A"].IsRunning = true // already running a top-level turn
 
@@ -177,7 +202,7 @@ func TestStreamStarted_SubSessionDoesNotDropPendingEvent(t *testing.T) {
 		SessionID: "child-xyz",
 	})
 
-	require.NotNil(t, s.runners["sess-A"].PendingEvent,
+	require.NotEmpty(t, s.runners["sess-A"].PendingEvents,
 		"nested StreamStarted must NOT clear the parent's pending elicitation")
 	assert.True(t, s.runners["sess-A"].NeedsAttn,
 		"nested StreamStarted must NOT clear NeedsAttn")
@@ -193,7 +218,7 @@ func TestStreamStopped_SubSessionDoesNotDropPendingEvent(t *testing.T) {
 	s := newTestSupervisor([]string{"sess-A", "sess-B"}, "sess-B")
 
 	elicitation := runtime.ElicitationRequest("confirm?", "form", nil, "", "eid-2", nil, "agent")
-	s.runners["sess-A"].PendingEvent = elicitation
+	s.runners["sess-A"].PendingEvents = []tea.Msg{elicitation}
 	s.runners["sess-A"].NeedsAttn = true
 	s.runners["sess-A"].IsRunning = true
 
@@ -203,7 +228,7 @@ func TestStreamStopped_SubSessionDoesNotDropPendingEvent(t *testing.T) {
 		SessionID: "child-xyz",
 	})
 
-	require.NotNil(t, s.runners["sess-A"].PendingEvent,
+	require.NotEmpty(t, s.runners["sess-A"].PendingEvents,
 		"nested StreamStopped must NOT clear the parent's pending elicitation")
 	assert.True(t, s.runners["sess-A"].NeedsAttn,
 		"nested StreamStopped must NOT clear NeedsAttn")
@@ -218,9 +243,9 @@ func TestStreamStarted_TopLevelSupersedesStalePending(t *testing.T) {
 	t.Parallel()
 	s := newTestSupervisor([]string{"sess-A"}, "sess-A")
 
-	s.runners["sess-A"].PendingEvent = runtime.ElicitationRequest(
+	s.runners["sess-A"].PendingEvents = []tea.Msg{runtime.ElicitationRequest(
 		"old?", "form", nil, "", "eid-stale", nil, "agent",
-	)
+	)}
 	s.runners["sess-A"].IsRunning = false
 
 	// New top-level turn starts.
@@ -229,7 +254,7 @@ func TestStreamStarted_TopLevelSupersedesStalePending(t *testing.T) {
 		SessionID: "sess-A",
 	})
 
-	assert.Nil(t, s.runners["sess-A"].PendingEvent,
+	assert.Empty(t, s.runners["sess-A"].PendingEvents,
 		"top-level StreamStarted must supersede any stale pending event")
 	assert.True(t, s.runners["sess-A"].IsRunning,
 		"top-level StreamStarted must set IsRunning")
@@ -259,7 +284,7 @@ func TestStreamStopped_TopLevelClearsPendingAndNeedsAttn(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			s := newTestSupervisor([]string{"sess-A"}, "sess-B")
-			s.runners["sess-A"].PendingEvent = tc.pending
+			s.runners["sess-A"].PendingEvents = []tea.Msg{tc.pending}
 			s.runners["sess-A"].NeedsAttn = true
 			s.runners["sess-A"].IsRunning = true
 
@@ -268,8 +293,8 @@ func TestStreamStopped_TopLevelClearsPendingAndNeedsAttn(t *testing.T) {
 				SessionID: "sess-A",
 			})
 
-			assert.Nil(t, s.runners["sess-A"].PendingEvent,
-				"top-level StreamStopped must clear PendingEvent")
+			assert.Empty(t, s.runners["sess-A"].PendingEvents,
+				"top-level StreamStopped must clear PendingEvents")
 			assert.False(t, s.runners["sess-A"].NeedsAttn,
 				"top-level StreamStopped must clear NeedsAttn")
 			assert.False(t, s.runners["sess-A"].IsRunning,
@@ -285,9 +310,9 @@ func TestStreamStarted_EmptySessionID_TreatedAsTopLevel(t *testing.T) {
 	t.Parallel()
 	s := newTestSupervisor([]string{"sess-A"}, "sess-A")
 
-	s.runners["sess-A"].PendingEvent = runtime.ElicitationRequest(
+	s.runners["sess-A"].PendingEvents = []tea.Msg{runtime.ElicitationRequest(
 		"old?", "form", nil, "", "eid-old", nil, "agent",
-	)
+	)}
 
 	// Emitter omits SessionID (empty string).
 	s.handleRuntimeEvent("sess-A", &runtime.StreamStartedEvent{
@@ -295,7 +320,7 @@ func TestStreamStarted_EmptySessionID_TreatedAsTopLevel(t *testing.T) {
 		SessionID: "",
 	})
 
-	assert.Nil(t, s.runners["sess-A"].PendingEvent,
+	assert.Empty(t, s.runners["sess-A"].PendingEvents,
 		"empty SessionID must be treated as top-level and supersede stale pending event")
 	assert.True(t, s.runners["sess-A"].IsRunning)
 }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1802,42 +1802,76 @@ func (m *appModel) applySidebarCollapsed(sessionID string) tea.Cmd {
 	return m.resizeAll()
 }
 
-// replayPendingEvent checks if a session has a pending attention event (e.g. tool confirmation,
-// max iterations, elicitation) that was received while the tab was inactive.
-// If found, it opens the appropriate dialog. The event was already processed by the chat page
-// (updating the message list), but the dialog command was discarded for inactive sessions.
+// replayPendingEvent checks if a session has pending attention events (e.g.
+// tool confirmation, max iterations, elicitation) that were received while
+// the tab was inactive. Every queued event is replayed, in arrival order, so
+// concurrent attention events (e.g. two background-job elicitations) all
+// reopen as stacked dialogs instead of only the most recent one (#3584). Each
+// event was already processed by the chat page (updating the message list),
+// but the dialog command was discarded for inactive sessions.
 //
 // If a stashed dialog instance is available for this session and its
-// associated event still matches the pending one, the same instance is
+// associated event still matches the first pending one, the same instance is
 // re-opened so any in-progress input survives the round trip (issue #2770).
 // Otherwise the stash is discarded and a fresh dialog is built.
 func (m *appModel) replayPendingEvent(sessionID string) tea.Cmd {
-	pendingEvent := m.supervisor.ConsumePendingEvent(sessionID)
-	if pendingEvent == nil {
-		// No pending event: any stash is stale (e.g. the agent finished).
-		delete(m.stashedDialogs, sessionID)
-		return nil
-	}
-
 	sessionState, ok := m.sessionStates[sessionID]
 	if !ok {
 		delete(m.stashedDialogs, sessionID)
 		return nil
 	}
 
-	// If we stashed the live dialog instance when leaving this tab and the
-	// pending event hasn't changed, re-open the same instance so the user's
-	// in-progress input is preserved.
-	if stash, ok := m.stashedDialogs[sessionID]; ok {
-		delete(m.stashedDialogs, sessionID)
-		if stash.event == pendingEvent && stash.dialog != nil {
-			return core.CmdHandler(dialog.OpenDialogMsg{
-				Model:            stash.dialog,
-				OriginatingEvent: pendingEvent,
-			})
+	var cmds []tea.Cmd
+	for first := true; ; first = false {
+		pendingEvent := m.supervisor.ConsumePendingEvent(sessionID)
+		if pendingEvent == nil {
+			if first {
+				// No pending event at all: any stash is stale (e.g. the agent finished).
+				delete(m.stashedDialogs, sessionID)
+			}
+			break
+		}
+
+		// Only the first (oldest) event can match a stashed live dialog
+		// instance: the stash holds exactly the one dialog that was on
+		// screen when the user left the tab.
+		if first {
+			if stash, ok := m.stashedDialogs[sessionID]; ok {
+				delete(m.stashedDialogs, sessionID)
+				if stash.event == pendingEvent && stash.dialog != nil {
+					cmds = append(cmds, core.CmdHandler(dialog.OpenDialogMsg{
+						Model:            stash.dialog,
+						OriginatingEvent: pendingEvent,
+					}))
+					continue
+				}
+			}
+		}
+
+		if cmd := m.dialogCmdForPendingEvent(pendingEvent, sessionState); cmd != nil {
+			cmds = append(cmds, cmd)
 		}
 	}
 
+	if len(cmds) == 0 {
+		return nil
+	}
+	// tea.Sequence (not tea.Batch) is required for deterministic ordering:
+	// tea.Batch runs commands concurrently with no ordering guarantee on
+	// which resulting Msg reaches Update first, so two concurrent attention
+	// events (e.g. two background-job elicitations queued while this tab was
+	// inactive) could stack in a random order on every replay even though
+	// they were popped off the FIFO queue above in arrival order (#3584
+	// should-fix: FIFO replay). tea.Sequence guarantees each OpenDialogMsg is
+	// delivered to Update in the order the commands were built, so the
+	// dialog stack's bottom-to-top order matches arrival order every time.
+	return tea.Sequence(cmds...)
+}
+
+// dialogCmdForPendingEvent builds the OpenDialogMsg command for a single
+// replayed attention event. Shared by every event replayPendingEvent pops off
+// the queue after the first (stash-eligible) one.
+func (m *appModel) dialogCmdForPendingEvent(pendingEvent tea.Msg, sessionState *service.SessionState) tea.Cmd {
 	switch ev := pendingEvent.(type) {
 	case *runtime.ToolCallConfirmationEvent:
 		return core.CmdHandler(dialog.OpenDialogMsg{

--- a/pkg/tui/tui_stash_dialog_test.go
+++ b/pkg/tui/tui_stash_dialog_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"reflect"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -169,4 +170,86 @@ func TestReplayPendingEvent_NoPendingEvent_ClearsStash(t *testing.T) {
 	assert.Nil(t, cmd, "no pending event ⇒ no command to run")
 	_, stillStashed := m.stashedDialogs[sessionID]
 	assert.False(t, stillStashed, "orphaned stash must be cleared")
+}
+
+// drainInOrder unwraps a tea.Cmd exactly the way bubbletea's real
+// Program.execSequenceMsg does (see charm.land/bubbletea/v2 tea.go): a
+// sequenceMsg (produced by tea.Sequence) is drained by executing each cmd
+// ONE AT A TIME, IN ORDER, recursing into any nested sequence; anything else
+// is a leaf Msg. sequenceMsg is an unexported `[]tea.Cmd`, so reflection is
+// used to recognize its shape without depending on bubbletea internals by
+// name — but a slice-of-Cmd shape alone is not enough to tell it apart from
+// the exported tea.BatchMsg (also `[]tea.Cmd`, produced by tea.Batch and run
+// CONCURRENTLY with no ordering guarantee by the real Program). Treating
+// both shapes the same here would make this helper — and the FIFO-order test
+// below — pass identically whether production used tea.Sequence or
+// tea.Batch, silently defeating the regression test it exists for. So a
+// tea.BatchMsg is rejected outright, and only a value whose concrete type is
+// bubbletea's private sequenceMsg is recursed into.
+func drainInOrder(t *testing.T, cmd tea.Cmd) []tea.Msg {
+	t.Helper()
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if msg == nil {
+		return []tea.Msg{msg}
+	}
+	rt := reflect.TypeOf(msg)
+	if rt == reflect.TypeFor[tea.BatchMsg]() {
+		t.Fatalf("drainInOrder got a tea.BatchMsg: production must batch replayed dialogs with tea.Sequence (ordered), not tea.Batch (concurrent, unordered)")
+	}
+	if rt.Kind() == reflect.Slice && rt.Elem() == reflect.TypeFor[tea.Cmd]() && rt.Name() == "sequenceMsg" {
+		v := reflect.ValueOf(msg)
+		var out []tea.Msg
+		for i := range v.Len() {
+			sub, _ := v.Index(i).Interface().(tea.Cmd)
+			out = append(out, drainInOrder(t, sub)...)
+		}
+		return out
+	}
+	return []tea.Msg{msg}
+}
+
+// TestReplayPendingEvent_ReplaysConcurrentElicitationsInFIFOOrder is the
+// should-fix regression test for deterministic replay ordering: two
+// concurrent background-job elicitations queued on the same inactive tab
+// must reopen as dialogs in the order they arrived. Before the fix,
+// replayPendingEvent batched the OpenDialogMsg commands with tea.Batch,
+// which bubbletea's real Program executes CONCURRENTLY with no ordering
+// guarantee on which resulting Msg reaches Update first (see
+// Program.execBatchMsg) — so which prompt ended up on top of the dialog
+// stack was nondeterministic. This drains the actual tea.Cmd graph the way
+// the real Program does (see drainInOrder) instead of only inspecting the
+// internal queue slice order, so it would catch a regression back to
+// tea.Batch.
+func TestReplayPendingEvent_ReplaysConcurrentElicitationsInFIFOOrder(t *testing.T) {
+	t.Parallel()
+
+	const sessionID = "session-A"
+
+	m, _ := newTestModel(t)
+	m.supervisor = supervisor.New(nil)
+	m.supervisor.AddSession(t.Context(), nil, &session.Session{ID: sessionID}, "/tmp", nil)
+	m.sessionStates[sessionID] = service.NewSessionState(&session.Session{ID: sessionID})
+
+	first := &runtime.ElicitationRequestEvent{Message: "worker1 needs input", ElicitationID: "e1"}
+	second := &runtime.ElicitationRequestEvent{Message: "worker2 needs input", ElicitationID: "e2"}
+	runner := m.supervisor.GetRunner(sessionID)
+	require.NotNil(t, runner)
+	runner.PendingEvents = []tea.Msg{first, second}
+
+	cmd := m.replayPendingEvent(sessionID)
+	require.NotNil(t, cmd)
+
+	msgs := drainInOrder(t, cmd)
+	require.Len(t, msgs, 2, "both queued elicitations must be replayed")
+
+	open1, ok := msgs[0].(dialog.OpenDialogMsg)
+	require.True(t, ok, "expected dialog.OpenDialogMsg, got %T", msgs[0])
+	open2, ok := msgs[1].(dialog.OpenDialogMsg)
+	require.True(t, ok, "expected dialog.OpenDialogMsg, got %T", msgs[1])
+
+	assert.Same(t, first, open1.OriginatingEvent, "the first-queued elicitation must be replayed first")
+	assert.Same(t, second, open2.OriginatingEvent, "the second-queued elicitation must be replayed second, not first")
 }


### PR DESCRIPTION
## Summary

The tab supervisor stored a pending "attention" event (e.g. an elicitation
request that arrives while its tab is not focused) in a single overwritable
slot. A second attention event for the same runner silently overwrote the
first, so one of the two prompts was lost.

Replace the single `PendingEvent` slot with a FIFO `PendingEvents` queue, and
replay the whole queue in arrival order (`tea.Sequence`, which unlike
`tea.Batch` guarantees ordering) so no queued prompt is dropped.

This is an independent, pre-existing bug on `main`. It is split out as the
bottom of the #3584 elicitation-concurrency stack because it stands entirely on
its own: it touches only the TUI supervisor queue and replay logic, with no
dependency on the runtime elicitation changes stacked above it.

## What changed

- `PendingEvent` slot → `PendingEvents` FIFO queue, with
  `SetPendingEvent`/`ConsumePendingEvent` queue semantics (re-stash keeps the
  currently-displayed dialog ahead of later queued events).
- `replayPendingEvent` drains the queue and replays via `tea.Sequence` for
  deterministic ordering.
- `drainInOrder` test helper rejects `tea.Batch` (unordered) so a regression to
  `Batch` fails the test.

## Testing

- `go test ./pkg/tui/...` — green.
- Full stack `task dev` + `-race` on runtime/server/app/tui — green.
