### PR TITLE
fix: bump Alpine to 3.23 to fix release build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION="1.26.5"
-ARG ALPINE_VERSION="3.22"
+ARG ALPINE_VERSION="3.23"
 ARG XX_VERSION="1.9.0"
 
 # xx is a helper for cross-compilation


### PR DESCRIPTION
The release workflow is failing because the Dockerfile derives from `golang:${GO_VERSION}-alpine${ALPINE_VERSION}`, which was resolving to `golang:1.26.5-alpine3.22`. That image does not exist on Docker Hub — Go 1.26.5 is only published on Alpine 3.23, so the build breaks at the very first `FROM`.

This PR bumps `ARG ALPINE_VERSION` from `"3.22"` to `"3.23"`. Both `golang:1.26.5-alpine3.23` and `alpine:3.23` exist on Docker Hub, so the multi-stage build resolves correctly again.