### PR TITLE
fix(rag): honor ctx cancellation in fan-in collectors

### DIFF
--- a/pkg/rag/manager.go
+++ b/pkg/rag/manager.go
@@ -215,12 +215,17 @@ func (m *Manager) Initialize(ctx context.Context) (err error) {
 		}()
 	}
 
-	// Wait for all strategies to complete
+	// Wait for all strategies to complete. On cancellation the buffered
+	// channel lets abandoned strategy goroutines send and exit.
 	var firstError error
 	for range len(m.strategies) {
-		res := <-resultsChan
-		if res.err != nil && firstError == nil {
-			firstError = res.err
+		select {
+		case res := <-resultsChan:
+			if res.err != nil && firstError == nil {
+				firstError = res.err
+			}
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
 
@@ -346,10 +351,16 @@ func (m *Manager) Query(ctx context.Context, query string) (results []database.S
 		}(strategyName, strategyImpl, strategyCfg)
 	}
 
-	// Collect results from all strategies
+	// Collect results from all strategies. On cancellation the buffered
+	// channel lets abandoned strategy goroutines send and exit.
 	strategyResults := make(map[string][]database.SearchResult)
 	for range len(m.strategies) {
-		result := <-resultsChan
+		var result strategyResult
+		select {
+		case result = <-resultsChan:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 
 		if result.err != nil {
 			slog.ErrorContext(ctx, "[RAG Manager] Strategy query failed",

--- a/pkg/rag/manager_test.go
+++ b/pkg/rag/manager_test.go
@@ -1,13 +1,126 @@
 package rag
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/rag/database"
+	"github.com/docker/docker-agent/pkg/rag/strategy"
 )
+
+// blockingStrategy deliberately ignores ctx and blocks Initialize and Query
+// until release is closed.
+type blockingStrategy struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func newBlockingStrategy(release chan struct{}) *blockingStrategy {
+	return &blockingStrategy{started: make(chan struct{}), release: release}
+}
+
+func (s *blockingStrategy) block() {
+	close(s.started)
+	<-s.release
+}
+
+func (s *blockingStrategy) Initialize(context.Context, []string, strategy.ChunkingConfig) error {
+	s.block()
+	return nil
+}
+
+func (s *blockingStrategy) Query(context.Context, string, int, float64) ([]database.SearchResult, error) {
+	s.block()
+	return nil, nil
+}
+
+func (s *blockingStrategy) CheckAndReindexChangedFiles(context.Context, []string, strategy.ChunkingConfig) error {
+	return nil
+}
+
+func (s *blockingStrategy) StartFileWatcher(context.Context, []string, strategy.ChunkingConfig) error {
+	return nil
+}
+
+func (s *blockingStrategy) Close() error { return nil }
+
+func TestInitializeReturnsOnContextCancellationWithBlockedStrategy(t *testing.T) {
+	t.Parallel()
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	blocked := newBlockingStrategy(release)
+
+	cfg := Config{
+		StrategyConfigs: []strategy.Config{{Name: "blocked", Strategy: blocked}},
+	}
+	m, err := New(t.Context(), "test", cfg, nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- m.Initialize(ctx) }()
+
+	<-blocked.started
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Initialize did not return after context cancellation")
+	}
+}
+
+func TestQueryReturnsOnContextCancellationWithBlockedStrategy(t *testing.T) {
+	t.Parallel()
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	first := newBlockingStrategy(release)
+	second := newBlockingStrategy(release)
+
+	// Two strategies so Query takes the multi-strategy fan-in path.
+	cfg := Config{
+		StrategyConfigs: []strategy.Config{
+			{Name: "first", Strategy: first, Limit: 5},
+			{Name: "second", Strategy: second, Limit: 5},
+		},
+	}
+	m, err := New(t.Context(), "test", cfg, nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	type queryResult struct {
+		results []database.SearchResult
+		err     error
+	}
+	resCh := make(chan queryResult, 1)
+	go func() {
+		results, err := m.Query(ctx, "some query")
+		resCh <- queryResult{results: results, err: err}
+	}()
+
+	<-first.started
+	<-second.started
+	cancel()
+
+	select {
+	case res := <-resCh:
+		require.ErrorIs(t, res.err, context.Canceled)
+		assert.Nil(t, res.results)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Query did not return after context cancellation")
+	}
+}
 
 func TestGetAbsolutePaths_WithBasePath(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- stop RAG initialization and hybrid query fan-in collectors when their context is canceled
- preserve buffered result delivery so detached strategy workers do not block on send
- add regression tests with strategies that deliberately ignore context cancellation

## Issue expectations

| Expectation | Implementation |
| --- | --- |
| `Initialize` stops waiting after context cancellation | The collector selects between `resultsChan` and `ctx.Done()` |
| Multi-strategy `Query` stops waiting after context cancellation | The collector selects between `resultsChan` and `ctx.Done()` |
| Hanging strategies do not strand result sends | Result channels remain buffered to the number of strategies |
| Regression coverage | Tests cover blocked `Initialize` and two-strategy `Query` calls |

## Validation

- `task build`
- `task lint`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy -u ALL_PROXY -u all_proxy task test`
- `go test ./pkg/rag/... -race -count=1`

## Scope

Single-strategy `Query` does not use the fan-in collector and remains unchanged.

Fixes #3597
