### PR TITLE
fix(session): lock title and usage scalar access

### DIFF
--- a/pkg/a2a/adapter.go
+++ b/pkg/a2a/adapter.go
@@ -91,7 +91,7 @@ func runDockerAgent(ctx agent.InvocationContext, t *team.Team, agentName string,
 				session.WithNonInteractive(true),
 				session.WithWorkingDir(workingDir),
 			)
-			sess.Title = "A2A Session " + sessionID
+			sess.SetTitle("A2A Session " + sessionID)
 		}
 
 		// Create runtime

--- a/pkg/acp/agent.go
+++ b/pkg/acp/agent.go
@@ -214,7 +214,7 @@ func (a *Agent) NewSession(ctx context.Context, params acp.NewSessionRequest) (a
 		session.WithMaxToolResultTokens(defaultAgent.MaxToolResultTokens()),
 		session.WithWorkingDir(workingDir),
 	)
-	sess.Title = "ACP Session " + sess.ID
+	sess.SetTitle("ACP Session " + sess.ID)
 
 	if err := a.sessionStore.AddSession(ctx, sess); err != nil {
 		return acp.NewSessionResponse{}, fmt.Errorf("failed to persist session: %w", err)

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -484,7 +484,7 @@ func (a *App) Run(ctx context.Context, cancel context.CancelFunc, message string
 	a.cancel = cancel
 
 	// If this is the first message and no title exists, start local title generation
-	if a.session.Title == "" && a.titleGen != nil {
+	if a.session.TitleSnapshot() == "" && a.titleGen != nil {
 		a.titleGenerating.Store(true)
 		go a.generateTitle(ctx, []string{message})
 	}
@@ -764,7 +764,7 @@ func (a *App) RunWithMessage(ctx context.Context, cancel context.CancelFunc, msg
 	a.cancel = cancel
 
 	// If this is the first message and no title exists, start local title generation
-	if a.session.Title == "" && a.titleGen != nil {
+	if a.session.TitleSnapshot() == "" && a.titleGen != nil {
 		a.titleGenerating.Store(true)
 		// Extract text content from the message for title generation
 		userMessage := msg.Message.Content

--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -90,7 +90,7 @@ func Run(ctx context.Context, out *Printer, cfg Config, rt runtime.Runtime, sess
 		ctx = telemetry.WithClient(ctx, telemetryClient)
 	}
 
-	sess.Title = "Running agent"
+	sess.SetTitle("Running agent")
 	// If the last received event was an error, return it. That way the exit code
 	// will be non-zero if the agent failed.
 	var lastErr error

--- a/pkg/evaluation/eval.go
+++ b/pkg/evaluation/eval.go
@@ -360,7 +360,7 @@ func (r *Runner) runSingleEval(ctx context.Context, evalSess *InputSession) (Res
 
 	// Re-apply the display title in case a session_title event overrode it.
 	// This ensures repeated evals retain their '#N' suffix in stored sessions.
-	result.Session.Title = title
+	result.Session.SetTitle(title)
 
 	if len(expectedToolCalls) > 0 || len(actualToolCalls) > 0 {
 		result.ToolCallsScore = toolCallF1Score(expectedToolCalls, actualToolCalls)

--- a/pkg/evaluation/save.go
+++ b/pkg/evaluation/save.go
@@ -211,15 +211,20 @@ func SessionFromEvents(events []map[string]any, title string, questions []string
 		case "token_usage":
 			// Update session token usage
 			if usage, ok := event["usage"].(map[string]any); ok {
+				// Route the write through the locked setter, keeping the
+				// previous value for any field absent from the event. sess is
+				// local to this import, so the pre-read cannot race.
+				sessInput, sessOutput, sessCost := sess.TokensAndCost()
 				if inputTokens, ok := usage["input_tokens"].(float64); ok {
-					sess.InputTokens = int64(inputTokens)
+					sessInput = int64(inputTokens)
 				}
 				if outputTokens, ok := usage["output_tokens"].(float64); ok {
-					sess.OutputTokens = int64(outputTokens)
+					sessOutput = int64(outputTokens)
 				}
 				if cost, ok := usage["cost"].(float64); ok {
-					sess.Cost = cost
+					sessCost = cost
 				}
+				sess.SetTokensAndCost(sessInput, sessOutput, sessCost)
 				// Extract per-message usage if available
 				if lastMsg, ok := usage["last_message"].(map[string]any); ok {
 					currentUsage = parseMessageUsage(lastMsg)
@@ -251,7 +256,7 @@ func SessionFromEvents(events []map[string]any, title string, questions []string
 		case "session_title":
 			// Update session title if provided (may override the one from eval config)
 			if eventTitle, ok := event["title"].(string); ok && eventTitle != "" {
-				sess.Title = eventTitle
+				sess.SetTitle(eventTitle)
 			}
 
 		case "stream_stopped":

--- a/pkg/evaluation/save_test.go
+++ b/pkg/evaluation/save_test.go
@@ -468,6 +468,71 @@ func TestSessionFromEventsTokenUsage(t *testing.T) {
 	assert.InDelta(t, 0.005, sess.Cost, 0.0001)
 }
 
+// TestSessionFromEventsPartialTokenUsage pins the merge semantics of
+// consecutive token_usage events: a later event that omits some usage
+// fields must preserve the previously recorded values for the omitted
+// fields instead of resetting them to zero.
+func TestSessionFromEventsPartialTokenUsage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		second     map[string]any
+		wantInput  int64
+		wantOutput int64
+		wantCost   float64
+	}{
+		{
+			name:       "second event omits input_tokens and cost",
+			second:     map[string]any{"output_tokens": float64(80)},
+			wantInput:  100,
+			wantOutput: 80,
+			wantCost:   0.005,
+		},
+		{
+			name:       "second event omits output_tokens",
+			second:     map[string]any{"input_tokens": float64(200), "cost": 0.01},
+			wantInput:  200,
+			wantOutput: 50,
+			wantCost:   0.01,
+		},
+		{
+			name:       "second event omits every field",
+			second:     map[string]any{},
+			wantInput:  100,
+			wantOutput: 50,
+			wantCost:   0.005,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			events := []map[string]any{
+				{"type": "agent_choice", "content": "Answer"},
+				{
+					"type": "token_usage",
+					"usage": map[string]any{
+						"input_tokens":  float64(100),
+						"output_tokens": float64(50),
+						"cost":          0.005,
+					},
+				},
+				{"type": "token_usage", "usage": tt.second},
+				{"type": "stream_stopped"},
+			}
+
+			sess := SessionFromEvents(events, "test", []string{"question"})
+
+			gotInput, gotOutput, gotCost := sess.TokensAndCost()
+			assert.Equal(t, tt.wantInput, gotInput)
+			assert.Equal(t, tt.wantOutput, gotOutput)
+			assert.InDelta(t, tt.wantCost, gotCost, 0.0001)
+		})
+	}
+}
+
 func TestParseToolCall(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -404,10 +404,13 @@ func (e *TokenUsageEvent) GetSessionID() string { return e.SessionID }
 // compactionThreshold is the agent's configured auto-compaction trigger
 // fraction (0 or omitted when unknown), passed along verbatim for UI gauges.
 func SessionUsage(sess *session.Session, contextLimit int64, compactionThreshold ...float64) *Usage {
+	// Usage() snapshots both counters under sess.mu so a concurrent
+	// SetUsage/ApplyCompaction cannot tear the pair.
+	input, output := sess.Usage()
 	u := &Usage{
-		InputTokens:   sess.InputTokens,
-		OutputTokens:  sess.OutputTokens,
-		ContextLength: sess.InputTokens + sess.OutputTokens,
+		InputTokens:   input,
+		OutputTokens:  output,
+		ContextLength: input + output,
 		ContextLimit:  contextLimit,
 		Cost:          sess.OwnCost(),
 	}

--- a/pkg/runtime/hooks.go
+++ b/pkg/runtime/hooks.go
@@ -502,10 +502,11 @@ func (r *LocalRuntime) executeBeforeCompactionHooks(
 	contextLimit int64,
 	events EventSink,
 ) *hooks.Result {
+	inputTokens, outputTokens := sess.Usage()
 	return r.dispatchHook(ctx, a, hooks.EventBeforeCompaction, &hooks.Input{
 		SessionID:        sess.ID,
-		InputTokens:      sess.InputTokens,
-		OutputTokens:     sess.OutputTokens,
+		InputTokens:      inputTokens,
+		OutputTokens:     outputTokens,
 		ContextLimit:     contextLimit,
 		CompactionReason: reason,
 	}, events)

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -525,7 +525,8 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 		// trigger and the UI context gauge (issue #3241); it equals the primary
 		// window unless a smaller compaction model is configured.
 		contextLimit := r.effectiveContextLimit(ctx, a, r.resolveContextLimit(ctx, model, modelID))
-		if contextLimit > 0 && r.sessionCompactionEnabled(a) && compaction.ShouldCompact(sess.InputTokens, sess.OutputTokens, 0, contextLimit, a.CompactionThreshold()) {
+		inputTokens, outputTokens := sess.Usage()
+		if contextLimit > 0 && r.sessionCompactionEnabled(a) && compaction.ShouldCompact(inputTokens, outputTokens, 0, contextLimit, a.CompactionThreshold()) {
 			r.compactWithReason(ctx, sess, "", compactionReasonThreshold, sink)
 		}
 
@@ -1160,17 +1161,18 @@ func (r *LocalRuntime) compactIfNeeded(
 		addedTokens += estimator.EstimateMessageTokens(&newMessages[i].Message)
 	}
 
-	if !compaction.ShouldCompact(sess.InputTokens, sess.OutputTokens, addedTokens, contextLimit, a.CompactionThreshold()) {
+	inputTokens, outputTokens := sess.Usage()
+	if !compaction.ShouldCompact(inputTokens, outputTokens, addedTokens, contextLimit, a.CompactionThreshold()) {
 		return
 	}
 
 	slog.InfoContext(ctx, "Proactive compaction: tool results pushed estimated context past the compaction threshold",
 		"agent", a.Name(),
-		"input_tokens", sess.InputTokens,
-		"output_tokens", sess.OutputTokens,
+		"input_tokens", inputTokens,
+		"output_tokens", outputTokens,
 		"added_estimated_tokens", addedTokens,
 		"estimator_scale", estimator.Scale(),
-		"estimated_total", sess.InputTokens+sess.OutputTokens+addedTokens,
+		"estimated_total", inputTokens+outputTokens+addedTokens,
 		"context_limit", contextLimit,
 	)
 	r.compactWithReason(ctx, sess, "", compactionReasonThreshold, events)

--- a/pkg/runtime/loop_steps.go
+++ b/pkg/runtime/loop_steps.go
@@ -163,11 +163,12 @@ func (r *LocalRuntime) handleStreamError(
 	// loop when compaction cannot reduce the context enough.
 	if _, ok := errors.AsType[*modelerrors.ContextOverflowError](err); ok && r.sessionCompactionEnabled(a) && *overflowCompactions < r.maxOverflowCompactions {
 		*overflowCompactions++
+		inputTokens, outputTokens := sess.Usage()
 		slog.WarnContext(ctx, "Context window overflow detected, attempting auto-compaction",
 			"agent", a.Name(),
 			"session_id", sess.ID,
-			"input_tokens", sess.InputTokens,
-			"output_tokens", sess.OutputTokens,
+			"input_tokens", inputTokens,
+			"output_tokens", outputTokens,
 			"context_limit", contextLimit,
 			"attempt", *overflowCompactions,
 		)

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -649,7 +649,7 @@ func (r *RemoteRuntime) RunSkillFork(context.Context, *session.Session, skills.R
 
 // UpdateSessionTitle updates the title of the current session on the remote server.
 func (r *RemoteRuntime) UpdateSessionTitle(ctx context.Context, sess *session.Session, title string) error {
-	sess.Title = title
+	sess.SetTitle(title)
 	if r.sessionID == "" {
 		return errors.New("cannot update session title: no session ID available")
 	}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1400,7 +1400,7 @@ func (r *LocalRuntime) Close() error {
 
 // UpdateSessionTitle persists the session title via the session store.
 func (r *LocalRuntime) UpdateSessionTitle(ctx context.Context, sess *session.Session, title string) error {
-	sess.Title = title
+	sess.SetTitle(title)
 	if r.sessionStore != nil {
 		return r.sessionStore.UpdateSession(ctx, sess)
 	}
@@ -1569,7 +1569,11 @@ func (r *LocalRuntime) EmitStartupInfo(ctx context.Context, sess *session.Sessio
 	// Use TotalCost (not OwnCost) because this is a restore/branch context:
 	// sub-sessions won't emit their own events, so the parent must include
 	// their costs.
-	if sess != nil && (sess.InputTokens > 0 || sess.OutputTokens > 0) {
+	var restoredInput, restoredOutput int64
+	if sess != nil {
+		restoredInput, restoredOutput = sess.Usage()
+	}
+	if restoredInput > 0 || restoredOutput > 0 {
 		contextLimit := r.contextLimitForAgentModel(ctx, a, modelID)
 		usage := SessionUsage(sess, contextLimit, a.CompactionThreshold())
 		usage.Cost = sess.TotalCost()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -229,13 +229,17 @@ func (s *Server) getSessions(c echo.Context) error {
 
 	responses := make([]api.SessionsResponse, len(sessions))
 	for i, sess := range sessions {
+		// The in-memory store hands back live session pointers, so read the
+		// mutable scalars through one locked snapshot each.
+		title := sess.TitleSnapshot()
+		inputTokens, outputTokens := sess.Usage()
 		responses[i] = api.SessionsResponse{
 			ID:           sess.ID,
-			Title:        sess.Title,
+			Title:        title,
 			CreatedAt:    sess.CreatedAt.Format(time.RFC3339),
 			NumMessages:  len(sess.GetAllMessages()),
-			InputTokens:  sess.InputTokens,
-			OutputTokens: sess.OutputTokens,
+			InputTokens:  inputTokens,
+			OutputTokens: outputTokens,
 			WorkingDir:   sess.WorkingDir,
 		}
 	}
@@ -295,14 +299,16 @@ func (s *Server) getSession(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("session not found: %v", err))
 	}
 
+	title := sess.TitleSnapshot()
+	inputTokens, outputTokens := sess.Usage()
 	return c.JSON(http.StatusOK, api.SessionResponse{
 		ID:            sess.ID,
-		Title:         sess.Title,
+		Title:         title,
 		CreatedAt:     sess.CreatedAt,
 		Messages:      sess.GetAllMessages(),
 		ToolsApproved: sess.ToolsApproved,
-		InputTokens:   sess.InputTokens,
-		OutputTokens:  sess.OutputTokens,
+		InputTokens:   inputTokens,
+		OutputTokens:  outputTokens,
 		WorkingDir:    sess.WorkingDir,
 		Permissions:   sess.Permissions,
 	})

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -242,6 +243,65 @@ func TestServer_UpdateSessionTitle(t *testing.T) {
 	unmarshal(t, getResp, &sessionResp)
 
 	assert.Equal(t, newTitle, sessionResp.Title)
+}
+
+// TestServer_GetSessionsRace pins the data-race fix for the GET
+// /api/sessions and GET /api/sessions/:id handlers (#3591): the in-memory
+// store hands them live *session.Session pointers, so reading
+// Title/InputTokens/OutputTokens directly races the granular store updates
+// (UpdateSessionTitle/UpdateSessionTokens) a running stream issues on other
+// goroutines. Both handlers must go through one TitleSnapshot() and one
+// Usage() snapshot. Run with -race; the writer goroutine keeps updating for
+// the whole duration of the HTTP reads. Every update stores an (n, 2n)
+// token pair, so the single-snapshot invariant output == 2*input holds in
+// every response regardless of scheduling.
+//
+// The name is kept short: it feeds t.TempDir(), which becomes a unix socket
+// path bounded by sun_path (104 bytes on macOS).
+func TestServer_GetSessionsRace(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sess := session.New(session.WithTitle("initial"))
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	lnPath := startServerWithStore(t, ctx, prepareAgentsDir(t), store)
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for n := int64(1); ; n++ {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			if err := store.UpdateSessionTitle(ctx, sess.ID, "concurrent title"); err != nil {
+				t.Errorf("UpdateSessionTitle: %v", err)
+				return
+			}
+			if err := store.UpdateSessionTokens(ctx, sess.ID, n, 2*n, float64(n)); err != nil {
+				t.Errorf("UpdateSessionTokens: %v", err)
+				return
+			}
+		}
+	})
+
+	for range 25 {
+		var sessions []api.SessionsResponse
+		unmarshal(t, httpGET(t, ctx, lnPath, "/api/sessions"), &sessions)
+		require.Len(t, sessions, 1)
+		assert.Equal(t, sess.ID, sessions[0].ID)
+		assert.Equal(t, 2*sessions[0].InputTokens, sessions[0].OutputTokens)
+
+		var single api.SessionResponse
+		unmarshal(t, httpGET(t, ctx, lnPath, "/api/sessions/"+sess.ID), &single)
+		assert.Equal(t, sess.ID, single.ID)
+		assert.Equal(t, 2*single.InputTokens, single.OutputTokens)
+	}
+	close(done)
+	wg.Wait()
 }
 
 // TestServer_ForkSession exercises the POST /api/sessions/:id/fork

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -299,13 +299,15 @@ func (sm *SessionManager) GetSessionStatus(ctx context.Context, id string) (*api
 		rs.streaming.Unlock()
 	}
 
+	title := sess.TitleSnapshot()
+	inputTokens, outputTokens := sess.Usage()
 	return &api.SessionStatusResponse{
 		ID:           sess.ID,
-		Title:        sess.Title,
+		Title:        title,
 		Streaming:    streaming,
 		Agent:        rs.runtime.CurrentAgentName(ctx),
-		InputTokens:  sess.InputTokens,
-		OutputTokens: sess.OutputTokens,
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
 		NumMessages:  len(sess.GetAllMessages()),
 	}, nil
 }
@@ -343,16 +345,18 @@ func (sm *SessionManager) GetSessionSnapshot(ctx context.Context, id string) (*a
 
 	lastSeq, _ := sm.LastEventSeq(id)
 
+	title := sess.TitleSnapshot()
+	inputTokens, outputTokens := sess.Usage()
 	return &api.SessionSnapshotResponse{
 		ID:            sess.ID,
-		Title:         sess.Title,
+		Title:         title,
 		CreatedAt:     sess.CreatedAt,
 		WorkingDir:    sess.WorkingDir,
 		Messages:      sess.GetAllMessages(),
 		ToolsApproved: sess.ToolsApproved,
 		Permissions:   sess.Permissions,
-		InputTokens:   sess.InputTokens,
-		OutputTokens:  sess.OutputTokens,
+		InputTokens:   inputTokens,
+		OutputTokens:  outputTokens,
 		Streaming:     streaming,
 		Agent:         agent,
 		LastEventSeq:  lastSeq,
@@ -458,9 +462,9 @@ func (sm *SessionManager) ForkSession(ctx context.Context, sessionID string, use
 	}
 	siblingTitles := make([]string, 0, len(siblings))
 	for _, s := range siblings {
-		siblingTitles = append(siblingTitles, s.Title)
+		siblingTitles = append(siblingTitles, s.TitleSnapshot())
 	}
-	forked.Title = session.NextForkTitle(parent.Title, siblingTitles)
+	forked.SetTitle(session.NextForkTitle(parent.TitleSnapshot(), siblingTitles))
 
 	if err := sm.sessionStore.AddSession(ctx, forked); err != nil {
 		return nil, err
@@ -705,10 +709,10 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 
 	streamChan := make(chan runtime.Event)
 
-	// Snapshot the title under sm.mux before launching the goroutine to
-	// avoid a data race with UpdateSessionTitle, which takes sm.mux and
-	// writes to sess.Title concurrently with the goroutine's read.
-	titleToEmit := sess.Title
+	// Snapshot the title under sess.mu before launching the goroutine: both
+	// UpdateSessionTitle and a previous run's still-in-flight generateTitle
+	// write sess.Title via SetTitle, concurrently with this read.
+	titleToEmit := sess.TitleSnapshot()
 	needsTitle := titleToEmit == "" && len(userMessages) > 0 && titleGen != nil
 
 	go func() {
@@ -975,7 +979,7 @@ func (sm *SessionManager) UpdateSessionTitle(ctx context.Context, sessionID, tit
 	// If session is actively running, update the in-memory session object directly.
 	// This ensures the runtime's saveSession won't overwrite our manual edit.
 	if rt, ok := sm.runtimeSessions.Load(sessionID); ok && rt.session != nil {
-		rt.session.Title = title
+		rt.session.SetTitle(title)
 		slog.DebugContext(ctx, "Updated title for active session", "session_id", sessionID, "title", title)
 		return sm.sessionStore.UpdateSession(ctx, rt.session)
 	}
@@ -986,7 +990,7 @@ func (sm *SessionManager) UpdateSessionTitle(ctx context.Context, sessionID, tit
 		return err
 	}
 
-	sess.Title = title
+	sess.SetTitle(title)
 	return sm.sessionStore.UpdateSession(ctx, sess)
 }
 
@@ -1009,7 +1013,7 @@ func (sm *SessionManager) generateTitle(ctx context.Context, sess *session.Sessi
 	}
 
 	// Update the in-memory session
-	sess.Title = title
+	sess.SetTitle(title)
 
 	// Persist the title
 	if err := sm.sessionStore.UpdateSession(ctx, sess); err != nil {
@@ -1482,9 +1486,13 @@ func (sm *SessionManager) SetSessionAgentModel(ctx context.Context, sessionID, m
 	// Clone the session for the store write. We'll apply mutations to the
 	// clone, persist it, and only then update the live session. This ensures
 	// concurrent readers never observe a not-yet-persisted state.
+	// Title and the token/cost triple are taken through the locked accessors
+	// because the runtime stream goroutine writes them concurrently.
+	title := sess.TitleSnapshot()
+	inputTokens, outputTokens, cost := sess.TokensAndCost()
 	updatedSess := &session.Session{
 		ID:                      sess.ID,
-		Title:                   sess.Title,
+		Title:                   title,
 		CreatedAt:               sess.CreatedAt,
 		WorkingDir:              sess.WorkingDir,
 		ToolsApproved:           sess.ToolsApproved,
@@ -1493,9 +1501,9 @@ func (sm *SessionManager) SetSessionAgentModel(ctx context.Context, sessionID, m
 		MaxConsecutiveToolCalls: sess.MaxConsecutiveToolCalls,
 		MaxOldToolCallTokens:    sess.MaxOldToolCallTokens,
 		MaxToolResultTokens:     sess.MaxToolResultTokens,
-		InputTokens:             sess.InputTokens,
-		OutputTokens:            sess.OutputTokens,
-		Cost:                    sess.Cost,
+		InputTokens:             inputTokens,
+		OutputTokens:            outputTokens,
+		Cost:                    cost,
 		Starred:                 sess.Starred,
 	}
 
@@ -1606,13 +1614,14 @@ func (sm *SessionManager) BatchExportSessions(ctx context.Context, sessionIDs []
 			continue // Skip sessions that can't be retrieved
 		}
 
+		inputTokens, outputTokens := sess.Usage()
 		sessData := map[string]any{
 			"id":             sess.ID,
-			"title":          sess.Title,
+			"title":          sess.TitleSnapshot(),
 			"created_at":     sess.CreatedAt,
 			"messages":       sess.GetAllMessages(),
-			"input_tokens":   sess.InputTokens,
-			"output_tokens":  sess.OutputTokens,
+			"input_tokens":   inputTokens,
+			"output_tokens":  outputTokens,
 			"working_dir":    sess.WorkingDir,
 			"tools_approved": sess.ToolsApproved,
 		}
@@ -1635,13 +1644,14 @@ func (sm *SessionManager) ExportSessionForRecovery(ctx context.Context, sessionI
 		return nil, err
 	}
 
+	inputTokens, outputTokens := sess.Usage()
 	return map[string]any{
 		"id":             sess.ID,
-		"title":          sess.Title,
+		"title":          sess.TitleSnapshot(),
 		"created_at":     sess.CreatedAt,
 		"messages":       sess.GetAllMessages(),
-		"input_tokens":   sess.InputTokens,
-		"output_tokens":  sess.OutputTokens,
+		"input_tokens":   inputTokens,
+		"output_tokens":  outputTokens,
 		"working_dir":    sess.WorkingDir,
 		"tools_approved": sess.ToolsApproved,
 		"permissions":    sess.Permissions,

--- a/pkg/session/branch.go
+++ b/pkg/session/branch.go
@@ -46,7 +46,7 @@ func branchSessionWithTitle(parent *Session, branchAtPosition int, titleFn func(
 	}
 
 	branched := New()
-	copySessionMetadata(branched, parent, titleFn(parent.Title))
+	copySessionMetadata(branched, parent, titleFn(parent.TitleSnapshot()))
 
 	branched.Messages = make([]Item, 0, branchAtPosition)
 	for i := range branchAtPosition {
@@ -161,7 +161,7 @@ func cloneSubSession(src *Session) (*Session, error) {
 	}
 
 	cloned := New()
-	copySessionMetadata(cloned, src, src.Title)
+	copySessionMetadata(cloned, src, src.TitleSnapshot())
 	cloned.CreatedAt = src.CreatedAt
 
 	// Snapshot under src.mu: a sub-session created by a background agent
@@ -185,7 +185,7 @@ func copySessionMetadata(dst, src *Session, title string) {
 	if src == nil || dst == nil {
 		return
 	}
-	dst.Title = title
+	dst.SetTitle(title)
 	dst.ToolsApproved = src.ToolsApproved
 	dst.HideToolResults = src.HideToolResults
 	dst.WorkingDir = src.WorkingDir
@@ -386,6 +386,5 @@ func recalculateSessionTotals(sess *Session) {
 		}
 	}
 
-	sess.InputTokens = inputTokens
-	sess.OutputTokens = outputTokens
+	sess.SetUsage(inputTokens, outputTokens)
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -116,7 +116,10 @@ type Error struct {
 
 // Session represents the agent's state including conversation history and variables
 type Session struct {
-	// mu protects Messages from concurrent read/write access.
+	// mu protects Messages and the scalar metadata that is written
+	// cross-goroutine (Title, InputTokens, OutputTokens, Cost, ...) from
+	// concurrent read/write access. Shared-session readers must go through
+	// the locked accessors (TitleSnapshot, Usage, TokensAndCost, ...).
 	mu sync.RWMutex `json:"-"`
 
 	// now and newID are per-session sources of time and identity. They are
@@ -137,7 +140,8 @@ type Session struct {
 	// and never used internally. The session's own "id" is always a fresh UUID.
 	InputID string `json:"input_id,omitempty"`
 
-	// Title is the title of the session, set by the runtime
+	// Title is the title of the session, set by the runtime. Protected by
+	// mu: shared-session callers must go through SetTitle/TitleSnapshot.
 	Title string `json:"title"`
 
 	// Evals contains evaluation criteria for this session (used by eval framework)
@@ -207,6 +211,9 @@ type Session struct {
 	// Starred indicates if this session has been starred by the user
 	Starred bool `json:"starred"`
 
+	// InputTokens, OutputTokens, and Cost are cumulative usage counters
+	// protected by mu: shared-session callers must go through
+	// SetTokensAndCost/SetUsage and TokensAndCost/Usage.
 	InputTokens  int64   `json:"input_tokens"`
 	OutputTokens int64   `json:"output_tokens"`
 	Cost         float64 `json:"cost"`
@@ -614,6 +621,48 @@ func (s *Session) Usage() (input, output int64) {
 	return s.InputTokens, s.OutputTokens
 }
 
+// TokensAndCost returns a consistent snapshot of the cumulative token
+// counts together with the session-level cost, the read-side counterpart
+// to SetTokensAndCost.
+func (s *Session) TokensAndCost() (inputTokens, outputTokens int64, cost float64) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.InputTokens, s.OutputTokens, s.Cost
+}
+
+// SetTokensAndCost atomically records the cumulative token counts
+// together with the session-level cost under s.mu. Granular store
+// updates (e.g. InMemorySessionStore.UpdateSessionTokens) and event
+// importers write these fields cross-goroutine with readers such as
+// the persistence observer's UpdateSession snapshot, which reads them
+// under the same lock.
+func (s *Session) SetTokensAndCost(inputTokens, outputTokens int64, cost float64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.InputTokens = inputTokens
+	s.OutputTokens = outputTokens
+	s.Cost = cost
+}
+
+// SetTitle updates the session title under s.mu. Title writers (title
+// generation, HTTP title updates, granular store updates) run on
+// different goroutines than readers like the UpdateSession snapshot,
+// so direct field writes would race.
+func (s *Session) SetTitle(title string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Title = title
+}
+
+// TitleSnapshot returns the session title under s.mu, the read-side
+// counterpart to SetTitle. Named TitleSnapshot because the Title field
+// and a method cannot share the name.
+func (s *Session) TitleSnapshot() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.Title
+}
+
 // ApplyCompaction atomically resets the session's cumulative token
 // counts and appends a summary item under s.mu so concurrent readers
 // (e.g. the persistence observer's UpdateSession snapshot) cannot
@@ -760,6 +809,15 @@ func (s *Session) AddMessageUsageRecord(agentName, model string, cost float64, u
 	})
 }
 
+// MessageUsageHistorySnapshot returns a copy of the per-message usage
+// records, the lock-safe read-side counterpart to AddMessageUsageRecord for
+// callers on other goroutines (e.g. the TUI cost dialog).
+func (s *Session) MessageUsageHistorySnapshot() []MessageUsageRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return slices.Clone(s.MessageUsageHistory)
+}
+
 // AddAttachedFile records absPath as a file the user attached to this session.
 // The path must be absolute; relative paths are silently dropped (with a debug
 // log) since they would be ambiguous to sub-agents started in a fresh working
@@ -870,7 +928,7 @@ func WithWorkingDir(workingDir string) Opt {
 
 func WithTitle(title string) Opt {
 	return func(s *Session) {
-		s.Title = title
+		s.SetTitle(title)
 	}
 }
 

--- a/pkg/session/session_race_test.go
+++ b/pkg/session/session_race_test.go
@@ -18,7 +18,7 @@ func TestAddMessageUsageRecordConcurrent(t *testing.T) {
 		})
 	}
 	wg.Wait()
-	if got := len(s.MessageUsageHistory); got != 100 {
+	if got := len(s.MessageUsageHistorySnapshot()); got != 100 {
 		t.Errorf("expected 100 records, got %d", got)
 	}
 }
@@ -155,4 +155,167 @@ func TestForkSessionConcurrentWithSubSessionMutation(t *testing.T) {
 		})
 	}
 	wg.Wait()
+}
+
+// TestSetTitleAndSetTokensAndCost pins the setter value contracts: SetTitle
+// stores the given title (including via the WithTitle constructor option)
+// and SetTokensAndCost stores both token counts and the session cost
+// together.
+func TestSetTitleAndSetTokensAndCost(t *testing.T) {
+	t.Parallel()
+
+	s := New(WithTitle("initial"))
+	if got := s.TitleSnapshot(); got != "initial" {
+		t.Errorf("expected title %q, got %q", "initial", got)
+	}
+
+	s.SetTitle("renamed")
+	if got := s.TitleSnapshot(); got != "renamed" {
+		t.Errorf("expected title %q, got %q", "renamed", got)
+	}
+
+	s.SetTokensAndCost(11, 22, 0.5)
+	input, output, cost := s.TokensAndCost()
+	if input != 11 || output != 22 {
+		t.Errorf("expected usage (11, 22), got (%d, %d)", input, output)
+	}
+	if cost != 0.5 {
+		t.Errorf("expected cost 0.5, got %v", cost)
+	}
+}
+
+// TestSetTitleSetTokensAndCostConcurrent pins the data-race fix for the
+// session's scalar metadata: Title, InputTokens/OutputTokens, and Cost used
+// to be written directly cross-goroutine (e.g. the server's title updates
+// racing the persistence observer's UpdateSession snapshot). SetTitle and
+// SetTokensAndCost must take s.mu so writers cannot race each other or the
+// locked readers (TitleSnapshot, Usage, TokensAndCost). Run with -race.
+//
+// Every SetTokensAndCost call writes a related (input, output, cost) triple;
+// the post-Wait check asserts the surviving triple is internally consistent,
+// pinning that the three fields are assigned atomically rather than torn
+// across concurrent calls. The assertion is order-independent, so it cannot
+// flake on scheduling.
+func TestSetTitleSetTokensAndCostConcurrent(t *testing.T) {
+	t.Parallel()
+
+	s := New()
+	var wg sync.WaitGroup
+	for i := range 100 {
+		n := int64(i + 1)
+		wg.Go(func() {
+			s.SetTitle("concurrent title")
+		})
+		wg.Go(func() {
+			s.SetTokensAndCost(n, 2*n, float64(n)/2)
+		})
+		wg.Go(func() {
+			_, _ = s.Usage()
+		})
+		wg.Go(func() {
+			_ = s.TitleSnapshot()
+		})
+		wg.Go(func() {
+			_, _, _ = s.TokensAndCost()
+		})
+	}
+	wg.Wait()
+
+	input, output, cost := s.TokensAndCost()
+	if output != 2*input || cost != float64(input)/2 {
+		t.Errorf("torn token/cost triple: input=%d output=%d cost=%v", input, output, cost)
+	}
+	if got := s.TitleSnapshot(); got != "concurrent title" {
+		t.Errorf("expected title %q, got %q", "concurrent title", got)
+	}
+}
+
+// TestInMemoryStoreGranularUpdatesConcurrent pins the data-race fix for
+// InMemorySessionStore.UpdateSessionTokens and UpdateSessionTitle: they used
+// to write the live session's Title/InputTokens/OutputTokens/Cost fields
+// directly, racing each other and the UpdateSession snapshot (which reads
+// those fields under session.mu). Both must route through the session's
+// locked setters. Run with -race.
+func TestInMemoryStoreGranularUpdatesConcurrent(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := NewInMemorySessionStore()
+	sess := New()
+	if err := store.AddSession(ctx, sess); err != nil {
+		t.Fatalf("AddSession: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := range 100 {
+		n := int64(i + 1)
+		wg.Go(func() {
+			if err := store.UpdateSessionTokens(ctx, sess.ID, n, n, float64(n)); err != nil {
+				t.Errorf("UpdateSessionTokens: %v", err)
+			}
+		})
+		wg.Go(func() {
+			if err := store.UpdateSessionTitle(ctx, sess.ID, "concurrent title"); err != nil {
+				t.Errorf("UpdateSessionTitle: %v", err)
+			}
+		})
+		wg.Go(func() {
+			if err := store.UpdateSession(ctx, sess); err != nil {
+				t.Errorf("UpdateSession: %v", err)
+			}
+		})
+	}
+	wg.Wait()
+}
+
+// TestInMemoryStoreGetSessionSummariesConcurrent pins the read-side of the
+// same fix: GetSessionSummaries reads each live session's Title, so it must
+// go through the locked accessor (TitleSnapshot) to stay safe against
+// concurrent SetTitle/granular store updates on the shared pointer. Run
+// with -race; with a direct value.Title read the detector flags the
+// concurrent SetTitle write.
+func TestInMemoryStoreGetSessionSummariesConcurrent(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := NewInMemorySessionStore()
+	sess := New()
+	if err := store.AddSession(ctx, sess); err != nil {
+		t.Fatalf("AddSession: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := range 100 {
+		n := int64(i + 1)
+		wg.Go(func() {
+			if err := store.UpdateSessionTitle(ctx, sess.ID, "concurrent title"); err != nil {
+				t.Errorf("UpdateSessionTitle: %v", err)
+			}
+		})
+		wg.Go(func() {
+			sess.SetTitle("direct title")
+		})
+		wg.Go(func() {
+			if err := store.UpdateSessionTokens(ctx, sess.ID, n, n, float64(n)); err != nil {
+				t.Errorf("UpdateSessionTokens: %v", err)
+			}
+		})
+		wg.Go(func() {
+			if _, err := store.GetSessionSummaries(ctx); err != nil {
+				t.Errorf("GetSessionSummaries: %v", err)
+			}
+		})
+	}
+	wg.Wait()
+
+	summaries, err := store.GetSessionSummaries(ctx)
+	if err != nil {
+		t.Fatalf("GetSessionSummaries: %v", err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("expected 1 summary, got %d", len(summaries))
+	}
+	if got := summaries[0].Title; got != "concurrent title" && got != "direct title" {
+		t.Errorf("unexpected title %q", got)
+	}
 }

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -180,7 +180,7 @@ func (s *InMemorySessionStore) GetSessionSummaries(_ context.Context) ([]Summary
 		}
 		summaries = append(summaries, Summary{
 			ID:          value.ID,
-			Title:       value.Title,
+			Title:       value.TitleSnapshot(),
 			CreatedAt:   value.CreatedAt,
 			Starred:     value.Starred,
 			NumMessages: value.MessageCount(),
@@ -436,9 +436,7 @@ func (s *InMemorySessionStore) UpdateSessionTokens(_ context.Context, sessionID 
 	if !exists {
 		return ErrNotFound
 	}
-	session.InputTokens = inputTokens
-	session.OutputTokens = outputTokens
-	session.Cost = cost
+	session.SetTokensAndCost(inputTokens, outputTokens, cost)
 	return nil
 }
 
@@ -451,7 +449,7 @@ func (s *InMemorySessionStore) UpdateSessionTitle(_ context.Context, sessionID, 
 	if !exists {
 		return ErrNotFound
 	}
-	session.Title = title
+	session.SetTitle(title)
 	return nil
 }
 

--- a/pkg/tui/dialog/cost.go
+++ b/pkg/tui/dialog/cost.go
@@ -238,7 +238,10 @@ func (d *costDialog) gatherCostData() costData {
 
 	var walkSession func(sess *session.Session)
 	walkSession = func(sess *session.Session) {
-		for _, item := range sess.Messages {
+		// Iterate a locked snapshot: runtime goroutines append to the live
+		// Messages slice while the dialog renders. The snapshot releases
+		// sess.mu before the recursive sub-session accessors take theirs.
+		for _, item := range sess.MessagesSnapshot() {
 			switch {
 			case item.IsMessage():
 				msg := item.Message
@@ -264,7 +267,7 @@ func (d *costDialog) gatherCostData() costData {
 
 	// Fall back to remote mode if no per-message data was found.
 	if !data.hasPerMessageData {
-		for _, record := range d.session.MessageUsageHistory {
+		for _, record := range d.session.MessageUsageHistorySnapshot() {
 			addRecord(record.AgentName, record.Model, record.Cost, &record.Usage)
 		}
 	}
@@ -278,11 +281,12 @@ func (d *costDialog) gatherCostData() costData {
 
 	// Fall back to session-level totals (e.g. past sessions without per-message data).
 	if !data.hasPerMessageData {
+		inputTokens, outputTokens := d.session.Usage()
 		data.total = totalUsage{
 			cost: d.session.TotalCost(),
 			Usage: chat.Usage{
-				InputTokens:  d.session.InputTokens,
-				OutputTokens: d.session.OutputTokens,
+				InputTokens:  inputTokens,
+				OutputTokens: outputTokens,
 			},
 		}
 	}

--- a/pkg/tui/dialog/cost_test.go
+++ b/pkg/tui/dialog/cost_test.go
@@ -1,6 +1,7 @@
 package dialog
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -456,6 +457,89 @@ func TestCostDialogSubSessionRendersInView(t *testing.T) {
 	assert.Contains(t, view, "sub-session start")
 	assert.Contains(t, view, "sub-session end")
 	assert.Contains(t, view, "sub-agent")
+}
+
+// TestGatherCostDataConcurrent pins the data-race fix for the cost dialog
+// (#3591): gatherCostData used to walk the live sess.Messages slice
+// (recursively for sub-sessions) and range MessageUsageHistory directly
+// while runtime goroutines mutate them. It must iterate MessagesSnapshot()
+// and MessageUsageHistorySnapshot() instead. Run with -race; restoring the
+// direct reads makes the detector flag the concurrent AddMessage /
+// AddMessageUsageRecord appends.
+//
+// The appended messages carry no usage, so every gatherCostData pass also
+// takes the remote-mode fallback and reads the usage history concurrently
+// with its writers. The post-Wait assertions only count the final records,
+// so they are independent of goroutine scheduling.
+func TestGatherCostDataConcurrent(t *testing.T) {
+	t.Parallel()
+
+	sub := session.New()
+	sess := session.New()
+	sess.AddSubSession(sub)
+	d := &costDialog{session: sess}
+
+	var wg sync.WaitGroup
+	for i := range 50 {
+		n := int64(i + 1)
+		wg.Go(func() {
+			sess.AddMessage(session.UserMessage("root"))
+		})
+		wg.Go(func() {
+			sub.AddMessage(session.UserMessage("sub"))
+		})
+		wg.Go(func() {
+			sess.AddMessageUsageRecord("agent", "model", 0.1, &chat.Usage{InputTokens: 10, OutputTokens: 5})
+		})
+		wg.Go(func() {
+			sess.SetUsage(n, 2*n)
+		})
+		wg.Go(func() {
+			sess.SetTokensAndCost(n, 2*n, float64(n))
+		})
+		wg.Go(func() {
+			_ = d.gatherCostData()
+		})
+	}
+	wg.Wait()
+
+	data := d.gatherCostData()
+	assert.Equal(t, 50, data.actualMessageCount())
+	assert.InDelta(t, 5.0, data.total.cost, 0.0001)
+	assert.Equal(t, int64(500), data.total.InputTokens)
+	assert.Equal(t, int64(250), data.total.OutputTokens)
+}
+
+// TestGatherCostDataConcurrentSessionUsageFallback pins the session-level
+// fallback of the same fix: with no per-message data at all, gatherCostData
+// used to read d.session.InputTokens/OutputTokens directly, racing the
+// runtime's SetUsage/SetTokensAndCost. It must take one Usage() snapshot,
+// which also keeps the reported pair internally consistent: every writer
+// stores an (n, 2n) pair, so any atomic snapshot satisfies the invariant
+// regardless of scheduling. Run with -race.
+func TestGatherCostDataConcurrentSessionUsageFallback(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	d := &costDialog{session: sess}
+
+	var wg sync.WaitGroup
+	for i := range 100 {
+		n := int64(i + 1)
+		wg.Go(func() {
+			sess.SetUsage(n, 2*n)
+		})
+		wg.Go(func() {
+			sess.SetTokensAndCost(n, 2*n, float64(n))
+		})
+		wg.Go(func() {
+			data := d.gatherCostData()
+			if data.total.OutputTokens != 2*data.total.InputTokens {
+				t.Errorf("torn usage pair: input=%d output=%d", data.total.InputTokens, data.total.OutputTokens)
+			}
+		})
+	}
+	wg.Wait()
 }
 
 func TestFormatCost(t *testing.T) {

--- a/pkg/tui/page/chat/runtime_events.go
+++ b/pkg/tui/page/chat/runtime_events.go
@@ -236,8 +236,7 @@ func (p *chatPage) handleTokenUsage(msg *runtime.TokenUsageEvent) {
 			// values into the parent would overwrite the parent's own
 			// context-tracking counters.
 			if msg.SessionID == "" || msg.SessionID == sess.ID {
-				sess.InputTokens = msg.Usage.InputTokens
-				sess.OutputTokens = msg.Usage.OutputTokens
+				sess.SetUsage(msg.Usage.InputTokens, msg.Usage.OutputTokens)
 			}
 
 			// Track per-message usage for /cost dialog


### PR DESCRIPTION
## Summary

Fixes #3591 by serializing access to session title, token, and cost fields through `Session.mu`.

- adds locked title and token/cost setters with matching snapshot accessors
- routes runtime, store, server, app, evaluation, and TUI call sites through those accessors
- snapshots message usage data before rendering the cost dialog
- adds race regressions for session accessors, in-memory store updates, API responses, and TUI cost rendering
- preserves omitted fields when importing partial token usage events

## Issue expectations

| Expectation | Implementation |
|---|---|
| Add locked `SetTitle` | Added `SetTitle` and `TitleSnapshot` |
| Add locked `SetTokensAndCost` | Added atomic `SetTokensAndCost` and `TokensAndCost` |
| Route all title/token/cost writes through setters | Updated production writers across session, runtime, server, app, evaluation, ACP, A2A, CLI, and TUI paths |
| Race-clean access | Updated live readers to use locked snapshots and added concurrent regression tests |
| Regression coverage | Added session, store, HTTP API, evaluation import, and TUI cost-dialog tests |

## Validation

- `task build`
- `task lint`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy task test`
- `go test -race -count=1 ./pkg/session/... ./pkg/server/... ./pkg/runtime/... ./pkg/app/... ./pkg/tui/dialog/...`
- `go test -race -count=1 ./pkg/a2a/... ./pkg/acp/... ./pkg/cli/... ./pkg/tui/page/chat/... ./pkg/chatserver/...`

The full evaluation race suite still reports the pre-existing `stderrData` race in `pkg/evaluation/eval.go`; the evaluation tests affected by this change pass, and the ordinary full suite is green.
