### PR TITLE
refactor(tui): let embedders supply the confirmation dialog's session state

### DIFF
--- a/pkg/tui/dialog/tool_confirmation.go
+++ b/pkg/tui/dialog/tool_confirmation.go
@@ -40,12 +40,25 @@ type ToolConfirmationResponse struct {
 	Response string // "approve", "reject", or "approve-session"
 }
 
+// ConfirmationSessionState is the session-state surface the confirmation
+// dialog needs: the message list's surface for rendering the tool call, plus
+// the session-wide approval flip for the "all tools" decision.
+type ConfirmationSessionState interface {
+	messages.SessionState
+	SetYoloMode(yoloMode bool)
+}
+
+var (
+	_ ConfirmationSessionState = (*service.SessionState)(nil)
+	_ ConfirmationSessionState = (*service.EmbeddedSessionState)(nil)
+)
+
 type toolConfirmationDialog struct {
 	BaseDialog
 
 	msg               *runtime.ToolCallConfirmationEvent
 	keyMap            toolconfirm.KeyMap
-	sessionState      *service.SessionState
+	sessionState      ConfirmationSessionState
 	scrollView        messages.Model
 	permissionPattern string // cached permission pattern for this tool call
 }
@@ -215,7 +228,7 @@ func (d *toolConfirmationDialog) renderMetadata(contentWidth int) string {
 }
 
 // NewToolConfirmationDialog creates a new tool confirmation dialog
-func NewToolConfirmationDialog(msg *runtime.ToolCallConfirmationEvent, sessionState *service.SessionState) Dialog {
+func NewToolConfirmationDialog(msg *runtime.ToolCallConfirmationEvent, sessionState ConfirmationSessionState) Dialog {
 	// Create scrollable view with minimal initial size (will be updated in SetSize)
 	scrollView := messages.NewScrollableView(1, 1, sessionState)
 

--- a/pkg/tui/dialog/tool_confirmation_test.go
+++ b/pkg/tui/dialog/tool_confirmation_test.go
@@ -150,3 +150,23 @@ func TestToolConfirmationDialog_ReasonOutsideSafetyVerdictRendersPlain(t *testin
 	assert.NotContains(t, view, "Destructive command",
 		"no warning block without a blast_radius classification")
 }
+
+// The dialog must work with an embedder-provided session state, not just the
+// full application's *service.SessionState; the "all tools" decision flips
+// the embedder's session-wide approval.
+func TestToolConfirmationDialog_EmbeddedSessionState(t *testing.T) {
+	t.Parallel()
+
+	state := &service.EmbeddedSessionState{}
+	dialog := NewToolConfirmationDialog(newConfirmationEvent(nil), state)
+	_, _ = dialog.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+
+	view := ansi.Strip(dialog.View())
+	assert.Contains(t, view, "shell")
+	assert.Contains(t, view, "Do you want to allow this tool call?")
+
+	require.False(t, state.YoloMode())
+	_, cmd := dialog.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+	require.NotNil(t, cmd)
+	assert.True(t, state.YoloMode(), "approving all tools must flip the embedder's session-wide approval")
+}

--- a/pkg/tui/service/embeddedsessionstate.go
+++ b/pkg/tui/service/embeddedsessionstate.go
@@ -6,16 +6,20 @@ import (
 
 // EmbeddedSessionState extends StaticSessionState with the mutable state the
 // message-list component maintains: the previous message (for grouping
-// consecutive messages from the same sender) and the tool-results visibility
-// toggle. Use it to host the message list outside the full TUI application.
+// consecutive messages from the same sender), the tool-results visibility
+// toggle, and the session-wide tool approval the confirmation dialog flips.
+// Use it to host the message list outside the full TUI application.
 type EmbeddedSessionState struct {
 	StaticSessionState
 
 	previousMessage *types.Message
 	hideToolResults bool
+	yoloMode        bool
 }
 
 func (s *EmbeddedSessionState) PreviousMessage() *types.Message       { return s.previousMessage }
 func (s *EmbeddedSessionState) SetPreviousMessage(msg *types.Message) { s.previousMessage = msg }
 func (s *EmbeddedSessionState) HideToolResults() bool                 { return s.hideToolResults }
 func (s *EmbeddedSessionState) ToggleHideToolResults()                { s.hideToolResults = !s.hideToolResults }
+func (s *EmbeddedSessionState) YoloMode() bool                        { return s.yoloMode }
+func (s *EmbeddedSessionState) SetYoloMode(yoloMode bool)             { s.yoloMode = yoloMode }


### PR DESCRIPTION
Follow-up to #3643, which applied the same treatment to the messages component the dialog embeds. `NewToolConfirmationDialog` previously demanded a concrete `*service.SessionState`, which blocked embedders that host the dialog outside the full TUI — Docker Sandboxes' Gordon panel was forking a 262-line copy of the confirmation dialog as a direct result.

The dialog now accepts a narrow `ConfirmationSessionState` interface: the message list's `messages.SessionState` surface (already loosened in #3643) plus `SetYoloMode` for the session-wide "approve all tools" decision. `service.EmbeddedSessionState` gains `YoloMode`/`SetYoloMode` so embedders get a working implementation without pulling in the full application state. `*service.SessionState` satisfies the interface unchanged, so existing callers (chat page, `tui.go`) require no edits.

A new test covers both the render path (an embedder-provided state produces a working dialog view) and the approval path (pressing `A` flips the embedder's `YoloMode`).