### PR TITLE
fix(session): lock scalar updates

### DIFF
--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -649,7 +649,7 @@ func (r *RemoteRuntime) RunSkillFork(context.Context, *session.Session, skills.R
 
 // UpdateSessionTitle updates the title of the current session on the remote server.
 func (r *RemoteRuntime) UpdateSessionTitle(ctx context.Context, sess *session.Session, title string) error {
-	sess.Title = title
+	sess.SetTitle(title)
 	if r.sessionID == "" {
 		return errors.New("cannot update session title: no session ID available")
 	}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1400,7 +1400,7 @@ func (r *LocalRuntime) Close() error {
 
 // UpdateSessionTitle persists the session title via the session store.
 func (r *LocalRuntime) UpdateSessionTitle(ctx context.Context, sess *session.Session, title string) error {
-	sess.Title = title
+	sess.SetTitle(title)
 	if r.sessionStore != nil {
 		return r.sessionStore.UpdateSession(ctx, sess)
 	}

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -460,7 +460,7 @@ func (sm *SessionManager) ForkSession(ctx context.Context, sessionID string, use
 	for _, s := range siblings {
 		siblingTitles = append(siblingTitles, s.Title)
 	}
-	forked.Title = session.NextForkTitle(parent.Title, siblingTitles)
+	forked.SetTitle(session.NextForkTitle(parent.Title, siblingTitles))
 
 	if err := sm.sessionStore.AddSession(ctx, forked); err != nil {
 		return nil, err
@@ -975,7 +975,7 @@ func (sm *SessionManager) UpdateSessionTitle(ctx context.Context, sessionID, tit
 	// If session is actively running, update the in-memory session object directly.
 	// This ensures the runtime's saveSession won't overwrite our manual edit.
 	if rt, ok := sm.runtimeSessions.Load(sessionID); ok && rt.session != nil {
-		rt.session.Title = title
+		rt.session.SetTitle(title)
 		slog.DebugContext(ctx, "Updated title for active session", "session_id", sessionID, "title", title)
 		return sm.sessionStore.UpdateSession(ctx, rt.session)
 	}
@@ -986,7 +986,7 @@ func (sm *SessionManager) UpdateSessionTitle(ctx context.Context, sessionID, tit
 		return err
 	}
 
-	sess.Title = title
+	sess.SetTitle(title)
 	return sm.sessionStore.UpdateSession(ctx, sess)
 }
 
@@ -1009,7 +1009,7 @@ func (sm *SessionManager) generateTitle(ctx context.Context, sess *session.Sessi
 	}
 
 	// Update the in-memory session
-	sess.Title = title
+	sess.SetTitle(title)
 
 	// Persist the title
 	if err := sm.sessionStore.UpdateSession(ctx, sess); err != nil {

--- a/pkg/session/branch.go
+++ b/pkg/session/branch.go
@@ -185,7 +185,7 @@ func copySessionMetadata(dst, src *Session, title string) {
 	if src == nil || dst == nil {
 		return
 	}
-	dst.Title = title
+	dst.SetTitle(title)
 	dst.ToolsApproved = src.ToolsApproved
 	dst.HideToolResults = src.HideToolResults
 	dst.WorkingDir = src.WorkingDir
@@ -375,6 +375,5 @@ func recalculateSessionTotals(sess *Session) {
 		}
 	}
 
-	sess.InputTokens = inputTokens
-	sess.OutputTokens = outputTokens
+	sess.SetUsage(inputTokens, outputTokens)
 }

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -608,6 +608,14 @@ func (s *Session) AddMessage(msg *Message) int {
 	return len(s.Messages) - 1
 }
 
+// SetTitle records the session title under s.mu.
+func (s *Session) SetTitle(title string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.Title = title
+}
+
 // SetUsage records cumulative input/output token counts under s.mu.
 // The runtime stream goroutine and the persistence observer race on
 // these fields without it.
@@ -616,6 +624,17 @@ func (s *Session) SetUsage(input, output int64) {
 	defer s.mu.Unlock()
 	s.InputTokens = input
 	s.OutputTokens = output
+}
+
+// SetTokensAndCost records cumulative input/output token counts and cost under s.mu.
+// The runtime stream goroutine and persistence paths race on these fields without it.
+func (s *Session) SetTokensAndCost(input, output int64, cost float64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.InputTokens = input
+	s.OutputTokens = output
+	s.Cost = cost
 }
 
 // Usage returns a consistent snapshot of the cumulative input/output
@@ -882,7 +901,7 @@ func WithWorkingDir(workingDir string) Opt {
 
 func WithTitle(title string) Opt {
 	return func(s *Session) {
-		s.Title = title
+		s.SetTitle(title)
 	}
 }
 

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -211,6 +211,33 @@ func TestSummaryMessageContentMatchesGetMessages(t *testing.T) {
 	assert.True(t, found, "GetMessages output must contain the exact SummaryMessageContent string")
 }
 
+func TestSessionSetTitle(t *testing.T) {
+	t.Parallel()
+
+	s := New()
+	s.SetTitle("Generated title")
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	assert.Equal(t, "Generated title", s.Title)
+}
+
+func TestSessionSetTokensAndCost(t *testing.T) {
+	t.Parallel()
+
+	s := New()
+	s.SetTokensAndCost(100, 200, 0.25)
+
+	input, output := s.Usage()
+	s.mu.RLock()
+	cost := s.Cost
+	s.mu.RUnlock()
+
+	assert.Equal(t, int64(100), input)
+	assert.Equal(t, int64(200), output)
+	assert.Equal(t, 0.25, cost)
+}
+
 func TestGetMessages_Instructions(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -436,9 +436,7 @@ func (s *InMemorySessionStore) UpdateSessionTokens(_ context.Context, sessionID 
 	if !exists {
 		return ErrNotFound
 	}
-	session.InputTokens = inputTokens
-	session.OutputTokens = outputTokens
-	session.Cost = cost
+	session.SetTokensAndCost(inputTokens, outputTokens, cost)
 	return nil
 }
 
@@ -451,7 +449,7 @@ func (s *InMemorySessionStore) UpdateSessionTitle(_ context.Context, sessionID, 
 	if !exists {
 		return ErrNotFound
 	}
-	session.Title = title
+	session.SetTitle(title)
 	return nil
 }
 

--- a/pkg/session/store_test.go
+++ b/pkg/session/store_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -285,6 +286,53 @@ func TestGetSessionSummaries_InMemory_WorkingDir(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, summaries, 1)
 	assert.Equal(t, "/work/project", summaries[0].WorkingDir)
+}
+
+func TestInMemorySessionStoreGranularUpdatesUseSessionLock(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := NewInMemorySessionStore()
+	sess := &Session{
+		ID:        "race-safe-session",
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	const iterations = 100
+	errs := make(chan error, iterations*2)
+	var wg sync.WaitGroup
+
+	for i := 0; i < iterations; i++ {
+		input := int64(i)
+
+		wg.Add(4)
+		go func() {
+			defer wg.Done()
+			errs <- store.UpdateSessionTokens(ctx, sess.ID, input, input+1, float64(input))
+		}()
+		go func() {
+			defer wg.Done()
+			errs <- store.UpdateSessionTitle(ctx, sess.ID, "updated")
+		}()
+		go func() {
+			defer wg.Done()
+			_, _ = sess.Usage()
+		}()
+		go func() {
+			defer wg.Done()
+			sess.mu.RLock()
+			_ = sess.Title
+			_ = sess.Cost
+			sess.mu.RUnlock()
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
 }
 
 func TestBranchSessionCopiesPrefix(t *testing.T) {


### PR DESCRIPTION
Closes #3591

## Summary

- Add locked `Session.SetTitle` and `Session.SetTokensAndCost` helpers.
- Route title/token/cost updates through the locked helpers in the runtime, remote runtime, session manager, in-memory store, and session branching helpers.
- Add regression coverage for the new setters and concurrent in-memory granular metadata updates.

## Why

Some session scalar fields were being written directly while nearby readers and snapshot paths use `Session.mu`. That leaves active session title and usage/cost updates vulnerable to races with persistence and runtime readers.

## Testing

- `gofmt`
- `git diff --check`

I also attempted `go test -race ./pkg/session` and a narrower `go test ./pkg/session -run 'TestSessionSet|TestInMemorySessionStoreGranularUpdatesUseSessionLock' -count=1` in `golang:1.26.5` with `GOPROXY=direct`. The container fetched dependencies but the local run did not complete in a reasonable time, so I interrupted it and am relying on CI for the full Go test signal.
