### PR TITLE
fix(browser): reap child process to avoid zombie after opening URL

### DIFF
--- a/pkg/browser/browser.go
+++ b/pkg/browser/browser.go
@@ -32,10 +32,12 @@ func Open(ctx context.Context, urlToOpen string) error {
 		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 	}
 
-	err := exec.CommandContext(ctx, cmd, args...).Start()
-	if err != nil {
+	command := exec.CommandContext(ctx, cmd, args...)
+	if err := command.Start(); err != nil {
 		return fmt.Errorf("failed to open browser: %w", err)
 	}
+	// Reap the child in the background so it does not linger as a zombie.
+	go func() { _ = command.Wait() }()
 
 	return nil
 }


### PR DESCRIPTION
## Summary
`pkg/browser/browser.go` called `exec.CommandContext(...).Start()` without ever calling `Wait()`, leaving a permanent defunct (`<defunct>`) child process parented to `docker-agent` after every URL/browser open. Long-running sessions accumulated zombies — one observed session had 5 zombies from 5 browser opens (MCP OAuth handshake, TUI open-link, `open_url` tool).

## Root cause
The result of `exec.CommandContext(...).Start()` was used only for its error return; the `*exec.Cmd` was discarded, so the child was never reaped.

## Fix
Hold the `*exec.Cmd` in a variable and reap it asynchronously with a background `Wait()`, mirroring the established pattern in `pkg/board/app.go` (`OpenEditor`).

## Verification
- `go build ./pkg/browser/` ✅
- `go vet ./pkg/browser/` ✅
- `go test ./pkg/browser/...` ✅ (existing tests pass)

Fixes #3630