### PR TITLE
test: raise input and protocol package coverage

### DIFF
--- a/pkg/a2a/adapter_run_test.go
+++ b/pkg/a2a/adapter_run_test.go
@@ -1,0 +1,392 @@
+package a2a
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/adk/agent"
+	adksession "google.golang.org/adk/session"
+	"google.golang.org/genai"
+
+	dagent "github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/model/provider"
+	"github.com/docker/docker-agent/pkg/model/provider/base"
+	"github.com/docker/docker-agent/pkg/modelsdev"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/team"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// mockStream replays a fixed sequence of completion chunks.
+type mockStream struct {
+	responses []chat.MessageStreamResponse
+	idx       int
+}
+
+func (m *mockStream) Recv() (chat.MessageStreamResponse, error) {
+	if m.idx >= len(m.responses) {
+		return chat.MessageStreamResponse{}, io.EOF
+	}
+	resp := m.responses[m.idx]
+	m.idx++
+	return resp, nil
+}
+
+func (m *mockStream) Close() {}
+
+// mockProvider returns a predetermined stream, or err when set.
+type mockProvider struct {
+	id     modelsdev.ID
+	stream chat.MessageStream
+	err    error
+}
+
+func (m *mockProvider) ID() modelsdev.ID { return m.id }
+
+func (m *mockProvider) CreateChatCompletionStream(context.Context, []chat.Message, []tools.Tool) (chat.MessageStream, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.stream, nil
+}
+
+func (m *mockProvider) BaseConfig() base.Config { return base.Config{} }
+
+func (m *mockProvider) MaxTokens() int { return 0 }
+
+// newMockTeam builds a single-agent team whose model streams the given
+// content chunks followed by a terminal stop.
+func newMockTeam(chunks ...string) (*team.Team, *dagent.Agent) {
+	responses := make([]chat.MessageStreamResponse, 0, len(chunks)+1)
+	for _, chunk := range chunks {
+		responses = append(responses, chat.MessageStreamResponse{
+			Choices: []chat.MessageStreamChoice{{
+				Index: 0,
+				Delta: chat.MessageDelta{Content: chunk},
+			}},
+		})
+	}
+	responses = append(responses, chat.MessageStreamResponse{
+		Choices: []chat.MessageStreamChoice{{
+			Index:        0,
+			FinishReason: chat.FinishReasonStop,
+		}},
+		Usage: &chat.Usage{InputTokens: 3, OutputTokens: 7},
+	})
+	prov := &mockProvider{
+		id:     modelsdev.NewID("test", "mock-model"),
+		stream: &mockStream{responses: responses},
+	}
+	return newTeamWithProvider(prov)
+}
+
+func newTeamWithProvider(prov provider.Provider) (*team.Team, *dagent.Agent) {
+	root := dagent.New("root", "You are a test agent", dagent.WithModel(prov))
+	return team.New(team.WithAgents(root)), root
+}
+
+// fakeADKSession implements the ADK session interface; only ID matters
+// to runDockerAgent.
+type fakeADKSession struct{ id string }
+
+func (s fakeADKSession) ID() string                { return s.id }
+func (s fakeADKSession) AppName() string           { return "test-app" }
+func (s fakeADKSession) UserID() string            { return "test-user" }
+func (s fakeADKSession) State() adksession.State   { return nil }
+func (s fakeADKSession) Events() adksession.Events { return nil }
+func (s fakeADKSession) LastUpdateTime() time.Time { return time.Time{} }
+
+// fakeInvocationContext implements agent.InvocationContext with the minimal
+// behavior runDockerAgent relies on: the embedded context, Session().ID(),
+// UserContent(), and Ended().
+type fakeInvocationContext struct {
+	context.Context //nolint:containedctx // agent.InvocationContext embeds context.Context
+
+	sess        adksession.Session
+	userContent *genai.Content
+	ended       *atomic.Bool
+}
+
+func newFakeInvocationContext(ctx context.Context, sessionID, userMessage string) *fakeInvocationContext {
+	return &fakeInvocationContext{
+		Context:     ctx,
+		sess:        fakeADKSession{id: sessionID},
+		userContent: genai.NewContentFromText(userMessage, genai.RoleUser),
+		ended:       &atomic.Bool{},
+	}
+}
+
+func (c *fakeInvocationContext) Agent() agent.Agent          { return nil }
+func (c *fakeInvocationContext) Artifacts() agent.Artifacts  { return nil }
+func (c *fakeInvocationContext) Memory() agent.Memory        { return nil }
+func (c *fakeInvocationContext) Session() adksession.Session { return c.sess }
+func (c *fakeInvocationContext) InvocationID() string        { return "test-invocation" }
+func (c *fakeInvocationContext) Branch() string              { return "" }
+func (c *fakeInvocationContext) UserContent() *genai.Content { return c.userContent }
+func (c *fakeInvocationContext) RunConfig() *agent.RunConfig { return nil }
+func (c *fakeInvocationContext) EndInvocation()              { c.ended.Store(true) }
+func (c *fakeInvocationContext) Ended() bool                 { return c.ended.Load() }
+
+func (c *fakeInvocationContext) WithContext(ctx context.Context) agent.InvocationContext {
+	return &fakeInvocationContext{
+		Context:     ctx,
+		sess:        c.sess,
+		userContent: c.userContent,
+		ended:       c.ended,
+	}
+}
+
+// recordingStore captures the live *session.Session pointers the runtime
+// persists via UpdateSession (fired on run start), so tests can inspect the
+// session runDockerAgent built or resumed, including fields the in-memory
+// store does not persist (e.g. NonInteractive).
+type recordingStore struct {
+	session.Store
+
+	mu      sync.Mutex
+	updated []*session.Session
+}
+
+func newRecordingStore() *recordingStore {
+	return &recordingStore{Store: session.NewInMemorySessionStore()}
+}
+
+func (s *recordingStore) UpdateSession(ctx context.Context, sess *session.Session) error {
+	s.mu.Lock()
+	s.updated = append(s.updated, sess)
+	s.mu.Unlock()
+	return s.Store.UpdateSession(ctx, sess)
+}
+
+func (s *recordingStore) updatedSessions() []*session.Session {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.updated)
+}
+
+type yieldedEvent struct {
+	event *adksession.Event
+	err   error
+}
+
+func collectRunEvents(ctx agent.InvocationContext, tm *team.Team, a *dagent.Agent, store session.Store) []yieldedEvent {
+	var out []yieldedEvent
+	for ev, err := range runDockerAgent(ctx, tm, a.Name(), a, store) {
+		out = append(out, yieldedEvent{event: ev, err: err})
+	}
+	return out
+}
+
+func eventText(t *testing.T, ev *adksession.Event) string {
+	t.Helper()
+
+	require.NotNil(t, ev)
+	require.NotNil(t, ev.Content)
+	require.Len(t, ev.Content.Parts, 1)
+	return ev.Content.Parts[0].Text
+}
+
+func TestRunDockerAgent_StreamsPartialAndFinalEvents(t *testing.T) {
+	t.Parallel()
+
+	tm, root := newMockTeam("Hello, ", "world!")
+	store := session.NewInMemorySessionStore()
+	ctx := newFakeInvocationContext(t.Context(), "a2a-ctx-events", "Hi there")
+
+	events := collectRunEvents(ctx, tm, root, store)
+
+	require.Len(t, events, 3)
+	for _, e := range events {
+		require.NoError(t, e.err)
+	}
+
+	first := events[0].event
+	assert.Equal(t, "root", first.Author)
+	assert.True(t, first.Partial)
+	assert.False(t, first.TurnComplete)
+	assert.Equal(t, genai.RoleModel, first.Content.Role)
+	assert.Equal(t, "Hello, ", eventText(t, first))
+
+	second := events[1].event
+	assert.True(t, second.Partial)
+	assert.Equal(t, "world!", eventText(t, second))
+
+	final := events[2].event
+	assert.Equal(t, "root", final.Author)
+	assert.False(t, final.Partial)
+	assert.True(t, final.TurnComplete)
+	assert.Equal(t, genai.FinishReasonStop, final.FinishReason)
+	assert.Equal(t, genai.RoleModel, final.Content.Role)
+	assert.Equal(t, "Hello, world!", eventText(t, final))
+}
+
+func TestRunDockerAgent_ErrorEventStopsIteration(t *testing.T) {
+	t.Parallel()
+
+	prov := &mockProvider{
+		id:  modelsdev.NewID("test", "mock-model"),
+		err: errors.New("simulated stream failure"),
+	}
+	tm, root := newTeamWithProvider(prov)
+	store := session.NewInMemorySessionStore()
+	ctx := newFakeInvocationContext(t.Context(), "a2a-ctx-error", "Hi")
+
+	events := collectRunEvents(ctx, tm, root, store)
+
+	require.Len(t, events, 1)
+	assert.Nil(t, events[0].event)
+	require.Error(t, events[0].err)
+	assert.Contains(t, events[0].err.Error(), "simulated stream failure")
+}
+
+// An empty stream (stop without content) currently produces no final event:
+// the StreamStopped branch only yields when content was accumulated.
+func TestRunDockerAgent_EmptyStreamEmitsNoFinalEvent(t *testing.T) {
+	t.Parallel()
+
+	tm, root := newMockTeam()
+	store := session.NewInMemorySessionStore()
+	ctx := newFakeInvocationContext(t.Context(), "a2a-ctx-empty", "Hi")
+
+	events := collectRunEvents(ctx, tm, root, store)
+
+	assert.Empty(t, events)
+}
+
+func TestRunDockerAgent_ConsumerStopsEarly(t *testing.T) {
+	t.Parallel()
+
+	tm, root := newMockTeam("first", "second")
+	store := session.NewInMemorySessionStore()
+	ctx := newFakeInvocationContext(t.Context(), "a2a-ctx-early-stop", "Hi")
+
+	var events []*adksession.Event
+	for ev, err := range runDockerAgent(ctx, tm, root.Name(), root, store) {
+		require.NoError(t, err)
+		events = append(events, ev)
+		break
+	}
+
+	require.Len(t, events, 1)
+	assert.True(t, events[0].Partial)
+	assert.Equal(t, "first", eventText(t, events[0]))
+}
+
+func TestRunDockerAgent_EndedInvocationStopsIteration(t *testing.T) {
+	t.Parallel()
+
+	tm, root := newMockTeam("first", "second")
+	store := session.NewInMemorySessionStore()
+	ctx := newFakeInvocationContext(t.Context(), "a2a-ctx-ended", "Hi")
+
+	var events []*adksession.Event
+	for ev, err := range runDockerAgent(ctx, tm, root.Name(), root, store) {
+		require.NoError(t, err)
+		events = append(events, ev)
+		// Ending the invocation after the first chunk must stop the
+		// adapter before it yields the second chunk or a final event.
+		ctx.EndInvocation()
+	}
+
+	require.Len(t, events, 1)
+	assert.Equal(t, "first", eventText(t, events[0]))
+}
+
+func TestRunDockerAgent_NewSessionUsesA2ASettings(t *testing.T) {
+	t.Parallel()
+
+	tm, root := newMockTeam("answer")
+	store := newRecordingStore()
+	ctx := newFakeInvocationContext(t.Context(), "a2a-ctx-new", "What is Docker?")
+
+	events := collectRunEvents(ctx, tm, root, store)
+	require.Len(t, events, 2)
+
+	updated := store.updatedSessions()
+	require.NotEmpty(t, updated)
+	sess := updated[0]
+
+	assert.Equal(t, "a2a-ctx-new", sess.ID)
+	assert.Equal(t, "A2A Session a2a-ctx-new", sess.Title)
+	assert.True(t, sess.ToolsApproved)
+	assert.True(t, sess.NonInteractive)
+
+	// runDockerAgent stamps new sessions with the process working directory
+	// via os.Getwd, so this assertion resolves the same value and relies on
+	// nothing in the test process changing directories.
+	workingDir, err := os.Getwd()
+	require.NoError(t, err)
+	assert.Equal(t, workingDir, sess.WorkingDir)
+
+	msgs := sess.GetAllMessages()
+	require.NotEmpty(t, msgs)
+	assert.Equal(t, chat.MessageRoleUser, msgs[0].Message.Role)
+	assert.Equal(t, "What is Docker?", msgs[0].Message.Content)
+
+	stored, err := store.GetSession(t.Context(), "a2a-ctx-new")
+	require.NoError(t, err)
+	assert.Equal(t, "a2a-ctx-new", stored.ID)
+	assert.Equal(t, "A2A Session a2a-ctx-new", stored.Title)
+}
+
+func TestRunDockerAgent_ResumesExistingSession(t *testing.T) {
+	t.Parallel()
+
+	tm, root := newMockTeam("resumed answer")
+	store := newRecordingStore()
+
+	existing := session.New(session.WithID("a2a-ctx-resume"), session.WithTitle("Existing Title"))
+	require.NoError(t, store.AddSession(t.Context(), existing))
+
+	ctx := newFakeInvocationContext(t.Context(), "a2a-ctx-resume", "follow-up question")
+
+	events := collectRunEvents(ctx, tm, root, store)
+	require.Len(t, events, 2)
+
+	updated := store.updatedSessions()
+	require.NotEmpty(t, updated)
+	assert.Same(t, existing, updated[0], "the stored session should be resumed, not recreated")
+
+	assert.Equal(t, "Existing Title", existing.Title)
+	assert.True(t, existing.ToolsApproved)
+	assert.True(t, existing.NonInteractive)
+
+	msgs := existing.GetAllMessages()
+	require.NotEmpty(t, msgs)
+	assert.Equal(t, chat.MessageRoleUser, msgs[0].Message.Role)
+	assert.Equal(t, "follow-up question", msgs[0].Message.Content)
+
+	final := events[1].event
+	assert.True(t, final.TurnComplete)
+	assert.Equal(t, "resumed answer", eventText(t, final))
+}
+
+func TestRunDockerAgent_RuntimeCreationError(t *testing.T) {
+	t.Parallel()
+
+	// The agent is deliberately not part of the team: runDockerAgent only
+	// reads session limits from the agent argument before building the
+	// runtime, while runtime.New consults the team alone — and fails here
+	// because the empty team has no default agent.
+	root := dagent.New("root", "You are a test agent")
+	emptyTeam := team.New()
+	store := session.NewInMemorySessionStore()
+	ctx := newFakeInvocationContext(t.Context(), "a2a-ctx-no-team", "Hi")
+
+	events := collectRunEvents(ctx, emptyTeam, root, store)
+
+	require.Len(t, events, 1)
+	assert.Nil(t, events[0].event)
+	require.Error(t, events[0].err)
+	assert.Contains(t, events[0].err.Error(), "failed to create runtime")
+}

--- a/pkg/acp/runagent_test.go
+++ b/pkg/acp/runagent_test.go
@@ -1,0 +1,925 @@
+package acp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/effort"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/sessiontitle"
+	"github.com/docker/docker-agent/pkg/tools"
+	skillstool "github.com/docker/docker-agent/pkg/tools/builtin/skills"
+	"github.com/docker/docker-agent/pkg/tools/builtin/todo"
+	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
+)
+
+const testSessionID = "acp-test-session"
+
+// fakeRuntime is a minimal runtime.Runtime for driving runAgent, adapted from
+// the mock in pkg/app/app_test.go: RunStream replays the configured events and
+// Resume records the requests it receives.
+type fakeRuntime struct {
+	events []runtime.Event
+	// onRunStream runs synchronously when RunStream is called, before any
+	// event is delivered (e.g. to cancel the turn context).
+	onRunStream func()
+
+	mu          sync.Mutex
+	resumeCalls []runtime.ResumeRequest
+}
+
+var _ runtime.Runtime = (*fakeRuntime)(nil)
+
+// RunStream returns a pre-filled closed channel so no producer goroutine can
+// leak when runAgent returns before draining all events.
+func (f *fakeRuntime) RunStream(context.Context, *session.Session) <-chan runtime.Event {
+	if f.onRunStream != nil {
+		f.onRunStream()
+	}
+	ch := make(chan runtime.Event, len(f.events))
+	for _, e := range f.events {
+		ch <- e
+	}
+	close(ch)
+	return ch
+}
+
+func (f *fakeRuntime) Resume(_ context.Context, req runtime.ResumeRequest) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.resumeCalls = append(f.resumeCalls, req)
+}
+
+func (f *fakeRuntime) resumeRequests() []runtime.ResumeRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.resumeCalls)
+}
+
+func (f *fakeRuntime) CurrentAgentInfo(context.Context) runtime.CurrentAgentInfo {
+	return runtime.CurrentAgentInfo{}
+}
+func (f *fakeRuntime) CurrentAgentName(context.Context) string                 { return "fake" }
+func (f *fakeRuntime) SetCurrentAgent(context.Context, string) error           { return nil }
+func (f *fakeRuntime) CurrentAgentTools(context.Context) ([]tools.Tool, error) { return nil, nil }
+func (f *fakeRuntime) CurrentAgentToolsetStatuses() []tools.ToolsetStatus      { return nil }
+func (f *fakeRuntime) RestartToolset(context.Context, string) error            { return nil }
+func (f *fakeRuntime) EmitStartupInfo(context.Context, *session.Session, runtime.EventSink) {
+}
+func (f *fakeRuntime) EmitAgentInfo(context.Context, runtime.EventSink) {}
+func (f *fakeRuntime) ResetStartupInfo()                                {}
+func (f *fakeRuntime) Run(context.Context, *session.Session) ([]session.Message, error) {
+	return nil, nil
+}
+
+func (f *fakeRuntime) ResumeElicitation(context.Context, tools.ElicitationAction, map[string]any) error {
+	return nil
+}
+func (f *fakeRuntime) SessionStore() session.Store { return nil }
+func (f *fakeRuntime) Summarize(context.Context, *session.Session, string, runtime.EventSink) {
+}
+func (f *fakeRuntime) PermissionsInfo() *runtime.PermissionsInfo      { return nil }
+func (f *fakeRuntime) CurrentAgentSkillsToolset() *skillstool.ToolSet { return nil }
+func (f *fakeRuntime) RunSkillFork(context.Context, *session.Session, skillstool.RunSkillArgs, runtime.EventSink) (*tools.ToolCallResult, error) {
+	return nil, nil
+}
+
+func (f *fakeRuntime) CurrentMCPPrompts(context.Context) map[string]mcptools.PromptInfo {
+	return nil
+}
+
+func (f *fakeRuntime) ExecuteMCPPrompt(context.Context, string, map[string]string) (string, error) {
+	return "", nil
+}
+
+func (f *fakeRuntime) UpdateSessionTitle(context.Context, *session.Session, string) error {
+	return nil
+}
+func (f *fakeRuntime) TitleGenerator(context.Context) *sessiontitle.Generator { return nil }
+func (f *fakeRuntime) Steer(context.Context, runtime.QueuedMessage) error     { return nil }
+func (f *fakeRuntime) FollowUp(context.Context, runtime.QueuedMessage) error  { return nil }
+func (f *fakeRuntime) QueueStatus() runtime.QueueStatus                       { return runtime.QueueStatus{} }
+func (f *fakeRuntime) TogglePause(context.Context) (bool, error)              { return false, nil }
+func (f *fakeRuntime) SetAgentModel(context.Context, string, string) error    { return nil }
+func (f *fakeRuntime) CycleAgentThinkingLevel(context.Context, string) (effort.Level, error) {
+	return "", runtime.ErrUnsupported
+}
+
+func (f *fakeRuntime) SetAgentThinkingLevel(context.Context, string, effort.Level) (effort.Level, error) {
+	return "", runtime.ErrUnsupported
+}
+func (f *fakeRuntime) AvailableModels(context.Context) []runtime.ModelChoice { return nil }
+func (f *fakeRuntime) SupportsModelSwitching() bool                          { return false }
+func (f *fakeRuntime) OnToolsChanged(func(runtime.Event))                    {}
+func (f *fakeRuntime) OnBackgroundEvent(func(runtime.Event))                 {}
+func (f *fakeRuntime) Close() error                                          { return nil }
+
+// captureWriter is a goroutine-safe sink for the connection's outbound
+// line-delimited JSON-RPC messages. failOn, when set, is called with the
+// 1-based write index and can inject write failures.
+type captureWriter struct {
+	failOn func(n int) error
+
+	mu     sync.Mutex
+	writes int
+	buf    bytes.Buffer
+}
+
+func (w *captureWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.writes++
+	if w.failOn != nil {
+		if err := w.failOn(w.writes); err != nil {
+			return 0, err
+		}
+	}
+	return w.buf.Write(p)
+}
+
+func (w *captureWriter) lines() []string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	var lines []string
+	for line := range strings.SplitSeq(w.buf.String(), "\n") {
+		if strings.TrimSpace(line) != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+// peerResponder plays the ACP client side of the connection's outbound
+// stream. Notifications pass through to the capture writer unchanged, while
+// session/request_permission requests are decoded, recorded, and answered on
+// the peer pipe with a JSON-RPC response echoing the request ID. respond
+// picks the result the client answers with, letting tests choose the
+// permission outcome; any other request fails the test immediately instead
+// of deadlocking the sender.
+type peerResponder struct {
+	t       *testing.T
+	out     io.Writer // outbound notifications, usually a captureWriter
+	peer    io.Writer // write half of the connection's inbound peer pipe
+	respond func(req acpsdk.RequestPermissionRequest) any
+
+	mu       sync.Mutex
+	requests []acpsdk.RequestPermissionRequest
+}
+
+// Write receives exactly one line-delimited JSON-RPC message per call: the
+// SDK marshals each message and writes it in a single call under its write
+// mutex. A batched write would fail to parse and fail the test loudly.
+func (p *peerResponder) Write(b []byte) (int, error) {
+	var msg struct {
+		ID     json.RawMessage `json:"id"`
+		Method string          `json:"method"`
+		Params json.RawMessage `json:"params"`
+	}
+	if err := json.Unmarshal(b, &msg); err != nil {
+		p.t.Errorf("peer received malformed JSON-RPC message %q: %v", b, err)
+		return 0, err
+	}
+	if len(msg.ID) == 0 {
+		return p.out.Write(b)
+	}
+	if msg.Method != "session/request_permission" || p.respond == nil {
+		err := fmt.Errorf("peer cannot answer JSON-RPC request %q (id %s)", msg.Method, msg.ID)
+		p.t.Error(err)
+		return 0, err
+	}
+
+	var req acpsdk.RequestPermissionRequest
+	if err := json.Unmarshal(msg.Params, &req); err != nil {
+		p.t.Errorf("peer failed to decode %s params: %v", msg.Method, err)
+		return 0, err
+	}
+	p.mu.Lock()
+	p.requests = append(p.requests, req)
+	p.mu.Unlock()
+
+	if err := p.reply(msg.ID, p.respond(req)); err != nil {
+		p.t.Errorf("peer failed to answer %s: %v", msg.Method, err)
+		return 0, err
+	}
+	return len(b), nil
+}
+
+// reply writes a JSON-RPC response with the given request ID and result into
+// the peer pipe. The pipe write only blocks until the connection's receive
+// loop consumes the line, which it does continuously until cleanup.
+func (p *peerResponder) reply(id json.RawMessage, result any) error {
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("marshal result: %w", err)
+	}
+	response, err := json.Marshal(struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Result  json.RawMessage `json:"result"`
+	}{JSONRPC: "2.0", ID: id, Result: resultJSON})
+	if err != nil {
+		return fmt.Errorf("marshal response: %w", err)
+	}
+	_, err = p.peer.Write(append(response, '\n'))
+	return err
+}
+
+func (p *peerResponder) recordedRequests() []acpsdk.RequestPermissionRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return slices.Clone(p.requests)
+}
+
+// permissionSelected is the JSON-RPC result for a user picking optionID.
+func permissionSelected(optionID string) acpsdk.RequestPermissionResponse {
+	return acpsdk.RequestPermissionResponse{Outcome: acpsdk.RequestPermissionOutcome{
+		Selected: &acpsdk.RequestPermissionOutcomeSelected{OptionId: acpsdk.PermissionOptionId(optionID)},
+	}}
+}
+
+// permissionCancelled is the JSON-RPC result for a cancelled prompt turn.
+func permissionCancelled() acpsdk.RequestPermissionResponse {
+	return acpsdk.RequestPermissionResponse{Outcome: acpsdk.RequestPermissionOutcome{
+		Cancelled: &acpsdk.RequestPermissionOutcomeCancelled{},
+	}}
+}
+
+// runAgentFixture wires an Agent to a real SDK AgentSideConnection whose
+// outbound messages flow through a peerResponder: notifications land in the
+// captureWriter, and session/request_permission requests are answered over
+// the peer pipe. Without a respond function the peer stays idle and only
+// keeps the connection's receive loop alive until cleanup.
+type runAgentFixture struct {
+	agent *Agent
+	sess  *Session
+	rt    *fakeRuntime
+	out   *captureWriter
+	peer  *peerResponder
+}
+
+func newRunAgentFixture(t *testing.T, rt *fakeRuntime, out *captureWriter) *runAgentFixture {
+	t.Helper()
+	return newRunAgentFixtureWithPermissions(t, rt, out, nil)
+}
+
+// newRunAgentFixtureWithPermissions additionally installs respond as the
+// peer-side handler for session/request_permission requests; its return
+// value is marshaled as the JSON-RPC result the client answers with.
+func newRunAgentFixtureWithPermissions(t *testing.T, rt *fakeRuntime, out *captureWriter, respond func(acpsdk.RequestPermissionRequest) any) *runAgentFixture {
+	t.Helper()
+
+	acpAgent := &Agent{sessions: make(map[string]*Session)}
+	peerReader, peerWriter := io.Pipe()
+	peer := &peerResponder{t: t, out: out, peer: peerWriter, respond: respond}
+	conn := acpsdk.NewAgentSideConnection(acpAgent, peer, peerReader)
+	conn.SetLogger(slog.New(slog.DiscardHandler))
+	acpAgent.SetAgentConnection(conn)
+
+	t.Cleanup(func() {
+		_ = peerWriter.Close()
+		select {
+		case <-conn.Done():
+		case <-time.After(5 * time.Second):
+			t.Error("timed out waiting for ACP connection shutdown")
+		}
+	})
+
+	return &runAgentFixture{
+		agent: acpAgent,
+		sess:  &Session{id: testSessionID, sess: session.New(), rt: rt},
+		rt:    rt,
+		out:   out,
+		peer:  peer,
+	}
+}
+
+// sessionUpdates parses the captured JSON-RPC notifications and returns the
+// decoded session updates in emission order.
+func (f *runAgentFixture) sessionUpdates(t *testing.T) []acpsdk.SessionUpdate {
+	t.Helper()
+
+	var updates []acpsdk.SessionUpdate
+	for _, line := range f.out.lines() {
+		var msg struct {
+			JSONRPC string          `json:"jsonrpc"`
+			Method  string          `json:"method"`
+			Params  json.RawMessage `json:"params"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(line), &msg))
+		require.Equal(t, "2.0", msg.JSONRPC)
+		require.Equal(t, "session/update", msg.Method)
+
+		var notification acpsdk.SessionNotification
+		require.NoError(t, json.Unmarshal(msg.Params, &notification))
+		require.Equal(t, acpsdk.SessionId(testSessionID), notification.SessionId)
+		updates = append(updates, notification.Update)
+	}
+	return updates
+}
+
+func requireAvailableCommands(t *testing.T, update acpsdk.SessionUpdate) {
+	t.Helper()
+
+	require.NotNil(t, update.AvailableCommandsUpdate)
+	names := make([]string, 0, len(update.AvailableCommandsUpdate.AvailableCommands))
+	for _, cmd := range update.AvailableCommandsUpdate.AvailableCommands {
+		names = append(names, cmd.Name)
+	}
+	assert.Equal(t, []string{"new", "compact", "usage"}, names)
+}
+
+func agentMessageText(t *testing.T, update acpsdk.SessionUpdate) string {
+	t.Helper()
+
+	require.NotNil(t, update.AgentMessageChunk)
+	require.NotNil(t, update.AgentMessageChunk.Content.Text)
+	return update.AgentMessageChunk.Content.Text.Text
+}
+
+func TestRunAgent_EmitsAvailableCommandsFirst(t *testing.T) {
+	t.Parallel()
+
+	f := newRunAgentFixture(t, &fakeRuntime{}, &captureWriter{})
+
+	require.NoError(t, f.agent.runAgent(t.Context(), f.sess))
+
+	updates := f.sessionUpdates(t)
+	require.Len(t, updates, 1)
+	requireAvailableCommands(t, updates[0])
+}
+
+func TestRunAgent_StreamsAssistantAndDiagnosticEvents(t *testing.T) {
+	t.Parallel()
+
+	rt := &fakeRuntime{events: []runtime.Event{
+		runtime.AgentChoice("root", testSessionID, "Hello"),
+		runtime.AgentChoiceReasoning("root", testSessionID, "pondering"),
+		runtime.Error("boom"),
+		runtime.Warning("careful", "root"),
+		runtime.ModelFallback("root", "gpt-5", "gpt-4o", "rate limited", 1, 3),
+	}}
+	f := newRunAgentFixture(t, rt, &captureWriter{})
+
+	require.NoError(t, f.agent.runAgent(t.Context(), f.sess))
+
+	updates := f.sessionUpdates(t)
+	require.Len(t, updates, 6)
+	requireAvailableCommands(t, updates[0])
+
+	assert.Equal(t, "Hello", agentMessageText(t, updates[1]))
+
+	require.NotNil(t, updates[2].AgentThoughtChunk)
+	require.NotNil(t, updates[2].AgentThoughtChunk.Content.Text)
+	assert.Equal(t, "pondering", updates[2].AgentThoughtChunk.Content.Text.Text)
+
+	assert.Equal(t, "\n\nError: boom\n", agentMessageText(t, updates[3]))
+	assert.Equal(t, "\nWarning: careful\n", agentMessageText(t, updates[4]))
+	assert.Equal(t, "\nModel gpt-5 failed, falling back to gpt-4o (rate limited)\n", agentMessageText(t, updates[5]))
+
+	assert.Empty(t, rt.resumeRequests())
+}
+
+func TestRunAgent_SessionTitleUpdate(t *testing.T) {
+	t.Parallel()
+
+	rt := &fakeRuntime{events: []runtime.Event{
+		runtime.SessionTitle(testSessionID, "Refactor plan"),
+	}}
+	f := newRunAgentFixture(t, rt, &captureWriter{})
+
+	require.NoError(t, f.agent.runAgent(t.Context(), f.sess))
+
+	updates := f.sessionUpdates(t)
+	require.Len(t, updates, 2)
+	require.NotNil(t, updates[1].SessionInfoUpdate)
+	require.NotNil(t, updates[1].SessionInfoUpdate.Title)
+	assert.Equal(t, "Refactor plan", *updates[1].SessionInfoUpdate.Title)
+}
+
+func TestRunAgent_TokenUsageUpdates(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with cost", func(t *testing.T) {
+		t.Parallel()
+
+		rt := &fakeRuntime{events: []runtime.Event{
+			runtime.NewTokenUsageEvent(testSessionID, "root", &runtime.Usage{
+				ContextLength: 1234,
+				ContextLimit:  200000,
+				Cost:          0.75,
+			}),
+		}}
+		f := newRunAgentFixture(t, rt, &captureWriter{})
+
+		require.NoError(t, f.agent.runAgent(t.Context(), f.sess))
+
+		updates := f.sessionUpdates(t)
+		require.Len(t, updates, 2)
+		require.NotNil(t, updates[1].UsageUpdate)
+		assert.Equal(t, 200000, updates[1].UsageUpdate.Size)
+		assert.Equal(t, 1234, updates[1].UsageUpdate.Used)
+		require.NotNil(t, updates[1].UsageUpdate.Cost)
+		assert.Equal(t, acpsdk.Cost{Amount: 0.75, Currency: "USD"}, *updates[1].UsageUpdate.Cost)
+	})
+
+	t.Run("without cost", func(t *testing.T) {
+		t.Parallel()
+
+		rt := &fakeRuntime{events: []runtime.Event{
+			runtime.NewTokenUsageEvent(testSessionID, "root", &runtime.Usage{
+				ContextLength: 42,
+				ContextLimit:  1000,
+			}),
+		}}
+		f := newRunAgentFixture(t, rt, &captureWriter{})
+
+		require.NoError(t, f.agent.runAgent(t.Context(), f.sess))
+
+		updates := f.sessionUpdates(t)
+		require.Len(t, updates, 2)
+		require.NotNil(t, updates[1].UsageUpdate)
+		assert.Equal(t, 1000, updates[1].UsageUpdate.Size)
+		assert.Equal(t, 42, updates[1].UsageUpdate.Used)
+		assert.Nil(t, updates[1].UsageUpdate.Cost)
+	})
+
+	t.Run("nil usage emits nothing", func(t *testing.T) {
+		t.Parallel()
+
+		rt := &fakeRuntime{events: []runtime.Event{
+			runtime.NewTokenUsageEvent(testSessionID, "root", nil),
+		}}
+		f := newRunAgentFixture(t, rt, &captureWriter{})
+
+		require.NoError(t, f.agent.runAgent(t.Context(), f.sess))
+
+		updates := f.sessionUpdates(t)
+		require.Len(t, updates, 1)
+		requireAvailableCommands(t, updates[0])
+	})
+}
+
+func TestRunAgent_ToolCallLifecycle(t *testing.T) {
+	t.Parallel()
+
+	shellTool := tools.Tool{Name: "shell", Annotations: tools.ToolAnnotations{Title: "Run Shell"}}
+	editTool := tools.Tool{Name: "edit_file"}
+	editArgs := `{"path":"/tmp/f.go","edits":[{"oldText":"a","newText":"b"}]}`
+
+	rt := &fakeRuntime{events: []runtime.Event{
+		runtime.ToolCall(tools.ToolCall{
+			ID:       "call-1",
+			Function: tools.FunctionCall{Name: "shell", Arguments: `{"command":"ls","path":"/tmp"}`},
+		}, shellTool, "root"),
+		runtime.ToolCallResponse("call-1", shellTool, tools.ResultSuccess("file.txt"), "file.txt", "root"),
+		runtime.ToolCall(tools.ToolCall{
+			ID:       "call-2",
+			Function: tools.FunctionCall{Name: "shell", Arguments: `{"command":"rm"}`},
+		}, shellTool, "root"),
+		runtime.ToolCallResponse("call-2", shellTool, tools.ResultError("denied"), "denied", "root"),
+		runtime.ToolCall(tools.ToolCall{
+			ID:       "call-3",
+			Function: tools.FunctionCall{Name: "edit_file", Arguments: editArgs},
+		}, editTool, "root"),
+		runtime.ToolCallResponse("call-3", editTool, tools.ResultSuccess("ok"), "ok", "root"),
+	}}
+	f := newRunAgentFixture(t, rt, &captureWriter{})
+
+	require.NoError(t, f.agent.runAgent(t.Context(), f.sess))
+
+	updates := f.sessionUpdates(t)
+	require.Len(t, updates, 7)
+	requireAvailableCommands(t, updates[0])
+
+	start := updates[1].ToolCall
+	require.NotNil(t, start)
+	assert.Equal(t, acpsdk.ToolCallId("call-1"), start.ToolCallId)
+	assert.Equal(t, "Run Shell", start.Title)
+	assert.Equal(t, acpsdk.ToolKindExecute, start.Kind)
+	assert.Equal(t, acpsdk.ToolCallStatusPending, start.Status)
+	assert.Equal(t, map[string]any{"command": "ls", "path": "/tmp"}, start.RawInput)
+	assert.Equal(t, []acpsdk.ToolCallLocation{{Path: "/tmp"}}, start.Locations)
+
+	completed := updates[2].ToolCallUpdate
+	require.NotNil(t, completed)
+	assert.Equal(t, acpsdk.ToolCallId("call-1"), completed.ToolCallId)
+	require.NotNil(t, completed.Status)
+	assert.Equal(t, acpsdk.ToolCallStatusCompleted, *completed.Status)
+	require.Len(t, completed.Content, 1)
+	require.NotNil(t, completed.Content[0].Content)
+	require.NotNil(t, completed.Content[0].Content.Content.Text)
+	assert.Equal(t, "file.txt", completed.Content[0].Content.Content.Text.Text)
+	assert.Equal(t, map[string]any{"content": "file.txt"}, completed.RawOutput)
+
+	require.NotNil(t, updates[3].ToolCall)
+	failed := updates[4].ToolCallUpdate
+	require.NotNil(t, failed)
+	assert.Equal(t, acpsdk.ToolCallId("call-2"), failed.ToolCallId)
+	require.NotNil(t, failed.Status)
+	assert.Equal(t, acpsdk.ToolCallStatusFailed, *failed.Status)
+
+	editStart := updates[5].ToolCall
+	require.NotNil(t, editStart)
+	assert.Equal(t, acpsdk.ToolKindEdit, editStart.Kind)
+
+	editDone := updates[6].ToolCallUpdate
+	require.NotNil(t, editDone)
+	require.NotNil(t, editDone.Status)
+	assert.Equal(t, acpsdk.ToolCallStatusCompleted, *editDone.Status)
+	require.Len(t, editDone.Content, 1)
+	diff := editDone.Content[0].Diff
+	require.NotNil(t, diff)
+	assert.Equal(t, "/tmp/f.go", diff.Path)
+	assert.Equal(t, "b\n", diff.NewText)
+	require.NotNil(t, diff.OldText)
+	assert.Equal(t, "a\n", *diff.OldText)
+
+	assert.Empty(t, rt.resumeRequests())
+}
+
+func TestRunAgent_ToolCallResponseWithoutStartFails(t *testing.T) {
+	t.Parallel()
+
+	rt := &fakeRuntime{events: []runtime.Event{
+		runtime.ToolCallResponse("orphan", tools.Tool{Name: "shell"}, tools.ResultSuccess("ok"), "ok", "root"),
+		runtime.AgentChoice("root", testSessionID, "never emitted"),
+	}}
+	f := newRunAgentFixture(t, rt, &captureWriter{})
+
+	err := f.agent.runAgent(t.Context(), f.sess)
+	require.EqualError(t, err, "missing tool call arguments for tool call ID orphan")
+
+	// The failure must stop the loop before later events are mapped.
+	updates := f.sessionUpdates(t)
+	require.Len(t, updates, 1)
+	requireAvailableCommands(t, updates[0])
+}
+
+func TestRunAgent_ToolCallConfirmationRequestFields(t *testing.T) {
+	t.Parallel()
+
+	tool := tools.Tool{Name: "shell", Annotations: tools.ToolAnnotations{Title: "Run Shell"}}
+	call := tools.ToolCall{
+		ID:       "confirm-1",
+		Function: tools.FunctionCall{Name: "shell", Arguments: `{"command":"rm -rf /tmp/scratch"}`},
+	}
+	rt := &fakeRuntime{events: []runtime.Event{
+		runtime.ToolCallConfirmation(call, tool, "root", nil),
+		runtime.AgentChoice("root", testSessionID, "approved"),
+	}}
+	f := newRunAgentFixtureWithPermissions(t, rt, &captureWriter{}, func(acpsdk.RequestPermissionRequest) any {
+		return permissionSelected("allow")
+	})
+
+	require.NoError(t, f.agent.runAgent(t.Context(), f.sess))
+
+	reqs := f.peer.recordedRequests()
+	require.Len(t, reqs, 1)
+	req := reqs[0]
+	assert.Equal(t, acpsdk.SessionId(testSessionID), req.SessionId)
+	assert.Equal(t, acpsdk.ToolCallId("confirm-1"), req.ToolCall.ToolCallId)
+	require.NotNil(t, req.ToolCall.Title)
+	assert.Equal(t, "Run Shell", *req.ToolCall.Title)
+	require.NotNil(t, req.ToolCall.Kind)
+	assert.Equal(t, acpsdk.ToolKindExecute, *req.ToolCall.Kind)
+	require.NotNil(t, req.ToolCall.Status)
+	assert.Equal(t, acpsdk.ToolCallStatusPending, *req.ToolCall.Status)
+	assert.Equal(t, map[string]any{"command": "rm -rf /tmp/scratch"}, req.ToolCall.RawInput)
+	assert.Equal(t, []acpsdk.PermissionOption{
+		{Kind: acpsdk.PermissionOptionKindAllowOnce, Name: "Allow this action", OptionId: "allow"},
+		{Kind: acpsdk.PermissionOptionKindAllowAlways, Name: "Allow and remember my choice", OptionId: "allow-always"},
+		{Kind: acpsdk.PermissionOptionKindRejectOnce, Name: "Skip this action", OptionId: "reject"},
+	}, req.Options)
+
+	assert.Equal(t, []runtime.ResumeRequest{{Type: runtime.ResumeTypeApprove}}, rt.resumeRequests())
+
+	// The turn keeps streaming after the permission round trip and the
+	// interleaved request does not disturb the captured notifications.
+	updates := f.sessionUpdates(t)
+	require.Len(t, updates, 2)
+	requireAvailableCommands(t, updates[0])
+	assert.Equal(t, "approved", agentMessageText(t, updates[1]))
+}
+
+func TestRunAgent_ToolCallConfirmationOutcomes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		result     any
+		wantResume []runtime.ResumeRequest
+	}{
+		{
+			name:       "allow approves once",
+			result:     permissionSelected("allow"),
+			wantResume: []runtime.ResumeRequest{{Type: runtime.ResumeTypeApprove}},
+		},
+		{
+			name:       "allow-always approves session",
+			result:     permissionSelected("allow-always"),
+			wantResume: []runtime.ResumeRequest{{Type: runtime.ResumeTypeApproveSession}},
+		},
+		{
+			name:       "reject rejects",
+			result:     permissionSelected("reject"),
+			wantResume: []runtime.ResumeRequest{{Type: runtime.ResumeTypeReject}},
+		},
+		{
+			name:       "cancelled rejects",
+			result:     permissionCancelled(),
+			wantResume: []runtime.ResumeRequest{{Type: runtime.ResumeTypeReject}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rt := &fakeRuntime{events: []runtime.Event{
+				runtime.ToolCallConfirmation(
+					tools.ToolCall{ID: "confirm-1", Function: tools.FunctionCall{Name: "shell", Arguments: `{"command":"ls"}`}},
+					tools.Tool{Name: "shell"},
+					"root",
+					nil,
+				),
+			}}
+			f := newRunAgentFixtureWithPermissions(t, rt, &captureWriter{}, func(acpsdk.RequestPermissionRequest) any {
+				return tt.result
+			})
+
+			require.NoError(t, f.agent.runAgent(t.Context(), f.sess))
+
+			assert.Equal(t, tt.wantResume, rt.resumeRequests())
+			assert.Len(t, f.peer.recordedRequests(), 1)
+		})
+	}
+}
+
+func TestRunAgent_ToolCallConfirmationBadOutcomeFailsRun(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		result  any
+		wantErr string
+	}{
+		{
+			name:    "unexpected selected option",
+			result:  permissionSelected("maybe"),
+			wantErr: "unexpected permission option: maybe",
+		},
+		{
+			// An empty result leaves both outcome union variants nil.
+			name:    "missing outcome",
+			result:  map[string]any{},
+			wantErr: "unexpected permission outcome",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rt := &fakeRuntime{events: []runtime.Event{
+				runtime.ToolCallConfirmation(
+					tools.ToolCall{ID: "confirm-1", Function: tools.FunctionCall{Name: "shell", Arguments: `{"command":"ls"}`}},
+					tools.Tool{Name: "shell"},
+					"root",
+					nil,
+				),
+				runtime.AgentChoice("root", testSessionID, "never emitted"),
+			}}
+			f := newRunAgentFixtureWithPermissions(t, rt, &captureWriter{}, func(acpsdk.RequestPermissionRequest) any {
+				return tt.result
+			})
+
+			err := f.agent.runAgent(t.Context(), f.sess)
+			require.EqualError(t, err, tt.wantErr)
+
+			assert.Empty(t, rt.resumeRequests())
+			// The failure must stop the loop before later events are mapped.
+			updates := f.sessionUpdates(t)
+			require.Len(t, updates, 1)
+			requireAvailableCommands(t, updates[0])
+		})
+	}
+}
+
+func TestRunAgent_MaxIterationsReachedRequestFields(t *testing.T) {
+	t.Parallel()
+
+	rt := &fakeRuntime{events: []runtime.Event{
+		runtime.MaxIterationsReached(25),
+	}}
+	f := newRunAgentFixtureWithPermissions(t, rt, &captureWriter{}, func(acpsdk.RequestPermissionRequest) any {
+		return permissionSelected("continue")
+	})
+
+	require.NoError(t, f.agent.runAgent(t.Context(), f.sess))
+
+	reqs := f.peer.recordedRequests()
+	require.Len(t, reqs, 1)
+	req := reqs[0]
+	assert.Equal(t, acpsdk.SessionId(testSessionID), req.SessionId)
+	assert.Equal(t, acpsdk.ToolCallId("max_iterations"), req.ToolCall.ToolCallId)
+	require.NotNil(t, req.ToolCall.Title)
+	assert.Equal(t, "Maximum iterations (25) reached", *req.ToolCall.Title)
+	require.NotNil(t, req.ToolCall.Kind)
+	assert.Equal(t, acpsdk.ToolKindExecute, *req.ToolCall.Kind)
+	require.NotNil(t, req.ToolCall.Status)
+	assert.Equal(t, acpsdk.ToolCallStatusPending, *req.ToolCall.Status)
+	assert.Nil(t, req.ToolCall.RawInput)
+	assert.Equal(t, []acpsdk.PermissionOption{
+		{Kind: acpsdk.PermissionOptionKindAllowOnce, Name: "Continue", OptionId: "continue"},
+		{Kind: acpsdk.PermissionOptionKindRejectOnce, Name: "Stop", OptionId: "stop"},
+	}, req.Options)
+
+	assert.Equal(t, []runtime.ResumeRequest{{Type: runtime.ResumeTypeApprove}}, rt.resumeRequests())
+}
+
+func TestRunAgent_MaxIterationsReachedOutcomes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		result     any
+		wantResume []runtime.ResumeRequest
+	}{
+		{
+			name:       "continue approves",
+			result:     permissionSelected("continue"),
+			wantResume: []runtime.ResumeRequest{{Type: runtime.ResumeTypeApprove}},
+		},
+		{
+			name:       "stop rejects",
+			result:     permissionSelected("stop"),
+			wantResume: []runtime.ResumeRequest{{Type: runtime.ResumeTypeReject}},
+		},
+		{
+			name:       "cancelled rejects",
+			result:     permissionCancelled(),
+			wantResume: []runtime.ResumeRequest{{Type: runtime.ResumeTypeReject}},
+		},
+		{
+			// Unlike tool confirmations, a missing selection rejects
+			// instead of failing the run.
+			name:       "missing selection rejects",
+			result:     map[string]any{},
+			wantResume: []runtime.ResumeRequest{{Type: runtime.ResumeTypeReject}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rt := &fakeRuntime{events: []runtime.Event{runtime.MaxIterationsReached(3)}}
+			f := newRunAgentFixtureWithPermissions(t, rt, &captureWriter{}, func(acpsdk.RequestPermissionRequest) any {
+				return tt.result
+			})
+
+			require.NoError(t, f.agent.runAgent(t.Context(), f.sess))
+
+			assert.Equal(t, tt.wantResume, rt.resumeRequests())
+			assert.Len(t, f.peer.recordedRequests(), 1)
+		})
+	}
+}
+
+func TestRunAgent_TodoToolEmitsPlanUpdate(t *testing.T) {
+	t.Parallel()
+
+	todoTool := tools.Tool{Name: todo.ToolNameCreateTodos}
+	todoCall := tools.ToolCall{
+		ID:       "call-1",
+		Function: tools.FunctionCall{Name: todo.ToolNameCreateTodos, Arguments: `{"descriptions":["write tests"]}`},
+	}
+
+	t.Run("todo metadata becomes a plan", func(t *testing.T) {
+		t.Parallel()
+
+		result := &tools.ToolCallResult{
+			Output: "ok",
+			Meta: []todo.Todo{
+				{ID: "1", Description: "write tests", Status: "in-progress"},
+				{ID: "2", Description: "review", Status: "pending"},
+			},
+		}
+		rt := &fakeRuntime{events: []runtime.Event{
+			runtime.ToolCall(todoCall, todoTool, "root"),
+			runtime.ToolCallResponse("call-1", todoTool, result, "ok", "root"),
+		}}
+		f := newRunAgentFixture(t, rt, &captureWriter{})
+
+		require.NoError(t, f.agent.runAgent(t.Context(), f.sess))
+
+		updates := f.sessionUpdates(t)
+		require.Len(t, updates, 4)
+		require.NotNil(t, updates[1].ToolCall)
+		require.NotNil(t, updates[2].ToolCallUpdate)
+
+		plan := updates[3].Plan
+		require.NotNil(t, plan)
+		assert.Equal(t, []acpsdk.PlanEntry{
+			{Content: "write tests", Status: acpsdk.PlanEntryStatusInProgress, Priority: acpsdk.PlanEntryPriorityMedium},
+			{Content: "review", Status: acpsdk.PlanEntryStatusPending, Priority: acpsdk.PlanEntryPriorityMedium},
+		}, plan.Entries)
+	})
+
+	t.Run("unexpected metadata emits no plan", func(t *testing.T) {
+		t.Parallel()
+
+		result := &tools.ToolCallResult{Output: "ok", Meta: "not-todos"}
+		rt := &fakeRuntime{events: []runtime.Event{
+			runtime.ToolCall(todoCall, todoTool, "root"),
+			runtime.ToolCallResponse("call-1", todoTool, result, "ok", "root"),
+		}}
+		f := newRunAgentFixture(t, rt, &captureWriter{})
+
+		require.NoError(t, f.agent.runAgent(t.Context(), f.sess))
+
+		updates := f.sessionUpdates(t)
+		require.Len(t, updates, 3)
+		assert.Nil(t, updates[2].Plan)
+	})
+}
+
+func TestRunAgent_SendUpdateFailureStopsRun(t *testing.T) {
+	t.Parallel()
+
+	out := &captureWriter{failOn: func(n int) error {
+		if n >= 2 {
+			return errors.New("peer gone")
+		}
+		return nil
+	}}
+	rt := &fakeRuntime{events: []runtime.Event{
+		runtime.AgentChoice("root", testSessionID, "one"),
+		runtime.AgentChoice("root", testSessionID, "two"),
+	}}
+	f := newRunAgentFixture(t, rt, out)
+
+	err := f.agent.runAgent(t.Context(), f.sess)
+	require.ErrorContains(t, err, "peer gone")
+
+	updates := f.sessionUpdates(t)
+	require.Len(t, updates, 1)
+	requireAvailableCommands(t, updates[0])
+}
+
+func TestRunAgent_AvailableCommandsFailureIsNonFatal(t *testing.T) {
+	t.Parallel()
+
+	out := &captureWriter{failOn: func(n int) error {
+		if n == 1 {
+			return errors.New("transient failure")
+		}
+		return nil
+	}}
+	rt := &fakeRuntime{events: []runtime.Event{
+		runtime.AgentChoice("root", testSessionID, "hello"),
+	}}
+	f := newRunAgentFixture(t, rt, out)
+
+	require.NoError(t, f.agent.runAgent(t.Context(), f.sess))
+
+	updates := f.sessionUpdates(t)
+	require.Len(t, updates, 1)
+	assert.Equal(t, "hello", agentMessageText(t, updates[0]))
+}
+
+func TestRunAgent_ContextCancellationStopsEventLoop(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	rt := &fakeRuntime{events: []runtime.Event{
+		runtime.AgentChoice("root", testSessionID, "never emitted"),
+	}}
+	// Cancel the turn after available commands were emitted but before the
+	// first event is consumed.
+	rt.onRunStream = cancel
+	f := newRunAgentFixture(t, rt, &captureWriter{})
+
+	err := f.agent.runAgent(ctx, f.sess)
+	require.ErrorIs(t, err, context.Canceled)
+
+	updates := f.sessionUpdates(t)
+	require.Len(t, updates, 1)
+	requireAvailableCommands(t, updates[0])
+	assert.Empty(t, rt.resumeRequests())
+}

--- a/pkg/acp/toolcall_test.go
+++ b/pkg/acp/toolcall_test.go
@@ -1,0 +1,466 @@
+package acp
+
+import (
+	"testing"
+
+	acpsdk "github.com/coder/acp-go-sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/builtin/todo"
+)
+
+func TestDetermineToolKind(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		toolName    string
+		annotations tools.ToolAnnotations
+		want        acpsdk.ToolKind
+	}{
+		{name: "read only hint wins", toolName: "delete_everything", annotations: tools.ToolAnnotations{ReadOnlyHint: true}, want: acpsdk.ToolKindRead},
+		{name: "read only hint wins over destructive", toolName: "shell", annotations: tools.ToolAnnotations{ReadOnlyHint: true, DestructiveHint: new(true)}, want: acpsdk.ToolKindRead},
+		{name: "destructive hint", toolName: "shell", annotations: tools.ToolAnnotations{DestructiveHint: new(true)}, want: acpsdk.ToolKindDelete},
+		{name: "destructive hint false falls through", toolName: "shell", annotations: tools.ToolAnnotations{DestructiveHint: new(false)}, want: acpsdk.ToolKindExecute},
+		{name: "read_ prefix", toolName: "read_file", want: acpsdk.ToolKindRead},
+		{name: "get_ prefix", toolName: "get_issue", want: acpsdk.ToolKindRead},
+		{name: "list_ prefix", toolName: "list_directory", want: acpsdk.ToolKindRead},
+		{name: "directory_tree", toolName: "directory_tree", want: acpsdk.ToolKindRead},
+		{name: "edit_ prefix", toolName: "edit_file", want: acpsdk.ToolKindEdit},
+		{name: "write_ prefix", toolName: "write_file", want: acpsdk.ToolKindEdit},
+		{name: "update_ prefix", toolName: "update_todos", want: acpsdk.ToolKindEdit},
+		{name: "create_ prefix", toolName: "create_directory", want: acpsdk.ToolKindEdit},
+		{name: "add_ prefix", toolName: "add_comment", want: acpsdk.ToolKindEdit},
+		{name: "delete_ prefix", toolName: "delete_file", want: acpsdk.ToolKindDelete},
+		{name: "remove_ prefix", toolName: "remove_directory", want: acpsdk.ToolKindDelete},
+		{name: "stop_ prefix", toolName: "stop_container", want: acpsdk.ToolKindDelete},
+		{name: "search_ prefix", toolName: "search_files_content", want: acpsdk.ToolKindSearch},
+		{name: "find_ prefix", toolName: "find_symbol", want: acpsdk.ToolKindSearch},
+		{name: "think", toolName: "think", want: acpsdk.ToolKindThink},
+		{name: "fetch", toolName: "fetch", want: acpsdk.ToolKindFetch},
+		{name: "http_ prefix", toolName: "http_get", want: acpsdk.ToolKindFetch},
+		{name: "shell", toolName: "shell", want: acpsdk.ToolKindExecute},
+		{name: "run_ prefix", toolName: "run_tests", want: acpsdk.ToolKindExecute},
+		{name: "exec_ prefix", toolName: "exec_command", want: acpsdk.ToolKindExecute},
+		{name: "transfer_task", toolName: "transfer_task", want: acpsdk.ToolKindSwitchMode},
+		{name: "handoff", toolName: "handoff", want: acpsdk.ToolKindSwitchMode},
+		{name: "unknown", toolName: "banana", want: acpsdk.ToolKindOther},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := determineToolKind(tt.toolName, tools.Tool{Annotations: tt.annotations})
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseToolCallArguments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args string
+		want map[string]any
+	}{
+		{name: "valid object", args: `{"path":"/tmp","line":42}`, want: map[string]any{"path": "/tmp", "line": float64(42)}},
+		{name: "empty object", args: `{}`, want: map[string]any{}},
+		{name: "null", args: `null`, want: nil},
+		{name: "invalid json wrapped as raw", args: `not-json`, want: map[string]any{"raw": "not-json"}},
+		{name: "empty string wrapped as raw", args: ``, want: map[string]any{"raw": ""}},
+		{name: "array wrapped as raw", args: `[1,2]`, want: map[string]any{"raw": "[1,2]"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, parseToolCallArguments(tt.args))
+		})
+	}
+}
+
+func TestExtractLocations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args map[string]any
+		want []acpsdk.ToolCallLocation
+	}{
+		{name: "no args", args: map[string]any{}, want: nil},
+		{name: "path key", args: map[string]any{"path": "/a.txt"}, want: []acpsdk.ToolCallLocation{{Path: "/a.txt"}}},
+		{name: "file key", args: map[string]any{"file": "/b.txt"}, want: []acpsdk.ToolCallLocation{{Path: "/b.txt"}}},
+		{name: "filepath key", args: map[string]any{"filepath": "/c.txt"}, want: []acpsdk.ToolCallLocation{{Path: "/c.txt"}}},
+		{name: "filename key", args: map[string]any{"filename": "/d.txt"}, want: []acpsdk.ToolCallLocation{{Path: "/d.txt"}}},
+		{name: "file_path key", args: map[string]any{"file_path": "/e.txt"}, want: []acpsdk.ToolCallLocation{{Path: "/e.txt"}}},
+		{
+			name: "first matching path key wins",
+			args: map[string]any{"path": "/a.txt", "file": "/b.txt"},
+			want: []acpsdk.ToolCallLocation{{Path: "/a.txt"}},
+		},
+		{
+			name: "path with line",
+			args: map[string]any{"path": "/a.txt", "line": float64(42)},
+			want: []acpsdk.ToolCallLocation{{Path: "/a.txt", Line: new(42)}},
+		},
+		{name: "empty path ignored", args: map[string]any{"path": ""}, want: nil},
+		{name: "non-string path ignored", args: map[string]any{"path": 12}, want: nil},
+		{
+			name: "paths array",
+			args: map[string]any{"paths": []any{"/a.txt", "/b.txt"}},
+			want: []acpsdk.ToolCallLocation{{Path: "/a.txt"}, {Path: "/b.txt"}},
+		},
+		{
+			name: "paths array skips empty and non-string entries",
+			args: map[string]any{"paths": []any{"", 1, "/ok.txt"}},
+			want: []acpsdk.ToolCallLocation{{Path: "/ok.txt"}},
+		},
+		{
+			name: "path and paths combined",
+			args: map[string]any{"path": "/a.txt", "paths": []any{"/b.txt"}},
+			want: []acpsdk.ToolCallLocation{{Path: "/a.txt"}, {Path: "/b.txt"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, extractLocations(tt.args))
+		})
+	}
+}
+
+func TestExtractDiffContent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		toolName  string
+		arguments string
+		want      *acpsdk.ToolCallContentDiff
+	}{
+		{
+			name:      "edit_file single edit",
+			toolName:  "edit_file",
+			arguments: `{"path":"/f.go","edits":[{"oldText":"a","newText":"b"}]}`,
+			want:      &acpsdk.ToolCallContentDiff{Path: "/f.go", OldText: new("a\n"), NewText: "b\n", Type: "diff"},
+		},
+		{
+			name:      "edit_file concatenates edits",
+			toolName:  "edit_file",
+			arguments: `{"path":"/f.go","edits":[{"oldText":"a","newText":"b"},{"oldText":"c","newText":"d"}]}`,
+			want:      &acpsdk.ToolCallContentDiff{Path: "/f.go", OldText: new("a\nc\n"), NewText: "b\nd\n", Type: "diff"},
+		},
+		{
+			name:      "edit_file skips non-object edits",
+			toolName:  "edit_file",
+			arguments: `{"path":"/f.go","edits":["bogus",{"oldText":"a","newText":"b"}]}`,
+			want:      &acpsdk.ToolCallContentDiff{Path: "/f.go", OldText: new("a\n"), NewText: "b\n", Type: "diff"},
+		},
+		{
+			name:      "edit_file all edits invalid",
+			toolName:  "edit_file",
+			arguments: `{"path":"/f.go","edits":["bogus"]}`,
+			want:      nil,
+		},
+		{
+			name:      "edit_file no edits",
+			toolName:  "edit_file",
+			arguments: `{"path":"/f.go","edits":[]}`,
+			want:      nil,
+		},
+		{
+			name:      "edit_file edits wrong outer type",
+			toolName:  "edit_file",
+			arguments: `{"path":"/f.go","edits":{"oldText":"a","newText":"b"}}`,
+			want:      nil,
+		},
+		{
+			name:      "edit_file missing path",
+			toolName:  "edit_file",
+			arguments: `{"edits":[{"oldText":"a","newText":"b"}]}`,
+			want:      nil,
+		},
+		{
+			name:      "write_file with content",
+			toolName:  "write_file",
+			arguments: `{"path":"/f.go","content":"hello"}`,
+			want:      &acpsdk.ToolCallContentDiff{Path: "/f.go", NewText: "hello", Type: "diff"},
+		},
+		{
+			name:      "write_file without content",
+			toolName:  "write_file",
+			arguments: `{"path":"/f.go"}`,
+			want:      nil,
+		},
+		{
+			name:      "write_file content wrong outer type",
+			toolName:  "write_file",
+			arguments: `{"path":"/f.go","content":["hello"]}`,
+			want:      nil,
+		},
+		{
+			name:      "unrelated tool",
+			toolName:  "read_file",
+			arguments: `{"path":"/f.go","content":"hello"}`,
+			want:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := extractDiffContent(tt.toolName, tt.arguments)
+			if tt.want == nil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, tt.want, got.Diff)
+		})
+	}
+}
+
+func TestBuildToolCallComplete(t *testing.T) {
+	t.Parallel()
+
+	editArgs := `{"path":"/f.go","edits":[{"oldText":"a","newText":"b"}]}`
+
+	tests := []struct {
+		name       string
+		arguments  string
+		event      *runtime.ToolCallResponseEvent
+		wantStatus acpsdk.ToolCallStatus
+		wantDiff   bool
+	}{
+		{
+			name:      "nil result completes with text content",
+			arguments: `{"command":"ls"}`,
+			event: &runtime.ToolCallResponseEvent{
+				ToolCallID:     "call-1",
+				ToolDefinition: tools.Tool{Name: "shell"},
+				Response:       "file.txt",
+			},
+			wantStatus: acpsdk.ToolCallStatusCompleted,
+		},
+		{
+			name:      "error result fails",
+			arguments: `{"command":"ls"}`,
+			event: &runtime.ToolCallResponseEvent{
+				ToolCallID:     "call-1",
+				ToolDefinition: tools.Tool{Name: "shell"},
+				Response:       "denied",
+				Result:         tools.ResultError("denied"),
+			},
+			wantStatus: acpsdk.ToolCallStatusFailed,
+		},
+		{
+			name:      "successful edit_file uses diff content",
+			arguments: editArgs,
+			event: &runtime.ToolCallResponseEvent{
+				ToolCallID:     "call-1",
+				ToolDefinition: tools.Tool{Name: "edit_file"},
+				Response:       "edited",
+				Result:         tools.ResultSuccess("edited"),
+			},
+			wantStatus: acpsdk.ToolCallStatusCompleted,
+			wantDiff:   true,
+		},
+		{
+			name:      "failed edit_file keeps text content",
+			arguments: editArgs,
+			event: &runtime.ToolCallResponseEvent{
+				ToolCallID:     "call-1",
+				ToolDefinition: tools.Tool{Name: "edit_file"},
+				Response:       "failed",
+				Result:         tools.ResultError("failed"),
+			},
+			wantStatus: acpsdk.ToolCallStatusFailed,
+		},
+		{
+			name:      "edit_file without diffable args falls back to text",
+			arguments: `{"path":"/f.go","edits":[]}`,
+			event: &runtime.ToolCallResponseEvent{
+				ToolCallID:     "call-1",
+				ToolDefinition: tools.Tool{Name: "edit_file"},
+				Response:       "edited",
+				Result:         tools.ResultSuccess("edited"),
+			},
+			wantStatus: acpsdk.ToolCallStatusCompleted,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			update := buildToolCallComplete(tt.arguments, tt.event)
+			require.NotNil(t, update.ToolCallUpdate)
+			tc := update.ToolCallUpdate
+
+			assert.Equal(t, acpsdk.ToolCallId(tt.event.ToolCallID), tc.ToolCallId)
+			require.NotNil(t, tc.Status)
+			assert.Equal(t, tt.wantStatus, *tc.Status)
+			assert.Equal(t, map[string]any{"content": tt.event.Response}, tc.RawOutput)
+
+			require.Len(t, tc.Content, 1)
+			if tt.wantDiff {
+				require.NotNil(t, tc.Content[0].Diff)
+				assert.Equal(t, "/f.go", tc.Content[0].Diff.Path)
+				assert.Equal(t, "b\n", tc.Content[0].Diff.NewText)
+				require.NotNil(t, tc.Content[0].Diff.OldText)
+				assert.Equal(t, "a\n", *tc.Content[0].Diff.OldText)
+			} else {
+				require.NotNil(t, tc.Content[0].Content)
+				require.NotNil(t, tc.Content[0].Content.Content.Text)
+				assert.Equal(t, tt.event.Response, tc.Content[0].Content.Content.Text.Text)
+			}
+		})
+	}
+}
+
+func TestBuildToolCallStart(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses annotation title and extracts locations", func(t *testing.T) {
+		t.Parallel()
+
+		toolCall := tools.ToolCall{
+			ID:       "call-1",
+			Function: tools.FunctionCall{Name: "read_file", Arguments: `{"path":"/a.txt"}`},
+		}
+		tool := tools.Tool{Name: "read_file", Annotations: tools.ToolAnnotations{Title: "Read File", ReadOnlyHint: true}}
+
+		update := buildToolCallStart(toolCall, tool)
+		require.NotNil(t, update.ToolCall)
+		tc := update.ToolCall
+
+		assert.Equal(t, acpsdk.ToolCallId("call-1"), tc.ToolCallId)
+		assert.Equal(t, "Read File", tc.Title)
+		assert.Equal(t, acpsdk.ToolKindRead, tc.Kind)
+		assert.Equal(t, acpsdk.ToolCallStatusPending, tc.Status)
+		assert.Equal(t, map[string]any{"path": "/a.txt"}, tc.RawInput)
+		assert.Equal(t, []acpsdk.ToolCallLocation{{Path: "/a.txt"}}, tc.Locations)
+	})
+
+	t.Run("falls back to function name without locations", func(t *testing.T) {
+		t.Parallel()
+
+		toolCall := tools.ToolCall{
+			ID:       "call-2",
+			Function: tools.FunctionCall{Name: "shell", Arguments: `{"command":"ls"}`},
+		}
+
+		update := buildToolCallStart(toolCall, tools.Tool{Name: "shell"})
+		require.NotNil(t, update.ToolCall)
+		tc := update.ToolCall
+
+		assert.Equal(t, "shell", tc.Title)
+		assert.Equal(t, acpsdk.ToolKindExecute, tc.Kind)
+		assert.Empty(t, tc.Locations)
+	})
+}
+
+func TestBuildToolCallUpdate(t *testing.T) {
+	t.Parallel()
+
+	toolCall := tools.ToolCall{
+		ID:       "call-1",
+		Function: tools.FunctionCall{Name: "shell", Arguments: `{"command":"ls"}`},
+	}
+
+	update := buildToolCallUpdate(toolCall, tools.Tool{Name: "shell"}, acpsdk.ToolCallStatusPending)
+	assert.Equal(t, acpsdk.ToolCallId("call-1"), update.ToolCallId)
+	require.NotNil(t, update.Title)
+	assert.Equal(t, "shell", *update.Title)
+	require.NotNil(t, update.Kind)
+	assert.Equal(t, acpsdk.ToolKindExecute, *update.Kind)
+	require.NotNil(t, update.Status)
+	assert.Equal(t, acpsdk.ToolCallStatusPending, *update.Status)
+	assert.Equal(t, map[string]any{"command": "ls"}, update.RawInput)
+
+	readOnly := tools.Tool{Name: "shell", Annotations: tools.ToolAnnotations{ReadOnlyHint: true}}
+	update = buildToolCallUpdate(toolCall, readOnly, acpsdk.ToolCallStatusCompleted)
+	require.NotNil(t, update.Kind)
+	assert.Equal(t, acpsdk.ToolKindRead, *update.Kind)
+}
+
+func TestIsTodoTool(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{
+		todo.ToolNameCreateTodo,
+		todo.ToolNameCreateTodos,
+		todo.ToolNameUpdateTodos,
+		todo.ToolNameListTodos,
+	} {
+		assert.True(t, isTodoTool(name), name)
+	}
+	assert.False(t, isTodoTool("todo"))
+	assert.False(t, isTodoTool("shell"))
+}
+
+func TestBuildPlanUpdateFromTodos(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		meta any
+		want []acpsdk.PlanEntry
+	}{
+		{name: "not a todo slice", meta: "bogus", want: nil},
+		{name: "nil meta", meta: nil, want: nil},
+		{name: "empty todos", meta: []todo.Todo{}, want: nil},
+		{
+			name: "todos map to plan entries",
+			meta: []todo.Todo{
+				{ID: "1", Description: "write tests", Status: "pending"},
+				{ID: "2", Description: "run tests", Status: "in-progress"},
+				{ID: "3", Description: "review", Status: "completed"},
+			},
+			want: []acpsdk.PlanEntry{
+				{Content: "write tests", Status: acpsdk.PlanEntryStatusPending, Priority: acpsdk.PlanEntryPriorityMedium},
+				{Content: "run tests", Status: acpsdk.PlanEntryStatusInProgress, Priority: acpsdk.PlanEntryPriorityMedium},
+				{Content: "review", Status: acpsdk.PlanEntryStatusCompleted, Priority: acpsdk.PlanEntryPriorityMedium},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			update := buildPlanUpdateFromTodos(tt.meta)
+			if tt.want == nil {
+				assert.Nil(t, update)
+				return
+			}
+			require.NotNil(t, update)
+			require.NotNil(t, update.Plan)
+			assert.Equal(t, tt.want, update.Plan.Entries)
+		})
+	}
+}
+
+func TestMapTodoStatusToACP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		status string
+		want   acpsdk.PlanEntryStatus
+	}{
+		{status: "pending", want: acpsdk.PlanEntryStatusPending},
+		{status: "in-progress", want: acpsdk.PlanEntryStatusInProgress},
+		{status: "completed", want: acpsdk.PlanEntryStatusCompleted},
+		{status: "", want: acpsdk.PlanEntryStatusPending},
+		{status: "unknown", want: acpsdk.PlanEntryStatusPending},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, mapTodoStatusToACP(tt.status), "status %q", tt.status)
+	}
+}

--- a/pkg/config/latest/validate_test.go
+++ b/pkg/config/latest/validate_test.go
@@ -1,0 +1,615 @@
+package latest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateCompactionThreshold(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   *float64
+		wantErr string
+	}{
+		{name: "nil is valid", value: nil},
+		{name: "just above zero", value: new(0.0001)},
+		{name: "mid range", value: new(0.5)},
+		{name: "exactly one", value: new(1.0)},
+		{name: "exactly zero", value: new(0.0), wantErr: "compaction_threshold must be greater than 0 and at most 1, got 0"},
+		{name: "negative", value: new(-0.5), wantErr: "compaction_threshold must be greater than 0 and at most 1, got -0.5"},
+		{name: "just above one", value: new(1.000001), wantErr: "compaction_threshold must be greater than 0 and at most 1"},
+		{name: "well above one", value: new(1.5), wantErr: "compaction_threshold must be greater than 0 and at most 1, got 1.5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateCompactionThreshold(tt.value)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestModelConfigValidateFirstAvailable(t *testing.T) {
+	t.Parallel()
+
+	candidates := []string{"openai/gpt-4o"}
+
+	tests := []struct {
+		name    string
+		model   ModelConfig
+		wantErr string
+	}{
+		{name: "nil selector", model: ModelConfig{Provider: "openai", Model: "gpt-4o"}},
+		{name: "single candidate", model: ModelConfig{FirstAvailable: candidates}},
+		{name: "multiple candidates", model: ModelConfig{FirstAvailable: []string{"anthropic/claude-sonnet-4-5", "dmr/local"}}},
+		{name: "empty selector", model: ModelConfig{FirstAvailable: []string{}}, wantErr: "first_available must contain at least one candidate"},
+		{name: "blank candidate", model: ModelConfig{FirstAvailable: []string{"openai/gpt-4o", "  "}}, wantErr: "first_available[1] must not be empty"},
+		{name: "with provider", model: ModelConfig{FirstAvailable: candidates, Provider: "openai"}, wantErr: "first_available cannot be combined with provider/model"},
+		{name: "with model", model: ModelConfig{FirstAvailable: candidates, Model: "gpt-4o"}, wantErr: "first_available cannot be combined with provider/model"},
+		{name: "with temperature", model: ModelConfig{FirstAvailable: candidates, Temperature: new(0.5)}, wantErr: "first_available cannot be combined with temperature"},
+		{name: "with max_tokens", model: ModelConfig{FirstAvailable: candidates, MaxTokens: new(int64(100))}, wantErr: "first_available cannot be combined with max_tokens"},
+		{name: "with top_p", model: ModelConfig{FirstAvailable: candidates, TopP: new(0.9)}, wantErr: "first_available cannot be combined with top_p"},
+		{name: "with frequency_penalty", model: ModelConfig{FirstAvailable: candidates, FrequencyPenalty: new(0.1)}, wantErr: "first_available cannot be combined with frequency_penalty"},
+		{name: "with presence_penalty", model: ModelConfig{FirstAvailable: candidates, PresencePenalty: new(0.1)}, wantErr: "first_available cannot be combined with presence_penalty"},
+		{name: "with base_url", model: ModelConfig{FirstAvailable: candidates, BaseURL: "https://example.invalid/v1"}, wantErr: "first_available cannot be combined with base_url"},
+		{name: "with token_key", model: ModelConfig{FirstAvailable: candidates, TokenKey: "MY_KEY"}, wantErr: "first_available cannot be combined with token_key"},
+		{name: "with bypass_models_gateway", model: ModelConfig{FirstAvailable: candidates, BypassModelsGateway: true}, wantErr: "first_available cannot be combined with bypass_models_gateway"},
+		{name: "with provider_opts", model: ModelConfig{FirstAvailable: candidates, ProviderOpts: map[string]any{"context_size": 4096}}, wantErr: "first_available cannot be combined with provider_opts"},
+		{name: "with track_usage", model: ModelConfig{FirstAvailable: candidates, TrackUsage: new(true)}, wantErr: "first_available cannot be combined with track_usage"},
+		{name: "with thinking_budget", model: ModelConfig{FirstAvailable: candidates, ThinkingBudget: &ThinkingBudget{Effort: "high"}}, wantErr: "first_available cannot be combined with thinking_budget"},
+		{name: "with task_budget", model: ModelConfig{FirstAvailable: candidates, TaskBudget: &TaskBudget{Type: "tokens", Total: 1000}}, wantErr: "first_available cannot be combined with task_budget"},
+		{name: "with auth", model: ModelConfig{FirstAvailable: candidates, Auth: &AuthConfig{Type: AuthTypeWorkloadIdentityFederation}}, wantErr: "first_available cannot be combined with auth"},
+		{name: "with routing", model: ModelConfig{FirstAvailable: candidates, Routing: []RoutingRule{{Model: "openai/gpt-4o-mini", Examples: []string{"hi"}}}}, wantErr: "first_available cannot be combined with routing"},
+		{name: "with title_model", model: ModelConfig{FirstAvailable: candidates, TitleModel: "small"}, wantErr: "first_available cannot be combined with title_model"},
+		{name: "with compaction_model", model: ModelConfig{FirstAvailable: candidates, CompactionModel: "small"}, wantErr: "first_available cannot be combined with compaction_model"},
+		{name: "with compaction_threshold", model: ModelConfig{FirstAvailable: candidates, CompactionThreshold: new(0.5)}, wantErr: "first_available cannot be combined with compaction_threshold"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.model.validateFirstAvailable()
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestAgentConfigValidateFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		fallback *FallbackConfig
+		wantErr  string
+	}{
+		{name: "nil fallback", fallback: nil},
+		{name: "defaults", fallback: &FallbackConfig{Models: []string{"backup"}}},
+		{name: "explicit no retries", fallback: &FallbackConfig{Retries: -1}},
+		{name: "positive retries and cooldown", fallback: &FallbackConfig{Retries: 3, Cooldown: Duration{Duration: time.Minute}}},
+		{name: "retries below -1", fallback: &FallbackConfig{Retries: -2}, wantErr: "fallback.retries must be >= -1"},
+		{name: "negative cooldown", fallback: &FallbackConfig{Cooldown: Duration{Duration: -time.Second}}, wantErr: "fallback.cooldown must be non-negative"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			agent := AgentConfig{Name: "root", Fallback: tt.fallback}
+			err := agent.validateFallback()
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestAgentConfigValidateHarness(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		harness *HarnessConfig
+		wantErr string
+	}{
+		{name: "nil harness", harness: nil},
+		{name: "claude-code", harness: &HarnessConfig{Type: "claude-code"}},
+		{name: "codex", harness: &HarnessConfig{Type: "codex"}},
+		{name: "pi", harness: &HarnessConfig{Type: "pi"}},
+		{name: "opencode", harness: &HarnessConfig{Type: "opencode"}},
+		{name: "missing type", harness: &HarnessConfig{}, wantErr: "harness.type is required"},
+		{name: "unsupported type", harness: &HarnessConfig{Type: "cursor"}, wantErr: `unsupported harness.type "cursor"`},
+		{name: "effort low", harness: &HarnessConfig{Type: "claude-code", Effort: "low"}},
+		{name: "effort medium", harness: &HarnessConfig{Type: "claude-code", Effort: "medium"}},
+		{name: "effort high", harness: &HarnessConfig{Type: "claude-code", Effort: "high"}},
+		{name: "effort max", harness: &HarnessConfig{Type: "claude-code", Effort: "max"}},
+		{name: "effort on wrong type", harness: &HarnessConfig{Type: "codex", Effort: "high"}, wantErr: "harness.effort can only be used with harness.type 'claude-code'"},
+		{name: "invalid effort", harness: &HarnessConfig{Type: "claude-code", Effort: "extreme"}, wantErr: "harness.effort must be one of: low, medium, high, max"},
+		{name: "agent on opencode", harness: &HarnessConfig{Type: "opencode", Agent: "build"}},
+		{name: "agent on wrong type", harness: &HarnessConfig{Type: "claude-code", Agent: "build"}, wantErr: "harness.agent can only be used with harness.type 'opencode'"},
+		{name: "thinking on opencode", harness: &HarnessConfig{Type: "opencode", Thinking: true}},
+		{name: "thinking on wrong type", harness: &HarnessConfig{Type: "codex", Thinking: true}, wantErr: "harness.thinking can only be used with harness.type 'opencode'"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			agent := AgentConfig{Name: "root", Harness: tt.harness}
+			err := agent.validateHarness()
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestToolsetValidateAttributeTypeMismatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		toolset Toolset
+		wantErr string
+	}{
+		{name: "shell map on non-script", toolset: Toolset{Type: "shell", Shell: map[string]ScriptShellToolConfig{"greet": {}}}, wantErr: "shell can only be used with type 'script'"},
+		{name: "path on non-memory/tasks", toolset: Toolset{Type: "shell", Path: "/tmp/db"}, wantErr: "path can only be used with type 'memory' or 'tasks'"},
+		{name: "post_edit on non-filesystem", toolset: Toolset{Type: "shell", PostEdit: []PostEditConfig{{}}}, wantErr: "post_edit can only be used with type 'filesystem'"},
+		{name: "ignore_vcs on non-filesystem", toolset: Toolset{Type: "shell", IgnoreVCS: new(true)}, wantErr: "ignore_vcs can only be used with type 'filesystem'"},
+		{name: "allow_list on non-filesystem", toolset: Toolset{Type: "shell", AllowList: []string{"."}}, wantErr: "allow_list can only be used with type 'filesystem'"},
+		{name: "deny_list on non-filesystem", toolset: Toolset{Type: "shell", DenyList: []string{"/etc"}}, wantErr: "deny_list can only be used with type 'filesystem'"},
+		{name: "blank allow_list entry", toolset: Toolset{Type: "filesystem", AllowList: []string{"  "}}, wantErr: "allow_list[0] must not be empty"},
+		{name: "blank deny_list entry", toolset: Toolset{Type: "filesystem", DenyList: []string{"/etc", ""}}, wantErr: "deny_list[1] must not be empty"},
+		{name: "env on wrong type", toolset: Toolset{Type: "filesystem", Env: map[string]string{"A": "b"}}, wantErr: "env can only be used with type 'shell', 'background_jobs', 'script', 'mcp' or 'lsp'"},
+		{name: "file_types on non-lsp", toolset: Toolset{Type: "shell", FileTypes: []string{"go"}}, wantErr: "file_types can only be used with type 'lsp'"},
+		{name: "allowed_servers on non-mcp_catalog", toolset: Toolset{Type: "shell", AllowedServers: []string{"github"}}, wantErr: "allowed_servers can only be used with type 'mcp_catalog'"},
+		{name: "blocked_servers on non-mcp_catalog", toolset: Toolset{Type: "shell", BlockedServers: []string{"github"}}, wantErr: "blocked_servers can only be used with type 'mcp_catalog'"},
+		{name: "blank allowed_servers entry", toolset: Toolset{Type: "mcp_catalog", AllowedServers: []string{""}}, wantErr: "allowed_servers[0] must not be empty"},
+		{name: "blank blocked_servers entry", toolset: Toolset{Type: "mcp_catalog", BlockedServers: []string{"github", " "}}, wantErr: "blocked_servers[1] must not be empty"},
+		{name: "allowed_domains on non-fetch", toolset: Toolset{Type: "shell", AllowedDomains: []string{"example.com"}}, wantErr: "allowed_domains can only be used with type 'fetch'"},
+		{name: "blocked_domains on non-fetch", toolset: Toolset{Type: "shell", BlockedDomains: []string{"example.com"}}, wantErr: "blocked_domains can only be used with type 'fetch'"},
+		{name: "allow_private_ips on wrong type", toolset: Toolset{Type: "shell", AllowPrivateIPs: new(true)}, wantErr: "allow_private_ips can only be used with type 'fetch', 'api', 'openapi', 'a2a' or remote MCP toolsets"},
+		{name: "sudo_askpass on non-shell", toolset: Toolset{Type: "fetch", SudoAskpass: new(true)}, wantErr: "sudo_askpass can only be used with type 'shell'"},
+		{name: "recall on non-background_jobs", toolset: Toolset{Type: "shell", Recall: new(true)}, wantErr: "recall can only be used with type 'background_jobs'"},
+		{name: "safer on non-shell", toolset: Toolset{Type: "fetch", Safer: new(true)}, wantErr: "safer can only be used with type 'shell'"},
+		{name: "allowed and blocked domains", toolset: Toolset{Type: "fetch", AllowedDomains: []string{"a.example.com"}, BlockedDomains: []string{"b.example.com"}}, wantErr: "allowed_domains and blocked_domains are mutually exclusive"},
+		{name: "invalid allowed_domains pattern", toolset: Toolset{Type: "fetch", AllowedDomains: []string{"foo.*"}}, wantErr: `allowed_domains[0] "foo.*" is invalid`},
+		{name: "invalid blocked_domains pattern", toolset: Toolset{Type: "fetch", BlockedDomains: []string{"10.0.0.0/33"}}, wantErr: `blocked_domains[0] "10.0.0.0/33" is invalid: not a valid CIDR`},
+		{name: "models on non-model_picker", toolset: Toolset{Type: "shell", Models: []string{"openai/gpt-4o"}}, wantErr: "models can only be used with type 'model_picker'"},
+		{name: "shared on non-todo", toolset: Toolset{Type: "shell", Shared: true}, wantErr: "shared can only be used with type 'todo'"},
+		{name: "version on wrong type", toolset: Toolset{Type: "shell", Version: "owner/repo"}, wantErr: "version can only be used with type 'mcp' or 'lsp'"},
+		{name: "command on wrong type", toolset: Toolset{Type: "shell", Command: "run"}, wantErr: "command can only be used with type 'mcp' or 'lsp'"},
+		{name: "args on wrong type", toolset: Toolset{Type: "shell", Args: []string{"-v"}}, wantErr: "args can only be used with type 'mcp' or 'lsp'"},
+		{name: "ref on wrong type", toolset: Toolset{Type: "shell", Ref: "docker/duckduckgo"}, wantErr: "ref can only be used with type 'mcp' or 'rag'"},
+		{name: "remote url on non-mcp", toolset: Toolset{Type: "shell", Remote: Remote{URL: "https://mcp.example.com"}}, wantErr: "remote can only be used with type 'mcp'"},
+		{name: "remote transport on non-mcp", toolset: Toolset{Type: "a2a", URL: "https://agent.example.com", Remote: Remote{TransportType: "sse"}}, wantErr: "remote can only be used with type 'mcp'"},
+		{name: "remote oauth on non-mcp", toolset: Toolset{Type: "shell", Remote: Remote{OAuth: &RemoteOAuthConfig{ClientID: "c"}}}, wantErr: "remote can only be used with type 'mcp'"},
+		{name: "remote headers on wrong type", toolset: Toolset{Type: "shell", Remote: Remote{Headers: map[string]string{"A": "b"}}}, wantErr: "remote headers can only be used with type 'mcp' or 'a2a'"},
+		{name: "headers on wrong type", toolset: Toolset{Type: "shell", Headers: map[string]string{"A": "b"}}, wantErr: "headers can only be used with type 'openapi', 'a2a' or 'fetch'"},
+		{name: "config on non-mcp", toolset: Toolset{Type: "shell", Config: map[string]any{"k": "v"}}, wantErr: "config can only be used with type 'mcp'"},
+		{name: "url on wrong type", toolset: Toolset{Type: "shell", URL: "https://example.com"}, wantErr: "url can only be used with type 'a2a', 'openapi' or 'open_url'"},
+		{name: "name on wrong type", toolset: Toolset{Type: "shell", Name: "custom"}, wantErr: "name can only be used with type 'mcp', 'a2a', 'rag', or 'open_url'"},
+		{name: "rag_config on non-rag", toolset: Toolset{Type: "shell", RAGConfig: &RAGConfig{}}, wantErr: "rag_config can only be used with type 'rag'"},
+		{name: "working_dir on wrong type", toolset: Toolset{Type: "shell", WorkingDir: "/tmp"}, wantErr: "working_dir can only be used with type 'mcp' or 'lsp'"},
+		{name: "working_dir on remote mcp", toolset: Toolset{Type: "mcp", WorkingDir: "/tmp", Remote: Remote{URL: "https://mcp.example.com"}}, wantErr: "working_dir is not valid for remote MCP toolsets"},
+		{name: "lifecycle on wrong type", toolset: Toolset{Type: "shell", Lifecycle: &LifecycleConfig{}}, wantErr: "lifecycle can only be used with type 'mcp' or 'lsp'"},
+		{name: "invalid lifecycle", toolset: Toolset{Type: "mcp", Command: "server", Lifecycle: &LifecycleConfig{Profile: "bogus"}}, wantErr: `lifecycle.profile "bogus" is not supported`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.ErrorContains(t, tt.toolset.validate(), tt.wantErr)
+		})
+	}
+}
+
+func TestToolsetValidateTypeRequirements(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		toolset Toolset
+		wantErr string
+	}{
+		{name: "mcp without source", toolset: Toolset{Type: "mcp"}, wantErr: "either command, remote or ref must be set"},
+		{name: "mcp command and remote", toolset: Toolset{Type: "mcp", Command: "server", Remote: Remote{URL: "https://mcp.example.com"}}, wantErr: "but only one of those"},
+		{name: "mcp command and ref", toolset: Toolset{Type: "mcp", Command: "server", Ref: "docker/duckduckgo"}, wantErr: "but only one of those"},
+		{name: "mcp remote and ref", toolset: Toolset{Type: "mcp", Remote: Remote{URL: "https://mcp.example.com"}, Ref: "docker/duckduckgo"}, wantErr: "but only one of those"},
+		{name: "local mcp with allow_private_ips", toolset: Toolset{Type: "mcp", Command: "server", AllowPrivateIPs: new(true)}, wantErr: "allow_private_ips can only be used with type 'fetch', 'api', 'openapi', 'a2a' or remote MCP toolsets"},
+		{name: "a2a without url", toolset: Toolset{Type: "a2a"}, wantErr: "a2a toolset requires a url to be set"},
+		{name: "lsp without command", toolset: Toolset{Type: "lsp"}, wantErr: "lsp toolset requires a command to be set"},
+		{name: "openapi without url", toolset: Toolset{Type: "openapi"}, wantErr: "openapi toolset requires a url to be set"},
+		{name: "open_url without url", toolset: Toolset{Type: "open_url"}, wantErr: "open_url toolset requires a url to be set"},
+		{name: "model_picker without models", toolset: Toolset{Type: "model_picker"}, wantErr: "model_picker toolset requires at least one model in the 'models' list"},
+		{name: "rag without ref or config", toolset: Toolset{Type: "rag"}, wantErr: "rag toolset requires either ref or rag_config"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.ErrorContains(t, tt.toolset.validate(), tt.wantErr)
+		})
+	}
+}
+
+func TestToolsetValidateOAuth(t *testing.T) {
+	t.Parallel()
+
+	remote := func(oauth *RemoteOAuthConfig) Toolset {
+		return Toolset{Type: "mcp", Remote: Remote{URL: "https://mcp.example.com", OAuth: oauth}}
+	}
+
+	tests := []struct {
+		name    string
+		toolset Toolset
+		wantErr string
+	}{
+		{name: "minimal oauth", toolset: remote(&RemoteOAuthConfig{ClientID: "client"})},
+		{name: "oauth without remote url", toolset: Toolset{Type: "mcp", Command: "server", Remote: Remote{OAuth: &RemoteOAuthConfig{ClientID: "client"}}}, wantErr: "oauth requires remote url to be set"},
+		{name: "missing clientId", toolset: remote(&RemoteOAuthConfig{}), wantErr: "oauth requires clientId to be set"},
+		{name: "callback port unset", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackPort: 0})},
+		{name: "callback port lower bound", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackPort: 1})},
+		{name: "callback port upper bound", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackPort: 65535})},
+		{name: "callback port negative", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackPort: -1}), wantErr: "oauth callbackPort must be between 1 and 65535"},
+		{name: "callback port too large", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackPort: 65536}), wantErr: "oauth callbackPort must be between 1 and 65535"},
+		{name: "https redirect url", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackRedirectURL: "https://redirect.example.com/cb"})},
+		{name: "loopback redirect url with placeholder", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackRedirectURL: "http://127.0.0.1:${callbackPort}/callback"})},
+		{name: "http redirect to non-loopback", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackRedirectURL: "http://redirect.example.com/cb"}), wantErr: "oauth callbackRedirectURL must use https for non-loopback hosts"},
+		{name: "relative redirect url", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackRedirectURL: "/callback"}), wantErr: "oauth callbackRedirectURL must be an absolute URL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.toolset.validate()
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestToolsetValidateValidToolsets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		toolset Toolset
+	}{
+		{name: "shell", toolset: Toolset{Type: "shell", Env: map[string]string{"A": "b"}, SudoAskpass: new(true), Safer: new(true)}},
+		{name: "background_jobs", toolset: Toolset{Type: "background_jobs", Env: map[string]string{"A": "b"}, Recall: new(true)}},
+		{name: "memory with path", toolset: Toolset{Type: "memory", Path: "/tmp/memory.db"}},
+		{name: "memory without path", toolset: Toolset{Type: "memory"}},
+		{name: "tasks", toolset: Toolset{Type: "tasks", Path: "./tasks.json"}},
+		{name: "todo shared", toolset: Toolset{Type: "todo", Shared: true}},
+		{name: "script", toolset: Toolset{Type: "script", Shell: map[string]ScriptShellToolConfig{"greet": {}}, Env: map[string]string{"A": "b"}}},
+		{name: "filesystem", toolset: Toolset{Type: "filesystem", PostEdit: []PostEditConfig{{}}, IgnoreVCS: new(false), AllowList: []string{".", "~/src"}, DenyList: []string{"/etc"}}},
+		{name: "fetch with allowed domains", toolset: Toolset{Type: "fetch", AllowedDomains: []string{"example.com", "*.example.org", ".sub.example.net", "10.0.0.0/8"}, Headers: map[string]string{"Accept": "text/html"}, AllowPrivateIPs: new(true)}},
+		{name: "fetch with blocked domains", toolset: Toolset{Type: "fetch", BlockedDomains: []string{"internal.example.com"}}},
+		{name: "api with allow_private_ips", toolset: Toolset{Type: "api", AllowPrivateIPs: new(true)}},
+		{name: "mcp_catalog", toolset: Toolset{Type: "mcp_catalog", AllowedServers: []string{"github"}, BlockedServers: []string{"slack"}}},
+		{name: "mcp local command", toolset: Toolset{Type: "mcp", Command: "server", Args: []string{"--stdio"}, Env: map[string]string{"A": "b"}, Version: "owner/repo@v1", WorkingDir: ".", Config: map[string]any{"k": "v"}, Lifecycle: &LifecycleConfig{Profile: LifecycleProfileResilient}}},
+		{name: "mcp local allow_private_ips disabled", toolset: Toolset{Type: "mcp", Command: "server", AllowPrivateIPs: new(false)}},
+		{name: "mcp remote", toolset: Toolset{Type: "mcp", Remote: Remote{URL: "https://mcp.example.com", TransportType: "sse", Headers: map[string]string{"Authorization": "Bearer x"}}, AllowPrivateIPs: new(true)}},
+		{name: "mcp ref", toolset: Toolset{Type: "mcp", Ref: "docker/duckduckgo", Name: "search", AllowPrivateIPs: new(true)}},
+		{name: "a2a", toolset: Toolset{Type: "a2a", URL: "https://agent.example.com", Name: "helper", Headers: map[string]string{"A": "b"}, Remote: Remote{Headers: map[string]string{"C": "d"}}}},
+		{name: "lsp", toolset: Toolset{Type: "lsp", Command: "gopls", Args: []string{"serve"}, FileTypes: []string{"go"}, Version: "golang/tools", WorkingDir: ".", Env: map[string]string{"A": "b"}, Lifecycle: &LifecycleConfig{Profile: LifecycleProfileStrict}}},
+		{name: "openapi", toolset: Toolset{Type: "openapi", URL: "https://api.example.com/spec.yaml", Headers: map[string]string{"A": "b"}}},
+		{name: "open_url", toolset: Toolset{Type: "open_url", URL: "https://example.com", Name: "docs"}},
+		{name: "model_picker", toolset: Toolset{Type: "model_picker", Models: []string{"openai/gpt-4o", "anthropic/claude-sonnet-4-5"}}},
+		{name: "rag with ref", toolset: Toolset{Type: "rag", Ref: "docs", Name: "kb"}},
+		{name: "rag with inline config", toolset: Toolset{Type: "rag", RAGConfig: &RAGConfig{}}},
+		{name: "background_agents", toolset: Toolset{Type: "background_agents"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.NoError(t, tt.toolset.validate())
+		})
+	}
+}
+
+// TestToolsetValidateUnknownType documents current behavior: validate only
+// checks field/type pairings and per-type requirements, so an unknown type
+// with no extra fields passes because the trailing type switch has no
+// default case. Unknown types are still rejected elsewhere: agent-schema.json
+// constrains `type` to an enum, and toolset creation fails with "unknown
+// toolset type" in the teamloader registry (pkg/teamloader/registry.go).
+func TestToolsetValidateUnknownType(t *testing.T) {
+	t.Parallel()
+
+	toolset := Toolset{Type: "no-such-toolset"}
+	require.NoError(t, toolset.validate())
+}
+
+func TestValidateNonEmptyEntries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		entries []string
+		wantErr string
+	}{
+		{name: "nil list", entries: nil},
+		{name: "valid entries", entries: []string{"github", "slack"}},
+		{name: "empty entry", entries: []string{""}, wantErr: "field[0] must not be empty"},
+		{name: "whitespace entry", entries: []string{"github", " \t"}, wantErr: "field[1] must not be empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateNonEmptyEntries("field", tt.entries)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidatePathRootEntries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		entries []string
+		wantErr string
+	}{
+		{name: "nil list", entries: nil},
+		{name: "valid entries", entries: []string{".", "~", "/srv/data", "relative/dir"}},
+		{name: "empty entry", entries: []string{""}, wantErr: "allow_list[0] must not be empty"},
+		{name: "whitespace entry", entries: []string{".", "   "}, wantErr: "allow_list[1] must not be empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validatePathRootEntries("allow_list", tt.entries)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateDomainPatterns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		patterns []string
+		wantErr  string
+	}{
+		{name: "nil list", patterns: nil},
+		{name: "plain hostname", patterns: []string{"example.com"}},
+		{name: "leading dot subdomain form", patterns: []string{".example.com"}},
+		{name: "leading wildcard", patterns: []string{"*.example.com"}},
+		{name: "ipv4 cidr", patterns: []string{"10.0.0.0/8"}},
+		{name: "ipv6 cidr", patterns: []string{"fd00::/8"}},
+		{name: "untrimmed valid entry", patterns: []string{"  example.com  "}},
+		{name: "empty entry", patterns: []string{"example.com", " "}, wantErr: "allowed_domains[1] must not be empty"},
+		{name: "invalid cidr", patterns: []string{"10.0.0.0/33"}, wantErr: `allowed_domains[0] "10.0.0.0/33" is invalid: not a valid CIDR`},
+		{name: "trailing wildcard", patterns: []string{"foo.*"}, wantErr: "'*' is only allowed as a leading '*.' wildcard"},
+		{name: "surrounding wildcards", patterns: []string{"*foo*"}, wantErr: "'*' is only allowed as a leading '*.' wildcard"},
+		{name: "double wildcard", patterns: []string{"**.example.com"}, wantErr: "'*' is only allowed as a leading '*.' wildcard"},
+		{name: "bare wildcard prefix", patterns: []string{"*."}, wantErr: "'*' is only allowed as a leading '*.' wildcard"},
+		{name: "mid-label wildcard", patterns: []string{"sub.*.example.com"}, wantErr: "'*' is only allowed as a leading '*.' wildcard"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateDomainPatterns("allowed_domains", tt.patterns)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestIsLoopbackHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		host string
+		want bool
+	}{
+		{name: "localhost", host: "localhost", want: true},
+		{name: "localhost mixed case", host: "LocalHost", want: true},
+		{name: "localhost with port", host: "localhost:8080", want: true},
+		{name: "ipv4 loopback", host: "127.0.0.1", want: true},
+		{name: "ipv4 loopback with port", host: "127.0.0.1:9090", want: true},
+		{name: "ipv4 loopback range", host: "127.1.2.3", want: true},
+		{name: "ipv6 loopback", host: "::1", want: true},
+		{name: "bracketed ipv6 loopback", host: "[::1]", want: true},
+		{name: "bracketed ipv6 loopback with port", host: "[::1]:8080", want: true},
+		{name: "public hostname", host: "example.com", want: false},
+		{name: "public hostname with port", host: "example.com:443", want: false},
+		{name: "private non-loopback ip", host: "192.168.1.10", want: false},
+		{name: "unspecified address", host: "0.0.0.0", want: false},
+		{name: "empty string", host: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isLoopbackHost(tt.host))
+		})
+	}
+}
+
+func TestValidateCallbackRedirectURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr string
+	}{
+		{name: "https non-loopback", raw: "https://redirect.example.com/oauth?state=x"},
+		{name: "https with placeholder", raw: "https://redirect.example.com/cb/${callbackPort}"},
+		{name: "http ipv4 loopback", raw: "http://127.0.0.1:8080/callback"},
+		{name: "http localhost with placeholder", raw: "http://localhost:${callbackPort}/callback"},
+		{name: "http ipv6 loopback with placeholder", raw: "http://[::1]:${callbackPort}/callback"},
+		{name: "http non-loopback", raw: "http://redirect.example.com/callback", wantErr: "oauth callbackRedirectURL must use https for non-loopback hosts"},
+		{name: "unsupported scheme", raw: "ftp://example.com/cb", wantErr: `oauth callbackRedirectURL scheme must be http or https, got "ftp"`},
+		{name: "scheme without host", raw: "javascript:alert(1)", wantErr: "oauth callbackRedirectURL must be an absolute URL"},
+		{name: "relative url", raw: "/callback", wantErr: "oauth callbackRedirectURL must be an absolute URL"},
+		{name: "empty string", raw: "", wantErr: "oauth callbackRedirectURL must be an absolute URL"},
+		{name: "unparseable url", raw: "://bad", wantErr: "oauth callbackRedirectURL must be an absolute URL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateCallbackRedirectURL(tt.raw)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestConfigValidateErrorWrapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr string
+	}{
+		{
+			name:    "provider auth error",
+			config:  Config{Providers: map[string]ProviderConfig{"corp": {Provider: "openai", Auth: &AuthConfig{}}}},
+			wantErr: "providers.corp: auth.type is required",
+		},
+		{
+			name:    "model first_available error",
+			config:  Config{Models: map[string]ModelConfig{"pick": {FirstAvailable: []string{}}}},
+			wantErr: "models.pick: first_available must contain at least one candidate",
+		},
+		{
+			name:    "model compaction threshold error",
+			config:  Config{Models: map[string]ModelConfig{"main": {Provider: "openai", Model: "gpt-4o", CompactionThreshold: new(1.5)}}},
+			wantErr: "models.main: compaction_threshold must be greater than 0 and at most 1",
+		},
+		{
+			name:    "model auth provider mismatch",
+			config:  Config{Models: map[string]ModelConfig{"main": {Provider: "openai", Model: "gpt-4o", Auth: &AuthConfig{Type: AuthTypeWorkloadIdentityFederation}}}},
+			wantErr: "models.main: auth.type \"workload_identity_federation\" is only supported with the anthropic provider",
+		},
+		{
+			name:    "named toolset error",
+			config:  Config{Toolsets: map[string]Toolset{"web": {Type: "fetch", AllowedDomains: []string{""}}}},
+			wantErr: "toolsets.web: allowed_domains[0] must not be empty",
+		},
+		{
+			name:    "agent fallback error",
+			config:  Config{Agents: Agents{{Name: "root", Fallback: &FallbackConfig{Retries: -2}}}},
+			wantErr: "fallback.retries must be >= -1",
+		},
+		{
+			name:    "agent harness error",
+			config:  Config{Agents: Agents{{Name: "root", Harness: &HarnessConfig{}}}},
+			wantErr: "harness.type is required",
+		},
+		{
+			name:    "agent compaction threshold error",
+			config:  Config{Agents: Agents{{Name: "root", CompactionThreshold: new(0.0)}}},
+			wantErr: "agents.root: compaction_threshold must be greater than 0 and at most 1",
+		},
+		{
+			name:    "agent toolset error",
+			config:  Config{Agents: Agents{{Name: "root", Toolsets: []Toolset{{Type: "a2a"}}}}},
+			wantErr: "a2a toolset requires a url to be set",
+		},
+		{
+			name:    "agent hooks error",
+			config:  Config{Agents: Agents{{Name: "root", Hooks: &HooksConfig{Stop: HookDefinitions{{}}}}}},
+			wantErr: "hooks.stop[0]: type is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.ErrorContains(t, tt.config.Validate(), tt.wantErr)
+		})
+	}
+}
+
+func TestConfigValidateValidConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Version: Version,
+		Providers: map[string]ProviderConfig{
+			"corp": {Provider: "anthropic", BaseURL: "https://llm.example.com/v1"},
+		},
+		Models: map[string]ModelConfig{
+			"main": {Provider: "openai", Model: "gpt-4o", CompactionThreshold: new(0.8)},
+			"pick": {FirstAvailable: []string{"anthropic/claude-sonnet-4-5", "dmr/local"}},
+			// Auth on a model routed through a custom provider exercises the
+			// EffectiveProviderType indirection in Config.Validate.
+			"wif": {
+				Provider: "corp",
+				Model:    "claude-sonnet-4-5",
+				Auth: &AuthConfig{
+					Type: AuthTypeWorkloadIdentityFederation,
+					Federation: &FederationAuthConfig{
+						FederationRuleID: "fdrl_123",
+						OrganizationID:   "org-id-for-tests",
+						IdentityToken:    &IdentityTokenSourceConfig{Env: "ANTHROPIC_OIDC_TOKEN"},
+					},
+				},
+			},
+		},
+		Toolsets: map[string]Toolset{
+			"web": {Type: "fetch", AllowedDomains: []string{"example.com", "*.example.org"}},
+		},
+		Agents: Agents{
+			{
+				Name:                "root",
+				Model:               "main",
+				Fallback:            &FallbackConfig{Models: []string{"pick"}, Retries: -1, Cooldown: Duration{Duration: time.Minute}},
+				Harness:             &HarnessConfig{Type: "claude-code", Effort: "high"},
+				CompactionThreshold: new(1.0),
+				Toolsets: []Toolset{
+					{Type: "shell"},
+					{Type: "mcp", Command: "server"},
+				},
+				Hooks: &HooksConfig{Stop: HookDefinitions{{Type: "command", Command: "echo done"}}},
+			},
+		},
+	}
+
+	require.NoError(t, cfg.Validate())
+}

--- a/pkg/gateway/catalog_cache_test.go
+++ b/pkg/gateway/catalog_cache_test.go
@@ -1,0 +1,423 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/paths"
+)
+
+const (
+	etagV1 = `"v1"`
+	etagV2 = `"v2"`
+
+	catalogBodyV1 = `{"registry":{"fetch":{"type":"server"}}}`
+	catalogBodyV2 = `{"registry":{"fetch":{"type":"server"},"github-official":{"type":"server"}}}`
+)
+
+var (
+	catalogV1 = Catalog{"fetch": {Type: "server"}}
+	catalogV2 = Catalog{
+		"fetch":           {Type: "server"},
+		"github-official": {Type: "server"},
+	}
+)
+
+// fakeCatalogTransport serves canned responses for the fixed catalog URL and
+// records the If-None-Match header of every request. It is deliberately not
+// an *http.Transport: remote.NewTransport returns any other RoundTripper
+// unchanged, so these tests never probe Docker Desktop (whose availability is
+// memoized process-wide) and never touch the network.
+type fakeCatalogTransport struct {
+	respond func(req *http.Request) (*http.Response, error)
+
+	mu          sync.Mutex
+	ifNoneMatch []string
+}
+
+func (f *fakeCatalogTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.String() != catalogJSON {
+		return nil, errors.New("unexpected request URL: " + req.URL.String())
+	}
+	f.mu.Lock()
+	f.ifNoneMatch = append(f.ifNoneMatch, req.Header.Get("If-None-Match"))
+	f.mu.Unlock()
+	return f.respond(req)
+}
+
+func (f *fakeCatalogTransport) sentIfNoneMatch() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.ifNoneMatch)
+}
+
+func catalogResponse(status int, etag, body string) *http.Response {
+	header := http.Header{}
+	if etag != "" {
+		header.Set("ETag", etag)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Status:     strconv.Itoa(status) + " " + http.StatusText(status),
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func respondWith(status int, etag, body string) func(*http.Request) (*http.Response, error) {
+	return func(*http.Request) (*http.Response, error) {
+		return catalogResponse(status, etag, body), nil
+	}
+}
+
+// catalogFetchScenarioEnv names the scenario TestCatalogFetchScenarioHelper
+// must run; runCatalogFetchScenario sets it in the child's environment.
+const catalogFetchScenarioEnv = "GATEWAY_CATALOG_FETCH_SCENARIO"
+
+type catalogFetchScenario struct {
+	// respond serves the canned response for the catalog request.
+	respond func(*http.Request) (*http.Response, error)
+	// seedCache pre-populates the on-disk cache with catalogV1/etagV1.
+	seedCache bool
+	// run is the scenario body, executed inside the child process.
+	run func(t *testing.T, cacheFile string, rt *fakeCatalogTransport)
+}
+
+// catalogFetchScenarios are the fetchAndCache/fetchFromNetwork cases that
+// depend on process globals (http.DefaultTransport and the paths cache-dir
+// override). Each runs in its own child process via runCatalogFetchScenario,
+// so the global swaps can never leak into other tests in this binary.
+var catalogFetchScenarios = map[string]catalogFetchScenario{
+	"initial fetch persists catalog and etag": {
+		respond: respondWith(http.StatusOK, etagV1, catalogBodyV1),
+		run: func(t *testing.T, cacheFile string, rt *fakeCatalogTransport) {
+			t.Helper()
+			catalog, err := fetchAndCache(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, catalogV1, catalog)
+
+			// First fetch has no cached ETag, so the request must be unconditional.
+			assert.Equal(t, []string{""}, rt.sentIfNoneMatch())
+
+			cached := loadFromDisk(cacheFile)
+			assert.Equal(t, catalogV1, cached.Catalog)
+			assert.Equal(t, etagV1, cached.ETag)
+		},
+	},
+	"not modified reuses cache": {
+		respond:   respondWith(http.StatusNotModified, "", ""),
+		seedCache: true,
+		run: func(t *testing.T, cacheFile string, rt *fakeCatalogTransport) {
+			t.Helper()
+			catalog, err := fetchAndCache(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, catalogV1, catalog)
+			assert.Equal(t, []string{etagV1}, rt.sentIfNoneMatch())
+
+			cached := loadFromDisk(cacheFile)
+			assert.Equal(t, catalogV1, cached.Catalog)
+			assert.Equal(t, etagV1, cached.ETag)
+		},
+	},
+	"refreshed fetch updates cache and etag": {
+		respond:   respondWith(http.StatusOK, etagV2, catalogBodyV2),
+		seedCache: true,
+		run: func(t *testing.T, cacheFile string, rt *fakeCatalogTransport) {
+			t.Helper()
+			catalog, err := fetchAndCache(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, catalogV2, catalog)
+			assert.Equal(t, []string{etagV1}, rt.sentIfNoneMatch())
+
+			cached := loadFromDisk(cacheFile)
+			assert.Equal(t, catalogV2, cached.Catalog)
+			assert.Equal(t, etagV2, cached.ETag)
+		},
+	},
+	"network error falls back to stale cache": {
+		respond: func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("connection reset")
+		},
+		seedCache: true,
+		run:       assertStaleCacheSurvivesFailedRefresh,
+	},
+	"unexpected status falls back to stale cache": {
+		respond:   respondWith(http.StatusInternalServerError, "", ""),
+		seedCache: true,
+		run:       assertStaleCacheSurvivesFailedRefresh,
+	},
+	"malformed body falls back to stale cache": {
+		respond:   respondWith(http.StatusOK, etagV2, "{not json"),
+		seedCache: true,
+		run:       assertStaleCacheSurvivesFailedRefresh,
+	},
+	"failure without cache returns error": {
+		respond: func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("connection reset")
+		},
+		run: func(t *testing.T, _ string, _ *fakeCatalogTransport) {
+			t.Helper()
+			catalog, err := fetchAndCache(t.Context())
+			require.ErrorContains(t, err, "fetching MCP catalog")
+			require.ErrorContains(t, err, "no cached copy available")
+			require.ErrorContains(t, err, "connection reset")
+			assert.Nil(t, catalog)
+		},
+	},
+	// A 304 can only follow an If-None-Match header, which requires a cached
+	// copy; if a server nevertheless sends one against an empty cache, the
+	// current behaviour is a nil catalog with no error. This scenario
+	// documents that behaviour without endorsing it.
+	"not modified without cache returns nil catalog": {
+		respond: respondWith(http.StatusNotModified, "", ""),
+		run: func(t *testing.T, _ string, rt *fakeCatalogTransport) {
+			t.Helper()
+			catalog, err := fetchAndCache(t.Context())
+			require.NoError(t, err)
+			assert.Nil(t, catalog)
+			assert.Equal(t, []string{""}, rt.sentIfNoneMatch())
+		},
+	},
+	// A zero-value Loader must fall back to the production fetch path instead
+	// of panicking inside once.Do.
+	"zero-value loader uses production fetch": {
+		respond: respondWith(http.StatusOK, etagV1, catalogBodyV1),
+		run: func(t *testing.T, _ string, _ *fakeCatalogTransport) {
+			t.Helper()
+			var loader Loader
+			catalog, err := loader.load(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, catalogV1, catalog)
+		},
+	},
+}
+
+func assertStaleCacheSurvivesFailedRefresh(t *testing.T, cacheFile string, _ *fakeCatalogTransport) {
+	t.Helper()
+	catalog, err := fetchAndCache(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, catalogV1, catalog)
+
+	// The stale cache must survive the failed refresh.
+	cached := loadFromDisk(cacheFile)
+	assert.Equal(t, catalogV1, cached.Catalog)
+	assert.Equal(t, etagV1, cached.ETag)
+}
+
+// TestCatalogFetchScenarioHelper is not a standalone test: it is the child
+// process body spawned by runCatalogFetchScenario and skips during a normal
+// test sweep. Because it is the only test running in its process, it may
+// safely swap the process globals fetchAndCache depends on.
+func TestCatalogFetchScenarioHelper(t *testing.T) {
+	name := os.Getenv(catalogFetchScenarioEnv)
+	if name == "" {
+		t.Skipf("helper process for catalog fetch scenarios; spawned with %s set", catalogFetchScenarioEnv)
+	}
+	scenario, ok := catalogFetchScenarios[name]
+	require.Truef(t, ok, "unknown catalog fetch scenario %q", name)
+
+	cacheDir := t.TempDir()
+	paths.SetCacheDir(cacheDir)
+	t.Cleanup(func() { paths.SetCacheDir("") })
+
+	rt := &fakeCatalogTransport{respond: scenario.respond}
+	previous := http.DefaultTransport
+	http.DefaultTransport = rt
+	t.Cleanup(func() { http.DefaultTransport = previous })
+
+	cacheFile := filepath.Join(cacheDir, catalogCacheFileName)
+	if scenario.seedCache {
+		saveToDisk(cacheFile, catalogV1, etagV1)
+	}
+
+	scenario.run(t, cacheFile, rt)
+}
+
+// runCatalogFetchScenario runs the named catalogFetchScenarios entry in a
+// child process by re-executing this test binary filtered down to
+// TestCatalogFetchScenarioHelper. Confining the global swaps to a throwaway
+// child keeps this binary's own state pristine, so callers are free to use
+// t.Parallel.
+func runCatalogFetchScenario(t *testing.T, name string) {
+	t.Helper()
+
+	_, ok := catalogFetchScenarios[name]
+	require.Truef(t, ok, "unknown catalog fetch scenario %q", name)
+
+	cmd := exec.CommandContext(t.Context(), os.Args[0],
+		"-test.run=^TestCatalogFetchScenarioHelper$", "-test.v", "-test.timeout=1m")
+	cmd.Env = append(os.Environ(), catalogFetchScenarioEnv+"="+name)
+
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "catalog fetch scenario %q failed:\n%s", name, out)
+
+	// Guard against a silent no-op: if the helper were renamed or skipped,
+	// every scenario would otherwise "pass" without running anything.
+	require.Containsf(t, string(out), "--- PASS: TestCatalogFetchScenarioHelper",
+		"catalog fetch scenario %q did not run the helper:\n%s", name, out)
+}
+
+func TestFetchAndCache_initialFetchPersistsCatalogAndETag(t *testing.T) {
+	t.Parallel()
+	runCatalogFetchScenario(t, "initial fetch persists catalog and etag")
+}
+
+func TestFetchAndCache_notModifiedReusesCache(t *testing.T) {
+	t.Parallel()
+	runCatalogFetchScenario(t, "not modified reuses cache")
+}
+
+func TestFetchAndCache_refreshedFetchUpdatesCacheAndETag(t *testing.T) {
+	t.Parallel()
+	runCatalogFetchScenario(t, "refreshed fetch updates cache and etag")
+}
+
+func TestFetchAndCache_fallsBackToStaleCacheOnFailure(t *testing.T) {
+	t.Parallel()
+
+	scenarios := []string{
+		"network error falls back to stale cache",
+		"unexpected status falls back to stale cache",
+		"malformed body falls back to stale cache",
+	}
+	for _, name := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			runCatalogFetchScenario(t, name)
+		})
+	}
+}
+
+func TestFetchAndCache_failureWithoutCacheReturnsError(t *testing.T) {
+	t.Parallel()
+	runCatalogFetchScenario(t, "failure without cache returns error")
+}
+
+func TestFetchAndCache_notModifiedWithoutCacheReturnsNilCatalog(t *testing.T) {
+	t.Parallel()
+	runCatalogFetchScenario(t, "not modified without cache returns nil catalog")
+}
+
+func TestLoader_zeroValueUsesProductionFetch(t *testing.T) {
+	t.Parallel()
+	runCatalogFetchScenario(t, "zero-value loader uses production fetch")
+}
+
+func TestLoadFromDisk(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing file", func(t *testing.T) {
+		t.Parallel()
+		cached := loadFromDisk(filepath.Join(t.TempDir(), catalogCacheFileName))
+		assert.Equal(t, cachedCatalog{}, cached)
+	})
+
+	t.Run("malformed json", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), catalogCacheFileName)
+		require.NoError(t, os.WriteFile(path, []byte("{not json"), 0o600))
+
+		cached := loadFromDisk(path)
+		assert.Equal(t, cachedCatalog{}, cached)
+	})
+
+	t.Run("valid cache", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), catalogCacheFileName)
+		data := `{"catalog":{"fetch":{"type":"server"}},"etag":"\"v1\""}`
+		require.NoError(t, os.WriteFile(path, []byte(data), 0o600))
+
+		cached := loadFromDisk(path)
+		assert.Equal(t, catalogV1, cached.Catalog)
+		assert.Equal(t, etagV1, cached.ETag)
+	})
+}
+
+func TestSaveToDisk_createsDirectoryAndWritesValidCache(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "nested", "cache", catalogCacheFileName)
+	saveToDisk(path, catalogV1, etagV1)
+
+	cached := loadFromDisk(path)
+	assert.Equal(t, catalogV1, cached.Catalog)
+	assert.Equal(t, etagV1, cached.ETag)
+
+	// The temp file used for the atomic rename must not linger.
+	entries, err := os.ReadDir(filepath.Dir(path))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, catalogCacheFileName, entries[0].Name())
+}
+
+func TestLoader_memoizesFetch(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	loader := &Loader{fetch: func(context.Context) (Catalog, error) {
+		calls++
+		return catalogV1, nil
+	}}
+
+	for range 3 {
+		catalog, err := loader.load(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, catalogV1, catalog)
+	}
+	assert.Equal(t, 1, calls)
+}
+
+func TestLoader_memoizesFetchError(t *testing.T) {
+	t.Parallel()
+
+	fetchErr := errors.New("catalog unavailable")
+	calls := 0
+	loader := &Loader{fetch: func(context.Context) (Catalog, error) {
+		calls++
+		return nil, fetchErr
+	}}
+
+	for range 2 {
+		_, err := loader.load(t.Context())
+		require.ErrorIs(t, err, fetchErr)
+	}
+	assert.Equal(t, 1, calls)
+}
+
+func TestWithLoader_nilLoaderFallsBackToDefault(t *testing.T) {
+	t.Parallel()
+
+	ctx := WithLoader(t.Context(), nil)
+	assert.Same(t, defaultLoader, loaderFrom(ctx))
+}
+
+func TestLoader_loadDetachesCallerCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	var fetchCtxErr error
+	loader := &Loader{fetch: func(fetchCtx context.Context) (Catalog, error) {
+		fetchCtxErr = fetchCtx.Err()
+		return catalogV1, nil
+	}}
+
+	catalog, err := loader.load(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, catalogV1, catalog)
+	require.NoError(t, fetchCtxErr, "a cancelled first caller must not poison the memoized result")
+}

--- a/pkg/reference/reference_test.go
+++ b/pkg/reference/reference_test.go
@@ -1,0 +1,79 @@
+package reference
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOciRefToFilename(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ref  string
+		want string
+	}{
+		{"ordinary ref with tag", "docker.io/myorg/agent:v1", "docker.io_myorg_agent_v1.yaml"},
+		{"registry with port", "localhost:5000/test", "localhost_5000_test.yaml"},
+		{"ref with digest", "myorg/agent@sha256:deadbeef", "myorg_agent_sha256_deadbeef.yaml"},
+		{"port tag and digest", "registry.example.com:443/org/agent:v2@sha256:abc123", "registry.example.com_443_org_agent_v2_sha256_abc123.yaml"},
+		{"no tag", "agentcatalog/pirate", "agentcatalog_pirate.yaml"},
+		{"slash", "a/b", "a_b.yaml"},
+		{"colon", "a:b", "a_b.yaml"},
+		{"at sign", "a@b", "a_b.yaml"},
+		{"backslash", `a\b`, "a_b.yaml"},
+		{"asterisk", "a*b", "a_b.yaml"},
+		{"question mark", "a?b", "a_b.yaml"},
+		{"double quote", `a"b`, "a_b.yaml"},
+		{"less than", "a<b", "a_b.yaml"},
+		{"greater than", "a>b", "a_b.yaml"},
+		{"pipe", "a|b", "a_b.yaml"},
+		{"all replaced characters", `/:@\*?"<>|`, "__________.yaml"},
+		{"empty input", "", ".yaml"},
+		{"existing .yaml suffix", "agent.yaml", "agent.yaml"},
+		{"ref with .yaml suffix", "myorg/agent.yaml", "myorg_agent.yaml"},
+		{"safe characters kept", "already_safe-name.v1", "already_safe-name.v1.yaml"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, OciRefToFilename(tt.ref))
+		})
+	}
+}
+
+// FuzzOciRefToFilename checks structural invariants only: the converter is
+// lossy (every replaced character maps to "_"), so no reverse parse exists.
+func FuzzOciRefToFilename(f *testing.F) {
+	seeds := []string{
+		"docker.io/myorg/agent:v1",
+		"localhost:5000/test",
+		"myorg/agent@sha256:deadbeef",
+		"",
+		".yaml",
+		"agent.yaml",
+		`/:@\*?"<>|`,
+		"already_safe",
+		"héllo/wörld:tag",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, ref string) {
+		got := OciRefToFilename(ref)
+
+		if !strings.HasSuffix(got, ".yaml") {
+			t.Errorf("OciRefToFilename(%q) = %q, want .yaml suffix", ref, got)
+		}
+		if strings.ContainsAny(got, `/:@\*?"<>|`) {
+			t.Errorf("OciRefToFilename(%q) = %q, contains a character that should have been replaced", ref, got)
+		}
+		if again := OciRefToFilename(got); again != got {
+			t.Errorf("OciRefToFilename is not idempotent: f(%q) = %q, f(f) = %q", ref, got, again)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds deterministic, focused test coverage for the input and protocol packages identified in #3600. The change is test-only and does not modify production behavior.

## Coverage

| package | before | after | increase |
|---|---:|---:|---:|
| `pkg/reference` | 0.0% | 100.0% | +100.0 pp |
| `pkg/config/latest` | 6.4% | 37.0% | +30.6 pp |
| `pkg/gateway` | 23.8% | 45.5% | +21.7 pp |
| `pkg/acp` | 20.9% | 45.4% | +24.5 pp |
| `pkg/a2a` | 23.4% | 56.1% | +32.7 pp |

The gateway percentage is conservative: network and ETag scenarios run in isolated helper subprocesses to prevent mutations of `http.DefaultTransport` and the cache directory from leaking into the parent test process. Go's parent coverage profile does not merge statements executed by those child processes.

## What changed

- Added OCI-reference conversion tables and fuzz invariants.
- Covered `validate.go` boundaries and error paths for models, agents, toolsets, OAuth redirects, domain patterns, fallback, and harness configuration.
- Covered catalog persistence, conditional ETag requests, `304 Not Modified`, refreshed caches, malformed responses, and stale-cache fallback.
- Covered ACP event translation, tool-call updates, todo plans, permission outcomes, max-iteration decisions, and JSON-RPC request/response behavior.
- Covered A2A partial/final events, errors, cancellation, session creation, and session resume behavior.

## Acceptance mapping

| issue expectation | implementation |
|---|---|
| `pkg/reference`: parse/conversion round trips and fuzz | table-driven conversion checks plus deterministic fuzz seeds and idempotence/safety invariants |
| `pkg/config/latest`: `validate.go` edge cases | focused tables for validation boundaries, mutually exclusive fields, required fields, and wrapped errors |
| `pkg/gateway`: cache and ETag paths | isolated network transport scenarios covering initial fetch, conditional fetch, refresh, and fallback |
| `pkg/acp` / `pkg/a2a`: protocol adapters | real adapter event mapping tests, including ACP JSON-RPC permission exchanges and A2A session lifecycle |
| deterministic tests | no external network calls; temporary storage and isolated child processes are used where global HTTP state is required |

## Validation

- `task build`
- `task lint`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy task test`
- `go test -race -count=1 ./pkg/reference ./pkg/config/latest ./pkg/gateway ./pkg/acp ./pkg/a2a`

The proxy variables are unset for the full suite because the local development proxy routes the repository's pre-existing private-address SSRF probes instead of allowing their dial guards to reject them. This is independent of the changes in this PR.

Closes #3600
