### PR TITLE
fix(tui): wrap long elicitation field content

### DIFF
--- a/pkg/tui/dialog/elicitation.go
+++ b/pkg/tui/dialog/elicitation.go
@@ -72,8 +72,40 @@ type ElicitationDialog struct {
 	// fieldStarts[i] is the line offset of field i's label inside the
 	// scrollable body. Populated by View() / Position().
 	fieldStarts []int
+	// fieldGeoms[i] describes field i's wrapped row layout (label height and
+	// per-option row ranges) relative to fieldStarts[i]. Populated together
+	// with fieldStarts by View().
+	fieldGeoms []fieldGeometry
 	// scrollableRow is the absolute screen row of the first scrollable line.
 	scrollableRow int
+	// reanchorFocus asks the next View() to scroll the focused control back
+	// into view. Set on real resizes: rewrapping at the new width can move
+	// the focused rows far from the current scroll offset, and only View()
+	// knows the fresh geometry. Consumed one-shot so ordinary renders never
+	// override the user's scroll position.
+	reanchorFocus bool
+}
+
+// fieldGeometry records the row layout of a single rendered field, relative
+// to the field's first line. Long labels and options wrap over several rows,
+// so focus and mouse hit-testing consult these offsets instead of assuming
+// one row per label/option.
+type fieldGeometry struct {
+	labelHeight   int   // rows used by the wrapped label
+	optionStarts  []int // first row of each enum/boolean option, relative to the field start
+	optionHeights []int // rows used by each option, parallel to optionStarts
+}
+
+// optionAt maps a row offset (relative to the field's first line) to the
+// index of the enum/boolean option rendered on that row, or -1 when the
+// offset falls outside every option (label rows, error line, trailing blank).
+func (g fieldGeometry) optionAt(offset int) int {
+	for j, start := range g.optionStarts {
+		if offset >= start && offset < start+g.optionHeights[j] {
+			return j
+		}
+	}
+	return -1
 }
 
 type elicitationKeyMap struct {
@@ -152,6 +184,13 @@ func (d *ElicitationDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
+		// A real resize rewraps the body, which can strand the focused
+		// control far from the current scroll offset; have the next View()
+		// reanchor it once fresh geometry exists. Skip the initial sizing at
+		// open so the dialog still opens scrolled to the top.
+		if d.Width() > 0 && (msg.Width != d.Width() || msg.Height != d.Height()) {
+			d.reanchorFocus = true
+		}
 		cmd := d.SetSize(msg.Width, msg.Height)
 		return d, cmd
 	case tea.PasteMsg:
@@ -297,35 +336,42 @@ func (d *ElicitationDialog) focusField(idx int) {
 	d.ensureFocusVisible()
 }
 
-// ensureFocusVisible scrolls so that the focused field's active line stays
+// ensureFocusVisible scrolls so that the focused field's active rows stay
 // in view. No-op before the first View() populates fieldStarts.
 func (d *ElicitationDialog) ensureFocusVisible() {
-	if line := d.focusLine(); line >= 0 {
-		d.scrollview.EnsureLineVisible(line)
+	if start, end := d.focusRange(); start >= 0 {
+		d.scrollview.EnsureRangeVisible(start, end)
 	}
 }
 
-// focusLine returns the line offset (within the scrollable body) of the
-// focused field's active line — the selected option for enums/booleans, the
-// input line for text fields. Returns -1 if no field is focused or layouts
-// haven't been computed yet.
-func (d *ElicitationDialog) focusLine() int {
-	if d.currentField < 0 || d.currentField >= len(d.fieldStarts) {
-		return -1
+// focusRange returns the first and last line offsets (within the scrollable
+// body) of the focused field's active rows — the selected option for
+// enums/booleans, the input line for text fields. Wrapping can spread an
+// option over several rows, hence a range. Returns (-1, -1) if no field is
+// focused or layouts haven't been computed yet.
+func (d *ElicitationDialog) focusRange() (start, end int) {
+	if d.currentField < 0 || d.currentField >= len(d.fieldStarts) || len(d.fieldGeoms) != len(d.fieldStarts) {
+		return -1, -1
 	}
-	start := d.fieldStarts[d.currentField]
+	fieldStart := d.fieldStarts[d.currentField]
+	geom := d.fieldGeoms[d.currentField]
+
+	idx := -1
 	switch f := d.fields[d.currentField]; f.Type {
 	case "boolean":
+		idx = 1 // "No"
 		if d.boolValues[d.currentField] {
-			return start + 1 // "Yes"
+			idx = 0 // "Yes"
 		}
-		return start + 2 // "No"
 	case "enum":
-		idx := max(0, min(d.enumIndexes[d.currentField], len(f.EnumValues)-1))
-		return start + 1 + idx
-	default:
-		return start + 1 // input line
+		idx = max(0, min(d.enumIndexes[d.currentField], len(f.EnumValues)-1))
 	}
+	if idx < 0 || idx >= len(geom.optionStarts) {
+		line := fieldStart + geom.labelHeight // input line
+		return line, line
+	}
+	start = fieldStart + geom.optionStarts[idx]
+	return start, start + geom.optionHeights[idx] - 1
 }
 
 // isTextInputField returns true if the current field uses a text input (not boolean/enum).
@@ -440,10 +486,11 @@ func (d *ElicitationDialog) parseAndValidateField(val string, field ElicitationF
 // and Position() share it so layout math lives in exactly one place.
 type elicitationLayout struct {
 	dialogWidth  int
-	contentWidth int      // inside dialog frame
-	viewport     int      // height of the scrollable region in lines
-	bodyLines    []string // pre-rendered body, one entry per line
-	fieldStarts  []int    // line offset of each field's label
+	contentWidth int             // inside dialog frame
+	viewport     int             // height of the scrollable region in lines
+	bodyLines    []string        // pre-rendered body, one entry per line
+	fieldStarts  []int           // line offset of each field's label
+	fieldGeoms   []fieldGeometry // wrapped row layout per field, relative to fieldStarts
 }
 
 // dialogHeight is the total rendered height of the dialog, including frame.
@@ -454,7 +501,7 @@ func (d *ElicitationDialog) layout() elicitationLayout {
 	contentWidth := d.ContentWidth(dialogWidth, 2)
 	innerWidth := max(1, contentWidth-d.scrollview.ReservedCols())
 
-	bodyLines, fieldStarts := d.buildBody(innerWidth)
+	bodyLines, fieldStarts, fieldGeoms := d.buildBody(innerWidth)
 	maxViewport := max(1, min(d.Height()*80/100, 40)-elicitationOverhead)
 	viewport := max(1, min(len(bodyLines), maxViewport))
 
@@ -464,13 +511,15 @@ func (d *ElicitationDialog) layout() elicitationLayout {
 		viewport:     viewport,
 		bodyLines:    bodyLines,
 		fieldStarts:  fieldStarts,
+		fieldGeoms:   fieldGeoms,
 	}
 }
 
 // buildBody renders the scrollable body using the existing Content-based
-// helpers and records the line offset of every field's label. Tracks line
-// count incrementally to keep buildBody O(N) in the number of fields.
-func (d *ElicitationDialog) buildBody(width int) (lines []string, fieldStarts []int) {
+// helpers and records the line offset of every field's label plus each
+// field's wrapped row geometry. Tracks line count incrementally to keep
+// buildBody O(N) in the number of fields.
+func (d *ElicitationDialog) buildBody(width int) (lines []string, fieldStarts []int, fieldGeoms []fieldGeometry) {
 	body := NewContent(width)
 	lineCount := 0
 
@@ -486,6 +535,7 @@ func (d *ElicitationDialog) buildBody(width int) (lines []string, fieldStarts []
 		lineCount++ // separator adds 1 line
 
 		fieldStarts = make([]int, len(d.fields))
+		fieldGeoms = make([]fieldGeometry, len(d.fields))
 		for i, field := range d.fields {
 			// Record the current line count as this field's start position.
 			// This avoids O(N²) by tracking line count incrementally instead
@@ -495,7 +545,7 @@ func (d *ElicitationDialog) buildBody(width int) (lines []string, fieldStarts []
 			// Render the field into a temporary Content to measure its height
 			// without rebuilding the entire body.
 			tempContent := NewContent(width)
-			d.renderField(tempContent, i, field, width)
+			fieldGeoms[i] = d.renderField(tempContent, i, field, width)
 			fieldRendered := tempContent.Build()
 			fieldHeight := lipgloss.Height(fieldRendered)
 
@@ -515,7 +565,7 @@ func (d *ElicitationDialog) buildBody(width int) (lines []string, fieldStarts []
 		body.AddContent(d.responseInput.View())
 	}
 
-	return strings.Split(body.Build(), "\n"), fieldStarts
+	return strings.Split(body.Build(), "\n"), fieldStarts, fieldGeoms
 }
 
 func (d *ElicitationDialog) View() string {
@@ -525,6 +575,7 @@ func (d *ElicitationDialog) View() string {
 	// produced by this render. View() is the only place that knows the final
 	// layout, so we accept the mutation as a render-cache compromise.
 	d.fieldStarts = l.fieldStarts //rubocop:disable Lint/TUIViewPurity // click-zone cache consumed by Update()
+	d.fieldGeoms = l.fieldGeoms   //rubocop:disable Lint/TUIViewPurity // click-zone cache consumed by Update()
 
 	// Configure the scrollview viewport and give it the body. Scroll position
 	// is intentionally not adjusted here: the dialog opens scrolled to the top
@@ -535,6 +586,16 @@ func (d *ElicitationDialog) View() string {
 	// initially focused option/field.
 	d.scrollview.SetSize(l.contentWidth, l.viewport)
 	d.scrollview.SetContent(l.bodyLines, len(l.bodyLines))
+
+	// One-shot exception to the no-auto-scroll rule above: right after a
+	// resize the rewrapped geometry can leave the focused control outside
+	// the old scroll offset, so reanchor it now that fieldStarts/fieldGeoms
+	// and the scrollview dimensions are fresh. Free-form dialogs have no
+	// field rows, so this is a no-op for them.
+	if d.reanchorFocus {
+		d.reanchorFocus = false //rubocop:disable Lint/TUIViewPurity // one-shot resize flag consumed by the first render at the new size
+		d.ensureFocusVisible()
+	}
 
 	// Tell the scrollview where it lives on screen (for scrollbar drag) and
 	// remember the body's top row for our own mouse click hit-testing.
@@ -581,7 +642,7 @@ func (d *ElicitationDialog) hasSelectionFields() bool {
 	return false
 }
 
-func (d *ElicitationDialog) renderField(content *Content, i int, field ElicitationField, contentWidth int) {
+func (d *ElicitationDialog) renderField(content *Content, i int, field ElicitationField, contentWidth int) fieldGeometry {
 	// Use Title if available, otherwise capitalize the property name
 	label := field.Title
 	if label == "" {
@@ -597,15 +658,19 @@ func (d *ElicitationDialog) renderField(content *Content, i int, field Elicitati
 	if hasError {
 		labelStyle = labelStyle.Foreground(styles.Error)
 	}
-	content.AddContent(labelStyle.Render(label))
+	// Wrap long agent-supplied labels to the content width; anything wider
+	// would be silently clipped by the scrollview.
+	renderedLabel := labelStyle.Width(contentWidth).Render(label)
+	content.AddContent(renderedLabel)
+	geom := fieldGeometry{labelHeight: lipgloss.Height(renderedLabel)}
 
 	// Render field input based on type
 	isFocused := i == d.currentField
 	switch field.Type {
 	case "boolean":
-		d.renderBooleanField(content, i, isFocused)
+		d.renderBooleanField(content, &geom, i, isFocused, contentWidth)
 	case "enum":
-		d.renderEnumField(content, i, field, isFocused)
+		d.renderEnumField(content, &geom, i, field, isFocused, contentWidth)
 	default:
 		d.inputs[i].SetWidth(contentWidth)
 		content.AddContent(d.inputs[i].View())
@@ -616,24 +681,29 @@ func (d *ElicitationDialog) renderField(content *Content, i int, field Elicitati
 		errorStyle := styles.DialogContentStyle.Foreground(styles.Error).Italic(true)
 		content.AddContent(errorStyle.Render("  ⚠ " + d.fieldErrors[i]))
 	}
+	return geom
 }
 
-func (d *ElicitationDialog) renderBooleanField(content *Content, i int, isFocused bool) {
+func (d *ElicitationDialog) renderBooleanField(content *Content, geom *fieldGeometry, i int, isFocused bool, contentWidth int) {
 	selectedIdx := 1
 	if d.boolValues[i] {
 		selectedIdx = 0
 	}
-	d.renderSelectionField(content, []string{"Yes", "No"}, selectedIdx, isFocused)
+	d.renderSelectionField(content, geom, []string{"Yes", "No"}, selectedIdx, isFocused, contentWidth)
 }
 
-func (d *ElicitationDialog) renderEnumField(content *Content, i int, field ElicitationField, isFocused bool) {
-	d.renderSelectionField(content, field.EnumValues, d.enumIndexes[i], isFocused)
+func (d *ElicitationDialog) renderEnumField(content *Content, geom *fieldGeometry, i int, field ElicitationField, isFocused bool, contentWidth int) {
+	d.renderSelectionField(content, geom, field.EnumValues, d.enumIndexes[i], isFocused, contentWidth)
 }
 
-func (d *ElicitationDialog) renderSelectionField(content *Content, options []string, selectedIdx int, isFocused bool) {
+func (d *ElicitationDialog) renderSelectionField(content *Content, geom *fieldGeometry, options []string, selectedIdx int, isFocused bool, contentWidth int) {
 	selectedStyle := styles.DialogContentStyle.Foreground(styles.TextBright).Bold(true)
 	unselectedStyle := styles.DialogContentStyle.Foreground(styles.TextMuted)
 
+	// All prefixes are equally wide, so option heights don't change with
+	// focus/selection and wrapped rows hang-indent under the option text.
+	textWidth := max(1, contentWidth-lipgloss.Width("  ○ "))
+	row := geom.labelHeight
 	for j, option := range options {
 		prefix := "  ○ "
 		style := unselectedStyle
@@ -644,7 +714,15 @@ func (d *ElicitationDialog) renderSelectionField(content *Content, options []str
 			}
 			style = selectedStyle
 		}
-		content.AddContent(style.Render(prefix + option))
+		// Wrap long agent-supplied options instead of letting the scrollview
+		// clip them; JoinHorizontal keeps continuation rows aligned under the
+		// first row's text column.
+		rendered := lipgloss.JoinHorizontal(lipgloss.Top, style.Render(prefix), style.Width(textWidth).Render(option))
+		content.AddContent(rendered)
+		height := lipgloss.Height(rendered)
+		geom.optionStarts = append(geom.optionStarts, row)
+		geom.optionHeights = append(geom.optionHeights, height)
+		row += height
 	}
 }
 
@@ -660,7 +738,7 @@ func capitalizeFirst(s string) string {
 
 // handleMouseClick handles mouse click events for field focus and selection toggling.
 func (d *ElicitationDialog) handleMouseClick(msg tea.MouseClickMsg) (layout.Model, tea.Cmd) {
-	if len(d.fieldStarts) == 0 || d.scrollableRow == 0 {
+	if len(d.fieldStarts) == 0 || len(d.fieldGeoms) != len(d.fieldStarts) || d.scrollableRow == 0 {
 		return d, nil
 	}
 	relY := msg.Y - d.scrollableRow
@@ -676,17 +754,19 @@ func (d *ElicitationDialog) handleMouseClick(msg tea.MouseClickMsg) (layout.Mode
 		if line < start {
 			continue
 		}
-		offset := line - start
 		d.focusField(i)
 		delete(d.fieldErrors, i)
+		// Any wrapped row of an option counts as a click on that option.
+		opt := d.fieldGeoms[i].optionAt(line - start)
+		if opt < 0 {
+			return d, nil
+		}
 		switch f := d.fields[i]; f.Type {
 		case "boolean":
-			if offset == 1 || offset == 2 {
-				d.boolValues[i] = offset == 1
-			}
+			d.boolValues[i] = opt == 0
 		case "enum":
-			if offset >= 1 && offset <= len(f.EnumValues) {
-				d.enumIndexes[i] = offset - 1
+			if opt < len(f.EnumValues) {
+				d.enumIndexes[i] = opt
 			}
 		}
 		return d, nil

--- a/pkg/tui/dialog/elicitation_test.go
+++ b/pkg/tui/dialog/elicitation_test.go
@@ -6,6 +6,7 @@ import (
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -790,4 +791,265 @@ func TestElicitationDialog_UserScrollUp_NotSnappedBack(t *testing.T) {
 	_ = dialog.View()
 	assert.Equal(t, 0, dialog.scrollview.ScrollOffset(),
 		"re-rendering must not auto-scroll back down to the focused option")
+}
+
+// TestElicitationDialog_ResizeReanchorsFocus pins that a window resize —
+// which rewraps long field titles and shifts the focused field far from the
+// old scroll offset — brings the focused control back into view on the next
+// render, and that this reanchor is one-shot: later ordinary renders must
+// not override a deliberate user scroll.
+func TestElicitationDialog_ResizeReanchorsFocus(t *testing.T) {
+	t.Parallel()
+
+	props := map[string]any{}
+	for i := range 6 {
+		name := "field" + string(rune('a'+i))
+		props[name] = map[string]any{
+			"type":  "string",
+			"title": "Field " + string(rune('A'+i)) + ": " + strings.Repeat("very long title ", 3),
+		}
+	}
+	schema := map[string]any{"type": "object", "properties": props}
+
+	dialog := NewElicitationDialog("Fill in:", schema, nil).(*ElicitationDialog)
+	_, _ = dialog.Update(tea.WindowSizeMsg{Width: 120, Height: 30})
+	_ = dialog.View()
+
+	// Focus the last field; the wide layout scrolls it into view.
+	dialog.focusField(len(dialog.fields) - 1)
+	_ = dialog.View()
+	require.Equal(t, 1, dialog.fieldGeoms[dialog.currentField].labelHeight,
+		"test setup: titles must fit on one row at 120 columns")
+	staleOffset := dialog.scrollview.ScrollOffset()
+
+	// Shrink to 20 columns: every title above the focused field now wraps
+	// over several rows, pushing the focused input far below the old offset.
+	_, _ = dialog.Update(tea.WindowSizeMsg{Width: 20, Height: 30})
+	_ = dialog.View()
+
+	require.Greater(t, dialog.fieldGeoms[dialog.currentField].labelHeight, 1,
+		"test setup: titles must wrap at 20 columns")
+	first, last := dialog.focusRange()
+	require.GreaterOrEqual(t, first, 0)
+	require.Greater(t, first, staleOffset+dialog.scrollview.VisibleHeight()-1,
+		"test setup: rewrapping must push the focused field below the pre-resize viewport")
+
+	offset := dialog.scrollview.ScrollOffset()
+	visEnd := offset + dialog.scrollview.VisibleHeight() - 1
+	assert.GreaterOrEqual(t, first, offset, "focused input must be at or below the scroll offset after resize")
+	assert.LessOrEqual(t, last, visEnd, "focused input must be visible after resize")
+
+	// The reanchor is one-shot: a deliberate scroll away from the focused
+	// field must survive subsequent ordinary renders.
+	dialog.scrollview.ScrollToTop()
+	_ = dialog.View()
+	assert.Equal(t, 0, dialog.scrollview.ScrollOffset(),
+		"ordinary re-render after the resize reanchor must not auto-scroll back to the focused field")
+}
+
+// TestElicitationDialog_ResizeFreeFormInput_NoJump pins that resizing a
+// free-form dialog (no schema fields, so nothing to reanchor to) neither
+// panics nor moves the user's scroll position.
+func TestElicitationDialog_ResizeFreeFormInput_NoJump(t *testing.T) {
+	t.Parallel()
+
+	longMessage := strings.Repeat("Long question line. ", 40)
+	dialog := NewElicitationDialog(longMessage, nil, nil).(*ElicitationDialog)
+	_, _ = dialog.Update(tea.WindowSizeMsg{Width: 120, Height: 16})
+	_ = dialog.View()
+
+	require.True(t, dialog.scrollview.NeedsScrollbar())
+	require.Equal(t, 0, dialog.scrollview.ScrollOffset(), "dialog must open scrolled to the top")
+
+	_, _ = dialog.Update(tea.WindowSizeMsg{Width: 20, Height: 16})
+	_ = dialog.View()
+	assert.Equal(t, 0, dialog.scrollview.ScrollOffset(),
+		"resizing a free-form dialog must not move the scroll position")
+}
+
+// squashText strips ANSI sequences and removes all whitespace, so wrapped
+// output can be compared against its source text regardless of where the
+// wrapping primitive breaks lines (word boundaries or mid-token).
+func squashText(s string) string {
+	return strings.Join(strings.Fields(ansi.Strip(s)), "")
+}
+
+// clickBodyLine simulates a left mouse click on the given line of the
+// scrollable body, translated to absolute screen coordinates via the
+// click-zone cache populated by View().
+func clickBodyLine(t *testing.T, d *ElicitationDialog, line int) {
+	t.Helper()
+	require.NotZero(t, d.scrollableRow, "View() must run before simulating clicks")
+	relY := line - d.scrollview.ScrollOffset()
+	require.GreaterOrEqual(t, relY, 0, "line %d must be inside the viewport", line)
+	require.Less(t, relY, d.scrollview.VisibleHeight(), "line %d must be inside the viewport", line)
+	_, _ = d.Update(tea.MouseClickMsg{X: 3, Y: d.scrollableRow + relY, Button: tea.MouseLeft})
+}
+
+// assertBodyTextFits asserts that no body line carries visible text wider
+// than the scrollview's inner width — wider text would be silently clipped.
+// Trailing padding spaces are ignored: the body is padded to its widest part
+// (e.g. the textinput renders one cell wider than its set width) and the
+// scrollview trims that padding back off without losing anything.
+func assertBodyTextFits(t *testing.T, bodyLines []string, innerWidth int) {
+	t.Helper()
+	for i, line := range bodyLines {
+		text := strings.TrimRight(ansi.Strip(line), " ")
+		assert.LessOrEqual(t, ansi.StringWidth(text), innerWidth,
+			"body line %d visible text must fit the scrollview width, got %q", i, text)
+	}
+}
+
+// TestElicitationDialog_LongFieldTitleWraps pins that an agent-supplied field
+// title wider than the dialog's content width wraps across multiple rows
+// instead of being silently clipped by the scrollview.
+func TestElicitationDialog_LongFieldTitleWraps(t *testing.T) {
+	t.Parallel()
+
+	longTitle := "Please choose the deployment strategy that best matches your current production rollout constraints and compliance requirements"
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"strategy": map[string]any{"type": "string", "title": longTitle},
+		},
+	}
+
+	dialog := NewElicitationDialog("Question:", schema, nil).(*ElicitationDialog)
+	_, _ = dialog.Update(tea.WindowSizeMsg{Width: 60, Height: 30})
+	_ = dialog.View()
+
+	l := dialog.layout()
+	innerWidth := max(1, l.contentWidth-dialog.scrollview.ReservedCols())
+	require.Greater(t, ansi.StringWidth(longTitle), innerWidth,
+		"test setup: the title must be wider than the body width")
+
+	require.Len(t, dialog.fieldGeoms, 1)
+	assert.Greater(t, dialog.fieldGeoms[0].labelHeight, 1, "long title must wrap over several rows")
+
+	assert.Contains(t, squashText(strings.Join(l.bodyLines, "\n")), squashText(longTitle),
+		"the full title must survive wrapping")
+	assertBodyTextFits(t, l.bodyLines, innerWidth)
+}
+
+// TestElicitationDialog_LongEnumOptionWrapsAndClicks pins that a long enum
+// option — including an unbroken token wider than the dialog — wraps without
+// losing text, and that every wrapped row still selects that option on click.
+func TestElicitationDialog_LongEnumOptionWrapsAndClicks(t *testing.T) {
+	t.Parallel()
+
+	longOption := "retry with exponential backoff " + strings.Repeat("x", 80)
+	schema := map[string]any{
+		"type":  "string",
+		"title": "Pick one",
+		"enum":  []any{"deploy-canary", longOption, "rollback"},
+	}
+
+	dialog := NewElicitationDialog("Choose:", schema, nil).(*ElicitationDialog)
+	_, _ = dialog.Update(tea.WindowSizeMsg{Width: 60, Height: 40})
+	_ = dialog.View()
+
+	require.Len(t, dialog.fieldGeoms, 1)
+	geom := dialog.fieldGeoms[0]
+	require.Len(t, geom.optionStarts, 3)
+	require.Greater(t, geom.optionHeights[1], 1, "long option must wrap over several rows")
+
+	l := dialog.layout()
+	innerWidth := max(1, l.contentWidth-dialog.scrollview.ReservedCols())
+	assert.Contains(t, squashText(strings.Join(l.bodyLines, "\n")), squashText(longOption),
+		"the full option text, including the unbroken token, must survive wrapping")
+	assertBodyTextFits(t, l.bodyLines, innerWidth)
+
+	// Every wrapped row of the long option must select it on click.
+	start := dialog.fieldStarts[0]
+	for row := range geom.optionHeights[1] {
+		dialog.enumIndexes[0] = 0
+		clickBodyLine(t, dialog, start+geom.optionStarts[1]+row)
+		assert.Equal(t, 1, dialog.enumIndexes[0], "click on wrapped row %d must select the long option", row)
+	}
+
+	// Options shifted down by the wrapping must still map correctly.
+	clickBodyLine(t, dialog, start+geom.optionStarts[2])
+	assert.Equal(t, 2, dialog.enumIndexes[0])
+
+	// Label rows must not select any option.
+	clickBodyLine(t, dialog, start)
+	assert.Equal(t, 2, dialog.enumIndexes[0], "clicking the label must not change the selection")
+}
+
+// TestElicitationDialog_WrappedOptionFocusStaysVisible pins that
+// ensureFocusVisible accounts for wrapped option rows: walking the selection
+// through multi-row options in a small viewport keeps every row of the
+// selected option on screen.
+func TestElicitationDialog_WrappedOptionFocusStaysVisible(t *testing.T) {
+	t.Parallel()
+
+	longMessage := strings.Repeat("Long question line. ", 30)
+	enumValues := make([]any, 0, 8)
+	for i := range 8 {
+		enumValues = append(enumValues, "option "+string(rune('A'+i))+" "+strings.Repeat("verbose descriptive choice text ", 3))
+	}
+	schema := map[string]any{"type": "string", "title": "Pick one", "enum": enumValues}
+
+	dialog := NewElicitationDialog(longMessage, schema, nil).(*ElicitationDialog)
+	_, _ = dialog.Update(tea.WindowSizeMsg{Width: 60, Height: 16})
+	_ = dialog.View()
+
+	require.True(t, dialog.scrollview.NeedsScrollbar(), "long message + wrapped options must require scrolling")
+	require.Greater(t, dialog.fieldGeoms[0].optionHeights[0], 1, "test setup: options must wrap")
+
+	// Walk the selection down through every option; each step must bring the
+	// whole wrapped option into the viewport.
+	for range len(enumValues) - 1 {
+		dialog.moveSelection(1)
+		_ = dialog.View()
+
+		idx := dialog.enumIndexes[0]
+		geom := dialog.fieldGeoms[0]
+		first := dialog.fieldStarts[0] + geom.optionStarts[idx]
+		last := first + geom.optionHeights[idx] - 1
+		offset := dialog.scrollview.ScrollOffset()
+		visEnd := offset + dialog.scrollview.VisibleHeight() - 1
+		assert.GreaterOrEqual(t, first, offset, "option %d first row must be visible", idx)
+		assert.LessOrEqual(t, last, visEnd, "option %d last row must be visible", idx)
+	}
+}
+
+// TestElicitationDialog_ExplicitNewlinesShiftRows pins that explicit newlines
+// in agent-supplied labels are preserved and that click geometry accounts for
+// the extra rows: a boolean's Yes/No rows sit below the full multi-row label
+// instead of being addressed by the old one-row-per-label offsets.
+func TestElicitationDialog_ExplicitNewlinesShiftRows(t *testing.T) {
+	t.Parallel()
+
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"confirm": map[string]any{
+				"type":  "boolean",
+				"title": "Proceed with the change?\n(this cannot be undone)",
+			},
+		},
+	}
+
+	dialog := NewElicitationDialog("Careful:", schema, nil).(*ElicitationDialog)
+	_, _ = dialog.Update(tea.WindowSizeMsg{Width: 80, Height: 30})
+	_ = dialog.View()
+
+	require.Len(t, dialog.fieldGeoms, 1)
+	geom := dialog.fieldGeoms[0]
+	require.Equal(t, 2, geom.labelHeight, "explicit newline must produce a second label row")
+	require.Equal(t, []int{2, 3}, geom.optionStarts, "Yes/No rows must start below the full label")
+
+	start := dialog.fieldStarts[0]
+
+	// Row 2 is "Yes" (the old one-row-per-label math mapped it to "No").
+	clickBodyLine(t, dialog, start+2)
+	assert.True(t, dialog.boolValues[0], "row below the two-line label must be Yes")
+
+	clickBodyLine(t, dialog, start+3)
+	assert.False(t, dialog.boolValues[0], "next row must be No")
+
+	// The label's second row must not toggle anything.
+	clickBodyLine(t, dialog, start+1)
+	assert.False(t, dialog.boolValues[0])
 }


### PR DESCRIPTION
## Summary

- Wrap long field labels and enum or boolean options in elicitation dialogs instead of silently clipping them.
- Track wrapped row geometry so keyboard focus, scrolling, and mouse selection continue to target the correct option.
- Re-anchor the focused control once after a terminal resize.
- Add regression coverage for long titles, long unbroken options, explicit line breaks, mouse selection, scrolling, and resizing.

This is a follow-up to #2495. The existing scrollview fixed vertical overflow, but individual field labels and options could still exceed the available width and lose their trailing text.

## Before and after

Actual TUI output using the same elicitation data and a 58-column terminal. The before preview was rendered from the parent commit; the after preview was rendered with this change.

### Before

The field title and both options are silently clipped. Their remaining text cannot be read or reached.

```text
╭────────────────────────────────────────────────────╮
│                                                    │
│                      Question                      │
│  ────────────────────────────────────────────────  │
│  The agent needs a decision before it can          │
│  continue.                                         │
│  ──────────────────────────────────────────────    │
│  Which deployment strategy should be applied to    │
│  › ● Deploy gradually to 10% of users, monitor     │
│    ○ Cancel the deployment and keep the version    │
│                                                    │
│   ↑/↓ select  tab next field  enter submit  esc    │
│                       cancel                       │
│                                                    │
╰────────────────────────────────────────────────────╯
```

### After

The complete field title and option text wrap inside the window and remain selectable.

```text
╭────────────────────────────────────────────────────╮
│                                                    │
│                      Question                      │
│  ────────────────────────────────────────────────  │
│  The agent needs a decision before it can          │
│  continue.                                         │
│  ──────────────────────────────────────────────    │
│  Which deployment strategy should be applied to    │
│  the production environment?*                      │
│  › ● Deploy gradually to 10% of users, monitor     │
│      errors, and automatically roll back to the    │
│      previous version if the threshold is          │
│      exceeded                                      │
│    ○ Cancel the deployment and keep the version    │
│      currently running in production               │
│                                                    │
│   ↑/↓ select  tab next field  enter submit  esc    │
│                       cancel                       │
│                                                    │
╰────────────────────────────────────────────────────╯
```

## Expected behavior mapping

| Expectation | Implementation |
|---|---|
| Preserve complete question content | Long labels and options wrap within the available display width |
| Keep wrapped options usable | Wrapped row ranges map back to their logical option |
| Preserve keyboard navigation | Focus scrolling uses the complete wrapped option range |
| Preserve mouse selection | Every wrapped row of an option selects that option |
| Handle terminal resizing | Focus is re-anchored once after width-dependent rewrapping |
| Prevent regressions | Focused tests cover wrapping, scrolling, clicking, explicit newlines, and resizing |

## Validation

- `go build ./...`
- `go test ./pkg/tui/dialog -count=1`
- `go test ./pkg/tui/... -count=1`
- `go vet ./pkg/tui/dialog/...`
- `golangci-lint run ./pkg/tui/dialog/...`
- `go run ./lint pkg/tui/dialog/elicitation.go pkg/tui/dialog/elicitation_test.go`

All checks pass.

## Scope

The change is limited to elicitation field labels and options. Existing handling of dialog chrome titles and non-string JSON Schema enum values is unchanged.
