### PR TITLE
fix(teamloader): propagate session working dir to toolsets

### DIFF
--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -235,8 +235,11 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 
 	// Load agents
 	workingDir := cmp.Or(loadOpts.workingDir, runConfig.WorkingDir)
-	// Toolsets read runConfig.WorkingDir directly, so propagate it here.
+	// Toolsets read runConfig.WorkingDir; propagate for this call and
+	// restore on return to avoid leaking across sessions that share rc.
+	originalWorkingDir := runConfig.WorkingDir
 	runConfig.WorkingDir = workingDir
+	defer func() { runConfig.WorkingDir = originalWorkingDir }()
 	parentDir := cmp.Or(agentSource.ParentDir(), workingDir)
 	configName := configNameFromSource(agentSource.Name())
 	var agents []*agent.Agent

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -235,6 +235,8 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 
 	// Load agents
 	workingDir := cmp.Or(loadOpts.workingDir, runConfig.WorkingDir)
+	// Toolsets read runConfig.WorkingDir directly, so propagate it here.
+	runConfig.WorkingDir = workingDir
 	parentDir := cmp.Or(agentSource.ParentDir(), workingDir)
 	configName := configNameFromSource(agentSource.Name())
 	var agents []*agent.Agent

--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -879,6 +879,50 @@ agents:
 	assert.Contains(t, err.Error(), "escapes parent directory")
 }
 
+// WithWorkingDir must not leak the merged value onto a shared *RuntimeConfig
+// that is reused across sessions: after Load returns, runConfig.WorkingDir
+// must be exactly what the caller passed in.
+func TestLoadWithConfig_WithWorkingDirDoesNotLeak(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+
+	data := []byte(`agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+    toolsets:
+      - type: shell
+        tools: [shell]
+`)
+
+	// Caller pins its own WorkingDir on the shared runConfig.
+	callerDir := t.TempDir()
+	runConfig := &config.RuntimeConfig{}
+	runConfig.WorkingDir = callerDir
+
+	// First load with a per-session override.
+	sessionDir := t.TempDir()
+	_, err := Load(
+		t.Context(),
+		config.NewBytesSource("t.yaml", data),
+		runConfig,
+		append(withTestProviderRegistry(), WithWorkingDir(sessionDir))...,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, callerDir, runConfig.WorkingDir,
+		"per-session WithWorkingDir must be restored on return")
+
+	// Second load with no override must see the caller's original WorkingDir,
+	// not the previous session's value.
+	_, err = Load(
+		t.Context(),
+		config.NewBytesSource("t.yaml", data),
+		runConfig,
+		withTestProviderRegistry()...,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, callerDir, runConfig.WorkingDir)
+}
+
 // TestLoadRetainsAgentConfig verifies the loader retains the raw resolved
 // per-agent config on the team (team.WithAgentConfigs) so the agent inspector
 // can surface declared toolset allow-lists, limits and flags. It uses a


### PR DESCRIPTION
### Why

`teamloader.LoadWithConfig` accepts a per-session working directory via `WithWorkingDir`, but the value was only used to resolve `parentDir` locally — it was never written back onto `runConfig`.

Toolsets read `runConfig.WorkingDir` directly at construction time:

```go
// pkg/tools/builtin/shell/shell.go
workingDir: runConfig.WorkingDir
```

So the option was silently dropped for every tool: `shell`, `filesystem`, and any other toolset that keys off `runConfig.WorkingDir` ran in the docker-agent process CWD instead of the session's directory.

Symptoms in a long-lived `docker-agent serve api` process: `shell` and `filesystem` calls in a session created with `working_dir: /home/user/project` end up operating on the server's own CWD (e.g. wherever the daemon was launched from), not `/home/user/project`.

### Regression

`65bffd71f` ("decouple WorkingDir from RuntimeConfig in SessionManager") moved the `WorkingDir` write-back into a local variable inside the loader while keeping the neighbouring writes (`Models`, `Providers`, `ProviderRegistry`) in place. This restores the write-back on the merged `workingDir` local so it reaches the toolsets, without reintroducing the previous `runConfig.Clone()` at the call site.

Saved on entry and defer-restored on exit so callers that reuse the same `*RuntimeConfig` across sessions do not leak the previous session's directory (see review discussion + regression test).
