### PR TITLE
refactor: adopt pkg/atomicfile for atomic writes

### DIFF
--- a/pkg/board/git.go
+++ b/pkg/board/git.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
+
+	"github.com/docker/docker-agent/pkg/atomicfile"
 )
 
 // removeWorktree removes a card's git worktree and its branch. Best-effort:
@@ -79,31 +81,31 @@ func copyIndex(ctx context.Context, worktree string) (string, func(), error) {
 	}
 	indexPath := strings.TrimSpace(out)
 
-	tmp, err := os.CreateTemp("", "board-index-*")
+	tmpDir, err := os.MkdirTemp("", "board-index-*")
 	if err != nil {
 		return "", nil, err
 	}
-	cleanup := func() { _ = os.Remove(tmp.Name()) }
+	cleanup := func() { _ = os.RemoveAll(tmpDir) }
 
+	indexCopy := filepath.Join(tmpDir, "index")
 	err = func() error {
-		defer func() { _ = tmp.Close() }()
 		src, err := os.Open(indexPath)
 		if os.IsNotExist(err) {
-			return nil // no index yet: start from an empty one
+			// No index yet: start from an empty one.
+			return atomicfile.Write(indexCopy, bytes.NewReader(nil), 0o600)
 		}
 		if err != nil {
 			return err
 		}
 		defer func() { _ = src.Close() }()
-		_, err = io.Copy(tmp, src)
-		return err
+		return atomicfile.Write(indexCopy, src, 0o600)
 	}()
 	if err != nil {
 		cleanup()
 		return "", nil, fmt.Errorf("copy index: %w", err)
 	}
 
-	return tmp.Name(), cleanup, nil
+	return indexCopy, cleanup, nil
 }
 
 // upstreamBase returns the ref worktrees branch from and diffs compare

--- a/pkg/board/git_test.go
+++ b/pkg/board/git_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -65,4 +66,49 @@ func TestWorktreeDiffInLocalOnlyRepo(t *testing.T) {
 	diff, err = worktreeDiff(ctx, filepath.Join(dir, "missing"))
 	require.NoError(t, err)
 	assert.Empty(t, diff)
+}
+
+func TestCopyIndex(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	dir := newLocalRepo(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("hi\n"), 0o644))
+	git(t, dir, "add", ".")
+
+	indexCopy, cleanup, err := copyIndex(ctx, dir)
+	require.NoError(t, err)
+
+	want, err := os.ReadFile(filepath.Join(dir, ".git", "index"))
+	require.NoError(t, err)
+	got, err := os.ReadFile(indexCopy)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+
+	// Unix mode bits are not enforced on Windows.
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(indexCopy)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "index copy must not be group- or world-readable")
+	}
+
+	cleanup()
+	_, err = os.Stat(indexCopy)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestCopyIndexMissingSource(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	// A fresh repository has no index file until the first git add.
+	dir := newLocalRepo(t)
+
+	indexCopy, cleanup, err := copyIndex(ctx, dir)
+	require.NoError(t, err)
+	defer cleanup()
+
+	got, err := os.ReadFile(indexCopy)
+	require.NoError(t, err)
+	assert.Empty(t, got)
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -32,6 +32,7 @@
 package cache
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -41,6 +42,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/docker/docker-agent/pkg/atomicfile"
 )
 
 // Config describes how a Cache should normalize keys and where it should
@@ -322,11 +325,10 @@ func lockFile(path string) (func(), error) {
 
 // writeJSON atomically writes entries to path as pretty-printed JSON.
 //
-// The new content is written to a sibling temp file, fsync'd, and renamed
-// over the destination. POSIX guarantees the rename is atomic, so a
-// concurrent reader sees either the previous content or the new content
-// in full — never a partial write. The parent directory is fsync'd
-// after the rename so the rename itself is durable across an OS crash.
+// atomicfile.Write publishes via a sibling temp file + fsync + rename, so a
+// concurrent reader sees either the previous content or the new content in
+// full — never a partial write. The parent directory is fsync'd after the
+// rename so the rename itself is durable across an OS crash.
 func writeJSON(path string, entries map[string]string) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
@@ -338,28 +340,8 @@ func writeJSON(path string, entries map[string]string) error {
 		return fmt.Errorf("marshaling cache: %w", err)
 	}
 
-	tmp, err := os.CreateTemp(dir, ".cache-*.json")
-	if err != nil {
-		return fmt.Errorf("creating temp cache file: %w", err)
-	}
-	tmpName := tmp.Name()
-	// Cleanup on any error path; harmless once Rename has moved the file.
-	defer os.Remove(tmpName)
-
-	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		return fmt.Errorf("writing temp cache file: %w", err)
-	}
-	if err := tmp.Sync(); err != nil {
-		tmp.Close()
-		return fmt.Errorf("syncing temp cache file: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("closing temp cache file: %w", err)
-	}
-
-	if err := os.Rename(tmpName, path); err != nil {
-		return fmt.Errorf("renaming cache file: %w", err)
+	if err := atomicfile.Write(path, bytes.NewReader(data), 0o600); err != nil {
+		return fmt.Errorf("writing cache file %q: %w", path, err)
 	}
 
 	syncDir(dir)

--- a/pkg/gateway/catalog.go
+++ b/pkg/gateway/catalog.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/docker/docker-agent/pkg/atomicfile"
 	"github.com/docker/docker-agent/pkg/paths"
 	"github.com/docker/docker-agent/pkg/remote"
 )
@@ -204,42 +206,13 @@ func saveToDisk(path string, catalog Catalog, etag string) {
 	}
 
 	dir := filepath.Dir(path)
-
-	// Write to a temp file and rename so readers never see a partial file.
-	// Try creating the temp file first; only create the directory if needed.
-	tmp, err := os.CreateTemp(dir, ".mcp_catalog_*.tmp")
-	if err != nil {
-		if !os.IsNotExist(err) {
-			slog.Warn("Failed to create MCP catalog temp file", "error", err)
-			return
-		}
-		if mkErr := os.MkdirAll(dir, 0o755); mkErr != nil { //nolint:gosec // shared with other docker MCP gateway processes
-			slog.Warn("Failed to create MCP catalog cache directory", "error", mkErr)
-			return
-		}
-		tmp, err = os.CreateTemp(dir, ".mcp_catalog_*.tmp")
-		if err != nil {
-			slog.Warn("Failed to create MCP catalog temp file", "error", err)
-			return
-		}
-	}
-	tmpName := tmp.Name()
-
-	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
-		slog.Warn("Failed to write MCP catalog temp file", "error", err)
-		return
-	}
-	if err := tmp.Close(); err != nil {
-		os.Remove(tmpName)
-		slog.Warn("Failed to close MCP catalog temp file", "error", err)
+	if err := os.MkdirAll(dir, 0o755); err != nil { //nolint:gosec // shared with other docker MCP gateway processes
+		slog.Warn("Failed to create MCP catalog cache directory", "error", err)
 		return
 	}
 
-	if err := os.Rename(tmpName, path); err != nil {
-		os.Remove(tmpName)
-		slog.Warn("Failed to rename MCP catalog cache file", "error", err)
+	if err := atomicfile.Write(path, bytes.NewReader(data), 0o600); err != nil {
+		slog.Warn("Failed to write MCP catalog cache file", "error", err)
 	}
 }
 

--- a/pkg/gateway/catalog_test.go
+++ b/pkg/gateway/catalog_test.go
@@ -2,6 +2,9 @@ package gateway
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -88,4 +91,22 @@ func TestParseServerRef(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, "github-official", ParseServerRef("docker:github-official"))
 	assert.Equal(t, "github-official", ParseServerRef("github-official"))
+}
+
+func TestSaveToDisk_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// The cache directory does not exist yet: saveToDisk must create it.
+	path := filepath.Join(t.TempDir(), "nested", catalogCacheFileName)
+	saveToDisk(path, testCatalog, `W/"abc"`)
+
+	cached := loadFromDisk(path)
+	assert.Equal(t, testCatalog, cached.Catalog)
+	assert.Equal(t, `W/"abc"`, cached.ETag)
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	}
 }

--- a/pkg/runregistry/registry.go
+++ b/pkg/runregistry/registry.go
@@ -5,6 +5,7 @@
 package runregistry
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,6 +19,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/docker/docker-agent/pkg/atomicfile"
 	"github.com/docker/docker-agent/pkg/paths"
 )
 
@@ -87,43 +89,11 @@ func (r *Registry) Write(rec Record) (func(), error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := writeAtomic(path, buf, 0o600); err != nil {
+	if err := atomicfile.Write(path, bytes.NewReader(buf), 0o600); err != nil {
 		return nil, err
 	}
 
 	return func() { _ = os.Remove(path) }, nil
-}
-
-// writeAtomic writes data to path through a sibling temp file + rename so
-// readers never observe a partially-written file.
-func writeAtomic(path string, data []byte, perm os.FileMode) error {
-	dir, name := filepath.Split(path)
-	tmp, err := os.CreateTemp(dir, name+".*")
-	if err != nil {
-		return err
-	}
-	tmpName := tmp.Name()
-	cleanup := func() { _ = os.Remove(tmpName) }
-
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		cleanup()
-		return err
-	}
-	if err := tmp.Chmod(perm); err != nil {
-		_ = tmp.Close()
-		cleanup()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		cleanup()
-		return err
-	}
-	if err := os.Rename(tmpName, path); err != nil {
-		cleanup()
-		return err
-	}
-	return nil
 }
 
 // List returns every record currently registered. Stale records (whose pid is

--- a/pkg/runregistry/registry_test.go
+++ b/pkg/runregistry/registry_test.go
@@ -37,6 +37,13 @@ func TestWriteAndList_RoundTrip(t *testing.T) {
 	cleanup, err := r.Write(rec)
 	require.NoError(t, err)
 
+	// Unix mode bits are not enforced on Windows.
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(filepath.Join(r.Dir(), "1234.json"))
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm(), "record must not be group- or world-readable")
+	}
+
 	records, err := r.List()
 	require.NoError(t, err)
 	require.Len(t, records, 1)


### PR DESCRIPTION
## Summary

- replace hand-rolled atomic writes in the gateway catalog cache, response cache, board Git index copy, and run registry with `pkg/atomicfile`
- preserve file and directory permissions, cache directory durability, error handling, and cleanup behavior
- add round-trip, cleanup, content, and POSIX permission regression coverage

## Issue expectations

| Expectation | Implementation |
|---|---|
| Gateway catalog uses `pkg/atomicfile` | `saveToDisk` writes through `atomicfile.Write` with mode `0o600` and retains the shared `0o755` cache directory |
| Response cache uses `pkg/atomicfile` | `writeJSON` writes through `atomicfile.Write` with mode `0o600` and retains the post-rename parent-directory sync |
| Board index copy uses `pkg/atomicfile` | `copyIndex` writes into a private temporary directory through `atomicfile.Write`, preserving empty-index and cleanup behavior |
| Run registry uses `pkg/atomicfile` | `Registry.Write` writes records through `atomicfile.Write` with mode `0o600`; the local duplicate helper is removed |
| Behavior remains covered | Added catalog round-trip, board index content/cleanup, and POSIX permission assertions |
| Tests remain green | Full tests, build, lint, focused race tests, and vet pass |

## Validation

- `task build`
- `task lint`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy -u ALL_PROXY -u all_proxy task test`
- `go test -race ./pkg/gateway ./pkg/cache ./pkg/board ./pkg/runregistry`
- `go vet ./pkg/gateway ./pkg/cache ./pkg/board ./pkg/runregistry`

The proxy variables are unset for the full test command because the local development proxy intercepts private-address requests used by SSRF rejection tests.

Closes #3599
