### PR TITLE
feat(embeddedchat): add embedder seams for code-built teams

### DIFF
--- a/pkg/embeddedchat/defaults/defaults.go
+++ b/pkg/embeddedchat/defaults/defaults.go
@@ -1,0 +1,14 @@
+// Package defaults provides docker-agent's full toolset and provider
+// registries for embeddedchat's AgentSource path. It is a separate package so
+// embedders that supply a pre-built team (Config.Team) never link the full
+// registries into their binary.
+package defaults
+
+import (
+	"github.com/docker/docker-agent/pkg/teamloader"
+	loaderdefaults "github.com/docker/docker-agent/pkg/teamloader/defaults"
+)
+
+// Opts returns team-loader options with docker-agent's full toolset and
+// provider registries, for embeddedchat.Config.LoadOpts.
+func Opts() []teamloader.Opt { return loaderdefaults.Opts() }

--- a/pkg/embeddedchat/embeddedchat.go
+++ b/pkg/embeddedchat/embeddedchat.go
@@ -12,16 +12,22 @@ import (
 	dagentcfg "github.com/docker/docker-agent/pkg/config"
 	dagentruntime "github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/team"
 	"github.com/docker/docker-agent/pkg/teamloader"
-	loaderdefaults "github.com/docker/docker-agent/pkg/teamloader/defaults"
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
 const defaultEventBuffer = 32
 
 var (
-	// ErrAgentSourceRequired is returned when New is called without an agent source.
-	ErrAgentSourceRequired = errors.New("embeddedchat: agent source is required")
+	// ErrAgentSourceRequired is returned when New is called without an agent
+	// source or a pre-built team.
+	ErrAgentSourceRequired = errors.New("embeddedchat: an agent source or a team is required")
+	// ErrRegistriesRequired is returned when an AgentSource is loaded without
+	// load options: the loader needs toolset and provider registries. Pass
+	// embeddedchat/defaults.Opts() for docker-agent's full registries, or
+	// your own via LoadOpts.
+	ErrRegistriesRequired = errors.New("embeddedchat: LoadOpts is required with AgentSource (e.g. embeddedchat/defaults.Opts())")
 	// ErrNotInitialized is returned when a Session has no runtime or conversation.
 	ErrNotInitialized = errors.New("embeddedchat: session is not initialized")
 	// ErrRunActive is returned when Send is called while a previous run is still active.
@@ -32,19 +38,33 @@ var (
 
 // Config describes an embedded agent session.
 type Config struct {
+	// Team is a pre-built team. Embedders that assemble their agents in code
+	// use it instead of AgentSource: no YAML loading happens, and — the point
+	// — docker-agent's full toolset and provider registries are never linked
+	// into their binary. Takes precedence over AgentSource.
+	Team *team.Team
 	// AgentSource is the agent/team definition to load. Bytes sources are a
 	// good fit for embedders that ship a pinned agent in their binary.
+	// Requires LoadOpts (see ErrRegistriesRequired).
 	AgentSource dagentcfg.Source
 	// RuntimeConfig is passed to the team loader. When nil, a zero runtime
 	// config is used.
 	RuntimeConfig *dagentcfg.RuntimeConfig
-	// ToolsetRegistry resolves toolsets declared by AgentSource. When nil,
-	// docker-agent's full YAML-loading registry is used.
+	// LoadOpts configures the team loader for the AgentSource path, most
+	// importantly the toolset and provider registries.
+	// embeddedchat/defaults.Opts() provides docker-agent's full registries.
+	LoadOpts []teamloader.Opt
+	// ToolsetRegistry resolves toolsets declared by AgentSource; appended to
+	// LoadOpts as a convenience.
 	ToolsetRegistry teamloader.ToolsetRegistry
 	// RuntimeOptions are appended when constructing the runtime.
 	RuntimeOptions []dagentruntime.Opt
 	// SessionOptions are appended when constructing each conversation session.
 	SessionOptions []session.Opt
+	// InitialSession, when set, is used as the first conversation instead of
+	// a fresh one — e.g. a conversation restored from a session store.
+	// Restart still replaces it with a fresh session.
+	InitialSession *session.Session
 	// EventBuffer controls the size of the channel returned by Send. When zero,
 	// a small default buffer is used.
 	EventBuffer int
@@ -68,10 +88,17 @@ type Event struct {
 
 // ToolActivity describes one tool call surfaced by the runtime.
 type ToolActivity struct {
-	Call     tools.ToolCall
-	Def      tools.Tool
+	Call tools.ToolCall
+	Def  tools.Tool
+	// Output is an incremental output line streamed by the running call
+	// (empty for lifecycle events).
+	Output   string
 	Finished bool
 	IsError  bool
+	// Response is the finished call's textual result.
+	Response string
+	// Result is the finished call's structured result (nil when unavailable).
+	Result *tools.ToolCallResult
 	// NeedsConfirmation is true when the runtime is blocked until Confirm is
 	// called with the user's decision.
 	NeedsConfirmation bool
@@ -99,9 +126,10 @@ type Session struct {
 	closed       bool
 }
 
-// New loads the configured agent and creates a fresh conversation session.
+// New builds the runtime for the configured team (or loads AgentSource) and
+// creates the first conversation session.
 func New(ctx context.Context, cfg Config) (*Session, error) {
-	if cfg.AgentSource == nil {
+	if cfg.Team == nil && cfg.AgentSource == nil {
 		return nil, ErrAgentSourceRequired
 	}
 	runConfig := cfg.RuntimeConfig
@@ -109,45 +137,57 @@ func New(ctx context.Context, cfg Config) (*Session, error) {
 		runConfig = &dagentcfg.RuntimeConfig{}
 	}
 
-	loadOpts := loaderdefaults.Opts()
-	if cfg.ToolsetRegistry != nil {
-		loadOpts = append(loadOpts, teamloader.WithToolsetRegistry(cfg.ToolsetRegistry))
-	}
-	loaded, err := teamloader.LoadWithConfig(ctx, cfg.AgentSource, runConfig, loadOpts...)
-	if err != nil {
-		return nil, fmt.Errorf("embeddedchat: load agent: %w", err)
+	tm := cfg.Team
+	var runtimeOpts []dagentruntime.Opt
+	if tm == nil {
+		loadOpts := append([]teamloader.Opt(nil), cfg.LoadOpts...)
+		if cfg.ToolsetRegistry != nil {
+			loadOpts = append(loadOpts, teamloader.WithToolsetRegistry(cfg.ToolsetRegistry))
+		}
+		if len(loadOpts) == 0 {
+			return nil, ErrRegistriesRequired
+		}
+		loaded, err := teamloader.LoadWithConfig(ctx, cfg.AgentSource, runConfig, loadOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("embeddedchat: load agent: %w", err)
+		}
+		tm = loaded.Team
+
+		modelSwitcher := &dagentruntime.ModelSwitcherConfig{
+			Models:             loaded.Models,
+			Providers:          loaded.Providers,
+			ModelsGateway:      runConfig.ModelsGateway,
+			EnvProvider:        runConfig.EnvProvider(),
+			ProviderRegistry:   loaded.ProviderRegistry,
+			AgentDefaultModels: loaded.AgentDefaultModels,
+		}
+		// Reuse the models.dev store the team loader already warmed so model-
+		// metadata lookups don't re-pay the cold catalog parse.
+		if store, storeErr := runConfig.ModelsDevStore(); storeErr == nil {
+			modelSwitcher.ModelsStore = store
+		}
+		runtimeOpts = append(runtimeOpts, dagentruntime.WithModelSwitcherConfig(modelSwitcher))
 	}
 
-	modelSwitcher := &dagentruntime.ModelSwitcherConfig{
-		Models:             loaded.Models,
-		Providers:          loaded.Providers,
-		ModelsGateway:      runConfig.ModelsGateway,
-		EnvProvider:        runConfig.EnvProvider(),
-		ProviderRegistry:   loaded.ProviderRegistry,
-		AgentDefaultModels: loaded.AgentDefaultModels,
-	}
-	// Reuse the models.dev store the team loader already warmed so model-
-	// metadata lookups don't re-pay the cold catalog parse.
-	if store, storeErr := runConfig.ModelsDevStore(); storeErr == nil {
-		modelSwitcher.ModelsStore = store
-	}
-
-	runtimeOpts := []dagentruntime.Opt{
-		dagentruntime.WithModelSwitcherConfig(modelSwitcher),
+	runtimeOpts = append(runtimeOpts,
 		dagentruntime.WithWorkingDir(runConfig.WorkingDir),
 		dagentruntime.WithSessionStore(session.NewInMemorySessionStore()),
-	}
+	)
 	runtimeOpts = append(runtimeOpts, cfg.RuntimeOptions...)
-	rt, err := dagentruntime.New(ctx, loaded.Team, runtimeOpts...)
+	rt, err := dagentruntime.New(ctx, tm, runtimeOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("embeddedchat: create runtime: %w", err)
 	}
 
 	s := &Session{cfg: cfg, rt: rt}
-	if root, err := loaded.Team.DefaultAgent(); err == nil {
+	if root, err := tm.DefaultAgent(); err == nil {
 		s.welcome = root.WelcomeMessage()
 	}
-	s.resetConversationLocked()
+	if cfg.InitialSession != nil {
+		s.session = cfg.InitialSession
+	} else {
+		s.resetConversationLocked()
+	}
 	return s, nil
 }
 
@@ -348,12 +388,23 @@ func TranslateRuntimeEvent(event dagentruntime.Event) (Event, bool) {
 		return Event{RuntimeEvent: event, Text: e.Content}, true
 	case *dagentruntime.ToolCallEvent:
 		return Event{RuntimeEvent: event, Tool: &ToolActivity{Call: e.ToolCall, Def: e.ToolDefinition}}, true
+	case *dagentruntime.ToolCallOutputEvent:
+		if e.Output == "" {
+			return Event{}, false
+		}
+		return Event{RuntimeEvent: event, Tool: &ToolActivity{
+			Call:   tools.ToolCall{ID: e.ToolCallID},
+			Def:    e.ToolDefinition,
+			Output: e.Output,
+		}}, true
 	case *dagentruntime.ToolCallResponseEvent:
 		return Event{RuntimeEvent: event, Tool: &ToolActivity{
 			Call:     tools.ToolCall{ID: e.ToolCallID},
 			Def:      e.ToolDefinition,
 			Finished: true,
 			IsError:  e.Result != nil && e.Result.IsError,
+			Response: e.Response,
+			Result:   e.Result,
 		}}, true
 	}
 	return Event{}, false

--- a/pkg/embeddedchat/embeddedchat_test.go
+++ b/pkg/embeddedchat/embeddedchat_test.go
@@ -8,9 +8,15 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
 	dagentcfg "github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/embeddedchat/defaults"
+	"github.com/docker/docker-agent/pkg/model/provider/base"
+	"github.com/docker/docker-agent/pkg/modelsdev"
 	dagentruntime "github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/team"
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
@@ -25,7 +31,10 @@ func TestNewLoadsAgentAndWelcomeMessage(t *testing.T) {
       type: claude-code
 `)
 
-	s, err := New(t.Context(), Config{AgentSource: dagentcfg.NewBytesSource("agent.yaml", cfg)})
+	s, err := New(t.Context(), Config{
+		AgentSource: dagentcfg.NewBytesSource("agent.yaml", cfg),
+		LoadOpts:    defaults.Opts(),
+	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, s.Close()) })
 	require.Equal(t, "Hello from embedded chat.", s.WelcomeMessage())
@@ -38,6 +47,56 @@ func TestNewRequiresAgentSource(t *testing.T) {
 	s, err := New(t.Context(), Config{})
 	require.Nil(t, s)
 	require.ErrorIs(t, err, ErrAgentSourceRequired)
+}
+
+func TestNewRequiresRegistriesForAgentSource(t *testing.T) {
+	t.Parallel()
+	s, err := New(t.Context(), Config{AgentSource: dagentcfg.NewBytesSource("agent.yaml", []byte("agents:"))})
+	require.Nil(t, s)
+	require.ErrorIs(t, err, ErrRegistriesRequired)
+}
+
+// newCodeBuiltTeam assembles a minimal team in code, the way embedders that
+// avoid the YAML loader (and its full registries) do.
+func newCodeBuiltTeam() *team.Team {
+	root := agent.New("root", "Be helpful.",
+		agent.WithModel(stubProvider{}),
+		agent.WithWelcomeMessage("Hello from a code-built team."))
+	return team.New(team.WithAgents(root))
+}
+
+// stubProvider satisfies the model validation for code-built teams; these
+// tests never run a completion.
+type stubProvider struct{}
+
+func (stubProvider) ID() modelsdev.ID { return modelsdev.ParseIDOrZero("test/stub-model") }
+func (stubProvider) CreateChatCompletionStream(context.Context, []chat.Message, []tools.Tool) (chat.MessageStream, error) {
+	return nil, errors.New("stub provider cannot complete")
+}
+func (stubProvider) BaseConfig() base.Config { return base.Config{} }
+
+func TestNewFromCodeBuiltTeam(t *testing.T) {
+	t.Parallel()
+	s, err := New(t.Context(), Config{Team: newCodeBuiltTeam()})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	require.Equal(t, "Hello from a code-built team.", s.WelcomeMessage())
+	require.NotNil(t, s.Runtime())
+	require.NotNil(t, s.Conversation())
+}
+
+func TestInitialSessionResumesConversation(t *testing.T) {
+	t.Parallel()
+	restored := session.New()
+	restored.AddMessage(session.UserMessage("earlier prompt"))
+
+	s, err := New(t.Context(), Config{Team: newCodeBuiltTeam(), InitialSession: restored})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	require.Same(t, restored, s.Conversation(), "the first conversation must be the restored one")
+
+	require.NoError(t, s.Restart())
+	require.NotSame(t, restored, s.Conversation(), "Restart must start a fresh conversation")
 }
 
 type fakeRuntime struct {


### PR DESCRIPTION
`embeddedchat` is the intended path for callers that drive an agent from their own UI, but it was unusable for embedders that assemble their agents in code: it demanded a YAML `AgentSource` and unconditionally pulled docker-agent's full toolset and provider registries through `teamloader/defaults` — ~77 MB of binary — at link time. Docker Sandboxes' Gordon assistant reimplements the entire wrapper (~440 lines including subtle stream-drain concurrency) purely to avoid that dependency. This change cuts the seams those embedders need.

`Config.Team` now accepts a pre-built `*team.Team`; when set, no YAML loading happens, no model switcher is wired, and the registries are never linked. A size check confirms the effect: a `Team`-only test binary is 42 MB with zero `teamloader`/`toolsets` symbols, versus 119 MB with the full registries. The `AgentSource` path is preserved but now takes its registries through `Config.LoadOpts`; a new `embeddedchat/defaults` sub-package re-exports the previous full registries so existing consumers can migrate with a one-line change. `Config.InitialSession` lets callers seed the first conversation from a restored session store; `Restart` still begins fresh. `ToolActivity` gains a streamed `Output` field and the finished call's `Response` and structured `Result`, giving embedded UIs live progress and tool-result parity with the TUI.

*Breaking change for `AgentSource` users*: `New` now returns `ErrRegistriesRequired` if `Config.LoadOpts` is empty. Pass `defaults.Opts()` (from `embeddedchat/defaults`) for docker-agent's full registries, or supply your own. There are no in-repo consumers of the `AgentSource` path.

New tests cover a code-built team, an `InitialSession` resume, and the registries-required error; existing tests are updated to pass `defaults.Opts()`.