### PR TITLE
fix(mcp): clean stale gateway temp files

### DIFF
--- a/pkg/tools/mcp/gateway.go
+++ b/pkg/tools/mcp/gateway.go
@@ -4,15 +4,33 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/goccy/go-yaml"
 
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/gateway"
 	"github.com/docker/docker-agent/pkg/tools"
+)
+
+const (
+	// Temp file names embed the creating PID (<prefix><pid>-<random>) so
+	// the sweep can spare files of the current process. Older releases
+	// used <prefix><random>; those legacy names are still swept by age.
+	secretsFilePrefix = "mcp-secrets-"
+	configFilePrefix  = "mcp-config-"
+
+	// staleTempFileAge is the sweep's grace period for files of other
+	// processes. It is a margin, not a guarantee: PID reuse or another
+	// process outliving it can still be misjudged.
+	staleTempFileAge = 24 * time.Hour
 )
 
 type GatewayToolset struct {
@@ -26,6 +44,10 @@ var _ tools.ToolSet = (*GatewayToolset)(nil)
 func NewGatewayToolset(ctx context.Context, name, mcpServerName string, secrets []gateway.Secret, config any, envProvider environment.Provider, cwd string) (*GatewayToolset, error) {
 	slog.DebugContext(ctx, "Creating MCP Gateway toolset", "name", mcpServerName)
 
+	// A crash or SIGKILL skips Stop and leaves plaintext secrets behind;
+	// sweep those leftovers before writing new files.
+	runStartupSweep(ctx)
+
 	// Make sure all the required secrets are available in the environment.
 	// TODO(dga): Ideally, the MCP gateway would use the same provider that we have.
 	fileSecrets, err := writeSecretsToFile(ctx, mcpServerName, secrets, envProvider)
@@ -35,12 +57,16 @@ func NewGatewayToolset(ctx context.Context, name, mcpServerName string, secrets 
 
 	fileConfig, err := writeConfigToFile(ctx, mcpServerName, config)
 	if err != nil {
-		os.Remove(fileSecrets)
+		if rmErr := removeIfExists(fileSecrets); rmErr != nil {
+			slog.WarnContext(ctx, "Failed to remove secrets file after config error", "error", rmErr, "path", fileSecrets)
+		}
 		return nil, fmt.Errorf("writing config to file: %w", err)
 	}
 
 	// Isolate ourselves from the MCP Toolkit config by always using the Docker MCP catalog and custom config and secrets.
 	// This improves shareability of agents.
+	// The gateway CLI only accepts file paths for --secrets/--config (stdin
+	// already carries the MCP transport), so temp files are necessary.
 	args := []string{
 		"mcp", "gateway", "run",
 		"--servers", mcpServerName,
@@ -55,7 +81,7 @@ func NewGatewayToolset(ctx context.Context, name, mcpServerName string, secrets 
 	return &GatewayToolset{
 		Toolset: inner,
 		cleanUp: func() error {
-			return errors.Join(os.Remove(fileSecrets), os.Remove(fileConfig))
+			return errors.Join(removeIfExists(fileSecrets), removeIfExists(fileConfig))
 		},
 	}, nil
 }
@@ -69,6 +95,15 @@ func (t *GatewayToolset) Stop(ctx context.Context) error {
 	}
 
 	return errors.Join(stopErr, cleanUpErr)
+}
+
+// removeIfExists treats a missing file as success so cleanUp, and
+// therefore Stop, stays idempotent.
+func removeIfExists(path string) error {
+	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return nil
 }
 
 func writeSecretsToFile(ctx context.Context, mcpServerName string, secrets []gateway.Secret, envProvider environment.Provider) (string, error) {
@@ -87,7 +122,7 @@ func writeSecretsToFile(ctx context.Context, mcpServerName string, secrets []gat
 	}
 
 	// We have all the secrets, let's create a file with all of them for the MCP Gateway
-	return writeTempFile("mcp-secrets-*", []byte(strings.Join(secretValues, "\n")))
+	return writeTempFile(tempFilePattern(secretsFilePrefix), []byte(strings.Join(secretValues, "\n")))
 }
 
 func writeConfigToFile(_ context.Context, mcpServerName string, config any) (string, error) {
@@ -98,7 +133,105 @@ func writeConfigToFile(_ context.Context, mcpServerName string, config any) (str
 		return "", err
 	}
 
-	return writeTempFile("mcp-config-*", buf)
+	return writeTempFile(tempFilePattern(configFilePrefix), buf)
+}
+
+// tempFilePattern embeds the current PID so the sweep can tell our files
+// from those of other processes.
+func tempFilePattern(prefix string) string {
+	return prefix + strconv.Itoa(os.Getpid()) + "-*"
+}
+
+// parseGatewayTempName matches gateway temp file names strictly:
+// <prefix><pid>-<random> (current scheme) yields the pid digits,
+// <prefix><random> (legacy) yields "". ok is false for any other name so
+// lookalikes are never removed.
+func parseGatewayTempName(name string) (pidPart string, ok bool) {
+	rest, found := strings.CutPrefix(name, secretsFilePrefix)
+	if !found {
+		rest, found = strings.CutPrefix(name, configFilePrefix)
+	}
+	if !found {
+		return "", false
+	}
+
+	pidPart, random, hasPID := strings.Cut(rest, "-")
+	if !hasPID {
+		return "", isDigits(rest)
+	}
+	if !isDigits(pidPart) || !isDigits(random) {
+		return "", false
+	}
+	return pidPart, true
+}
+
+func isDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := range len(s) {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// sweepStaleGatewayTempFiles removes regular files in dir whose names match
+// a gateway temp scheme and whose mtime is older than maxAge, except files
+// owned by currentPID, which are kept regardless of age. Symlinks and
+// directories are skipped so nothing outside dir can be affected.
+// Best-effort: per-entry errors don't stop the loop; the first is returned.
+func sweepStaleGatewayTempFiles(dir string, currentPID int, now time.Time, maxAge time.Duration) error {
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("scanning temp dir: %w", err)
+	}
+
+	ownPIDPart := strconv.Itoa(currentPID)
+	cutoff := now.Add(-maxAge)
+	var firstErr error
+	for _, e := range entries {
+		if !e.Type().IsRegular() {
+			continue
+		}
+		pidPart, ours := parseGatewayTempName(e.Name())
+		if !ours || pidPart == ownPIDPart {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			if !errors.Is(err, fs.ErrNotExist) && firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if !info.ModTime().Before(cutoff) {
+			continue
+		}
+		if err := os.Remove(filepath.Join(dir, e.Name())); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return firstErr
+}
+
+var startupSweepOnce sync.Once
+
+// runStartupSweep swallows the sweep error so an unreadable temp dir does
+// not block the toolset from being created.
+func runStartupSweep(ctx context.Context) {
+	startupSweepOnce.Do(func() {
+		tempDir := os.TempDir()
+		if err := sweepStaleGatewayTempFiles(tempDir, os.Getpid(), time.Now(), staleTempFileAge); err != nil {
+			slog.WarnContext(ctx, "Failed to sweep stale MCP Gateway temp files", "error", err, "dir", tempDir)
+		}
+	})
 }
 
 func writeTempFile(nameTemplate string, content []byte) (string, error) {

--- a/pkg/tools/mcp/gateway_test.go
+++ b/pkg/tools/mcp/gateway_test.go
@@ -1,0 +1,301 @@
+package mcp
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/gateway"
+)
+
+// mapEnvProvider is a test double for environment.Provider.
+type mapEnvProvider map[string]string
+
+func (m mapEnvProvider) Get(_ context.Context, name string) (string, bool) {
+	v, ok := m[name]
+	return v, ok
+}
+
+// redirectTempDir points os.TempDir (and therefore writeTempFile) at a
+// per-test directory so tests never touch the real global temp dir.
+// Callers must not use t.Parallel because of t.Setenv.
+func redirectTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		t.Setenv("TMP", dir)
+		t.Setenv("TEMP", dir)
+	} else {
+		t.Setenv("TMPDIR", dir)
+	}
+	return dir
+}
+
+// writeFileWithMtime creates a file and pins its mtime so sweep age checks
+// are deterministic.
+func writeFileWithMtime(t *testing.T, path string, mtime time.Time) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte("x"), 0o600))
+	require.NoError(t, os.Chtimes(path, mtime, mtime))
+}
+
+func assertGone(t *testing.T, path string) {
+	t.Helper()
+	_, err := os.Lstat(path)
+	assert.ErrorIs(t, err, fs.ErrNotExist, "%s should have been removed", path)
+}
+
+func assertExists(t *testing.T, path string) {
+	t.Helper()
+	_, err := os.Lstat(path)
+	assert.NoError(t, err, "%s should have been preserved", path)
+}
+
+func TestSweepStaleGatewayTempFiles(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// Whole-second times survive coarse filesystem mtime granularity.
+	now := time.Now().Truncate(time.Second)
+	stale := now.Add(-staleTempFileAge - time.Hour)
+	fresh := now.Add(-time.Hour)
+
+	const currentPID = 1234
+	const otherPID = "99999"
+
+	staleOtherSecrets := filepath.Join(dir, secretsFilePrefix+otherPID+"-1111")
+	staleOtherConfig := filepath.Join(dir, configFilePrefix+otherPID+"-1111")
+	staleOwnSecrets := filepath.Join(dir, secretsFilePrefix+"1234-2222")
+	staleOwnConfig := filepath.Join(dir, configFilePrefix+"1234-2222")
+	staleLegacySecrets := filepath.Join(dir, secretsFilePrefix+"3333")
+	staleLegacyConfig := filepath.Join(dir, configFilePrefix+"3333")
+	freshOtherSecrets := filepath.Join(dir, secretsFilePrefix+otherPID+"-4444")
+	freshLegacyConfig := filepath.Join(dir, configFilePrefix+"4444")
+	unrelated := filepath.Join(dir, "other-file")
+
+	writeFileWithMtime(t, staleOtherSecrets, stale)
+	writeFileWithMtime(t, staleOtherConfig, stale)
+	writeFileWithMtime(t, staleOwnSecrets, stale)
+	writeFileWithMtime(t, staleOwnConfig, stale)
+	writeFileWithMtime(t, staleLegacySecrets, stale)
+	writeFileWithMtime(t, staleLegacyConfig, stale)
+	writeFileWithMtime(t, freshOtherSecrets, fresh)
+	writeFileWithMtime(t, freshLegacyConfig, fresh)
+	writeFileWithMtime(t, unrelated, stale)
+
+	// A directory with a matching name must survive, contents included.
+	matchingDir := filepath.Join(dir, secretsFilePrefix+"5555")
+	require.NoError(t, os.Mkdir(matchingDir, 0o700))
+	nested := filepath.Join(matchingDir, "nested")
+	writeFileWithMtime(t, nested, stale)
+	require.NoError(t, os.Chtimes(matchingDir, stale, stale))
+
+	require.NoError(t, sweepStaleGatewayTempFiles(dir, currentPID, now, staleTempFileAge))
+
+	assertGone(t, staleOtherSecrets)
+	assertGone(t, staleOtherConfig)
+	assertGone(t, staleLegacySecrets)
+	assertGone(t, staleLegacyConfig)
+	assertExists(t, staleOwnSecrets)
+	assertExists(t, staleOwnConfig)
+	assertExists(t, freshOtherSecrets)
+	assertExists(t, freshLegacyConfig)
+	assertExists(t, unrelated)
+	assertExists(t, matchingDir)
+	assertExists(t, nested)
+}
+
+func TestSweepStaleGatewayTempFiles_PreservesLookalikes(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	now := time.Now().Truncate(time.Second)
+	stale := now.Add(-staleTempFileAge - time.Hour)
+
+	lookalikes := []string{
+		secretsFilePrefix,                 // empty rest
+		secretsFilePrefix + "abc",         // legacy shape, non-digits
+		secretsFilePrefix + "12a34",       // legacy shape, mixed
+		configFilePrefix + "abc-123",      // non-digit pid part
+		configFilePrefix + "123-abc",      // non-digit random part
+		secretsFilePrefix + "123-456-789", // extra hyphen segment
+		configFilePrefix + "-123",         // empty pid part
+	}
+	for _, name := range lookalikes {
+		writeFileWithMtime(t, filepath.Join(dir, name), stale)
+	}
+
+	require.NoError(t, sweepStaleGatewayTempFiles(dir, 4242, now, staleTempFileAge))
+
+	for _, name := range lookalikes {
+		assertExists(t, filepath.Join(dir, name))
+	}
+}
+
+func TestSweepStaleGatewayTempFiles_AgeBoundary(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	now := time.Now().Truncate(time.Second)
+	// A maxAge different from staleTempFileAge proves the parameter is
+	// honored rather than hardcoded.
+	maxAge := time.Hour
+
+	atCutoff := filepath.Join(dir, secretsFilePrefix+"99999-1")
+	justPast := filepath.Join(dir, configFilePrefix+"8888")
+	writeFileWithMtime(t, atCutoff, now.Add(-maxAge))
+	writeFileWithMtime(t, justPast, now.Add(-maxAge-time.Second))
+
+	require.NoError(t, sweepStaleGatewayTempFiles(dir, 4242, now, maxAge))
+
+	// Exactly maxAge old is not yet stale; one second past is.
+	assertExists(t, atCutoff)
+	assertGone(t, justPast)
+}
+
+func TestSweepStaleGatewayTempFiles_MissingDirIsNoOp(t *testing.T) {
+	t.Parallel()
+	err := sweepStaleGatewayTempFiles(filepath.Join(t.TempDir(), "does-not-exist"), 4242, time.Now(), staleTempFileAge)
+	assert.NoError(t, err)
+}
+
+func TestSweepStaleGatewayTempFiles_IgnoresSymlinks(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test not reliable on Windows")
+	}
+
+	dir := t.TempDir()
+	targetDir := t.TempDir()
+	now := time.Now().Truncate(time.Second)
+	stale := now.Add(-staleTempFileAge - time.Hour)
+
+	target := filepath.Join(targetDir, "target")
+	writeFileWithMtime(t, target, stale)
+
+	// The link carries a sweepable stale name; only its type protects it.
+	link := filepath.Join(dir, secretsFilePrefix+"777")
+	require.NoError(t, os.Symlink(target, link))
+
+	require.NoError(t, sweepStaleGatewayTempFiles(dir, 4242, now, staleTempFileAge))
+
+	// Neither the link nor its out-of-dir target may be touched.
+	assertExists(t, link)
+	assertExists(t, target)
+}
+
+func TestWriteTempFile_ContentAndPermissions(t *testing.T) {
+	dir := redirectTempDir(t)
+
+	path, err := writeTempFile(secretsFilePrefix+"*", []byte("KEY=value"))
+	require.NoError(t, err)
+
+	assert.Equal(t, dir, filepath.Dir(path))
+	assert.True(t, strings.HasPrefix(filepath.Base(path), secretsFilePrefix))
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "KEY=value", string(content))
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.Equal(t, fs.FileMode(0o600), info.Mode().Perm())
+	}
+}
+
+func TestWriteSecretsToFile(t *testing.T) {
+	secrets := []gateway.Secret{
+		{Name: "github.token", Env: "GITHUB_TOKEN"},
+		{Name: "other.token", Env: "OTHER_TOKEN"},
+	}
+
+	t.Run("writes name=value lines", func(t *testing.T) {
+		dir := redirectTempDir(t)
+		env := mapEnvProvider{"GITHUB_TOKEN": "abc", "OTHER_TOKEN": "def"}
+
+		path, err := writeSecretsToFile(t.Context(), "github", secrets, env)
+		require.NoError(t, err)
+		assert.Equal(t, dir, filepath.Dir(path))
+
+		// The written name must parse as owned by this process, otherwise
+		// the sweep could reclaim live files.
+		pidPart, ours := parseGatewayTempName(filepath.Base(path))
+		assert.True(t, ours)
+		assert.Equal(t, strconv.Itoa(os.Getpid()), pidPart)
+
+		content, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, "github.token=abc\nother.token=def", string(content))
+	})
+
+	t.Run("missing env var", func(t *testing.T) {
+		_, err := writeSecretsToFile(t.Context(), "github", secrets, mapEnvProvider{"GITHUB_TOKEN": "abc"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "OTHER_TOKEN")
+	})
+
+	t.Run("newline in secret", func(t *testing.T) {
+		env := mapEnvProvider{"GITHUB_TOKEN": "a\nb", "OTHER_TOKEN": "def"}
+		_, err := writeSecretsToFile(t.Context(), "github", secrets, env)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "newline")
+	})
+}
+
+func TestNewGatewayToolset_ErrorLeavesNoFiles(t *testing.T) {
+	dir := redirectTempDir(t)
+
+	_, err := NewGatewayToolset(t.Context(), "toolset", "github",
+		[]gateway.Secret{{Name: "github.token", Env: "MISSING_VAR"}},
+		nil, mapEnvProvider{}, "")
+	require.Error(t, err)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "no temp files should remain after a constructor error")
+}
+
+func TestNewGatewayToolset_ConfigErrorLeavesNoFiles(t *testing.T) {
+	dir := redirectTempDir(t)
+
+	_, err := NewGatewayToolset(t.Context(), "toolset", "github",
+		[]gateway.Secret{{Name: "github.token", Env: "GITHUB_TOKEN"}},
+		make(chan int), // goccy/go-yaml cannot marshal channels
+		mapEnvProvider{"GITHUB_TOKEN": "abc"}, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "writing config to file")
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "secrets file must be removed when the config write fails")
+}
+
+func TestNewGatewayToolset_CleanUpRemovesFiles(t *testing.T) {
+	dir := redirectTempDir(t)
+
+	ts, err := NewGatewayToolset(t.Context(), "toolset", "github",
+		[]gateway.Secret{{Name: "github.token", Env: "GITHUB_TOKEN"}},
+		map[string]any{"key": "value"},
+		mapEnvProvider{"GITHUB_TOKEN": "abc"}, "")
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 2, "constructor should create one secrets and one config file")
+
+	require.NoError(t, ts.cleanUp())
+
+	entries, err = os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "cleanUp should remove both temp files")
+
+	// Stop is documented idempotent, so a second cleanUp must not error.
+	require.NoError(t, ts.cleanUp())
+}


### PR DESCRIPTION
## Summary

- sweep stale MCP gateway secret and config files on startup
- keep current-process files and apply a 24-hour grace period to other-process and legacy files
- make cleanup idempotent and cover startup, error, permission, age, and symlink cases

## Issue expectations

| Expectation | Implementation |
|---|---|
| Clean stale `mcp-secrets-*` files on startup | A best-effort startup sweep removes matching regular files older than 24 hours |
| Clean stale `mcp-config-*` files on startup | The same sweep handles matching config files |
| Avoid plaintext persistence after abnormal exit where feasible | Crash leftovers are removed on the next gateway toolset startup; normal shutdown cleanup remains in place |
| Evaluate stdin or file descriptors | The gateway CLI currently requires paths for `--secrets` and `--config`, while stdin carries MCP transport, so path-based files remain the compatibility fallback |
| Preserve concurrent active instances | New files include the creating PID; current-process files are preserved and other-process files receive a 24-hour grace period |

## Validation

- `task build`
- `task lint`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY -u http_proxy -u https_proxy -u all_proxy -u no_proxy task test`
- `go test -race -count=1 ./pkg/tools/mcp/...`

## Residual consideration

The 24-hour age threshold is a safety margin rather than a process-liveness guarantee. PID reuse or a separate gateway process running longer than the grace period can still be misclassified. This avoids platform-specific liveness checks while ensuring abandoned plaintext files do not persist indefinitely.

Fixes #3596
