### PR TITLE
chore(mcp): resolve OAuth TODOs and expand headers per request

### DIFF
--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -110,19 +110,21 @@ func CreateToolSet(ctx context.Context, toolset latest.Toolset, runConfig *confi
 		return NewToolsetCommand(toolset.Name, resolvedCommand, toolset.Args, env, cwd, lifecycle.PolicyFromConfig(toolset.Name, toolset.Lifecycle)), nil
 
 	case toolset.Remote.URL != "":
-		expander := js.NewJsExpander(envProvider)
+		// The URL is expanded once: it identifies the connection for the
+		// toolset's lifetime. Headers are deliberately NOT expanded here —
+		// they may reference ${env.X} values backed by dynamic providers
+		// (e.g. rotating tokens), so the remote client re-expands them on
+		// every HTTP request (see remoteMCPClient.expandHeaders).
+		remoteURL := js.NewJsExpander(envProvider).Expand(ctx, toolset.Remote.URL, nil)
 
-		// TODO: expand headers on each request, not at creation time.
-		headers := expander.ExpandMap(ctx, toolset.Remote.Headers)
-		remoteURL := expander.Expand(ctx, toolset.Remote.URL, nil)
-
-		return NewRemoteToolsetWithAllowPrivateIPs(
+		return newRemoteToolset(
 			toolset.Name,
 			remoteURL,
 			toolset.Remote.TransportType,
-			headers,
+			toolset.Remote.Headers,
 			toolset.Remote.OAuth,
 			toolset.AllowPrivateIPsEnabled(),
+			envProvider,
 			lifecycle.PolicyFromConfig(toolset.Name, toolset.Lifecycle),
 		), nil
 
@@ -240,7 +242,7 @@ func NewToolsetCommand(name, command string, args, env []string, cwd string, pol
 // The optional policy lets callers tune restart/backoff behaviour;
 // see NewToolsetCommand for the semantics.
 func NewRemoteToolset(name, urlString, transport string, headers map[string]string, oauthConfig *latest.RemoteOAuthConfig, policy ...lifecycle.Policy) *Toolset {
-	return newRemoteToolset(name, urlString, transport, headers, oauthConfig, false, policy...)
+	return newRemoteToolset(name, urlString, transport, headers, oauthConfig, false, nil, policy...)
 }
 
 // NewRemoteToolsetWithAllowPrivateIPs creates a new remote MCP toolset and
@@ -252,14 +254,19 @@ func NewRemoteToolsetWithAllowPrivateIPs(
 	allowPrivateIPs bool,
 	policy ...lifecycle.Policy,
 ) *Toolset {
-	return newRemoteToolset(name, urlString, transport, headers, oauthConfig, allowPrivateIPs, policy...)
+	return newRemoteToolset(name, urlString, transport, headers, oauthConfig, allowPrivateIPs, nil, policy...)
 }
 
+// newRemoteToolset is the shared constructor behind the exported remote
+// toolset variants. env is optional: when non-nil, ${env.X} placeholders in
+// header values are resolved against it on every outbound HTTP request; when
+// nil (programmatic callers), header values are used as configured.
 func newRemoteToolset(
 	name, urlString, transport string,
 	headers map[string]string,
 	oauthConfig *latest.RemoteOAuthConfig,
 	allowPrivateIPs bool,
+	env environment.Provider,
 	policy ...lifecycle.Policy,
 ) *Toolset {
 	slog.Debug("Creating Remote MCP toolset",
@@ -272,7 +279,7 @@ func newRemoteToolset(
 	desc := buildRemoteDescription(urlString, transport)
 	ts := &Toolset{
 		name:        name,
-		mcpClient:   newRemoteClient(urlString, transport, headers, NewKeyringTokenStore(), oauthConfig, allowPrivateIPs),
+		mcpClient:   newRemoteClient(urlString, transport, headers, NewKeyringTokenStore(), oauthConfig, allowPrivateIPs, env),
 		logID:       urlString,
 		description: desc,
 	}
@@ -473,9 +480,8 @@ func (ts *Toolset) Stop(ctx context.Context) error {
 }
 
 // clientConnector adapts an mcpClient to the lifecycle.Connector interface.
-// It owns the initialize handshake (including the upstream-bug retry for the
-// "failed to send initialized notification" case) and exposes the shared
-// mcpClient as a Session.
+// It owns the initialize handshake and exposes the shared mcpClient as a
+// Session.
 type clientConnector struct {
 	ts *Toolset
 }
@@ -550,54 +556,38 @@ func (c *clientConnector) Connect(ctx context.Context) (lifecycle.Session, error
 		},
 	}
 
-	var result *mcp.InitializeResult
-	const maxRetries = 3
-	for attempt := 0; ; attempt++ {
-		var err error
-		result, err = ts.mcpClient.Initialize(ctx, initRequest)
-		if err == nil {
-			break
+	// Note: a retry loop for "failed to send initialized notification" used
+	// to live here. Its predicate matched an error string only the retired
+	// mark3labs/mcp-go client produced; neither transport in the official
+	// modelcontextprotocol/go-sdk (in use since 814d46a1) emits that string,
+	// so the loop was dead code (docker/docker-agent#3601). Transient
+	// initialize failures are handled by the supervisor's restart policy
+	// instead.
+	result, err := ts.mcpClient.Initialize(ctx, initRequest)
+	if err != nil {
+		classified := lifecycle.Classify(err)
+		if errors.Is(classified, lifecycle.ErrServerUnavailable) {
+			slog.DebugContext(ctx, "MCP client unavailable, will retry on next conversation turn",
+				"server", ts.logID,
+				"error", err,
+			)
+			return nil, errServerUnavailable
 		}
-		// TODO(krissetto): This is a temporary fix to handle the case where the remote server hasn't finished its async init
-		// and we send the notifications/initialized message before the server is ready. Fix upstream in mcp-go if possible.
+		// Map auth-related transport failures to ErrAuthRequired so the
+		// supervisor treats them as permanent (no retry storm) and the
+		// toolset lands in StateFailed for clean interactive recovery on
+		// the next turn. Two signals to check:
 		//
-		// Only retry when initialization fails due to sending the initialized notification.
-		if !isInitNotificationSendError(err) {
-			classified := lifecycle.Classify(err)
-			if errors.Is(classified, lifecycle.ErrServerUnavailable) {
-				slog.DebugContext(ctx, "MCP client unavailable, will retry on next conversation turn",
-					"server", ts.logID,
-					"error", err,
-				)
-				return nil, errServerUnavailable
-			}
-			// Map auth-related transport failures to ErrAuthRequired so the
-			// supervisor treats them as permanent (no retry storm) and the
-			// toolset lands in StateFailed for clean interactive recovery on
-			// the next turn. Two signals to check:
-			//
-			// 1. AuthorizationRequiredError / OAuthDeclinedError from the
-			//    transport: enrichConnectError re-emits these through the SDK's
-			//    %v wrapping so errors.As still works.
-			// 2. lifecycle.Classify detected "invalid_token" in the error
-			//    message, which also resolves to ErrAuthRequired.
-			if IsAuthorizationRequired(err) || IsOAuthDeclined(err) || errors.Is(classified, lifecycle.ErrAuthRequired) {
-				return nil, fmt.Errorf("%w: %w", lifecycle.ErrAuthRequired, err)
-			}
-			slog.ErrorContext(ctx, "Failed to initialize MCP client", "error", err)
-			return nil, fmt.Errorf("failed to initialize MCP client: %w", err)
+		// 1. AuthorizationRequiredError / OAuthDeclinedError from the
+		//    transport: enrichConnectError re-emits these through the SDK's
+		//    %v wrapping so errors.As still works.
+		// 2. lifecycle.Classify detected "invalid_token" in the error
+		//    message, which also resolves to ErrAuthRequired.
+		if IsAuthorizationRequired(err) || IsOAuthDeclined(err) || errors.Is(classified, lifecycle.ErrAuthRequired) {
+			return nil, fmt.Errorf("%w: %w", lifecycle.ErrAuthRequired, err)
 		}
-		if attempt >= maxRetries {
-			slog.ErrorContext(ctx, "Failed to initialize MCP client after retries", "error", err)
-			return nil, fmt.Errorf("failed to initialize MCP client after retries: %w", err)
-		}
-		backoff := time.Duration(200*(attempt+1)) * time.Millisecond
-		slog.DebugContext(ctx, "MCP initialize failed to send initialized notification; retrying", "id", ts.logID, "attempt", attempt+1, "backoff_ms", backoff.Milliseconds())
-		select {
-		case <-time.After(backoff):
-		case <-ctx.Done():
-			return nil, fmt.Errorf("failed to initialize MCP client: %w", ctx.Err())
-		}
+		slog.ErrorContext(ctx, "Failed to initialize MCP client", "error", err)
+		return nil, fmt.Errorf("failed to initialize MCP client: %w", err)
 	}
 
 	slog.DebugContext(ctx, "Started MCP toolset successfully", "server", ts.logID)
@@ -768,20 +758,6 @@ func (ts *Toolset) callTool(ctx context.Context, toolCall tools.ToolCall, _ tool
 	slog.DebugContext(ctx, "MCP tool call completed", "tool", toolCall.Function.Name, "output_length", len(result.Output))
 	slog.DebugContext(ctx, result.Output)
 	return result, nil
-}
-
-// isInitNotificationSendError returns true if initialization failed while sending the
-// notifications/initialized message to the server.
-func isInitNotificationSendError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-	// mcp-go client returns this error
-	if strings.Contains(msg, "failed to send initialized notification") {
-		return true
-	}
-	return false
 }
 
 func processMCPContent(toolResult *mcp.CallToolResult) *tools.ToolCallResult {

--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -307,8 +307,16 @@ func callbackRedirectURLFrom(c *latest.RemoteOAuthConfig) string {
 // oauthTransport wraps an HTTP transport with OAuth support
 type oauthTransport struct {
 	base http.RoundTripper
-	// TODO(rumpl): remove client reference, we need to find a better way to send elicitation requests
-	client                    *remoteMCPClient
+	// requestElicitation forwards an elicitation request raised by the OAuth
+	// flow to the runtime's registered handler; production wiring points it
+	// at sessionClient.requestElicitation. May be nil (tests); elicit() then
+	// defers the flow with AuthorizationRequiredError, matching the
+	// no-handler behaviour of sessionClient.requestElicitation.
+	requestElicitation func(ctx context.Context, params *mcpsdk.ElicitParams) (tools.ElicitationResult, error)
+	// onOAuthSuccess notifies the runtime that a token was obtained or
+	// silently refreshed; production wiring points it at
+	// sessionClient.oauthSuccess. May be nil (tests); then it's a no-op.
+	onOAuthSuccess            func()
 	tokenStore                OAuthTokenStore
 	baseURL                   string
 	managed                   bool
@@ -354,6 +362,24 @@ type oauthTransport struct {
 
 func (t *oauthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.roundTrip(req, false)
+}
+
+// elicit sends an elicitation request through the injected callback. When no
+// callback is wired up, the flow is deferred with the recognisable
+// AuthorizationRequiredError sentinel, exactly like
+// sessionClient.requestElicitation does when no handler is registered.
+func (t *oauthTransport) elicit(ctx context.Context, params *mcpsdk.ElicitParams) (tools.ElicitationResult, error) {
+	if t.requestElicitation == nil {
+		return tools.ElicitationResult{}, &AuthorizationRequiredError{URL: t.baseURL}
+	}
+	return t.requestElicitation(ctx, params)
+}
+
+// notifyOAuthSuccess invokes the injected OAuth-success callback, if any.
+func (t *oauthTransport) notifyOAuthSuccess() {
+	if t.onOAuthSuccess != nil {
+		t.onOAuthSuccess()
+	}
 }
 
 func (t *oauthTransport) oauthClient() *http.Client {
@@ -411,7 +437,7 @@ func (t *oauthTransport) handleServerRejectedToken(ctx context.Context, prev *OA
 		_, err := t.refreshStoredToken(ctx, prev)
 		if err == nil {
 			slog.DebugContext(ctx, "Silently refreshed server-rejected token", "url", t.baseURL)
-			t.client.oauthSuccess()
+			t.notifyOAuthSuccess()
 			return nil
 		}
 		slog.DebugContext(ctx, "Refresh failed after server-side token rejection; falling back to interactive auth",
@@ -1061,7 +1087,7 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 		scopes,
 	)
 
-	result, err := t.client.requestElicitation(ctx, &mcpsdk.ElicitParams{
+	result, err := t.elicit(ctx, &mcpsdk.ElicitParams{
 		Message:         fmt.Sprintf("The MCP server at %s requires OAuth authorization. Do you want to proceed?", t.baseURL),
 		RequestedSchema: nil,
 		Meta: map[string]any{
@@ -1118,7 +1144,7 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 	}
 
 	// Notify the runtime that the OAuth flow was successful
-	t.client.oauthSuccess()
+	t.notifyOAuthSuccess()
 
 	slog.DebugContext(ctx, "OAuth flow completed successfully")
 	return nil
@@ -1128,7 +1154,8 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 // scopes) used for both the authorize URL and the token exchange. Explicit
 // credentials from the per-toolset config take precedence; otherwise we
 // attempt RFC 7591 Dynamic Client Registration against the authorization
-// server. Returns an error if neither path is available.
+// server. When registration is unsupported or fails, we fall back to asking
+// the user for pre-registered client credentials via a form elicitation.
 func (t *oauthTransport) resolveClientCredentials(ctx context.Context, authServerMetadata *AuthorizationServerMetadata, redirectURI string) (clientID, clientSecret string, scopes []string, err error) {
 	switch {
 	case t.oauthConfig != nil && t.oauthConfig.ClientID != "":
@@ -1145,15 +1172,71 @@ func (t *oauthTransport) resolveClientCredentials(ctx context.Context, authServe
 			nil,
 		)
 		if err != nil {
-			slog.DebugContext(ctx, "Dynamic registration failed", "error", err)
-			// TODO(rumpl): fall back to requesting client ID from user
-			return "", "", nil, err
+			slog.DebugContext(ctx, "Dynamic registration failed, asking the user for client credentials", "error", err)
+			promptedID, promptedSecret, promptErr := t.promptForClientCredentials(ctx, "Dynamic client registration failed.")
+			if promptErr != nil {
+				return "", "", nil, fmt.Errorf("dynamic client registration failed (%w): %w", err, promptErr)
+			}
+			return promptedID, promptedSecret, configuredScopes(t.oauthConfig), nil
 		}
 		return clientID, clientSecret, nil, nil
 	default:
-		// TODO(rumpl): fall back to requesting client ID from user
-		return "", "", nil, errors.New("authorization server does not support dynamic client registration and no explicit OAuth credentials configured")
+		slog.DebugContext(ctx, "Authorization server does not support dynamic client registration, asking the user for client credentials")
+		promptedID, promptedSecret, promptErr := t.promptForClientCredentials(ctx, "The authorization server does not support dynamic client registration.")
+		if promptErr != nil {
+			return "", "", nil, fmt.Errorf("authorization server does not support dynamic client registration and no explicit OAuth credentials configured: %w", promptErr)
+		}
+		return promptedID, promptedSecret, configuredScopes(t.oauthConfig), nil
 	}
+}
+
+// promptForClientCredentials asks the user for an OAuth client_id and an
+// optional client_secret via a form elicitation. It is the fallback for
+// authorization servers where Dynamic Client Registration is unavailable or
+// failed: the user may have registered an application with the provider
+// manually and can supply its credentials directly. reason is a short,
+// user-facing sentence explaining why the credentials are needed.
+//
+// A decline or cancel surfaces as *OAuthDeclinedError so callers latch it
+// exactly like a declined authorization dialog; when no elicitation bridge
+// is available, elicit() defers with AuthorizationRequiredError. The secret
+// is never logged.
+func (t *oauthTransport) promptForClientCredentials(ctx context.Context, reason string) (clientID, clientSecret string, err error) {
+	result, err := t.elicit(ctx, &mcpsdk.ElicitParams{
+		Message: fmt.Sprintf("%s Enter the OAuth client ID (and client secret, if any) of an application registered with the authorization server for %s.", reason, t.baseURL),
+		RequestedSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"client_id": map[string]any{
+					"type":  "string",
+					"title": "Client ID",
+				},
+				"client_secret": map[string]any{
+					"type":   "string",
+					"title":  "Client secret (optional)",
+					"format": "password",
+				},
+			},
+			"required": []any{"client_id"},
+		},
+		Meta: map[string]any{
+			"docker-agent/type":       "oauth_client_credentials",
+			"docker-agent/server_url": t.baseURL,
+		},
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("failed to request OAuth client credentials: %w", err)
+	}
+	if result.Action != tools.ElicitationActionAccept {
+		return "", "", &OAuthDeclinedError{URL: t.baseURL}
+	}
+	clientID, _ = result.Content["client_id"].(string)
+	clientID = strings.TrimSpace(clientID)
+	if clientID == "" {
+		return "", "", errors.New("elicitation reply did not include a client_id")
+	}
+	clientSecret, _ = result.Content["client_secret"].(string)
+	return clientID, clientSecret, nil
 }
 
 // unmanagedRedirectURI returns the redirect_uri docker-agent should use when
@@ -1328,7 +1411,7 @@ func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServe
 	elicCtx, elicCancel := context.WithTimeout(ctx, waitTimeout)
 	defer elicCancel()
 	go func() {
-		r, e := t.client.requestElicitation(elicCtx, &mcpsdk.ElicitParams{
+		r, e := t.elicit(elicCtx, &mcpsdk.ElicitParams{
 			Message:         "OAuth authorization required for " + t.baseURL,
 			RequestedSchema: nil,
 			Meta:            meta,
@@ -1457,7 +1540,7 @@ func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServe
 	}
 
 	// Notify the runtime that the OAuth flow was successful
-	t.client.oauthSuccess()
+	t.notifyOAuthSuccess()
 
 	slog.DebugContext(ctx, "Unmanaged OAuth flow completed successfully")
 	return nil

--- a/pkg/tools/mcp/oauth_helpers.go
+++ b/pkg/tools/mcp/oauth_helpers.go
@@ -46,7 +46,9 @@ func oauthHTTPClientForAllowPrivateIPs(allowPrivateIPs bool) *http.Client {
 // (protected-resource / authorization-server metadata discovery, dynamic
 // client registration, token exchange and refresh). It layers the configured
 // custom headers on top of the SSRF-safe (or allow_private_ips) transport,
-// but ONLY for requests that target the MCP server's own host.
+// but ONLY for requests that target the MCP server's own host. Header values
+// are resolved per request through resolve (nil means ${headers.NAME}-only
+// resolution), so env-backed values stay as fresh here as on the main channel.
 //
 // OAuth metadata can advertise authorization servers on hosts chosen by the
 // (untrusted) server response, so forwarding the configured headers to every
@@ -61,7 +63,7 @@ func oauthHTTPClientForAllowPrivateIPs(allowPrivateIPs bool) *http.Client {
 //
 // The returned client is a fresh instance; the shared oauthHTTPClient
 // singleton is never mutated.
-func oauthHTTPClientWithHeaders(rawURL string, headers map[string]string, allowPrivateIPs bool) *http.Client {
+func oauthHTTPClientWithHeaders(rawURL string, headers map[string]string, allowPrivateIPs bool, resolve upstream.HeaderResolver) *http.Client {
 	base := oauthHTTPClientForAllowPrivateIPs(allowPrivateIPs)
 	if len(headers) == 0 {
 		return base
@@ -83,7 +85,7 @@ func oauthHTTPClientWithHeaders(rawURL string, headers map[string]string, allowP
 		CheckRedirect: base.CheckRedirect,
 		Transport: &hostScopedHeaderTransport{
 			host:        hostWithoutDefaultPort(u.Host, u.Scheme),
-			withHeaders: upstream.NewHeaderTransport(inner, headers),
+			withHeaders: upstream.NewHeaderTransportWithResolver(inner, headers, resolve),
 			base:        inner,
 		},
 	}

--- a/pkg/tools/mcp/oauth_test.go
+++ b/pkg/tools/mcp/oauth_test.go
@@ -927,7 +927,7 @@ func TestOAuthHTTPClientWithHeaders_StripsDefaultPort(t *testing.T) {
 	t.Parallel()
 
 	client := oauthHTTPClientWithHeaders("https://mcp.example.com:443/mcp",
-		map[string]string{"X-Grafana-URL": "https://instance.grafana.net/"}, false)
+		map[string]string{"X-Grafana-URL": "https://instance.grafana.net/"}, false, nil)
 	hst, ok := client.Transport.(*hostScopedHeaderTransport)
 	require.True(t, ok, "expected a host-scoped transport when headers are configured")
 	assert.Equal(t, "mcp.example.com", hst.host,
@@ -1061,11 +1061,11 @@ func TestOAuthTransportCoalescesConcurrentAuthorization(t *testing.T) {
 	})
 
 	transport := &oauthTransport{
-		base:            base,
-		client:          client,
-		tokenStore:      NewInMemoryTokenStore(),
-		baseURL:         "http://mcp.example.test/mcp",
-		oauthHTTPClient: authSrv.Client(),
+		base:               base,
+		requestElicitation: client.requestElicitation,
+		tokenStore:         NewInMemoryTokenStore(),
+		baseURL:            "http://mcp.example.test/mcp",
+		oauthHTTPClient:    authSrv.Client(),
 	}
 
 	firstReq, err := http.NewRequestWithContext(t.Context(), http.MethodGet, transport.baseURL, http.NoBody)
@@ -1444,7 +1444,7 @@ func (e *elicitCaptured) handler(_ context.Context, req *gomcp.ElicitParams) (to
 // unmanaged flow and wires the supplied elicitation handler.
 func newUnmanagedTestTransport(t *testing.T, baseURL, redirectURI string, capture *elicitCaptured) (*oauthTransport, *remoteMCPClient) {
 	t.Helper()
-	client := newRemoteClient(baseURL, "streamable", nil, NewInMemoryTokenStore(), nil, false)
+	client := newRemoteClient(baseURL, "streamable", nil, NewInMemoryTokenStore(), nil, false, nil)
 	client.unmanagedOAuthRedirectURI = redirectURI
 	client.SetElicitationHandler(capture.handler)
 	// Allow private-IP destinations so the httptest server's 127.0.0.1 URLs
@@ -1452,7 +1452,8 @@ func newUnmanagedTestTransport(t *testing.T, baseURL, redirectURI string, captur
 	client.allowPrivateIPs = true
 	transport := &oauthTransport{
 		base:                      http.DefaultTransport,
-		client:                    client,
+		requestElicitation:        client.requestElicitation,
+		onOAuthSuccess:            client.oauthSuccess,
 		tokenStore:                client.tokenStore,
 		baseURL:                   baseURL,
 		managed:                   false,
@@ -1542,7 +1543,7 @@ func TestInitialize_CustomHeadersReachOAuthDiscovery(t *testing.T) {
 	defer srv.Close()
 
 	headers := map[string]string{"X-Grafana-URL": "https://instance.grafana.net/"}
-	client := newRemoteClient(srv.URL, "streamable", headers, NewInMemoryTokenStore(), nil, true)
+	client := newRemoteClient(srv.URL, "streamable", headers, NewInMemoryTokenStore(), nil, true, nil)
 
 	// Decline the OAuth elicitation: the unmanaged flow reaches the
 	// protected-resource-metadata discovery request (which carries the
@@ -2229,7 +2230,6 @@ func newTransportWithStaleToken(t *testing.T, baseURL string) *oauthTransport {
 	require.NoError(t, err)
 	return &oauthTransport{
 		base:       http.DefaultTransport,
-		client:     &remoteMCPClient{},
 		tokenStore: store,
 		baseURL:    baseURL,
 		// Allow private IPs so the httptest 127.0.0.1 server is reachable.
@@ -2249,7 +2249,7 @@ func TestRoundTrip_ServerInvalidTokenEvictsAndRefreshes(t *testing.T) {
 
 	var oauthSuccessFired atomic.Bool
 	transport := newTransportWithStaleToken(t, srv.URL)
-	transport.client.SetOAuthSuccessHandler(func() { oauthSuccessFired.Store(true) })
+	transport.onOAuthSuccess = func() { oauthSuccessFired.Store(true) }
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, strings.NewReader("{}"))
 	require.NoError(t, err)
@@ -2375,7 +2375,6 @@ func TestRoundTrip_ServerInvalidToken_NoRefreshToken_NonInteractive(t *testing.T
 
 	transport := &oauthTransport{
 		base:            http.DefaultTransport,
-		client:          &remoteMCPClient{},
 		tokenStore:      store,
 		baseURL:         srv.URL,
 		oauthHTTPClient: oauthHTTPClientForAllowPrivateIPs(true),
@@ -2437,7 +2436,7 @@ func TestRoundTrip_ConcurrentInvalidToken_RefreshesOnce(t *testing.T) {
 	srv, tokenCalls := newInvalidTokenTestServer(t)
 
 	transport := newTransportWithStaleToken(t, srv.URL)
-	transport.client.SetOAuthSuccessHandler(func() {})
+	transport.onOAuthSuccess = func() {}
 
 	const n = 6
 	results := make(chan error, n)
@@ -2511,7 +2510,6 @@ func TestRoundTrip_Bare401WithAttachedTokenUnchanged(t *testing.T) {
 
 	transport := &oauthTransport{
 		base:            http.DefaultTransport,
-		client:          &remoteMCPClient{},
 		tokenStore:      store,
 		baseURL:         srv.URL,
 		oauthHTTPClient: oauthHTTPClientForAllowPrivateIPs(true),
@@ -2600,17 +2598,17 @@ func TestRoundTrip_ConcurrentInvalidToken_NoRefresh_StickyDecline(t *testing.T) 
 		return tools.ElicitationResult{Action: tools.ElicitationActionDecline}
 	}
 
-	client := newRemoteClient(srv.URL, "streamable", nil, store, nil, false)
+	client := newRemoteClient(srv.URL, "streamable", nil, store, nil, false, nil)
 	client.SetElicitationHandler(capture.handler)
 	client.allowPrivateIPs = true
 
 	transport := &oauthTransport{
-		base:            http.DefaultTransport,
-		client:          client,
-		tokenStore:      store,
-		baseURL:         srv.URL,
-		managed:         false,
-		oauthHTTPClient: oauthHTTPClientForAllowPrivateIPs(true),
+		base:               http.DefaultTransport,
+		requestElicitation: client.requestElicitation,
+		tokenStore:         store,
+		baseURL:            srv.URL,
+		managed:            false,
+		oauthHTTPClient:    oauthHTTPClientForAllowPrivateIPs(true),
 	}
 
 	const n = 5
@@ -2730,4 +2728,341 @@ func TestBuildAuthorizationURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+// --------- Client-credential elicitation fallback ---------
+
+// clientCredsElicit returns an elicitation callback that captures the
+// oauth_client_credentials request and answers with the given result.
+func clientCredsElicit(captured **gomcp.ElicitParams, result tools.ElicitationResult) func(context.Context, *gomcp.ElicitParams) (tools.ElicitationResult, error) {
+	return func(_ context.Context, params *gomcp.ElicitParams) (tools.ElicitationResult, error) {
+		*captured = params
+		return result, nil
+	}
+}
+
+// TestResolveClientCredentials_NoDCR_PromptsUser verifies the fallback when
+// the authorization server does not advertise a registration endpoint: the
+// user is asked for pre-registered client credentials via a form
+// elicitation, and the configured scopes are preserved on accept.
+func TestResolveClientCredentials_NoDCR_PromptsUser(t *testing.T) {
+	t.Parallel()
+
+	var captured *gomcp.ElicitParams
+	transport := &oauthTransport{
+		baseURL: "https://mcp.example.test/mcp",
+		requestElicitation: clientCredsElicit(&captured, tools.ElicitationResult{
+			Action: tools.ElicitationActionAccept,
+			Content: map[string]any{
+				"client_id":     "user-client-id",
+				"client_secret": "user-secret",
+			},
+		}),
+		oauthConfig: &latest.RemoteOAuthConfig{Scopes: []string{"read", "write"}},
+	}
+
+	clientID, clientSecret, scopes, err := transport.resolveClientCredentials(
+		t.Context(), &AuthorizationServerMetadata{}, "https://example.test/cb")
+	require.NoError(t, err)
+	assert.Equal(t, "user-client-id", clientID)
+	assert.Equal(t, "user-secret", clientSecret)
+	assert.Equal(t, []string{"read", "write"}, scopes,
+		"configured scopes must be preserved when the user supplies the client credentials")
+
+	require.NotNil(t, captured, "a client-credentials elicitation must have been sent")
+	assert.Equal(t, "oauth_client_credentials", captured.Meta["docker-agent/type"])
+	assert.Equal(t, transport.baseURL, captured.Meta["docker-agent/server_url"])
+	schema, ok := captured.RequestedSchema.(map[string]any)
+	require.True(t, ok, "the elicitation must carry a form schema")
+	assert.Contains(t, schema["required"], "client_id", "client_id must be a required form field")
+}
+
+// TestResolveClientCredentials_DCRFails_PromptsUser verifies that a failing
+// dynamic client registration falls back to asking the user, instead of
+// aborting the flow outright.
+func TestResolveClientCredentials_DCRFails_PromptsUser(t *testing.T) {
+	t.Parallel()
+
+	var registerCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		registerCalls.Add(1)
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	var captured *gomcp.ElicitParams
+	transport := &oauthTransport{
+		baseURL: "https://mcp.example.test/mcp",
+		requestElicitation: clientCredsElicit(&captured, tools.ElicitationResult{
+			Action:  tools.ElicitationActionAccept,
+			Content: map[string]any{"client_id": "user-client-id"},
+		}),
+		oauthHTTPClient: oauthHTTPClientForAllowPrivateIPs(true),
+	}
+
+	clientID, clientSecret, scopes, err := transport.resolveClientCredentials(
+		t.Context(),
+		&AuthorizationServerMetadata{RegistrationEndpoint: srv.URL},
+		"https://example.test/cb",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), registerCalls.Load(), "dynamic registration must be attempted first")
+	assert.Equal(t, "user-client-id", clientID)
+	assert.Empty(t, clientSecret, "client_secret is optional")
+	assert.Nil(t, scopes, "no scopes configured, none returned")
+	require.NotNil(t, captured)
+	assert.Equal(t, "oauth_client_credentials", captured.Meta["docker-agent/type"])
+}
+
+// TestResolveClientCredentials_PromptDeclined verifies decline and cancel
+// both surface the OAuthDeclinedError sentinel (wrapped, but reachable via
+// errors.As) so the sticky-decline latch in startInteractiveFlowLocked keeps
+// working for this dialog too.
+func TestResolveClientCredentials_PromptDeclined(t *testing.T) {
+	t.Parallel()
+
+	for _, action := range []tools.ElicitationAction{tools.ElicitationActionDecline, tools.ElicitationActionCancel} {
+		t.Run(string(action), func(t *testing.T) {
+			t.Parallel()
+
+			var captured *gomcp.ElicitParams
+			transport := &oauthTransport{
+				baseURL:            "https://mcp.example.test/mcp",
+				requestElicitation: clientCredsElicit(&captured, tools.ElicitationResult{Action: action}),
+			}
+
+			clientID, clientSecret, _, err := transport.resolveClientCredentials(
+				t.Context(), &AuthorizationServerMetadata{}, "https://example.test/cb")
+			require.Error(t, err)
+			assert.Empty(t, clientID)
+			assert.Empty(t, clientSecret)
+			assert.True(t, IsOAuthDeclined(err),
+				"a declined/cancelled credentials prompt must surface OAuthDeclinedError; got: %v", err)
+			assert.Contains(t, err.Error(), "dynamic client registration",
+				"the error must explain why the credentials were needed")
+		})
+	}
+}
+
+// TestResolveClientCredentials_PromptMissingClientID verifies that an
+// accepted reply without a usable client_id is rejected.
+func TestResolveClientCredentials_PromptMissingClientID(t *testing.T) {
+	t.Parallel()
+
+	for name, content := range map[string]map[string]any{
+		"absent":     {},
+		"empty":      {"client_id": ""},
+		"whitespace": {"client_id": "   "},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var captured *gomcp.ElicitParams
+			transport := &oauthTransport{
+				baseURL: "https://mcp.example.test/mcp",
+				requestElicitation: clientCredsElicit(&captured, tools.ElicitationResult{
+					Action:  tools.ElicitationActionAccept,
+					Content: content,
+				}),
+			}
+
+			clientID, clientSecret, _, err := transport.resolveClientCredentials(
+				t.Context(), &AuthorizationServerMetadata{}, "https://example.test/cb")
+			require.Error(t, err)
+			assert.Empty(t, clientID)
+			assert.Empty(t, clientSecret)
+			assert.Contains(t, err.Error(), "client_id", "the error must mention the missing field")
+		})
+	}
+}
+
+// TestResolveClientCredentials_NoElicitationBridgeDefersAuth verifies the
+// no-handler behaviour: with no elicitation callback wired up the fallback
+// defers with the recognisable AuthorizationRequiredError (same contract as
+// requestElicitation), so a non-interactive startup probe doesn't hard-fail.
+func TestResolveClientCredentials_NoElicitationBridgeDefersAuth(t *testing.T) {
+	t.Parallel()
+
+	transport := &oauthTransport{baseURL: "https://mcp.example.test/mcp"}
+
+	clientID, clientSecret, _, err := transport.resolveClientCredentials(
+		t.Context(), &AuthorizationServerMetadata{}, "https://example.test/cb")
+	require.Error(t, err)
+	assert.Empty(t, clientID)
+	assert.Empty(t, clientSecret)
+	assert.True(t, IsAuthorizationRequired(err),
+		"a missing elicitation bridge must defer with AuthorizationRequiredError; got: %v", err)
+}
+
+// TestUnmanagedOAuthFlow_DriveFlow_NoDCR_UsesPromptedCredentials proves the
+// fallback end-to-end on the docker-agent-driven unmanaged flow: with no
+// registration endpoint advertised, the flow prompts for client
+// credentials, builds the authorize URL with them, and uses them for the
+// token exchange.
+func TestUnmanagedOAuthFlow_DriveFlow_NoDCR_UsesPromptedCredentials(t *testing.T) {
+	t.Parallel()
+
+	var tokenForm url.Values
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	mux.HandleFunc("/.well-known/oauth-protected-resource", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(protectedResourceMetadata{
+			Resource:             srv.URL,
+			AuthorizationServers: []string{srv.URL},
+		})
+	})
+	// Metadata WITHOUT a registration endpoint: DCR is unsupported.
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(AuthorizationServerMetadata{
+			Issuer:                srv.URL,
+			AuthorizationEndpoint: srv.URL + "/authorize",
+			TokenEndpoint:         srv.URL + "/token",
+		})
+	})
+	mux.HandleFunc("/.well-known/openid-configuration", http.NotFound)
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		tokenForm = r.Form
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"exchanged-at","token_type":"Bearer","expires_in":3600}`))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.Header().Set("WWW-Authenticate", `Bearer resource="`+srv.URL+`/.well-known/oauth-protected-resource"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+
+	const redirectURI = "https://example.test/oauth/cb"
+	capture := &elicitCaptured{}
+	var credsPrompted atomic.Int32
+	capture.replyFn = func(req *gomcp.ElicitParams) tools.ElicitationResult {
+		// First elicitation asks for client credentials, second runs the
+		// OAuth flow itself.
+		if req.Meta["docker-agent/type"] == "oauth_client_credentials" {
+			credsPrompted.Add(1)
+			return tools.ElicitationResult{
+				Action: tools.ElicitationActionAccept,
+				Content: map[string]any{
+					"client_id":     "user-client-id",
+					"client_secret": "user-secret",
+				},
+			}
+		}
+		state, _ := req.Meta["docker-agent/state"].(string)
+		authorizeURL, _ := req.Meta["docker-agent/authorize_url"].(string)
+		assert.Contains(t, authorizeURL, "client_id=user-client-id",
+			"the authorize URL must be built with the prompted client_id")
+		return tools.ElicitationResult{
+			Action:  tools.ElicitationActionAccept,
+			Content: map[string]any{"code": "abc", "state": state},
+		}
+	}
+	transport, client := newUnmanagedTestTransport(t, srv.URL, redirectURI, capture)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, strings.NewReader("{}"))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	assert.Equal(t, int32(1), credsPrompted.Load(), "the client-credentials form must be shown exactly once")
+	require.NotNil(t, tokenForm, "the token endpoint must have been hit")
+	assert.Equal(t, "user-client-id", tokenForm.Get("client_id"),
+		"the token exchange must use the prompted client_id")
+	assert.Equal(t, "user-secret", tokenForm.Get("client_secret"),
+		"the token exchange must use the prompted client_secret")
+
+	tok, err := client.tokenStore.GetToken(srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "user-client-id", tok.ClientID, "credentials must be stamped on the token for later refresh")
+	assert.Equal(t, "user-secret", tok.ClientSecret)
+}
+
+// TestManagedOAuthFlow_NoDCR_PromptsForCredentialsThenHonorsConsentDecline
+// drives handleManagedOAuthFlow directly against an httptest authorization
+// server whose metadata advertises no registration endpoint. The flow must
+// reach the client-credentials prompt fallback, then stop with the user's
+// decline of the subsequent authorization consent. The decline lands before
+// RequestAuthorizationCode, so no browser is ever launched, and the callback
+// server binds an ephemeral 127.0.0.1 port (oauthConfig is nil → port 0), so
+// the test needs no port coordination.
+func TestManagedOAuthFlow_NoDCR_PromptsForCredentialsThenHonorsConsentDecline(t *testing.T) {
+	t.Parallel()
+
+	var tokenCalls atomic.Int32
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	mux.HandleFunc("/.well-known/oauth-protected-resource", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(protectedResourceMetadata{
+			Resource:             srv.URL,
+			AuthorizationServers: []string{srv.URL},
+		})
+	})
+	// Metadata WITHOUT a registration endpoint: DCR is unsupported, so the
+	// flow must fall back to prompting for client credentials.
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(AuthorizationServerMetadata{
+			Issuer:                srv.URL,
+			AuthorizationEndpoint: srv.URL + "/authorize",
+			TokenEndpoint:         srv.URL + "/token",
+		})
+	})
+	mux.HandleFunc("/.well-known/openid-configuration", http.NotFound)
+	mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
+		tokenCalls.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+	})
+
+	// The flow is single-goroutine, so plain slice appends are safe here.
+	var elicitTypes []string
+	capture := &elicitCaptured{}
+	capture.replyFn = func(req *gomcp.ElicitParams) tools.ElicitationResult {
+		typ, _ := req.Meta["docker-agent/type"].(string)
+		elicitTypes = append(elicitTypes, typ)
+		if typ == "oauth_client_credentials" {
+			return tools.ElicitationResult{
+				Action: tools.ElicitationActionAccept,
+				Content: map[string]any{
+					"client_id":     "user-client-id",
+					"client_secret": "user-secret",
+				},
+			}
+		}
+		// The authorization consent that would otherwise open the browser.
+		return tools.ElicitationResult{Action: tools.ElicitationActionDecline}
+	}
+
+	store := NewInMemoryTokenStore()
+	transport := &oauthTransport{
+		base:               http.DefaultTransport,
+		requestElicitation: capture.handler,
+		tokenStore:         store,
+		baseURL:            srv.URL,
+		managed:            true,
+		oauthHTTPClient:    oauthHTTPClientForAllowPrivateIPs(true),
+	}
+
+	err := transport.handleManagedOAuthFlow(t.Context(), srv.URL, "")
+	require.EqualError(t, err, "user declined OAuth authorization")
+
+	assert.Equal(t, []string{"oauth_client_credentials", "oauth_flow"}, elicitTypes,
+		"the credentials fallback must run first, then the authorization consent")
+	assert.Equal(t, int32(0), tokenCalls.Load(),
+		"token endpoint must NOT be hit after the consent decline")
+	_, getErr := store.GetToken(srv.URL)
+	require.Error(t, getErr, "no token must be stored after a declined consent")
 }

--- a/pkg/tools/mcp/remote.go
+++ b/pkg/tools/mcp/remote.go
@@ -13,7 +13,9 @@ import (
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/httpclient"
+	"github.com/docker/docker-agent/pkg/js"
 	"github.com/docker/docker-agent/pkg/upstream"
 )
 
@@ -23,6 +25,7 @@ type remoteMCPClient struct {
 	url                       string
 	transportType             string
 	headers                   map[string]string
+	envExpander               *js.Expander // nil when no env provider was supplied
 	tokenStore                OAuthTokenStore
 	managed                   bool
 	unmanagedOAuthRedirectURI string
@@ -36,6 +39,7 @@ func newRemoteClient(
 	tokenStore OAuthTokenStore,
 	oauthConfig *latest.RemoteOAuthConfig,
 	allowPrivateIPs bool,
+	env environment.Provider,
 ) *remoteMCPClient {
 	slog.Debug("Creating remote MCP client",
 		"url", url,
@@ -48,11 +52,17 @@ func newRemoteClient(
 		tokenStore = NewInMemoryTokenStore()
 	}
 
+	var envExpander *js.Expander
+	if env != nil {
+		envExpander = js.NewJsExpander(env)
+	}
+
 	return &remoteMCPClient{
 		sessionClient:   sessionClient{serverAddress: sanitizeRemoteAddress(url)},
 		url:             url,
 		transportType:   transportType,
 		headers:         headers,
+		envExpander:     envExpander,
 		tokenStore:      tokenStore,
 		oauthConfig:     oauthConfig,
 		allowPrivateIPs: allowPrivateIPs,
@@ -201,8 +211,9 @@ func (c *remoteMCPClient) SetUnmanagedOAuthRedirectURI(uri string) {
 }
 
 // createHTTPClient creates an HTTP client with custom headers and OAuth support.
-// Header values may contain ${headers.NAME} placeholders that are resolved
-// at request time from upstream headers stored in the request context.
+// Header values may contain ${env.NAME} and ${headers.NAME} placeholders that
+// are resolved on every request (see expandHeaders), so dynamically-provided
+// values never go stale on a long-lived connection.
 //
 // The oauthTransport is returned alongside the client so callers can inspect
 // the most recent server-side failure (via lastServerError) when Connect()
@@ -223,13 +234,14 @@ func (c *remoteMCPClient) createHTTPClient() (*http.Client, *oauthTransport, err
 	// Then wrap with OAuth support
 	oauthT := &oauthTransport{
 		base:                      base,
-		client:                    c,
+		requestElicitation:        c.requestElicitation,
+		onOAuthSuccess:            c.oauthSuccess,
 		tokenStore:                c.tokenStore,
 		baseURL:                   c.url,
 		managed:                   c.managed,
 		unmanagedOAuthRedirectURI: c.unmanagedOAuthRedirectURI,
 		oauthConfig:               c.oauthConfig,
-		oauthHTTPClient:           oauthHTTPClientWithHeaders(c.url, c.headers, c.allowPrivateIPs),
+		oauthHTTPClient:           oauthHTTPClientWithHeaders(c.url, c.headers, c.allowPrivateIPs, c.expandHeaders),
 	}
 
 	// Persist cookies across requests
@@ -239,6 +251,23 @@ func (c *remoteMCPClient) createHTTPClient() (*http.Client, *oauthTransport, err
 		return nil, nil, fmt.Errorf("creating cookie jar: %w", err)
 	}
 	return &http.Client{Transport: httpclient.WrapWithOTel(oauthT), Jar: jar}, oauthT, nil
+}
+
+// expandHeaders resolves the configured header values for one outbound
+// request: ${env.X} placeholders first (via the toolset's environment
+// provider, when one was supplied), then ${headers.X} placeholders (via
+// upstream headers carried in ctx). Running once per request keeps
+// env-backed values (e.g. short-lived tokens from a dynamic provider)
+// fresh on a long-lived connection.
+//
+// Env expansion deliberately runs first, on the configured values only,
+// so untrusted upstream header values are never fed through the JS
+// expander. Placeholders that cannot be resolved are left as-is.
+func (c *remoteMCPClient) expandHeaders(ctx context.Context, headers map[string]string) map[string]string {
+	if c.envExpander != nil {
+		headers = c.envExpander.ExpandMap(ctx, headers)
+	}
+	return upstream.ResolveHeaders(ctx, headers)
 }
 
 func (c *remoteMCPClient) headerTransport() http.RoundTripper {
@@ -251,7 +280,7 @@ func (c *remoteMCPClient) headerTransport() http.RoundTripper {
 		base = t
 	}
 	if len(c.headers) > 0 {
-		return upstream.NewHeaderTransport(base, c.headers)
+		return upstream.NewHeaderTransportWithResolver(base, c.headers, c.expandHeaders)
 	}
 	return base
 }

--- a/pkg/tools/mcp/remote_test.go
+++ b/pkg/tools/mcp/remote_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -16,6 +17,8 @@ import (
 	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/upstream"
 )
 
 // TestSanitizeRemoteAddress verifies that URLs with embedded credentials
@@ -81,7 +84,7 @@ func TestRemoteClientCustomHeaders(t *testing.T) {
 		"Authorization": "Bearer custom-token",
 	}
 
-	client := newRemoteClient(server.URL, "sse", expectedHeaders, NewInMemoryTokenStore(), nil, false)
+	client := newRemoteClient(server.URL, "sse", expectedHeaders, NewInMemoryTokenStore(), nil, false, nil)
 
 	// Try to initialize (which will make the HTTP request)
 	// We don't care if it succeeds or fails, we just need it to make the request
@@ -130,7 +133,7 @@ func TestRemoteClientHeadersWithStreamable(t *testing.T) {
 		"X-Custom-Auth": "custom-auth-value",
 	}
 
-	client := newRemoteClient(server.URL, "streamable", expectedHeaders, NewInMemoryTokenStore(), nil, false)
+	client := newRemoteClient(server.URL, "streamable", expectedHeaders, NewInMemoryTokenStore(), nil, false, nil)
 
 	// Try to initialize
 	_, _ = client.Initialize(t.Context(), nil)
@@ -170,7 +173,7 @@ func TestRemoteClientNoHeaders(t *testing.T) {
 	defer server.Close()
 
 	// Create remote client without custom headers (nil)
-	client := newRemoteClient(server.URL, "sse", nil, NewInMemoryTokenStore(), nil, false)
+	client := newRemoteClient(server.URL, "sse", nil, NewInMemoryTokenStore(), nil, false, nil)
 
 	_, _ = client.Initialize(t.Context(), nil)
 
@@ -206,7 +209,7 @@ func TestRemoteClientEmptyHeaders(t *testing.T) {
 	defer server.Close()
 
 	// Create remote client with empty headers map
-	client := newRemoteClient(server.URL, "sse", map[string]string{}, NewInMemoryTokenStore(), nil, false)
+	client := newRemoteClient(server.URL, "sse", map[string]string{}, NewInMemoryTokenStore(), nil, false, nil)
 
 	_, _ = client.Initialize(t.Context(), nil)
 
@@ -247,7 +250,7 @@ func TestOAuthHTTPClientWithHeaders_ScopesHeadersToMCPHost(t *testing.T) {
 	defer thirdParty.Close()
 
 	headers := map[string]string{"X-Grafana-URL": "https://instance.grafana.net/"}
-	client := oauthHTTPClientWithHeaders(mcpServer.URL, headers, true)
+	client := oauthHTTPClientWithHeaders(mcpServer.URL, headers, true, nil)
 
 	mcpReq, err := http.NewRequestWithContext(t.Context(), http.MethodGet, mcpServer.URL, http.NoBody)
 	require.NoError(t, err)
@@ -274,7 +277,7 @@ func TestOAuthHTTPClientWithHeaders_ScopesHeadersToMCPHost(t *testing.T) {
 func TestOAuthHTTPClientWithHeaders_NoHeadersReusesBaseClient(t *testing.T) {
 	t.Parallel()
 
-	got := oauthHTTPClientWithHeaders("https://mcp.example.com/mcp", nil, false)
+	got := oauthHTTPClientWithHeaders("https://mcp.example.com/mcp", nil, false, nil)
 	assert.Same(t, oauthHTTPClientForAllowPrivateIPs(false), got,
 		"with no headers the helper must return the base OAuth client unchanged")
 }
@@ -310,7 +313,7 @@ func TestInitialize_SurfacesServerErrorInReturnedError(t *testing.T) {
 	store := NewInMemoryTokenStore()
 	require.NoError(t, store.StoreToken(server.URL, &OAuthToken{AccessToken: "at", TokenType: "Bearer"}))
 
-	client := newRemoteClient(server.URL, "streamable", nil, store, nil, false)
+	client := newRemoteClient(server.URL, "streamable", nil, store, nil, false, nil)
 
 	_, err := client.Initialize(t.Context(), nil)
 	require.Error(t, err, "Initialize should fail against a server that rejects initialize")
@@ -342,7 +345,7 @@ func TestInitialize_NonInteractiveCtxDefersOAuthAndDoesNotBlock(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := newRemoteClient(server.URL, "streamable", nil, NewInMemoryTokenStore(), nil, false)
+	client := newRemoteClient(server.URL, "streamable", nil, NewInMemoryTokenStore(), nil, false, nil)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
@@ -417,7 +420,7 @@ func TestInitialize_OAuthDefersWhenElicitationBridgeNotReady(t *testing.T) {
 	// flow runs. That path reaches requestElicitation without needing
 	// dynamic client registration, which keeps the test focused on the
 	// bridge-not-ready behaviour.
-	client := newRemoteClient(srv.URL, "streamable", nil, NewInMemoryTokenStore(), nil, false)
+	client := newRemoteClient(srv.URL, "streamable", nil, NewInMemoryTokenStore(), nil, false, nil)
 
 	// Plain interactive ctx (no WithoutInteractivePrompts marker). The
 	// elicitation handler is intentionally not wired up.
@@ -467,7 +470,7 @@ func TestCreateHTTPClient_PersistsCookies(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := newRemoteClient(server.URL, "streamable", nil, NewInMemoryTokenStore(), nil, false)
+	client := newRemoteClient(server.URL, "streamable", nil, NewInMemoryTokenStore(), nil, false, nil)
 	httpClient, _, err := client.createHTTPClient()
 	require.NoError(t, err)
 	require.NotNil(t, httpClient.Jar, "createHTTPClient must attach a cookie jar so sticky sessions stick")
@@ -524,7 +527,7 @@ func TestRemoteClientUnixSocket(t *testing.T) {
 	go func() { _ = httpServer.Serve(ln) }()
 	t.Cleanup(func() { _ = httpServer.Close() })
 
-	client := newRemoteClient("unix://"+sockPath, "streamable", nil, NewInMemoryTokenStore(), nil, false)
+	client := newRemoteClient("unix://"+sockPath, "streamable", nil, NewInMemoryTokenStore(), nil, false, nil)
 	_, err = client.Initialize(t.Context(), nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = client.Close(context.WithoutCancel(t.Context())) })
@@ -535,4 +538,274 @@ func TestRemoteClientUnixSocket(t *testing.T) {
 		names = append(names, tool.Name)
 	}
 	assert.Equal(t, []string{"ping"}, names)
+}
+
+// mutableEnvProvider is a context-aware, mutable environment.Provider for
+// tests that need to change a value between two requests on the same
+// connection.
+type mutableEnvProvider struct {
+	mu   sync.Mutex
+	vals map[string]string
+}
+
+func (p *mutableEnvProvider) Get(_ context.Context, name string) (string, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	v, ok := p.vals[name]
+	return v, ok
+}
+
+func (p *mutableEnvProvider) set(name, value string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.vals[name] = value
+}
+
+// headerCaptureMCPServer runs a real streamable MCP server behind a
+// middleware that records the headers of every request it serves.
+type headerCaptureMCPServer struct {
+	*httptest.Server
+
+	mu       sync.Mutex
+	captured []http.Header
+}
+
+func newHeaderCaptureMCPServer(t *testing.T) *headerCaptureMCPServer {
+	t.Helper()
+
+	server := gomcp.NewServer(&gomcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+	gomcp.AddTool(server, &gomcp.Tool{Name: "ping", Description: "ping"}, func(context.Context, *gomcp.CallToolRequest, struct{}) (*gomcp.CallToolResult, struct{}, error) {
+		return &gomcp.CallToolResult{Content: []gomcp.Content{&gomcp.TextContent{Text: "pong"}}}, struct{}{}, nil
+	})
+
+	srv := &headerCaptureMCPServer{}
+	inner := gomcp.NewStreamableHTTPHandler(func(*http.Request) *gomcp.Server { return server }, nil)
+	srv.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srv.mu.Lock()
+		srv.captured = append(srv.captured, r.Header.Clone())
+		srv.mu.Unlock()
+		inner.ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// snapshot returns the number of requests captured so far.
+func (s *headerCaptureMCPServer) snapshot() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.captured)
+}
+
+// valuesSince returns the given header's value for every request captured
+// after the from snapshot.
+func (s *headerCaptureMCPServer) valuesSince(from int, header string) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []string
+	for _, h := range s.captured[from:] {
+		out = append(out, h.Get(header))
+	}
+	return out
+}
+
+// TestRemoteClient_ExpandsEnvHeadersPerRequest is the stale-token regression
+// test: a configured header referencing ${env.X} must be re-expanded on every
+// HTTP request of a live connection (same long-lived http.Client/transport),
+// so a value rotated in the environment provider between two requests is
+// picked up without a reconnect.
+func TestRemoteClient_ExpandsEnvHeadersPerRequest(t *testing.T) {
+	t.Parallel()
+
+	srv := newHeaderCaptureMCPServer(t)
+
+	env := &mutableEnvProvider{vals: map[string]string{"TOKEN": "token-1"}}
+	headers := map[string]string{"X-Env-Token": "${env.TOKEN}"}
+	client := newRemoteClient(srv.URL, "streamable", headers, NewInMemoryTokenStore(), nil, false, env)
+
+	_, err := client.Initialize(t.Context(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close(context.WithoutCancel(t.Context())) })
+
+	listTools := func() {
+		t.Helper()
+		for _, err := range client.ListTools(t.Context(), nil) {
+			require.NoError(t, err)
+		}
+	}
+
+	listTools()
+	before := srv.snapshot()
+	require.Positive(t, before, "server should have seen the initialize + tools/list requests")
+	for _, v := range srv.valuesSince(0, "X-Env-Token") {
+		assert.Equal(t, "token-1", v, "every request before the rotation must carry the initial env value")
+	}
+
+	// Rotate the env-backed value; the SAME live connection must pick it up.
+	env.set("TOKEN", "token-2")
+	listTools()
+
+	values := srv.valuesSince(before, "X-Env-Token")
+	require.NotEmpty(t, values, "second tools/list must reach the server")
+	for _, v := range values {
+		assert.Equal(t, "token-2", v, "requests after the env rotation must carry the fresh value, not the stale one")
+	}
+}
+
+// TestRemoteClient_ResolvesUpstreamHeaderPlaceholdersPerRequest verifies the
+// pre-existing ${headers.X} contract still holds alongside env expansion:
+// values are resolved per request from the upstream headers carried in the
+// request context, so two calls with different contexts produce different
+// outbound headers on the same connection.
+func TestRemoteClient_ResolvesUpstreamHeaderPlaceholdersPerRequest(t *testing.T) {
+	t.Parallel()
+
+	srv := newHeaderCaptureMCPServer(t)
+
+	env := &mutableEnvProvider{vals: map[string]string{"TOKEN": "env-tok"}}
+	headers := map[string]string{
+		"Authorization": "${headers.Authorization}",
+		"X-Env-Token":   "${env.TOKEN}",
+	}
+	client := newRemoteClient(srv.URL, "streamable", headers, NewInMemoryTokenStore(), nil, false, env)
+
+	_, err := client.Initialize(t.Context(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close(context.WithoutCancel(t.Context())) })
+
+	listTools := func(ctx context.Context) {
+		t.Helper()
+		for _, err := range client.ListTools(ctx, nil) {
+			require.NoError(t, err)
+		}
+	}
+
+	up1 := http.Header{}
+	up1.Set("Authorization", "Bearer upstream-1")
+	before := srv.snapshot()
+	listTools(upstream.WithHeaders(t.Context(), up1))
+	for _, v := range srv.valuesSince(before, "Authorization") {
+		assert.Equal(t, "Bearer upstream-1", v, "first call must carry the first upstream Authorization")
+	}
+
+	up2 := http.Header{}
+	up2.Set("Authorization", "Bearer upstream-2")
+	before = srv.snapshot()
+	listTools(upstream.WithHeaders(t.Context(), up2))
+	values := srv.valuesSince(before, "Authorization")
+	require.NotEmpty(t, values)
+	for _, v := range values {
+		assert.Equal(t, "Bearer upstream-2", v, "second call must carry the second upstream Authorization")
+	}
+	// Env expansion applies on the same requests too.
+	for _, v := range srv.valuesSince(before, "X-Env-Token") {
+		assert.Equal(t, "env-tok", v)
+	}
+}
+
+// TestRemoteClient_ExpandsMixedEnvAndUpstreamPlaceholdersInOneValue covers a
+// single configured value mixing both placeholder kinds: phase one resolves
+// ${env.X} and leaves ${headers.Y} untouched, phase two fills it from the
+// upstream headers in the request context. Both phases run per request on
+// the same connection, so rotating either source shows up on the next call.
+func TestRemoteClient_ExpandsMixedEnvAndUpstreamPlaceholdersInOneValue(t *testing.T) {
+	t.Parallel()
+
+	srv := newHeaderCaptureMCPServer(t)
+
+	env := &mutableEnvProvider{vals: map[string]string{"SCHEME": "Env"}}
+	headers := map[string]string{"X-Combined": "${env.SCHEME} ${headers.X-Upstream-Token}"}
+	client := newRemoteClient(srv.URL, "streamable", headers, NewInMemoryTokenStore(), nil, false, env)
+
+	_, err := client.Initialize(t.Context(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close(context.WithoutCancel(t.Context())) })
+
+	listTools := func(ctx context.Context) {
+		t.Helper()
+		for _, err := range client.ListTools(ctx, nil) {
+			require.NoError(t, err)
+		}
+	}
+
+	up1 := http.Header{}
+	up1.Set("X-Upstream-Token", "upstream-1")
+	before := srv.snapshot()
+	listTools(upstream.WithHeaders(t.Context(), up1))
+	values := srv.valuesSince(before, "X-Combined")
+	require.NotEmpty(t, values)
+	for _, v := range values {
+		assert.Equal(t, "Env upstream-1", v,
+			"both placeholder kinds in one value must resolve to the combined outbound value")
+	}
+
+	// Rotate both sources; the SAME live connection must combine the fresh
+	// values on the next request.
+	env.set("SCHEME", "Env2")
+	up2 := http.Header{}
+	up2.Set("X-Upstream-Token", "upstream-2")
+	before = srv.snapshot()
+	listTools(upstream.WithHeaders(t.Context(), up2))
+	values = srv.valuesSince(before, "X-Combined")
+	require.NotEmpty(t, values)
+	for _, v := range values {
+		assert.Equal(t, "Env2 upstream-2", v,
+			"the mixed value must be re-expanded per request from both sources")
+	}
+}
+
+// TestOAuthHTTPClientWithHeaders_ResolverKeepsEnvHeadersFreshAndHostScoped
+// verifies the OAuth channel gets the same per-request dynamic expansion as
+// the main channel — a rotated ${env.X} value reaches the next same-host
+// OAuth request — while custom headers still never leak to a third-party
+// authorization-server host.
+func TestOAuthHTTPClientWithHeaders_ResolverKeepsEnvHeadersFreshAndHostScoped(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var mcpHostValues []string
+	mcpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		mcpHostValues = append(mcpHostValues, r.Header.Get("X-Env-Header"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mcpServer.Close()
+
+	var thirdPartyHeader atomic.Value
+	thirdParty := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		thirdPartyHeader.Store(r.Header.Get("X-Env-Header"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer thirdParty.Close()
+
+	env := &mutableEnvProvider{vals: map[string]string{"SECRET": "secret-1"}}
+	headers := map[string]string{"X-Env-Header": "${env.SECRET}"}
+	// Same wiring as remote.go createHTTPClient: the remote client's
+	// expandHeaders is the per-request resolver for the OAuth channel.
+	mcpClient := newRemoteClient(mcpServer.URL, "streamable", headers, NewInMemoryTokenStore(), nil, true, env)
+	client := oauthHTTPClientWithHeaders(mcpServer.URL, headers, true, mcpClient.expandHeaders)
+
+	get := func(url string) {
+		t.Helper()
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, http.NoBody)
+		require.NoError(t, err)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+	}
+
+	get(mcpServer.URL)
+	env.set("SECRET", "secret-2")
+	get(mcpServer.URL)
+
+	mu.Lock()
+	assert.Equal(t, []string{"secret-1", "secret-2"}, mcpHostValues,
+		"same-host OAuth requests must re-expand env-backed headers per request")
+	mu.Unlock()
+
+	get(thirdParty.URL)
+	v, _ := thirdPartyHeader.Load().(string)
+	assert.Empty(t, v,
+		"requests to a third-party host must NOT carry the configured header even with a resolver (credential-leak guard)")
 }

--- a/pkg/upstream/headers.go
+++ b/pkg/upstream/headers.go
@@ -34,22 +34,40 @@ func Handler(next http.Handler) http.Handler {
 	})
 }
 
+// HeaderResolver resolves configured header values into the final values to
+// set on an outbound request. It is invoked once per request with the
+// request's context, so implementations can consult dynamic sources (e.g.
+// upstream headers stored in the context, or environment providers backed
+// by rotating credentials) without going stale on long-lived connections.
+type HeaderResolver func(ctx context.Context, headers map[string]string) map[string]string
+
 // NewHeaderTransport wraps an http.RoundTripper to set custom headers on
 // every outbound request. Header values may contain ${headers.NAME}
 // placeholders that are resolved at request time from upstream headers
 // stored in the request context.
 func NewHeaderTransport(base http.RoundTripper, headers map[string]string) http.RoundTripper {
-	return &headerTransport{base: base, headers: headers}
+	return NewHeaderTransportWithResolver(base, headers, nil)
+}
+
+// NewHeaderTransportWithResolver is like NewHeaderTransport but resolves the
+// header values through resolve on every request. A nil resolve falls back
+// to ResolveHeaders (i.e. ${headers.NAME} placeholder resolution only).
+func NewHeaderTransportWithResolver(base http.RoundTripper, headers map[string]string, resolve HeaderResolver) http.RoundTripper {
+	if resolve == nil {
+		resolve = ResolveHeaders
+	}
+	return &headerTransport{base: base, headers: headers, resolve: resolve}
 }
 
 type headerTransport struct {
 	base    http.RoundTripper
 	headers map[string]string
+	resolve HeaderResolver
 }
 
 func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
-	for key, value := range ResolveHeaders(req.Context(), t.headers) {
+	for key, value := range t.resolve(req.Context(), t.headers) {
 		req.Header.Set(key, value)
 	}
 	return t.base.RoundTrip(req)

--- a/pkg/upstream/headers_test.go
+++ b/pkg/upstream/headers_test.go
@@ -1,6 +1,8 @@
 package upstream
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -135,4 +137,67 @@ func TestResolveHeaders_NoUpstreamContext(t *testing.T) {
 	// No upstream headers in context — placeholders are left as-is.
 	got := ResolveHeaders(t.Context(), headers)
 	assert.Equal(t, headers, got)
+}
+
+// captureTransport is a stub RoundTripper that records the headers of each
+// request it receives.
+type captureTransport struct {
+	seen []http.Header
+}
+
+func (c *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.seen = append(c.seen, req.Header.Clone())
+	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Request: req}, nil
+}
+
+func TestNewHeaderTransport_ResolvesFromContextPerRequest(t *testing.T) {
+	t.Parallel()
+
+	capture := &captureTransport{}
+	transport := NewHeaderTransport(capture, map[string]string{"Authorization": "${headers.Authorization}"})
+
+	do := func(ctx context.Context) {
+		req := httptest.NewRequestWithContext(ctx, http.MethodGet, "http://example.test/", http.NoBody)
+		resp, err := transport.RoundTrip(req)
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+	}
+
+	up1 := http.Header{}
+	up1.Set("Authorization", "Bearer one")
+	do(WithHeaders(t.Context(), up1))
+
+	up2 := http.Header{}
+	up2.Set("Authorization", "Bearer two")
+	do(WithHeaders(t.Context(), up2))
+
+	require.Len(t, capture.seen, 2)
+	assert.Equal(t, "Bearer one", capture.seen[0].Get("Authorization"))
+	assert.Equal(t, "Bearer two", capture.seen[1].Get("Authorization"),
+		"each request must resolve against its own context, not a cached value")
+}
+
+func TestNewHeaderTransportWithResolver_InvokedPerRequest(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	resolve := func(_ context.Context, headers map[string]string) map[string]string {
+		calls++
+		return map[string]string{"X-Call": fmt.Sprintf("%s-%d", headers["X-Call"], calls)}
+	}
+
+	capture := &captureTransport{}
+	transport := NewHeaderTransportWithResolver(capture, map[string]string{"X-Call": "req"}, resolve)
+
+	for range 2 {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.test/", http.NoBody)
+		resp, err := transport.RoundTrip(req)
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+	}
+
+	require.Len(t, capture.seen, 2)
+	assert.Equal(t, "req-1", capture.seen[0].Get("X-Call"))
+	assert.Equal(t, "req-2", capture.seen[1].Get("X-Call"),
+		"the resolver must run on every request so dynamic values stay fresh")
 }


### PR DESCRIPTION
## Summary

- expand remote MCP `${env.*}` and `${headers.*}` header templates on every HTTP request
- preserve same-host scoping for custom headers used by OAuth discovery and token operations
- decouple the OAuth transport from the concrete remote MCP client
- request pre-registered OAuth client credentials when dynamic client registration is unavailable or fails
- remove the obsolete initialization-notification retry inherited from the retired MCP SDK

## Issue expectations

| Expectation | Implementation |
|---|---|
| Resolve the OAuth elicitation client reference TODO | Injected elicitation and OAuth-success callbacks into `oauthTransport` |
| Add a fallback when no client ID is available | Added form elicitation for required `client_id` and optional masked `client_secret` |
| Expand headers per request | Added a per-request resolver for environment and upstream-header placeholders on live connections |
| Resolve the temporary async-init retry | Removed the dead retry tied to the former `mark3labs/mcp-go` error string |
| Add tests where feasible | Added managed and unmanaged OAuth fallback tests, live-connection token rotation tests, mixed-placeholder tests, host-scope tests, and race coverage |

## Validation

- `task build`
- `task lint`
- `task test`
- `go test -race -count=1 ./pkg/tools/mcp ./pkg/upstream ./pkg/js`

`task test` was run with inherited HTTP proxy variables unset because the local proxy intercepts private-address requests and invalidates the repository's SSRF rejection tests.

Closes #3601
