### PR TITLE
build: set MACOSX_VERSION_MIN=11.0 for darwin cross-builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,10 @@ RUN --mount=type=bind,from=osxcross,src=/osxsdk,target=/xx-sdk \
     set -ex
     if [ "$TARGETOS" != "darwin" ]; then
       export XX_GO_PREFER_C_COMPILER=zig
+    else
+      # clang 21 (alpine 3.23) rejects xx's default "10.16" Big Sur alias with
+      # -Werror,-Woverriding-deployment-version when targeting arm64.
+      export MACOSX_VERSION_MIN=11.0
     fi
     xx-go build -trimpath -tags no_audio -ldflags "-s -w -linkmode=external -X 'github.com/docker/docker-agent/pkg/version.Version=$GIT_TAG' -X 'github.com/docker/docker-agent/pkg/version.Commit=$GIT_COMMIT'" -o /binaries/docker-agent-$TARGETOS-$TARGETARCH .
     xx-verify --static /binaries/docker-agent-$TARGETOS-$TARGETARCH


### PR DESCRIPTION
## Summary

Release builds fail on darwin/arm64 since the Alpine 3.23 bump (#3645):

```
clang: error: overriding deployment version from '10.16' to '11.0' [-Werror,-Woverriding-deployment-version]
```

| item | detail |
|---|---|
| Failing runs | docker/gordon [29398706771](https://github.com/docker/gordon/actions/runs/29398706771), [29403633562](https://github.com/docker/gordon/actions/runs/29403633562) |
| Cause | xx v1.9.0 defaults `MACOSX_VERSION_MIN=10.16` for darwin/arm64; clang 21 (alpine 3.23) warns on the 10.16 to 11.0 canonicalization; `runtime/cgo` builds with `-Wall -Werror`, turning it fatal |
| Fix | export `MACOSX_VERSION_MIN=11.0` for darwin in `builder-cross`; `xx-info` only applies its default when the variable is unset |
| Upstream | fixed in tonistiigi/xx@203eae866b, not in any tagged release yet (latest v1.9.0) |

## Validation

- `docker buildx build --target=cross --platform darwin/arm64` succeeds locally on this branch
- Produced binary carries `LC_BUILD_VERSION minos 11.0` (SDK 15.5) and runs
- darwin/amd64 minimum also moves from 10.6 to 11.0; no practical impact since Go 1.26 requires macOS 12+

Note: the failed release runs already pushed tags v1.104.0 to v1.106.0 (tag creation precedes the build in the release workflow); those tags have no matching releases.
