### PR TITLE
refactor(tui): loosen messages and reasoningblock to accept interfaces instead of *service.SessionState

### DIFF
--- a/pkg/tui/components/messages/embedded_state_test.go
+++ b/pkg/tui/components/messages/embedded_state_test.go
@@ -1,0 +1,41 @@
+package messages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tui/service"
+	"github.com/docker/docker-agent/pkg/tui/types"
+)
+
+// The message list must work with an embedder-provided session state, not
+// just the full application's *service.SessionState.
+func TestEmbeddedSessionState(t *testing.T) {
+	t.Parallel()
+
+	state := &service.EmbeddedSessionState{
+		StaticSessionState: service.StaticSessionState{AgentName: "Gordon"},
+	}
+	m := NewScrollableView(80, 24, state).(*model)
+
+	t.Run("previous message tracked for grouping", func(t *testing.T) {
+		cmd := m.AddUserMessage("hello")
+		require.NotNil(t, cmd)
+		require.NotNil(t, state.PreviousMessage())
+		assert.Equal(t, types.MessageTypeUser, state.PreviousMessage().Type)
+	})
+
+	t.Run("tool results toggle round-trips", func(t *testing.T) {
+		require.False(t, state.HideToolResults())
+		_, _ = m.Update(ToggleHideToolResultsMsg{})
+		assert.True(t, state.HideToolResults())
+		_, _ = m.Update(ToggleHideToolResultsMsg{})
+		assert.False(t, state.HideToolResults())
+	})
+
+	t.Run("renders", func(t *testing.T) {
+		assert.Contains(t, m.View(), "hello")
+	})
+}

--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -38,6 +38,21 @@ import (
 // ToggleHideToolResultsMsg triggers hiding/showing tool results
 type ToggleHideToolResultsMsg struct{}
 
+// SessionState is the session-state surface the message list depends on:
+// read access for rendering, plus the two mutations the component performs.
+// *service.SessionState satisfies it; embedders outside the full TUI can
+// provide their own implementation.
+type SessionState interface {
+	service.SessionStateReader
+	SetPreviousMessage(msg *types.Message)
+	ToggleHideToolResults()
+}
+
+var (
+	_ SessionState = (*service.SessionState)(nil)
+	_ SessionState = (*service.EmbeddedSessionState)(nil)
+)
+
 // scrollToBottomMsg requests the message list scroll to the bottom. It is
 // returned by commands (e.g. after appending a message) instead of mutating
 // scroll state directly from the command goroutine: bubbletea runs command
@@ -144,7 +159,7 @@ type model struct {
 
 	selection selectionState
 
-	sessionState *service.SessionState
+	sessionState SessionState
 	scrollview   *scrollview.Model
 
 	xPos, yPos int
@@ -175,17 +190,17 @@ type model struct {
 }
 
 // New creates a new message list component
-func New(sessionState *service.SessionState) Model {
+func New(sessionState SessionState) Model {
 	return newModel(120, 24, sessionState)
 }
 
 // NewScrollableView creates a simple scrollable view for displaying messages in dialogs
 // This is a lightweight version that doesn't require app or session state management
-func NewScrollableView(width, height int, sessionState *service.SessionState) Model {
+func NewScrollableView(width, height int, sessionState SessionState) Model {
 	return newModel(width, height, sessionState)
 }
 
-func newModel(width, height int, sessionState *service.SessionState) *model {
+func newModel(width, height int, sessionState SessionState) *model {
 	sv := scrollview.New(
 		scrollview.WithReserveScrollbarSpace(true),
 	)

--- a/pkg/tui/components/reasoningblock/reasoningblock.go
+++ b/pkg/tui/components/reasoningblock/reasoningblock.go
@@ -114,7 +114,7 @@ type Model struct {
 	selected            bool
 	width               int
 	height              int
-	sessionState        *service.SessionState
+	sessionState        service.SessionStateReader
 	reasoningVersion    int          // increments when reasoning content changes
 	cache               *renderCache // cached rendering results
 	animationRegistered bool         // whether we're registered with animation coordinator
@@ -124,7 +124,7 @@ type Model struct {
 }
 
 // New creates a new reasoning block.
-func New(id, agentName string, sessionState *service.SessionState) *Model {
+func New(id, agentName string, sessionState service.SessionStateReader) *Model {
 	return &Model{
 		id:           id,
 		agentName:    agentName,

--- a/pkg/tui/service/embeddedsessionstate.go
+++ b/pkg/tui/service/embeddedsessionstate.go
@@ -1,0 +1,21 @@
+package service
+
+import (
+	"github.com/docker/docker-agent/pkg/tui/types"
+)
+
+// EmbeddedSessionState extends StaticSessionState with the mutable state the
+// message-list component maintains: the previous message (for grouping
+// consecutive messages from the same sender) and the tool-results visibility
+// toggle. Use it to host the message list outside the full TUI application.
+type EmbeddedSessionState struct {
+	StaticSessionState
+
+	previousMessage *types.Message
+	hideToolResults bool
+}
+
+func (s *EmbeddedSessionState) PreviousMessage() *types.Message       { return s.previousMessage }
+func (s *EmbeddedSessionState) SetPreviousMessage(msg *types.Message) { s.previousMessage = msg }
+func (s *EmbeddedSessionState) HideToolResults() bool                 { return s.hideToolResults }
+func (s *EmbeddedSessionState) ToggleHideToolResults()                { s.hideToolResults = !s.hideToolResults }


### PR DESCRIPTION
The `messages` and `reasoningblock` components previously required a concrete `*service.SessionState`, which forced any embedder that wants to host the message-list outside the full TUI app to either pull in the entire session state or fork roughly 2,500 lines of selection, URL-detection, clipboard, and scroll logic. This blocked Docker Sandboxes (and similar embedders) from reusing the component as-is.

`reasoningblock.New` and its `model` field now accept the narrow `service.SessionStateReader` interface instead of the concrete pointer. `messages.New` and `messages.NewScrollableView` accept a new `messages.SessionState` interface that composes `SessionStateReader` with the two mutating methods those constructors actually need (`SetPreviousMessage` and `ToggleHideToolResults`). A new `service.EmbeddedSessionState` type implements that interface with safe, conservative defaults — `YoloMode` stays false and tool results remain visible — so embedders have a ready-made value to pass without instantiating the full session-state machinery. A unit test (`TestEmbeddedSessionState`) covers the accessor and toggle behaviour.

Existing callers — the chat page and the tool-confirmation dialog — already pass `*service.SessionState`, which satisfies both interfaces unchanged, so this is fully backward compatible.