### PR TITLE
feat(tui): add StopAnimations to the messages component

### DIFF
--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -94,6 +94,11 @@ type Model interface {
 	AddAgentReturn(fromAgent, toAgent string) tea.Cmd
 	LoadFromSession(sess *session.Session) tea.Cmd
 
+	// StopAnimations unregisters every view from the animation coordinator.
+	// Call it when the list is discarded or its host view goes away, so
+	// abandoned spinners do not keep the tick stream alive.
+	StopAnimations()
+
 	RemoveSpinner()
 	ScrollToBottom() tea.Cmd
 	AdjustBottomSlack(delta int)
@@ -1449,6 +1454,7 @@ func (m *model) LoadFromSession(sess *session.Session) tea.Cmd {
 		appendSessionMessage(toolMsg, view)
 	}
 
+	m.StopAnimations()
 	m.messages = nil
 	m.views = nil
 	m.renderedItems.Clear()
@@ -2305,4 +2311,10 @@ func (m *model) commitInlineEdit() tea.Cmd {
 type InlineEditCommittedMsg struct {
 	SessionPosition int
 	Content         string
+}
+
+func (m *model) StopAnimations() {
+	for _, v := range m.views {
+		animation.StopView(v)
+	}
 }


### PR DESCRIPTION
Follow-up to #3643. Embedders that discard the message list (or close its host view) while a spinner or running tool call is animating had no way to unregister its views from the animation coordinator — a leaked subscription keeps the global tick stream alive indefinitely. The transcript component documents the same hazard and exposes `StopAnimations` for it; the messages component had no equivalent.

This adds `messages.Model.StopAnimations()`, mirroring the transcript API, which iterates over all registered views and calls `animation.StopView` on each. It also fixes a latent leak in `LoadFromSession`, which replaced the full view list without stopping animations on the outgoing views first — meaning any in-flight spinner or tool-call animation from a previous session would quietly keep ticking.

The immediate consumer is Docker Sandboxes' embedded Gordon panel: its `/new` command discards a possibly-streaming conversation, and without this hook the tick stream would stay alive for the lifetime of the process.