### PR TITLE
fix(server): limit API request body size

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	"github.com/docker/docker-agent/pkg/api"
@@ -44,12 +45,15 @@ func New(ctx context.Context, sessionStore session.Store, runConfig *config.Runt
 	return NewWithManager(NewSessionManager(ctx, agentSources, sessionStore, refreshInterval, runConfig), authToken), nil
 }
 
+const defaultMaxRequestBytes int64 = 1 << 20 // 1 MiB
+
 // NewWithManager builds a Server around an already-constructed SessionManager.
 // Useful when the runtime is owned by another component (e.g. the TUI) and
 // only needs to be exposed over HTTP.
 func NewWithManager(sm *SessionManager, authToken string) *Server {
 	e := echo.New()
 	e.Use(echolog.RedactedRequestLogger())
+	e.Use(middleware.BodyLimit(strconv.FormatInt(defaultMaxRequestBytes, 10)))
 	e.Use(echo.WrapMiddleware(upstream.Handler))
 
 	// Add bearer token middleware if token is configured

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -78,6 +79,25 @@ func TestServer_ZeroAgentSource(t *testing.T) {
 
 	require.Len(t, agents, 1)
 	assert.Contains(t, agents[0].Name, "pirate")
+}
+
+// TestServer_OversizedBodyRejected pins the fix for docker/docker-agent#3595:
+// a request body over the 1 MiB cap must be rejected with 413 before it
+// reaches a JSON-decoding handler. The Content-Length header alone triggers
+// the rejection, so no SessionManager is needed.
+func TestServer_OversizedBodyRejected(t *testing.T) {
+	t.Parallel()
+
+	srv := NewWithManager(nil, "")
+
+	body := bytes.Repeat([]byte("a"), int(defaultMaxRequestBytes)+1)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/sessions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	srv.e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
 }
 
 func TestServer_ListSessions(t *testing.T) {


### PR DESCRIPTION
## Summary

- Limit API server request bodies to 1 MiB with Echo's `BodyLimit` middleware.
- Reject oversized bodies before upstream middleware, authentication, or JSON handlers process them.
- Add a regression test asserting an HTTP 413 response.

## Issue expectations

| expectation | implementation |
|---|---|
| Add `BodyLimit` middleware mirroring chatserver | Register `middleware.BodyLimit` in `NewWithManager` with the same 1 MiB default |
| Oversized request body returns 413 | Reject a 1 MiB + 1 byte request before it reaches the handler |
| Add a middleware test | Add `TestServer_OversizedBodyRejected` |

## Validation

- `task build`
- `task lint`
- `task test`

## Design note

The limit is fixed at 1 MiB to match the chatserver default. No new configuration option is introduced.

Fixes #3595
