### PR TITLE
Add cache-safe deferred tool loading

### DIFF
--- a/examples/deferred.yaml
+++ b/examples/deferred.yaml
@@ -1,6 +1,6 @@
 agents:
   root:
-    model: openai/gpt-4o
+    model: openai/gpt-5.6-sol
     description: Simple agent with filesystem access
     instruction: Use the tools to help the user with filesystem operations.
     toolsets:

--- a/pkg/model/provider/anthropic/beta_client.go
+++ b/pkg/model/provider/anthropic/beta_client.go
@@ -36,13 +36,14 @@ func (c *Client) createBetaStream(
 		return nil, err
 	}
 
+	requestTools = c.toolsWithSupportedDeferral(requestTools)
 	allTools, err := convertBetaTools(requestTools)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to convert tools for Anthropic Beta request", "error", err)
 		return nil, err
 	}
 
-	converted, err := c.convertBetaMessages(ctx, messages)
+	converted, err := c.convertBetaMessagesWithDeferred(ctx, messages, requestTools)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to convert messages for Anthropic Beta request", "error", err)
 		return nil, err

--- a/pkg/model/provider/anthropic/beta_converter.go
+++ b/pkg/model/provider/anthropic/beta_converter.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/packages/param"
 
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/tools"
@@ -21,7 +22,12 @@ import (
 // Important: Anthropic API requires that all tool_result blocks corresponding to tool_use
 // blocks from the same assistant message MUST be grouped into a single user message.
 func (c *Client) convertBetaMessages(ctx context.Context, messages []chat.Message) ([]anthropic.BetaMessageParam, error) {
+	return c.convertBetaMessagesWithDeferred(ctx, messages, nil)
+}
+
+func (c *Client) convertBetaMessagesWithDeferred(ctx context.Context, messages []chat.Message, requestTools []tools.Tool) ([]anthropic.BetaMessageParam, error) {
 	var betaMessages []anthropic.BetaMessageParam
+	deferredByCallID := deferredToolNamesByCallID(requestTools)
 
 	for i := 0; i < len(messages); i++ {
 		msg := &messages[i]
@@ -102,7 +108,7 @@ func (c *Client) convertBetaMessages(ctx context.Context, messages []chat.Messag
 			// Collect consecutive tool messages and merge them into a single user message
 			// This is required by Anthropic API: all tool_result blocks for tool_use blocks
 			// from the same assistant message must be in the same user message
-			firstBlock, err := c.convertBetaToolResultBlock(ctx, msg)
+			firstBlock, err := c.convertBetaToolResultBlockWithDeferred(ctx, msg, deferredByCallID[msg.ToolCallID])
 			if err != nil {
 				return nil, err
 			}
@@ -111,7 +117,7 @@ func (c *Client) convertBetaMessages(ctx context.Context, messages []chat.Messag
 			// Look ahead for consecutive tool messages and merge them
 			j := i + 1
 			for j < len(messages) && messages[j].Role == chat.MessageRoleTool {
-				block, err := c.convertBetaToolResultBlock(ctx, &messages[j])
+				block, err := c.convertBetaToolResultBlockWithDeferred(ctx, &messages[j], deferredByCallID[messages[j].ToolCallID])
 				if err != nil {
 					return nil, err
 				}
@@ -141,7 +147,20 @@ func (c *Client) convertBetaMessages(ctx context.Context, messages []chat.Messag
 // It handles text, images (base64 and URL), and document attachments.
 // convertBetaToolResultBlock converts a tool message to a Beta API tool_result block,
 // including inline image and document content from MultiContent.
-func (c *Client) convertBetaToolResultBlock(ctx context.Context, msg *chat.Message) (anthropic.BetaContentBlockParamUnion, error) {
+func (c *Client) convertBetaToolResultBlockWithDeferred(ctx context.Context, msg *chat.Message, names []string) (anthropic.BetaContentBlockParamUnion, error) {
+	if len(names) > 0 {
+		content := make([]anthropic.BetaToolResultBlockParamContentUnion, 0, len(names))
+		for _, name := range names {
+			content = append(content, anthropic.BetaToolResultBlockParamContentUnion{
+				OfToolReference: &anthropic.BetaToolReferenceBlockParam{ToolName: name},
+			})
+		}
+		return anthropic.BetaContentBlockParamUnion{OfToolResult: &anthropic.BetaToolResultBlockParam{
+			ToolUseID: msg.ToolCallID,
+			IsError:   param.NewOpt(msg.IsError),
+			Content:   content,
+		}}, nil
+	}
 	if !hasRichToolResultMultiContent(msg.MultiContent) {
 		return anthropic.BetaContentBlockParamUnion{
 			OfToolResult: &anthropic.BetaToolResultBlockParam{
@@ -326,9 +345,11 @@ func extractBetaSystemBlocks(messages []chat.Message) []anthropic.BetaTextBlockP
 
 // convertBetaTools converts tools to Beta API format
 func convertBetaTools(t []tools.Tool) ([]anthropic.BetaToolUnionParam, error) {
-	betaTools := make([]anthropic.BetaToolUnionParam, len(t))
+	hasDeferredTools := containsDeferredTool(t)
+	t, immediateCount := orderToolsForDeferredLoading(t)
+	betaTools := make([]anthropic.BetaToolUnionParam, 0, len(t))
 
-	for i, tool := range t {
+	for _, tool := range t {
 		inputSchema, err := ConvertParametersToSchema(tool.Parameters)
 		if err != nil {
 			return nil, err
@@ -341,13 +362,18 @@ func convertBetaTools(t []tools.Tool) ([]anthropic.BetaToolUnionParam, error) {
 		}
 
 		// Create BetaToolParam and wrap it in BetaToolUnionParam
-		betaTools[i] = anthropic.BetaToolUnionParam{
-			OfTool: &anthropic.BetaToolParam{
-				Name:        tool.Name,
-				Description: anthropic.String(tool.Description),
-				InputSchema: betaInputSchema,
-			},
+		betaTool := &anthropic.BetaToolParam{
+			Name:        tool.Name,
+			Description: anthropic.String(tool.Description),
+			InputSchema: betaInputSchema,
 		}
+		if tool.Deferred {
+			betaTool.DeferLoading = param.NewOpt(true)
+		}
+		if hasDeferredTools && len(betaTools) == immediateCount-1 {
+			betaTool.CacheControl = anthropic.NewBetaCacheControlEphemeralParam()
+		}
+		betaTools = append(betaTools, anthropic.BetaToolUnionParam{OfTool: betaTool})
 	}
 
 	return betaTools, nil

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -202,13 +202,14 @@ func (c *Client) CreateChatCompletionStream(
 		return c.createBetaStream(ctx, client, messages, requestTools, maxTokens)
 	}
 
+	requestTools = c.toolsWithSupportedDeferral(requestTools)
 	allTools, err := convertTools(requestTools)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to convert tools for Anthropic request", "error", err)
 		return nil, err
 	}
 
-	converted, err := c.convertMessages(ctx, messages)
+	converted, err := c.convertMessagesWithDeferred(ctx, messages, requestTools)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to convert messages for Anthropic request", "error", err)
 		return nil, err
@@ -309,6 +310,11 @@ func (c *Client) convertDoc(ctx context.Context, doc chat.Document) ([]anthropic
 }
 
 func (c *Client) convertMessages(ctx context.Context, messages []chat.Message) ([]anthropic.MessageParam, error) {
+	return c.convertMessagesWithDeferred(ctx, messages, nil)
+}
+
+func (c *Client) convertMessagesWithDeferred(ctx context.Context, messages []chat.Message, requestTools []tools.Tool) ([]anthropic.MessageParam, error) {
+	deferredByCallID := deferredToolNamesByCallID(requestTools)
 	var anthropicMessages []anthropic.MessageParam
 	// Track whether the last appended assistant message included tool_use blocks
 	// so we can ensure the immediate next message is the grouped tool_result user message.
@@ -396,6 +402,21 @@ func (c *Client) convertMessages(ctx context.Context, messages []chat.Message) (
 			var blocks []anthropic.ContentBlockParamUnion
 			j := i
 			for j < len(messages) && messages[j].Role == chat.MessageRoleTool {
+				if names := deferredByCallID[messages[j].ToolCallID]; len(names) > 0 {
+					content := make([]anthropic.ToolResultBlockParamContentUnion, 0, len(names))
+					for _, name := range names {
+						content = append(content, anthropic.ToolResultBlockParamContentUnion{
+							OfToolReference: &anthropic.ToolReferenceBlockParam{ToolName: name},
+						})
+					}
+					blocks = append(blocks, anthropic.ContentBlockParamUnion{OfToolResult: &anthropic.ToolResultBlockParam{
+						ToolUseID: messages[j].ToolCallID,
+						IsError:   param.NewOpt(messages[j].IsError),
+						Content:   content,
+					}})
+					j++
+					continue
+				}
 				tr, err := c.convertToolResultBlock(ctx, &messages[j])
 				if err != nil {
 					return nil, err
@@ -422,6 +443,16 @@ func (c *Client) convertMessages(ctx context.Context, messages []chat.Message) (
 	applyMessageCacheControl(anthropicMessages)
 
 	return anthropicMessages, nil
+}
+
+func deferredToolNamesByCallID(requestTools []tools.Tool) map[string][]string {
+	result := make(map[string][]string)
+	for _, tool := range requestTools {
+		if tool.Deferred && tool.DeferredAtToolCallID != "" {
+			result[tool.DeferredAtToolCallID] = append(result[tool.DeferredAtToolCallID], tool.Name)
+		}
+	}
+	return result
 }
 
 // convertToolResultBlock converts a tool message to an Anthropic tool_result block.
@@ -652,7 +683,29 @@ func extractSystemBlocks(messages []chat.Message) []anthropic.TextBlockParam {
 	return systemBlocks
 }
 
+func (c *Client) supportsDeferredTools() bool {
+	if enabled, ok := providerutil.GetProviderOptBool(c.ModelConfig.ProviderOpts, "supports_deferred_tools"); ok {
+		return enabled
+	}
+	return modelinfo.SupportsDeferredTools(c.ModelConfig.Provider, c.ModelConfig.Model)
+}
+
+func (c *Client) toolsWithSupportedDeferral(requestTools []tools.Tool) []tools.Tool {
+	if c.supportsDeferredTools() {
+		return requestTools
+	}
+	result := make([]tools.Tool, len(requestTools))
+	copy(result, requestTools)
+	for i := range result {
+		result[i].Deferred = false
+		result[i].DeferredAtToolCallID = ""
+	}
+	return result
+}
+
 func convertTools(tooles []tools.Tool) ([]anthropic.ToolUnionParam, error) {
+	hasDeferredTools := containsDeferredTool(tooles)
+	tooles, immediateCount := orderToolsForDeferredLoading(tooles)
 	toolParams := make([]anthropic.ToolParam, len(tooles))
 
 	for i, tool := range tooles {
@@ -666,6 +719,12 @@ func convertTools(tooles []tools.Tool) ([]anthropic.ToolUnionParam, error) {
 			Description: anthropic.String(tool.Description),
 			InputSchema: inputSchema,
 		}
+		if tool.Deferred {
+			toolParams[i].DeferLoading = param.NewOpt(true)
+		}
+		if hasDeferredTools && i == immediateCount-1 {
+			toolParams[i].CacheControl = anthropic.NewCacheControlEphemeralParam()
+		}
 	}
 	anthropicTools := make([]anthropic.ToolUnionParam, len(toolParams))
 	for i := range toolParams {
@@ -673,6 +732,38 @@ func convertTools(tooles []tools.Tool) ([]anthropic.ToolUnionParam, error) {
 	}
 
 	return anthropicTools, nil
+}
+
+func containsDeferredTool(requestTools []tools.Tool) bool {
+	for _, tool := range requestTools {
+		if tool.Deferred {
+			return true
+		}
+	}
+	return false
+}
+
+func orderToolsForDeferredLoading(requestTools []tools.Tool) ([]tools.Tool, int) {
+	ordered := make([]tools.Tool, 0, len(requestTools))
+	for _, tool := range requestTools {
+		if !tool.Deferred {
+			ordered = append(ordered, tool)
+		}
+	}
+	immediateCount := len(ordered)
+	if immediateCount == 0 {
+		ordered = append(ordered, requestTools...)
+		for i := range ordered {
+			ordered[i].Deferred = false
+		}
+		return ordered, len(ordered)
+	}
+	for _, tool := range requestTools {
+		if tool.Deferred {
+			ordered = append(ordered, tool)
+		}
+	}
+	return ordered, immediateCount
 }
 
 // ConvertParametersToSchema converts parameters to Anthropic Schema format

--- a/pkg/model/provider/anthropic/tool_deferrals_test.go
+++ b/pkg/model/provider/anthropic/tool_deferrals_test.go
@@ -1,0 +1,72 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/model/provider/base"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+func TestSupportsDeferredToolsCompatibility(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, (&Client{Config: base.Config{ModelConfig: latest.ModelConfig{Provider: "anthropic", Model: "claude-sonnet-4-5"}}}).supportsDeferredTools())
+	assert.False(t, (&Client{Config: base.Config{ModelConfig: latest.ModelConfig{Provider: "anthropic", Model: "claude-haiku-4-5"}}}).supportsDeferredTools())
+	assert.True(t, (&Client{Config: base.Config{ModelConfig: latest.ModelConfig{
+		Provider: "anthropic-proxy", Model: "claude-opus-4-6", ProviderOpts: map[string]any{"supports_deferred_tools": true},
+	}}}).supportsDeferredTools())
+}
+
+func TestConvertToolsMarksOnlyDeferredTools(t *testing.T) {
+	requestTools := []tools.Tool{
+		{Name: "read", Parameters: map[string]any{"type": "object"}},
+		{Name: "search", Parameters: map[string]any{"type": "object"}, Deferred: true},
+	}
+
+	standard, err := convertTools(requestTools)
+	require.NoError(t, err)
+	require.Len(t, standard, 2)
+	assert.False(t, standard[0].OfTool.DeferLoading.Valid())
+	assert.Equal(t, "ephemeral", string(standard[0].OfTool.CacheControl.Type))
+	require.True(t, standard[1].OfTool.DeferLoading.Valid())
+	assert.True(t, standard[1].OfTool.DeferLoading.Value)
+
+	beta, err := convertBetaTools(requestTools)
+	require.NoError(t, err)
+	require.Len(t, beta, 2)
+	assert.False(t, beta[0].OfTool.DeferLoading.Valid())
+	assert.Equal(t, "ephemeral", string(beta[0].OfTool.CacheControl.Type))
+	require.True(t, beta[1].OfTool.DeferLoading.Valid())
+	assert.True(t, beta[1].OfTool.DeferLoading.Value)
+}
+
+func TestDeferredToolsAreReferencedAtTheirLoadPoint(t *testing.T) {
+	messages := []chat.Message{
+		{Role: chat.MessageRoleAssistant, ToolCalls: []tools.ToolCall{{
+			ID: "call-1", Function: tools.FunctionCall{Name: "add_tool", Arguments: `{}`},
+		}}},
+		{Role: chat.MessageRoleTool, ToolCallID: "call-1", Content: "activated"},
+	}
+	requestTools := []tools.Tool{{
+		Name: "search", Parameters: map[string]any{"type": "object"},
+		Deferred: true, DeferredAtToolCallID: "call-1",
+	}}
+
+	standard, err := testClient().convertMessagesWithDeferred(t.Context(), messages, requestTools)
+	require.NoError(t, err)
+	standardJSON, err := json.Marshal(standard)
+	require.NoError(t, err)
+	assert.Contains(t, string(standardJSON), `"tool_name":"search","type":"tool_reference"`)
+
+	beta, err := testClient().convertBetaMessagesWithDeferred(t.Context(), messages, requestTools)
+	require.NoError(t, err)
+	betaJSON, err := json.Marshal(beta)
+	require.NoError(t, err)
+	assert.Contains(t, string(betaJSON), `"tool_name":"search","type":"tool_reference"`)
+}

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"cmp"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -520,6 +521,72 @@ func (c *Client) CreateChatCompletionStream(
 	return newStreamAdapter(stream, trackUsage), nil
 }
 
+func (c *Client) supportsDeferredTools() bool {
+	if enabled, ok := providerutil.GetProviderOptBool(c.ModelConfig.ProviderOpts, "supports_deferred_tools"); ok {
+		return enabled
+	}
+	return modelinfo.SupportsDeferredTools(c.ModelConfig.Provider, c.ModelConfig.Model)
+}
+
+func injectDeferredToolLoads(input []responses.ResponseInputItemUnionParam, requestTools []tools.Tool) ([]responses.ResponseInputItemUnionParam, error) {
+	byCallID := make(map[string][]tools.Tool)
+	for _, tool := range requestTools {
+		if tool.Deferred && tool.DeferredAtToolCallID != "" {
+			byCallID[tool.DeferredAtToolCallID] = append(byCallID[tool.DeferredAtToolCallID], tool)
+		}
+	}
+	if len(byCallID) == 0 {
+		return input, nil
+	}
+
+	result := make([]responses.ResponseInputItemUnionParam, 0, len(input)+2*len(byCallID))
+	for _, item := range input {
+		result = append(result, item)
+		if item.OfFunctionCallOutput == nil {
+			continue
+		}
+		deferred := byCallID[item.OfFunctionCallOutput.CallID]
+		if len(deferred) == 0 {
+			continue
+		}
+
+		loaded := make([]responses.ToolUnionParam, 0, len(deferred))
+		names := make([]string, 0, len(deferred))
+		for _, tool := range deferred {
+			parameters, strict, err := ConvertParametersToSchema(tool.Parameters)
+			if err != nil {
+				return nil, err
+			}
+			loaded = append(loaded, responses.ToolUnionParam{OfFunction: &responses.FunctionToolParam{
+				Name:         tool.Name,
+				Description:  param.NewOpt(tool.Description),
+				Parameters:   parameters,
+				Strict:       param.NewOpt(strict),
+				DeferLoading: param.NewOpt(true),
+			}})
+			names = append(names, tool.Name)
+		}
+
+		digest := fmt.Sprintf("%x", sha256.Sum256([]byte(item.OfFunctionCallOutput.CallID+":"+strings.Join(names, ","))))
+		callID := "cagent_tool_load_" + digest[:16]
+		result = append(result,
+			responses.ResponseInputItemUnionParam{OfToolSearchCall: &responses.ResponseInputItemToolSearchCallParam{
+				Arguments: map[string]any{"query": strings.Join(names, " "), "limit": len(names)},
+				CallID:    param.NewOpt(callID),
+				Execution: "client",
+				Status:    "completed",
+			}},
+			responses.ResponseInputItemUnionParam{OfToolSearchOutput: &responses.ResponseToolSearchOutputItemParam{
+				Tools:     loaded,
+				CallID:    param.NewOpt(callID),
+				Execution: responses.ResponseToolSearchOutputItemParamExecutionClient,
+				Status:    responses.ResponseToolSearchOutputItemParamStatusCompleted,
+			}},
+		)
+	}
+	return result, nil
+}
+
 func (c *Client) CreateResponseStream(
 	ctx context.Context,
 	messages []chat.Message,
@@ -533,6 +600,14 @@ func (c *Client) CreateResponseStream(
 	}
 
 	input := c.convertMessagesToResponseInput(ctx, messages)
+	deferredToolsEnabled := c.supportsDeferredTools()
+	if deferredToolsEnabled {
+		loadedInput, err := injectDeferredToolLoads(input, requestTools)
+		if err != nil {
+			return nil, err
+		}
+		input = loadedInput
+	}
 
 	params := responses.ResponseNewParams{
 		Model: c.ModelConfig.Model,
@@ -554,22 +629,24 @@ func (c *Client) CreateResponseStream(
 
 	if len(requestTools) > 0 {
 		slog.DebugContext(ctx, "Adding tools to OpenAI responses request", "tool_count", len(requestTools))
-		toolsParam := make([]responses.ToolUnionParam, len(requestTools))
-		for i, tool := range requestTools {
+		toolsParam := make([]responses.ToolUnionParam, 0, len(requestTools))
+		for _, tool := range requestTools {
+			if deferredToolsEnabled && tool.Deferred {
+				continue
+			}
 			parameters, strict, err := ConvertParametersToSchema(tool.Parameters)
 			if err != nil {
 				slog.DebugContext(ctx, "Failed to convert tool parameters to OpenAI schema", "tool_name", tool.Name, "error", err)
 				return nil, err
 			}
 
-			toolsParam[i] = responses.ToolUnionParam{
-				OfFunction: &responses.FunctionToolParam{
-					Name:        tool.Name,
-					Description: param.NewOpt(tool.Description),
-					Parameters:  parameters,
-					Strict:      param.NewOpt(strict),
-				},
+			functionTool := &responses.FunctionToolParam{
+				Name:        tool.Name,
+				Description: param.NewOpt(tool.Description),
+				Parameters:  parameters,
+				Strict:      param.NewOpt(strict),
 			}
+			toolsParam = append(toolsParam, responses.ToolUnionParam{OfFunction: functionTool})
 
 			if !strict {
 				slog.DebugContext(ctx, "Tool not compatible with OpenAI strict mode, falling back", "tool_name", tool.Name)
@@ -577,17 +654,19 @@ func (c *Client) CreateResponseStream(
 
 			slog.DebugContext(ctx, "Added tool to OpenAI responses request", "tool_name", tool.Name)
 		}
-		params.Tools = toolsParam
+		if len(toolsParam) > 0 {
+			params.Tools = toolsParam
 
-		// Explicitly send tool_choice="auto". See the matching comment in the
-		// Chat Completions path above for rationale (LiteLLM-style gateways
-		// reject requests where tool_choice is omitted).
-		params.ToolChoice = responses.ResponseNewParamsToolChoiceUnion{
-			OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptionsAuto),
-		}
+			// Explicitly send tool_choice="auto". See the matching comment in the
+			// Chat Completions path above for rationale (LiteLLM-style gateways
+			// reject requests where tool_choice is omitted).
+			params.ToolChoice = responses.ResponseNewParamsToolChoiceUnion{
+				OfToolChoiceMode: param.NewOpt(responses.ToolChoiceOptionsAuto),
+			}
 
-		if c.ModelConfig.ParallelToolCalls != nil {
-			params.ParallelToolCalls = param.NewOpt(*c.ModelConfig.ParallelToolCalls)
+			if c.ModelConfig.ParallelToolCalls != nil {
+				params.ParallelToolCalls = param.NewOpt(*c.ModelConfig.ParallelToolCalls)
+			}
 		}
 	}
 

--- a/pkg/model/provider/openai/tool_deferrals_test.go
+++ b/pkg/model/provider/openai/tool_deferrals_test.go
@@ -1,0 +1,138 @@
+package openai
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/model/provider/base"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+type deferredToolPayload struct {
+	Name         string `json:"name"`
+	Type         string `json:"type"`
+	DeferLoading *bool  `json:"defer_loading"`
+}
+
+type deferredInputPayload struct {
+	Type      string                `json:"type"`
+	CallID    string                `json:"call_id"`
+	Execution string                `json:"execution"`
+	Tools     []deferredToolPayload `json:"tools"`
+}
+
+type deferredRequestPayload struct {
+	Tools []deferredToolPayload  `json:"tools"`
+	Input []deferredInputPayload `json:"input"`
+}
+
+func TestSupportsDeferredToolsCompatibility(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, (&Client{Config: base.Config{ModelConfig: latest.ModelConfig{Provider: "openai", Model: "gpt-5.4"}}}).supportsDeferredTools())
+	assert.False(t, (&Client{Config: base.Config{ModelConfig: latest.ModelConfig{Provider: "openai", Model: "gpt-5.4-nano"}}}).supportsDeferredTools())
+	assert.True(t, (&Client{Config: base.Config{ModelConfig: latest.ModelConfig{
+		Provider: "custom", Model: "gpt-5.4", ProviderOpts: map[string]any{"supports_deferred_tools": true},
+	}}}).supportsDeferredTools())
+}
+
+func TestResponsesAPI_LoadsDeferredToolsThroughClientToolSearch(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		requests []deferredRequestPayload
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if !assert.NoError(t, err) {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		var request deferredRequestPayload
+		if !assert.NoError(t, json.Unmarshal(body, &request)) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		requests = append(requests, request)
+		mu.Unlock()
+		writeResponsesSSEResponse(w)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(t.Context(), &latest.ModelConfig{
+		Provider: "openai",
+		Model:    "gpt-5.4",
+		BaseURL:  server.URL,
+		ProviderOpts: map[string]any{
+			"api_type": "openai_responses",
+		},
+	}, environment.NewMapEnvProvider(map[string]string{"OPENAI_API_KEY": "secret"}))
+	require.NoError(t, err)
+
+	readTool := tools.Tool{Name: "read", Parameters: map[string]any{"type": "object"}}
+	searchTool := tools.Tool{
+		Name:                 "search",
+		Parameters:           map[string]any{"type": "object"},
+		Deferred:             true,
+		DeferredAtToolCallID: "call-1",
+	}
+	initialMessages := []chat.Message{{Role: chat.MessageRoleUser, Content: "hi"}}
+	loadedMessages := []chat.Message{
+		{Role: chat.MessageRoleUser, Content: "hi"},
+		{Role: chat.MessageRoleAssistant, ToolCalls: []tools.ToolCall{{
+			ID: "call-1", Type: "function", Function: tools.FunctionCall{Name: "add_tool", Arguments: `{}`},
+		}}},
+		{Role: chat.MessageRoleTool, ToolCallID: "call-1", Content: "activated"},
+	}
+
+	for _, request := range []struct {
+		messages []chat.Message
+		tools    []tools.Tool
+	}{{initialMessages, []tools.Tool{readTool}}, {loadedMessages, []tools.Tool{readTool, searchTool}}} {
+		stream, err := client.CreateResponseStream(t.Context(), request.messages, request.tools)
+		require.NoError(t, err)
+		for {
+			if _, err := stream.Recv(); err != nil {
+				break
+			}
+		}
+		stream.Close()
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, requests, 2)
+	require.Len(t, requests[0].Tools, 1)
+	assert.Equal(t, "read", requests[0].Tools[0].Name)
+	require.Len(t, requests[1].Tools, 1)
+	assert.Equal(t, "read", requests[1].Tools[0].Name)
+
+	var call *deferredInputPayload
+	var output *deferredInputPayload
+	for i := range requests[1].Input {
+		switch requests[1].Input[i].Type {
+		case "tool_search_call":
+			call = &requests[1].Input[i]
+		case "tool_search_output":
+			output = &requests[1].Input[i]
+		}
+	}
+	require.NotNil(t, call)
+	require.NotNil(t, output)
+	assert.Equal(t, "client", call.Execution)
+	assert.Equal(t, call.CallID, output.CallID)
+	require.Len(t, output.Tools, 1)
+	assert.Equal(t, "search", output.Tools[0].Name)
+	require.NotNil(t, output.Tools[0].DeferLoading)
+	assert.True(t, *output.Tools[0].DeferLoading)
+}

--- a/pkg/modelinfo/modelinfo.go
+++ b/pkg/modelinfo/modelinfo.go
@@ -60,6 +60,35 @@ func SupportsResponsesAPI(modelID string) bool {
 	return isOSeries(m)
 }
 
+// SupportsDeferredTools reports whether a first-party model supports loading
+// tool definitions at a point in the transcript without invalidating its cache.
+func SupportsDeferredTools(provider, modelID string) bool {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	switch provider {
+	case "openai", "chatgpt":
+		switch normalizeOpenAI(modelID) {
+		case "gpt-5.4", "gpt-5.4-mini", "gpt-5.5", "gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra":
+			return true
+		case "gpt-5.4-pro":
+			return provider == "openai"
+		default:
+			return false
+		}
+	case "anthropic":
+		m := normalize(modelID)
+		if strings.Contains(m, "haiku") {
+			return false
+		}
+		if strings.Contains(m, "fable") {
+			return true
+		}
+		major, minor, ok := claudeOpusSonnetVersion(m)
+		return ok && (major > 4 || major == 4 && minor >= 5)
+	default:
+		return false
+	}
+}
+
 // UsesReasoningEffort reports whether an OpenAI model accepts the
 // `reasoning.effort` API parameter.
 //

--- a/pkg/modelinfo/modelinfo_test.go
+++ b/pkg/modelinfo/modelinfo_test.go
@@ -64,6 +64,53 @@ func TestSupportsResponsesAPI(t *testing.T) {
 	}
 }
 
+func TestSupportsDeferredTools(t *testing.T) {
+	t.Parallel()
+
+	openAI := []struct {
+		provider string
+		model    string
+		want     bool
+	}{
+		{"openai", "gpt-5.4", true},
+		{"openai", "gpt-5.4-mini", true},
+		{"openai", "gpt-5.4-pro", true},
+		{"openai", "gpt-5.4-nano", false},
+		{"openai", "gpt-5.5", true},
+		{"openai", "gpt-5.5-pro", false},
+		{"openai", "gpt-5.6-luna", true},
+		{"openai", "gpt-5.6-sol", true},
+		{"openai", "gpt-5.6-terra", true},
+		{"chatgpt", "gpt-5.4", true},
+		{"chatgpt", "gpt-5.4-pro", false},
+		{"openai", "gpt-5.3-codex-spark", false},
+		{"openai", "gpt-5.2", false},
+		{"custom", "gpt-5.4", false},
+	}
+	for _, tc := range openAI {
+		assert.Equal(t, tc.want, SupportsDeferredTools(tc.provider, tc.model), "%s/%s", tc.provider, tc.model)
+	}
+
+	anthropic := []struct {
+		provider string
+		model    string
+		want     bool
+	}{
+		{"anthropic", "claude-opus-4-5", true},
+		{"anthropic", "claude-opus-4-5-20251101", true},
+		{"anthropic", "claude-sonnet-4-5", true},
+		{"anthropic", "claude-opus-4-1", false},
+		{"anthropic", "claude-sonnet-4-0", false},
+		{"anthropic", "claude-haiku-4-5", false},
+		{"anthropic", "claude-fable-5", true},
+		{"anthropic", "claude-sonnet-5", true},
+		{"anthropic-proxy", "claude-opus-4-6", false},
+	}
+	for _, tc := range anthropic {
+		assert.Equal(t, tc.want, SupportsDeferredTools(tc.provider, tc.model), "%s/%s", tc.provider, tc.model)
+	}
+}
+
 func TestUsesReasoningEffort(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -755,6 +755,7 @@ func (r *LocalRuntime) runTurn(
 	messages = r.applyBeforeLLMCallTransforms(ctx, sess, a, modelID.String(), messages)
 
 	// Try primary model with fallback chain if configured
+	agentTools = r.toolDeferrals.MarkAt(sess.ID, lastToolCallID(messages), agentTools)
 	res, usedModel, err := r.fallback.execute(streamCtx, a, model, messages, agentTools, sess, m, events)
 	if err != nil {
 		outcome := r.handleStreamError(ctx, sess, a, err, contextLimit, &ls.overflowCompactions, streamSpan, events)
@@ -1244,6 +1245,15 @@ func formatToolWarning(a *agent.Agent, warnings []string) string {
 		fmt.Fprintf(&builder, "- %s\n", warning)
 	}
 	return strings.TrimSuffix(builder.String(), "\n")
+}
+
+func lastToolCallID(messages []chat.Message) string {
+	for _, message := range slices.Backward(messages) {
+		if message.Role == chat.MessageRoleTool {
+			return message.ToolCallID
+		}
+	}
+	return ""
 }
 
 // filterExcludedTools removes tools whose names appear in the excluded list.

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -215,6 +215,7 @@ type ModelStore interface {
 type LocalRuntime struct {
 	ctx                       func() context.Context
 	toolMap                   map[string]ToolHandlerFunc
+	toolDeferrals             tools.DeferralTracker
 	team                      *team.Team
 	agents                    *agentRouter
 	resumeChan                chan ResumeRequest

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -3350,10 +3350,20 @@ func TestReprobe_NewToolsAvailableAfterToolCall(t *testing.T) {
 	call1Names := toolNames(prov.recordedCalls[0])
 	assert.Contains(t, call1Names, "install_mcp", "turn 1 must include install_mcp")
 	assert.NotContains(t, call1Names, "mcp_hello", "turn 1 must NOT include mcp_hello before install")
+	for _, tool := range prov.recordedCalls[0] {
+		assert.False(t, tool.Deferred)
+	}
 
-	// Second model call: mcp_hello must be visible.
+	// Second model call: mcp_hello must be visible and deferred so it preserves
+	// the provider's cached tool prefix.
 	call2Names := toolNames(prov.recordedCalls[1])
 	assert.Contains(t, call2Names, "mcp_hello", "turn 2 must include mcp_hello after reprobe")
+	for _, tool := range prov.recordedCalls[1] {
+		assert.Equal(t, tool.Name == "mcp_hello", tool.Deferred)
+		if tool.Name == "mcp_hello" {
+			assert.Equal(t, "call_1", tool.DeferredAtToolCallID)
+		}
+	}
 
 	// A ToolsetInfo event with the new count must have been emitted during reprobe.
 	var toolsetInfoCounts []int

--- a/pkg/tools/deferrals.go
+++ b/pkg/tools/deferrals.go
@@ -1,0 +1,52 @@
+package tools
+
+import "sync"
+
+// DeferralTracker marks tools absent from a session's first model call as deferred.
+type DeferralTracker struct {
+	mu          sync.Mutex
+	initial     map[string]map[string]struct{}
+	loadPointBy map[string]map[string]string
+}
+
+func (t *DeferralTracker) Mark(sessionID string, requestTools []Tool) []Tool {
+	return t.MarkAt(sessionID, "", requestTools)
+}
+
+func (t *DeferralTracker) MarkAt(sessionID, toolCallID string, requestTools []Tool) []Tool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.initial == nil {
+		t.initial = make(map[string]map[string]struct{})
+		t.loadPointBy = make(map[string]map[string]string)
+	}
+	initial, ok := t.initial[sessionID]
+	if !ok {
+		initial = make(map[string]struct{}, len(requestTools))
+		for _, tool := range requestTools {
+			initial[tool.Name] = struct{}{}
+		}
+		t.initial[sessionID] = initial
+		t.loadPointBy[sessionID] = make(map[string]string)
+		return requestTools
+	}
+
+	marked := make([]Tool, len(requestTools))
+	copy(marked, requestTools)
+	loadPoints := t.loadPointBy[sessionID]
+	for i := range marked {
+		if _, presentInitially := initial[marked[i].Name]; presentInitially {
+			continue
+		}
+		if _, exists := loadPoints[marked[i].Name]; !exists {
+			if toolCallID == "" {
+				continue
+			}
+			loadPoints[marked[i].Name] = toolCallID
+		}
+		marked[i].Deferred = true
+		marked[i].DeferredAtToolCallID = loadPoints[marked[i].Name]
+	}
+	return marked
+}

--- a/pkg/tools/deferrals_test.go
+++ b/pkg/tools/deferrals_test.go
@@ -1,0 +1,51 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeferralTracker(t *testing.T) {
+	var tracker DeferralTracker
+
+	initial := tracker.Mark("session", []Tool{{Name: "read"}, {Name: "write"}})
+	assert.False(t, initial[0].Deferred)
+	assert.False(t, initial[1].Deferred)
+
+	updated := tracker.MarkAt("session", "call-1", []Tool{{Name: "read"}, {Name: "write"}, {Name: "search"}})
+	require.Len(t, updated, 3)
+	assert.False(t, updated[0].Deferred)
+	assert.False(t, updated[1].Deferred)
+	assert.True(t, updated[2].Deferred)
+	assert.Equal(t, "call-1", updated[2].DeferredAtToolCallID)
+
+	stillDeferred := tracker.MarkAt("session", "call-2", []Tool{{Name: "search"}})
+	assert.True(t, stillDeferred[0].Deferred)
+	assert.Equal(t, "call-1", stillDeferred[0].DeferredAtToolCallID)
+}
+
+func TestDeferralTrackerScopesToolsBySession(t *testing.T) {
+	var tracker DeferralTracker
+
+	tracker.Mark("first", []Tool{{Name: "read"}})
+	tracker.Mark("second", []Tool{{Name: "search"}})
+
+	first := tracker.MarkAt("first", "call-1", []Tool{{Name: "read"}, {Name: "search"}})
+	second := tracker.MarkAt("second", "call-2", []Tool{{Name: "read"}, {Name: "search"}})
+	assert.False(t, first[0].Deferred)
+	assert.True(t, first[1].Deferred)
+	assert.True(t, second[0].Deferred)
+	assert.False(t, second[1].Deferred)
+}
+
+func TestDeferralTrackerRecordsEmptyFirstCall(t *testing.T) {
+	var tracker DeferralTracker
+
+	assert.Empty(t, tracker.Mark("session", nil))
+	withoutLoadPoint := tracker.Mark("session", []Tool{{Name: "read"}})
+	assert.False(t, withoutLoadPoint[0].Deferred)
+	marked := tracker.MarkAt("session", "call-1", []Tool{{Name: "read"}})
+	assert.True(t, marked[0].Deferred)
+}

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -153,6 +153,9 @@ type Tool struct {
 	OutputSchema            any             `json:"outputSchema"`
 	Handler                 ToolHandler     `json:"-"`
 	AddDescriptionParameter bool            `json:"-"`
+	// Deferred keeps tools added after the first model call out of cached prompt prefixes.
+	Deferred             bool   `json:"-"`
+	DeferredAtToolCallID string `json:"-"`
 	// ModelOverride is the per-toolset model for the LLM turn that processes
 	// this tool's results. Set automatically from the toolset "model" field.
 	ModelOverride string `json:"-"`


### PR DESCRIPTION
Track deferred tool load points in the shared runtime and translate them into native OpenAI tool-search and Anthropic tool-reference messages.

Before and after screenshots show a run with a slightly changed examples/deferred.yaml agent run (I had to add more content to its system prompt in order for the caching to kick in).
My messages were:

> Hello

> enable the shell tool please, query with only "shell"

> now please run ls -l

Before:

<img width="697" height="497" alt="Screenshot 2026-07-15 at 14 22 04" src="https://github.com/user-attachments/assets/a8f9dade-bf45-4a17-a325-303c92cc1261" />

After:

<img width="688" height="500" alt="Screenshot 2026-07-15 at 15 15 37" src="https://github.com/user-attachments/assets/e1c95817-2ff0-4d34-a522-d55b686e22c7" />
<img width="692" height="510" alt="Screenshot 2026-07-15 at 15 11 49" src="https://github.com/user-attachments/assets/73012cf0-7e95-44cf-a594-f71c5c6b1b9d" />
