### PR TITLE
fix(tui): stop replaced and slack animation subscriptions

### DIFF
--- a/pkg/tui/components/messages/messages.go
+++ b/pkg/tui/components/messages/messages.go
@@ -1683,6 +1683,8 @@ func (m *model) AddToolResult(msg *runtime.ToolCallResponseEvent, status types.T
 			toolMessage.ToolResult = msg.Result.WithoutPayload()
 			m.invalidateItem(i)
 
+			// The replaced view may still hold a running-spinner subscription.
+			animation.StopView(m.views[i])
 			view := m.createToolCallView(toolMessage)
 			m.views[i] = view
 			return view.Init()
@@ -2314,6 +2316,7 @@ type InlineEditCommittedMsg struct {
 }
 
 func (m *model) StopAnimations() {
+	m.slackAnimationSub.Stop()
 	for _, v := range m.views {
 		animation.StopView(v)
 	}

--- a/pkg/tui/components/messages/stop_animations_test.go
+++ b/pkg/tui/components/messages/stop_animations_test.go
@@ -1,0 +1,36 @@
+package messages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tui/animation"
+	"github.com/docker/docker-agent/pkg/tui/service"
+	"github.com/docker/docker-agent/pkg/tui/types"
+)
+
+// The animation coordinator is package-global: a leaked subscription keeps
+// the tick stream alive for the rest of the process. Not parallel — the test
+// asserts on the global coordinator.
+func TestStopAnimationsReleasesEverySubscription(t *testing.T) {
+	m := NewScrollableView(80, 24, &service.SessionState{})
+
+	// A completed tool call replaces the running view; the old view's
+	// spinner subscription must not survive the swap.
+	call := tools.ToolCall{ID: "call-1", Function: tools.FunctionCall{Name: "list"}}
+	_ = m.AddOrUpdateToolCall("agent", call, tools.Tool{Name: "list"}, types.ToolStatusRunning)
+	_ = m.View() // running view renders and registers its spinner
+	require.True(t, animation.HasActive())
+	_ = m.AddToolResult(&runtime.ToolCallResponseEvent{ToolCallID: "call-1", Response: "done"}, types.ToolStatusCompleted)
+
+	// A waiting spinner still animating when the list is discarded.
+	_ = m.AddAssistantMessage("agent", "")
+	_ = m.View()
+
+	m.StopAnimations()
+	require.False(t, animation.HasActive(),
+		"discarding the list must release every animation subscription")
+}


### PR DESCRIPTION
Follow-up to #3644.

`AddToolResult` swapped in the completed tool view without stopping the old running view's spinner subscription, and `StopAnimations` missed the list's own bottom-slack subscription. Either leak keeps the package-global animation tick stream alive for the rest of the process (found by an embedder's shuffled tests: a completed tool call left `animation.HasActive()` true after `StopAnimations`).

- `AddToolResult` now stops the replaced view's animation before swapping.
- `StopAnimations` also stops `slackAnimationSub`.
- Regression test: running tool → result → discarded list releases every subscription.