### PR TITLE
Add opt-in cache-stable dynamic prompts

### DIFF
--- a/pkg/hooks/builtins/add_date.go
+++ b/pkg/hooks/builtins/add_date.go
@@ -12,5 +12,11 @@ const AddDate = "add_date"
 
 // addDate emits today's date as turn_start additional context.
 func addDate(_ context.Context, _ *hooks.Input, _ []string) (*hooks.Output, error) {
-	return hooks.NewAdditionalContextOutput(hooks.EventTurnStart, "Today's date: "+time.Now().Format("2006-01-02")), nil
+	date := time.Now().Format("2006-01-02")
+	return hooks.NewInstructionContextOutput(hooks.EventTurnStart, hooks.InstructionContext{
+		Key:            "core/date",
+		Label:          "date",
+		Content:        "Today's date: " + date,
+		ChangedContent: "Today's date is now: " + date,
+	}), nil
 }

--- a/pkg/hooks/builtins/add_directory_listing.go
+++ b/pkg/hooks/builtins/add_directory_listing.go
@@ -39,7 +39,9 @@ func addDirectoryListing(_ context.Context, in *hooks.Input, _ []string) (*hooks
 	entries, err := os.ReadDir(in.Cwd)
 	if err != nil {
 		slog.Debug("add_directory_listing: read dir failed; skipping", "cwd", in.Cwd, "error", err)
-		return nil, nil
+		return hooks.NewInstructionContextOutput(hooks.EventSessionStart, hooks.InstructionContext{
+			Key: "core/directory-listing", Unavailable: true,
+		}), nil
 	}
 
 	var names []string
@@ -54,7 +56,10 @@ func addDirectoryListing(_ context.Context, in *hooks.Input, _ []string) (*hooks
 		names = append(names, name)
 	}
 	if len(names) == 0 {
-		return nil, nil
+		return hooks.NewInstructionContextOutput(hooks.EventSessionStart, hooks.InstructionContext{
+			Key: "core/directory-listing", Removed: true,
+			RemovedContent: "The working directory no longer has visible top-level entries.",
+		}), nil
 	}
 	slices.Sort(names)
 
@@ -75,5 +80,12 @@ func addDirectoryListing(_ context.Context, in *hooks.Input, _ []string) (*hooks
 		fmt.Fprintf(&b, "... and %d more\n", truncated)
 	}
 
-	return hooks.NewAdditionalContextOutput(hooks.EventSessionStart, strings.TrimRight(b.String(), "\n")), nil
+	listing := strings.TrimRight(b.String(), "\n")
+	return hooks.NewInstructionContextOutput(hooks.EventSessionStart, hooks.InstructionContext{
+		Key:            "core/directory-listing",
+		Label:          "top-level directory entries",
+		Content:        listing,
+		ChangedContent: "The working-directory listing is now:\n\n" + listing,
+		RemovedContent: "The working directory no longer has visible top-level entries.",
+	}), nil
 }

--- a/pkg/hooks/builtins/add_directory_listing_test.go
+++ b/pkg/hooks/builtins/add_directory_listing_test.go
@@ -36,7 +36,9 @@ func TestAddDirectoryListingIncludesFilesAndDirs(t *testing.T) {
 	assert.Equal(t, hooks.EventSessionStart, out.HookSpecificOutput.HookEventName,
 		"add_directory_listing must target session_start, not turn_start")
 
-	ctx := out.HookSpecificOutput.AdditionalContext
+	require.Len(t, out.HookSpecificOutput.InstructionContext, 1)
+	ctx := out.HookSpecificOutput.InstructionContext[0].Content
+	assert.Equal(t, "core/directory-listing", out.HookSpecificOutput.InstructionContext[0].Key)
 	assert.Contains(t, ctx, "README.md")
 	assert.Contains(t, ctx, "main.go")
 	assert.Contains(t, ctx, "subdir/", "directories must be marked with a trailing slash")
@@ -61,7 +63,8 @@ func TestAddDirectoryListingTruncatesLongList(t *testing.T) {
 	out, err := fn(t.Context(), &hooks.Input{SessionID: "s", Cwd: dir}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, out)
-	assert.Contains(t, out.HookSpecificOutput.AdditionalContext, "and 50 more",
+	require.Len(t, out.HookSpecificOutput.InstructionContext, 1)
+	assert.Contains(t, out.HookSpecificOutput.InstructionContext[0].Content, "and 50 more",
 		"truncation summary must report the dropped count")
 }
 
@@ -86,7 +89,8 @@ func TestAddDirectoryListingEmptyOrNoCwdIsNoop(t *testing.T) {
 	writeFile(t, hiddenOnly, ".hidden", "")
 	out, err = fn(t.Context(), &hooks.Input{SessionID: "s", Cwd: hiddenOnly}, nil)
 	require.NoError(t, err)
-	assert.Nil(t, out, "directory with only hidden entries must yield no output")
+	require.Len(t, out.HookSpecificOutput.InstructionContext, 1)
+	assert.True(t, out.HookSpecificOutput.InstructionContext[0].Removed)
 }
 
 // TestAddDirectoryListingUnreadableDirIsNoop documents the graceful
@@ -103,5 +107,6 @@ func TestAddDirectoryListingUnreadableDirIsNoop(t *testing.T) {
 		Cwd:       filepath.Join(t.TempDir(), "does-not-exist"),
 	}, nil)
 	require.NoError(t, err)
-	assert.Nil(t, out)
+	require.Len(t, out.HookSpecificOutput.InstructionContext, 1)
+	assert.True(t, out.HookSpecificOutput.InstructionContext[0].Unavailable)
 }

--- a/pkg/hooks/builtins/add_git_diff.go
+++ b/pkg/hooks/builtins/add_git_diff.go
@@ -38,10 +38,23 @@ func addGitDiff(ctx context.Context, in *hooks.Input, args []string) (*hooks.Out
 	out, err := gitOutput(ctx, in.Cwd, gitArgs...)
 	if err != nil {
 		slog.DebugContext(ctx, "add_git_diff: git diff failed; skipping", "cwd", in.Cwd, "error", err)
-		return nil, nil
+		return hooks.NewInstructionContextOutput(hooks.EventTurnStart, hooks.InstructionContext{
+			Key: "core/git-diff", Removed: true,
+			RemovedContent: "The previously reported working-tree diff no longer applies.",
+		}), nil
 	}
 	if out == "" {
-		return nil, nil
+		return hooks.NewInstructionContextOutput(hooks.EventTurnStart, hooks.InstructionContext{
+			Key: "core/git-diff", Removed: true,
+			RemovedContent: "The working tree no longer has a diff.",
+		}), nil
 	}
-	return hooks.NewAdditionalContextOutput(hooks.EventTurnStart, header+out), nil
+	content := header + out
+	return hooks.NewInstructionContextOutput(hooks.EventTurnStart, hooks.InstructionContext{
+		Key:            "core/git-diff",
+		Label:          "working-tree diff",
+		Content:        content,
+		ChangedContent: "The current working-tree diff is now:\n\n" + out,
+		RemovedContent: "The working tree no longer has a diff.",
+	}), nil
 }

--- a/pkg/hooks/builtins/add_git_diff_test.go
+++ b/pkg/hooks/builtins/add_git_diff_test.go
@@ -34,8 +34,11 @@ func TestAddGitDiffStatModeShowsTouchedFile(t *testing.T) {
 	require.NotNil(t, out.HookSpecificOutput)
 	assert.Equal(t, hooks.EventTurnStart, out.HookSpecificOutput.HookEventName,
 		"add_git_diff must target turn_start, not session_start")
-	assert.Contains(t, out.HookSpecificOutput.AdditionalContext, "README.md")
-	assert.Contains(t, out.HookSpecificOutput.AdditionalContext, "stat",
+	require.Len(t, out.HookSpecificOutput.InstructionContext, 1)
+	ctx := out.HookSpecificOutput.InstructionContext[0].Content
+	assert.Equal(t, "core/git-diff", out.HookSpecificOutput.InstructionContext[0].Key)
+	assert.Contains(t, ctx, "README.md")
+	assert.Contains(t, ctx, "stat",
 		"default mode must announce itself as the stat view")
 }
 
@@ -57,7 +60,8 @@ func TestAddGitDiffFullModeShowsHunks(t *testing.T) {
 	out, err := fn(t.Context(), &hooks.Input{SessionID: "s", Cwd: dir}, []string{"full"})
 	require.NoError(t, err)
 	require.NotNil(t, out)
-	assert.Contains(t, out.HookSpecificOutput.AdditionalContext, "+second",
+	require.Len(t, out.HookSpecificOutput.InstructionContext, 1)
+	assert.Contains(t, out.HookSpecificOutput.InstructionContext[0].Content, "+second",
 		"full mode must include the unified-diff hunk lines")
 }
 
@@ -76,7 +80,8 @@ func TestAddGitDiffCleanTreeIsNoop(t *testing.T) {
 
 	out, err := fn(t.Context(), &hooks.Input{SessionID: "s", Cwd: dir}, nil)
 	require.NoError(t, err)
-	assert.Nil(t, out, "clean tree must yield no additional context")
+	require.Len(t, out.HookSpecificOutput.InstructionContext, 1)
+	assert.True(t, out.HookSpecificOutput.InstructionContext[0].Removed)
 }
 
 // TestAddGitDiffNoCwdOrNotARepoIsNoop documents the safety / graceful
@@ -97,5 +102,6 @@ func TestAddGitDiffNoCwdOrNotARepoIsNoop(t *testing.T) {
 
 	out, err = fn(t.Context(), &hooks.Input{SessionID: "s", Cwd: t.TempDir()}, nil)
 	require.NoError(t, err)
-	assert.Nil(t, out)
+	require.Len(t, out.HookSpecificOutput.InstructionContext, 1)
+	assert.True(t, out.HookSpecificOutput.InstructionContext[0].Removed)
 }

--- a/pkg/hooks/builtins/add_git_status.go
+++ b/pkg/hooks/builtins/add_git_status.go
@@ -29,10 +29,17 @@ func addGitStatus(ctx context.Context, in *hooks.Input, _ []string) (*hooks.Outp
 	out, err := gitOutput(ctx, in.Cwd, "status", "--short", "--branch")
 	if err != nil {
 		slog.DebugContext(ctx, "add_git_status: git status failed; skipping", "cwd", in.Cwd, "error", err)
-		return nil, nil
+		return hooks.NewInstructionContextOutput(hooks.EventTurnStart, hooks.InstructionContext{
+			Key: "core/git-status", Removed: true,
+			RemovedContent: "Previously reported git status no longer applies.",
+		}), nil
 	}
-	if out == "" {
-		return nil, nil
-	}
-	return hooks.NewAdditionalContextOutput(hooks.EventTurnStart, "Current git status:\n\n"+out), nil
+	content := "Current git status:\n\n" + out
+	return hooks.NewInstructionContextOutput(hooks.EventTurnStart, hooks.InstructionContext{
+		Key:            "core/git-status",
+		Label:          "git status",
+		Content:        content,
+		ChangedContent: "The current git status is now:\n\n" + out,
+		RemovedContent: "Previously reported git status no longer applies.",
+	}), nil
 }

--- a/pkg/hooks/builtins/add_git_status_test.go
+++ b/pkg/hooks/builtins/add_git_status_test.go
@@ -30,7 +30,9 @@ func TestAddGitStatusReportsUntrackedFiles(t *testing.T) {
 	require.NotNil(t, out.HookSpecificOutput)
 	assert.Equal(t, hooks.EventTurnStart, out.HookSpecificOutput.HookEventName,
 		"add_git_status must target turn_start, not session_start")
-	assert.Contains(t, out.HookSpecificOutput.AdditionalContext, "NEWFILE.txt",
+	require.Len(t, out.HookSpecificOutput.InstructionContext, 1)
+	assert.Equal(t, "core/git-status", out.HookSpecificOutput.InstructionContext[0].Key)
+	assert.Contains(t, out.HookSpecificOutput.InstructionContext[0].Content, "NEWFILE.txt",
 		"git status output must mention the untracked file")
 }
 
@@ -52,11 +54,7 @@ func TestAddGitStatusNoCwdIsNoop(t *testing.T) {
 	assert.Nil(t, out)
 }
 
-// TestAddGitStatusNotARepoIsNoop documents the graceful-failure path:
-// pointing the builtin at a directory that isn't a git repo must not
-// surface an error to the runtime — `git status` exits non-zero, the
-// hook logs at debug and returns nil. Without this contract, simply
-// running an agent outside a checkout would abort session start.
+// TestAddGitStatusNotARepoIsRemoved documents the graceful-failure path.
 func TestAddGitStatusNotARepoIsNoop(t *testing.T) {
 	t.Parallel()
 
@@ -64,5 +62,6 @@ func TestAddGitStatusNotARepoIsNoop(t *testing.T) {
 
 	out, err := fn(t.Context(), &hooks.Input{SessionID: "s", Cwd: t.TempDir()}, nil)
 	require.NoError(t, err)
-	assert.Nil(t, out)
+	require.Len(t, out.HookSpecificOutput.InstructionContext, 1)
+	assert.True(t, out.HookSpecificOutput.InstructionContext[0].Removed)
 }

--- a/pkg/hooks/builtins/add_prompt_files.go
+++ b/pkg/hooks/builtins/add_prompt_files.go
@@ -2,9 +2,10 @@ package builtins
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"log/slog"
 	"os"
-	"strings"
 
 	"github.com/docker/docker-agent/pkg/hooks"
 	"github.com/docker/docker-agent/pkg/promptfiles"
@@ -13,29 +14,54 @@ import (
 // AddPromptFiles is the registered name of the add_prompt_files builtin.
 const AddPromptFiles = "add_prompt_files"
 
-// addPromptFiles reads each filename in args from the workdir hierarchy
-// and the user's home directory (or the staged kit when running in a
-// sandbox), joining their contents into a turn_start AdditionalContext.
-// Missing or unreadable files are logged and skipped; surviving files
-// still contribute.
+const promptFilesGroup = "core/prompt-files"
+
+// addPromptFiles reads each filename from the workdir hierarchy and home
+// directory, preserving each resolved path in independently diffable context.
 func addPromptFiles(_ context.Context, in *hooks.Input, args []string) (*hooks.Output, error) {
 	if in == nil || in.Cwd == "" || len(args) == 0 {
 		return nil, nil
 	}
-	home, _ := os.UserHomeDir() // empty string disables the home-dir lookup
-	var parts []string
+	home, _ := os.UserHomeDir()
+	var sources []hooks.InstructionContext
 	for _, name := range args {
 		for _, path := range promptfiles.PathsFromEnv(in.Cwd, home, name) {
 			content, err := os.ReadFile(path)
 			if err != nil {
 				slog.Warn("reading prompt file", "path", path, "error", err)
-				continue
+				return instructionContextOutput(hooks.InstructionContext{
+					Group: promptFilesGroup, Unavailable: true, SetMarker: true,
+				}), nil
 			}
-			parts = append(parts, string(content))
+			rendered := "Instructions from: " + path + "\n" + string(content)
+			sources = append(sources, hooks.InstructionContext{
+				Key:            promptFileKey(path),
+				Group:          promptFilesGroup,
+				Label:          "instructions from " + path,
+				Content:        rendered,
+				ChangedContent: "The instructions from " + path + " have changed and replace the previous instructions from that file.\n\n" + rendered,
+				RemovedContent: "The previously loaded instructions from " + path + " no longer apply.",
+			})
 		}
 	}
-	if len(parts) == 0 {
-		return nil, nil
+	if len(sources) == 0 {
+		sources = append(sources, hooks.InstructionContext{
+			Group: promptFilesGroup, CompleteGroup: true, SetMarker: true,
+		})
+	} else {
+		sources[0].CompleteGroup = true
 	}
-	return hooks.NewAdditionalContextOutput(hooks.EventTurnStart, strings.Join(parts, "\n\n")), nil
+	return instructionContextOutput(sources...), nil
+}
+
+func instructionContextOutput(sources ...hooks.InstructionContext) *hooks.Output {
+	return &hooks.Output{HookSpecificOutput: &hooks.HookSpecificOutput{
+		HookEventName:      hooks.EventTurnStart,
+		InstructionContext: sources,
+	}}
+}
+
+func promptFileKey(path string) string {
+	sum := sha256.Sum256([]byte(path))
+	return "core/prompt-file-" + hex.EncodeToString(sum[:])
 }

--- a/pkg/hooks/builtins/add_recent_commits.go
+++ b/pkg/hooks/builtins/add_recent_commits.go
@@ -45,12 +45,21 @@ func addRecentCommits(ctx context.Context, in *hooks.Input, args []string) (*hoo
 	}
 
 	out, err := gitOutput(ctx, in.Cwd, "log", "--oneline", "-n", strconv.Itoa(limit))
-	if err != nil {
-		slog.DebugContext(ctx, "add_recent_commits: git log failed; skipping", "cwd", in.Cwd, "error", err)
-		return nil, nil
+	if err != nil || out == "" {
+		if err != nil {
+			slog.DebugContext(ctx, "add_recent_commits: git log failed; skipping", "cwd", in.Cwd, "error", err)
+		}
+		return hooks.NewInstructionContextOutput(hooks.EventSessionStart, hooks.InstructionContext{
+			Key: "core/recent-commits", Removed: true,
+			RemovedContent: "Previously reported recent commits no longer apply.",
+		}), nil
 	}
-	if out == "" {
-		return nil, nil
-	}
-	return hooks.NewAdditionalContextOutput(hooks.EventSessionStart, "Recent commits:\n\n"+out), nil
+	content := "Recent commits:\n\n" + out
+	return hooks.NewInstructionContextOutput(hooks.EventSessionStart, hooks.InstructionContext{
+		Key:            "core/recent-commits",
+		Label:          "recent commits",
+		Content:        content,
+		ChangedContent: "The recent commits are now:\n\n" + out,
+		RemovedContent: "Previously reported recent commits no longer apply.",
+	}), nil
 }

--- a/pkg/hooks/builtins/add_recent_commits_test.go
+++ b/pkg/hooks/builtins/add_recent_commits_test.go
@@ -34,7 +34,8 @@ func TestAddRecentCommitsListsHistory(t *testing.T) {
 	assert.Equal(t, hooks.EventSessionStart, out.HookSpecificOutput.HookEventName,
 		"add_recent_commits must target session_start, not turn_start")
 
-	ctx := out.HookSpecificOutput.AdditionalContext
+	require.Len(t, out.HookSpecificOutput.InstructionContext, 1)
+	ctx := out.HookSpecificOutput.InstructionContext[0].Content
 	for _, subject := range []string{"first commit", "second commit", "third commit"} {
 		assert.Contains(t, ctx, subject)
 	}
@@ -62,7 +63,8 @@ func TestAddRecentCommitsHonorsLimitArg(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, out)
 
-	ctx := out.HookSpecificOutput.AdditionalContext
+	require.Len(t, out.HookSpecificOutput.InstructionContext, 1)
+	ctx := out.HookSpecificOutput.InstructionContext[0].Content
 	assert.Contains(t, ctx, "gamma", "newest commit must be present")
 	assert.NotContains(t, ctx, "beta", "limit=1 must drop the older commits")
 	assert.NotContains(t, ctx, "alpha", "limit=1 must drop the older commits")
@@ -86,7 +88,8 @@ func TestAddRecentCommitsInvalidLimitFallsBack(t *testing.T) {
 		out, err := fn(t.Context(), &hooks.Input{SessionID: "s", Cwd: dir}, []string{arg})
 		require.NoError(t, err)
 		require.NotNilf(t, out, "invalid arg %q must fall back to default rather than no-op", arg)
-		assert.Contains(t, out.HookSpecificOutput.AdditionalContext, "only commit",
+		require.Len(t, out.HookSpecificOutput.InstructionContext, 1)
+		assert.Contains(t, out.HookSpecificOutput.InstructionContext[0].Content, "only commit",
 			"fallback must still emit the existing history")
 	}
 }
@@ -104,7 +107,8 @@ func TestAddRecentCommitsEmptyRepoIsNoop(t *testing.T) {
 
 	out, err := fn(t.Context(), &hooks.Input{SessionID: "s", Cwd: dir}, nil)
 	require.NoError(t, err)
-	assert.Nil(t, out)
+	require.Len(t, out.HookSpecificOutput.InstructionContext, 1)
+	assert.True(t, out.HookSpecificOutput.InstructionContext[0].Removed)
 }
 
 // TestAddRecentCommitsNoCwdOrNotARepoIsNoop documents the safety /
@@ -125,5 +129,6 @@ func TestAddRecentCommitsNoCwdOrNotARepoIsNoop(t *testing.T) {
 
 	out, err = fn(t.Context(), &hooks.Input{SessionID: "s", Cwd: t.TempDir()}, nil)
 	require.NoError(t, err)
-	assert.Nil(t, out)
+	require.Len(t, out.HookSpecificOutput.InstructionContext, 1)
+	assert.True(t, out.HookSpecificOutput.InstructionContext[0].Removed)
 }

--- a/pkg/hooks/builtins/builtins_test.go
+++ b/pkg/hooks/builtins/builtins_test.go
@@ -47,10 +47,8 @@ func TestRegisterInstallsAllBuiltins(t *testing.T) {
 	}
 }
 
-// TestAddDateReturnsTodaysDate verifies the date builtin emits a
-// turn_start AdditionalContext containing today's ISO date. It does NOT
-// verify the exact "Today's date: " prefix — that's a UX detail, but we
-// keep the assertion loose-but-meaningful by anchoring on the date.
+// TestAddDateReturnsTodaysDate verifies the date builtin emits independently
+// diffable date context.
 func TestAddDateReturnsTodaysDate(t *testing.T) {
 	t.Parallel()
 
@@ -62,7 +60,9 @@ func TestAddDateReturnsTodaysDate(t *testing.T) {
 	require.NotNil(t, out.HookSpecificOutput)
 	assert.Equal(t, hooks.EventTurnStart, out.HookSpecificOutput.HookEventName,
 		"add_date must target turn_start, not session_start")
-	assert.Contains(t, out.HookSpecificOutput.AdditionalContext, time.Now().Format("2006-01-02"))
+	require.Len(t, out.HookSpecificOutput.InstructionContext, 1)
+	assert.Equal(t, "core/date", out.HookSpecificOutput.InstructionContext[0].Key)
+	assert.Contains(t, out.HookSpecificOutput.InstructionContext[0].Content, time.Now().Format("2006-01-02"))
 }
 
 // TestAddEnvironmentInfoUsesInputCwd verifies that the env-info builtin
@@ -104,9 +104,8 @@ func TestAddEnvironmentInfoNoCwdIsNoop(t *testing.T) {
 	assert.Nil(t, out)
 }
 
-// TestAddPromptFilesReadsFromCwd verifies that add_prompt_files reads
-// each file named in args (relative to Input.Cwd) and joins their
-// contents into the turn_start AdditionalContext.
+// TestAddPromptFilesReadsFromCwd verifies that add_prompt_files includes
+// both the resolved source path and its contents.
 func TestAddPromptFilesReadsFromCwd(t *testing.T) {
 	t.Parallel()
 
@@ -122,14 +121,18 @@ func TestAddPromptFilesReadsFromCwd(t *testing.T) {
 	require.NotNil(t, out.HookSpecificOutput)
 	assert.Equal(t, hooks.EventTurnStart, out.HookSpecificOutput.HookEventName,
 		"add_prompt_files must target turn_start, not session_start")
-	assert.Contains(t, out.HookSpecificOutput.AdditionalContext, promptBody)
+	require.Len(t, out.HookSpecificOutput.InstructionContext, 1)
+	source := out.HookSpecificOutput.InstructionContext[0]
+	assert.Contains(t, source.Key, "core/prompt-file-")
+	assert.True(t, source.CompleteGroup)
+	assert.Contains(t, source.Content, "Instructions from: "+filepath.Join(dir, "PROMPT.md"))
+	assert.Contains(t, source.Content, promptBody)
+	assert.Contains(t, source.ChangedContent, "replace the previous instructions from that file")
+	assert.Contains(t, source.ChangedContent, filepath.Join(dir, "PROMPT.md"))
 }
 
-// TestAddPromptFilesMissingFileIsTolerated documents that a missing
-// prompt file is logged-and-skipped, not an error: surviving files
-// still contribute, and an args list with only missing files yields a
-// nil Output rather than a hard failure. This matches the original
-// inline loop's silent-skip behavior.
+// TestAddPromptFilesMissingFileIsTolerated documents that missing configured
+// files do not prevent surviving files from contributing.
 func TestAddPromptFilesMissingFileIsTolerated(t *testing.T) {
 	t.Parallel()
 
@@ -143,7 +146,14 @@ func TestAddPromptFilesMissingFileIsTolerated(t *testing.T) {
 	out, err := fn(t.Context(), &hooks.Input{SessionID: "s", Cwd: dir}, []string{"MISSING.md", "OK.md"})
 	require.NoError(t, err)
 	require.NotNil(t, out)
-	assert.Contains(t, out.HookSpecificOutput.AdditionalContext, promptBody)
+	require.Len(t, out.HookSpecificOutput.InstructionContext, 1)
+	assert.Contains(t, out.HookSpecificOutput.InstructionContext[0].Content, promptBody)
+
+	out, err = fn(t.Context(), &hooks.Input{SessionID: "s", Cwd: dir}, []string{"MISSING.md"})
+	require.NoError(t, err)
+	require.Len(t, out.HookSpecificOutput.InstructionContext, 1)
+	assert.True(t, out.HookSpecificOutput.InstructionContext[0].SetMarker)
+	assert.True(t, out.HookSpecificOutput.InstructionContext[0].CompleteGroup)
 }
 
 // TestAddPromptFilesNoArgsIsNoop pins the early-return behavior: with

--- a/pkg/hooks/executor.go
+++ b/pkg/hooks/executor.go
@@ -557,6 +557,7 @@ func aggregate(results []hookResult, event EventType) *Result {
 			if hso.AdditionalContext != "" {
 				contexts = append(contexts, hso.AdditionalContext)
 			}
+			final.InstructionContext = append(final.InstructionContext, hso.InstructionContext...)
 		}
 	}
 

--- a/pkg/hooks/types.go
+++ b/pkg/hooks/types.go
@@ -471,6 +471,29 @@ func NewAdditionalContextOutput(event EventType, content string) *Output {
 	}
 }
 
+// NewInstructionContextOutput returns context with a stable semantic identity,
+// allowing the runtime to diff it independently from other hook output.
+func NewInstructionContextOutput(event EventType, source InstructionContext) *Output {
+	return &Output{HookSpecificOutput: &HookSpecificOutput{
+		HookEventName:      event,
+		InstructionContext: []InstructionContext{source},
+	}}
+}
+
+// InstructionContext describes independently changing trusted context.
+type InstructionContext struct {
+	Key            string `json:"key"`
+	Group          string `json:"group,omitempty"`
+	Label          string `json:"label,omitempty"`
+	Content        string `json:"content,omitempty"`
+	ChangedContent string `json:"changed_content,omitempty"`
+	RemovedContent string `json:"removed_content,omitempty"`
+	Removed        bool   `json:"removed,omitempty"`
+	Unavailable    bool   `json:"unavailable,omitempty"`
+	CompleteGroup  bool   `json:"complete_group,omitempty"`
+	SetMarker      bool   `json:"set_marker,omitempty"`
+}
+
 // Output is the JSON-decoded output of a hook.
 type Output struct {
 	// Continue indicates whether to continue execution (default: true).
@@ -510,7 +533,8 @@ type HookSpecificOutput struct {
 	UpdatedInput             map[string]any `json:"updated_input,omitempty"`
 
 	// PostToolUse / SessionStart / TurnStart / Stop fields.
-	AdditionalContext string `json:"additional_context,omitempty"`
+	AdditionalContext  string               `json:"additional_context,omitempty"`
+	InstructionContext []InstructionContext `json:"instruction_context,omitempty"`
 
 	// BeforeCompaction: when non-empty, the runtime applies this string as
 	// the compaction summary verbatim and skips the LLM-based
@@ -564,7 +588,8 @@ type Result struct {
 	// ModifiedInput contains modifications to tool input (PreToolUse).
 	ModifiedInput map[string]any
 	// AdditionalContext is context added by the hooks.
-	AdditionalContext string
+	AdditionalContext  string
+	InstructionContext []InstructionContext
 	// SystemMessage is a warning to show the user.
 	SystemMessage string
 	// ExitCode is the worst exit code seen (0 = success, 2 = blocking error, -1 = exec failure).

--- a/pkg/runtime/harness.go
+++ b/pkg/runtime/harness.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -20,7 +21,7 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
-func (r *LocalRuntime) runHarnessAgent(ctx context.Context, sess *session.Session, a *agent.Agent, baseExtra []chat.Message, events EventSink) string {
+func (r *LocalRuntime) runHarnessAgent(ctx context.Context, sess *session.Session, a *agent.Agent, baseExtra, baseLegacy []chat.Message, baseSources []session.InstructionSource, events EventSink) string {
 	ctx, span := r.startSpan(ctx, "runtime.harness", trace.WithAttributes(traceAttributesForHarness(sess, a)...))
 	defer span.End()
 
@@ -46,7 +47,9 @@ func (r *LocalRuntime) runHarnessAgent(ctx context.Context, sess *session.Sessio
 	}()
 
 	turnStartMsgs := r.executeTurnStartHooks(ctx, sess, a, events)
-	messages := sess.GetMessages(a, append(baseExtra, turnStartMsgs...)...)
+	legacyExtras := append(slices.Clone(baseLegacy), turnStartMsgs.legacyMessages()...)
+	messages := r.messagesWithDynamicContext(ctx, sess, a,
+		instructionSources(baseExtra, nil, turnStartMsgs, baseSources...), legacyExtras)
 	stop, msg, rewritten := r.executeBeforeLLMCallHooks(ctx, sess, a, modelID, 1, messages)
 	if stop {
 		slog.WarnContext(ctx, "before_llm_call hook signalled run termination",

--- a/pkg/runtime/hooks.go
+++ b/pkg/runtime/hooks.go
@@ -3,6 +3,8 @@ package runtime
 import (
 	"context"
 	"log/slog"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/docker/docker-agent/pkg/agent"
@@ -12,6 +14,7 @@ import (
 	"github.com/docker/docker-agent/pkg/runtime/toolexec"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/userconfig"
 )
 
 // buildHooksExecutors builds a [hooks.Executor] for every agent in the
@@ -128,36 +131,21 @@ func (r *LocalRuntime) dispatchHook(
 	return result
 }
 
-// executeSessionStartHooks fires session_start once at the top of
-// RunStream and returns its AdditionalContext as transient system
-// messages. The result is NOT persisted to the session: persisting
-// would pollute the visible transcript and (because session_start
-// fires after the user message has been added) shift the message the
-// runtime relays as the [UserMessageEvent]. Callers thread the
-// returned slice through [session.Session.GetMessages] on every
-// iteration so cwd / OS / arch context reaches the model without ever
-// being stored.
-//
-// Compaction does NOT re-fire session_start. The transient nature of
-// sessionStartMsgs means env / cwd / OS context is automatically
-// included in every model call after a compaction, without any extra
-// dispatch — there's nothing to "re-inject" because nothing was
-// persisted in the first place.
-func (r *LocalRuntime) executeSessionStartHooks(ctx context.Context, sess *session.Session, a *agent.Agent, events EventSink) []chat.Message {
-	return contextMessages(r.dispatchHook(ctx, a, hooks.EventSessionStart, &hooks.Input{
+// executeSessionStartHooks fires session_start once at the top of RunStream.
+// Its context is fed into the cache-stable instruction snapshot rather than
+// appended to the visible transcript.
+func (r *LocalRuntime) executeSessionStartHooks(ctx context.Context, sess *session.Session, a *agent.Agent, events EventSink) instructionObservation {
+	return observeInstructions(r.dispatchHook(ctx, a, hooks.EventSessionStart, &hooks.Input{
 		SessionID: sess.ID,
 		Source:    "startup",
 	}, events))
 }
 
-// executeTurnStartHooks fires turn_start before each model call and
-// returns its AdditionalContext as transient system messages. Like
-// session_start the result is never persisted, but turn_start runs
-// every iteration so its content is recomputed each turn — the right
-// semantics for fast-changing context like the current date or the
-// contents of a prompt file the user might be editing mid-session.
-func (r *LocalRuntime) executeTurnStartHooks(ctx context.Context, sess *session.Session, a *agent.Agent, events EventSink) []chat.Message {
-	return contextMessages(r.dispatchHook(ctx, a, hooks.EventTurnStart, &hooks.Input{
+// executeTurnStartHooks fires turn_start before each model call. Recomputing
+// its context each turn lets the instruction layer detect date and prompt-file
+// changes without mutating the initial system prefix.
+func (r *LocalRuntime) executeTurnStartHooks(ctx context.Context, sess *session.Session, a *agent.Agent, events EventSink) instructionObservation {
+	return observeInstructions(r.dispatchHook(ctx, a, hooks.EventTurnStart, &hooks.Input{
 		SessionID: sess.ID,
 	}, events))
 }
@@ -220,6 +208,94 @@ func contextMessages(result *hooks.Result) []chat.Message {
 		Role:    chat.MessageRoleSystem,
 		Content: result.AdditionalContext,
 	}}
+}
+
+type instructionObservation struct {
+	messages []chat.Message
+	sources  []session.InstructionSource
+}
+
+func (o instructionObservation) legacyMessages() []chat.Message {
+	messages := slices.Clone(o.messages)
+	for _, source := range o.sources {
+		if !source.Available || source.Removed || source.SetMarker || strings.TrimSpace(source.Content) == "" {
+			continue
+		}
+		messages = append(messages, chat.Message{Role: chat.MessageRoleSystem, Content: source.Content})
+	}
+	return messages
+}
+
+func observeInstructions(result *hooks.Result) instructionObservation {
+	observation := instructionObservation{messages: contextMessages(result)}
+	if result == nil {
+		return observation
+	}
+	for _, source := range result.InstructionContext {
+		observation.sources = append(observation.sources, session.InstructionSource{
+			Key:            source.Key,
+			Group:          source.Group,
+			Label:          source.Label,
+			Content:        source.Content,
+			ChangedContent: source.ChangedContent,
+			RemovedContent: source.RemovedContent,
+			Removed:        source.Removed,
+			Available:      !source.Unavailable,
+			CompleteGroup:  source.CompleteGroup,
+			SetMarker:      source.SetMarker,
+		})
+	}
+	return observation
+}
+
+func instructionSources(sessionStart, userPrompt []chat.Message, turnStart instructionObservation, additional ...session.InstructionSource) []session.InstructionSource {
+	sources := []session.InstructionSource{
+		instructionSource("hooks/session-start", "environment context", sessionStart),
+		instructionSource("hooks/user-prompt", "user-request context", userPrompt),
+		instructionSource("hooks/turn-start", "dynamic context", turnStart.messages),
+	}
+	sources = append(sources, additional...)
+	return append(sources, turnStart.sources...)
+}
+
+func (r *LocalRuntime) messagesWithDynamicContext(
+	ctx context.Context,
+	sess *session.Session,
+	a *agent.Agent,
+	sources []session.InstructionSource,
+	legacyExtras []chat.Message,
+) []chat.Message {
+	if !userconfig.Get().CacheStablePromptsEnabled() {
+		if sess.ClearInstructionContext() {
+			if err := r.sessionStore.UpdateSession(ctx, sess); err != nil {
+				slog.WarnContext(ctx, "Failed to clear instruction context", "session_id", sess.ID, "error", err)
+			}
+		}
+		return sess.GetMessagesWithoutInstructionContext(a, legacyExtras...)
+	}
+	if sess.PrepareInstructionContext(sources) {
+		if err := r.sessionStore.UpdateSession(ctx, sess); err != nil {
+			slog.WarnContext(ctx, "Failed to persist instruction context", "session_id", sess.ID, "error", err)
+		}
+	}
+	return sess.GetMessages(a)
+}
+
+func instructionSource(key, label string, messages []chat.Message) session.InstructionSource {
+	contents := make([]string, 0, len(messages))
+	for _, message := range messages {
+		if strings.TrimSpace(message.Content) != "" {
+			contents = append(contents, message.Content)
+		}
+	}
+	content := strings.Join(contents, "\n")
+	return session.InstructionSource{
+		Key:       key,
+		Label:     label,
+		Content:   content,
+		Removed:   content == "",
+		Available: true,
+	}
 }
 
 // executeSessionEndHooks fires session_end when the run loop exits.

--- a/pkg/runtime/instruction_observation_test.go
+++ b/pkg/runtime/instruction_observation_test.go
@@ -1,0 +1,34 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/hooks"
+)
+
+func TestInstructionObservationLegacyMessagesIncludesSemanticContext(t *testing.T) {
+	observation := observeInstructions(&hooks.Result{
+		AdditionalContext: "custom context",
+		InstructionContext: []hooks.InstructionContext{
+			{Key: "core/date", Content: "Today's date: 2026-07-15"},
+			{Key: "core/prompt-file-a", Content: "Instructions from: /a\ncontent"},
+			{Group: "core/prompt-files", SetMarker: true},
+			{Key: "core/unavailable", Content: "stale", Unavailable: true},
+		},
+	})
+
+	messages := observation.legacyMessages()
+	require.Len(t, messages, 3)
+	assert.Equal(t, []string{
+		"custom context",
+		"Today's date: 2026-07-15",
+		"Instructions from: /a\ncontent",
+	}, []string{messages[0].Content, messages[1].Content, messages[2].Content})
+	for _, message := range messages {
+		assert.Equal(t, chat.MessageRoleSystem, message.Role)
+	}
+}

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -336,9 +336,12 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 	// extras and threaded into every model call below — never persisted,
 	// to keep the visible transcript clean and the user message tail
 	// stable.
+	sessionStart := r.executeSessionStartHooks(ctx, sess, a, sink)
 	ls := &loopState{
-		maxIterations:    sess.MaxIterations,
-		sessionStartMsgs: r.executeSessionStartHooks(ctx, sess, a, sink),
+		maxIterations:          sess.MaxIterations,
+		sessionStartMsgs:       sessionStart.messages,
+		sessionStartLegacyMsgs: sessionStart.legacyMessages(),
+		sessionStartSources:    sessionStart.sources,
 	}
 
 	// Emit team information
@@ -363,7 +366,7 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 
 	sink.Emit(ToolsetInfo(len(agentTools), false, a.Name()))
 
-	messages := sess.GetMessages(a)
+	messages := sess.GetMessagesWithoutInstructionContext(a)
 
 	// Sub-sessions (transferred tasks, background agents, skill
 	// sub-sessions) carry a synthesised "Please proceed." message that
@@ -391,7 +394,9 @@ func (r *LocalRuntime) runStreamLoop(ctx context.Context, sess *session.Session,
 	sink.Emit(StreamStarted(sess.ID, a.Name()))
 
 	if a.HasHarness() {
-		streamReason = r.runHarnessAgent(ctx, sess, a, slices.Concat(ls.sessionStartMsgs, ls.userPromptMsgs), sink)
+		streamReason = r.runHarnessAgent(ctx, sess, a,
+			slices.Concat(ls.sessionStartMsgs, ls.userPromptMsgs),
+			slices.Concat(ls.sessionStartLegacyMsgs, ls.userPromptMsgs), ls.sessionStartSources, sink)
 		return
 	}
 
@@ -585,15 +590,17 @@ const (
 // new per-stream tracking (cost ceiling, token budget, turn timing)
 // without touching any signature.
 type loopState struct {
-	iteration           int
-	maxIterations       int
-	overflowCompactions int
-	toolModelOverride   string
-	prevAgentName       string
-	loopDetector        *toolexec.LoopDetector
-	sessionStartMsgs    []chat.Message
-	userPromptMsgs      []chat.Message
-	exitReason          string
+	iteration              int
+	maxIterations          int
+	overflowCompactions    int
+	toolModelOverride      string
+	prevAgentName          string
+	loopDetector           *toolexec.LoopDetector
+	sessionStartMsgs       []chat.Message
+	sessionStartLegacyMsgs []chat.Message
+	sessionStartSources    []session.InstructionSource
+	userPromptMsgs         []chat.Message
+	exitReason             string
 	// prevTurnMadeToolCalls reports whether the immediately preceding
 	// turn emitted tool calls. Used to classify an empty trailing turn:
 	// a clean stop right after tool work is benign (the model already
@@ -710,15 +717,13 @@ func (r *LocalRuntime) runTurn(
 		ls.exitReason = endReason
 	}()
 
-	// Run turn_start hooks BEFORE building messages so their
-	// AdditionalContext, alongside the session_start extras captured
-	// once at the top of RunStream, can be spliced after the invariant
-	// cache checkpoint and before the conversation history. Neither
-	// hook's output is persisted, so per-turn signals (date, prompt
-	// files) refresh every turn while session-level context (cwd, OS,
-	// arch) stays stable — all without bloating the stored history.
+	// Run turn_start hooks before assembly so dynamic context can be diffed
+	// against what the model already knows. Changes extend the conversation;
+	// they never rewrite the frozen instruction prefix.
 	turnStartMsgs := r.executeTurnStartHooks(ctx, sess, a, events)
-	messages := sess.GetMessages(a, slices.Concat(ls.sessionStartMsgs, ls.userPromptMsgs, turnStartMsgs)...)
+	legacyExtras := slices.Concat(ls.sessionStartLegacyMsgs, ls.userPromptMsgs, turnStartMsgs.legacyMessages())
+	messages := r.messagesWithDynamicContext(ctx, sess, a,
+		instructionSources(ls.sessionStartMsgs, ls.userPromptMsgs, turnStartMsgs, ls.sessionStartSources...), legacyExtras)
 	slog.DebugContext(ctx, "Retrieved messages for processing", "agent", a.Name(), "message_count", len(messages))
 
 	// before_llm_call hooks fire just before the model is invoked.

--- a/pkg/session/branch.go
+++ b/pkg/session/branch.go
@@ -106,6 +106,7 @@ func (s *Session) Clone() *Session {
 		ExtraToolSets:           slices.Clone(s.ExtraToolSets),
 		AgentName:               s.AgentName,
 		ParentID:                s.ParentID,
+		InstructionContext:      cloneInstructionContext(s.InstructionContext),
 		MessageUsageHistory:     slices.Clone(s.MessageUsageHistory),
 	}
 

--- a/pkg/session/instruction_context_test.go
+++ b/pkg/session/instruction_context_test.go
@@ -1,0 +1,156 @@
+package session
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+func TestInstructionContextKeepsInitialPromptStableAndAppendsChanges(t *testing.T) {
+	sess := New()
+	a := agent.New("test", "base prompt")
+	sess.AddMessage(UserMessage("first"))
+
+	require.True(t, sess.PrepareInstructionContext([]InstructionSource{{
+		Key: "core/date", Label: "date", Content: "Today's date: 2026-07-15", Available: true,
+	}}))
+	first := sess.GetMessages(a)
+	require.Len(t, first, 3)
+	assert.Equal(t, chat.MessageRoleSystem, first[1].Role)
+	assert.Equal(t, "Today's date: 2026-07-15", first[1].Content)
+
+	assert.False(t, sess.PrepareInstructionContext([]InstructionSource{{
+		Key: "core/date", Label: "date", Content: "Today's date: 2026-07-15", Available: true,
+	}}))
+	assert.Equal(t, first, sess.GetMessages(a))
+
+	sess.AddMessage(NewAgentMessage("test", &chat.Message{Role: chat.MessageRoleAssistant, Content: "reply"}))
+	require.True(t, sess.PrepareInstructionContext([]InstructionSource{{
+		Key: "core/date", Label: "date", Content: "Today's date: 2026-07-16", Available: true,
+	}}))
+	updated := sess.GetMessages(a)
+
+	assert.Equal(t, first[0].Content, updated[0].Content)
+	assert.Equal(t, first[1].Content, updated[1].Content, "the initial snapshot must remain byte-stable")
+	require.Len(t, updated, 5)
+	assert.Equal(t, chat.MessageRoleUser, updated[4].Role)
+	assert.Contains(t, updated[4].Content, "<system-update>")
+	assert.Contains(t, updated[4].Content, "2026-07-16")
+}
+
+func TestInstructionContextUsesSourceSpecificChangeNarration(t *testing.T) {
+	sess := New()
+	a := agent.New("test", "base prompt")
+	sess.PrepareInstructionContext([]InstructionSource{{
+		Key: "core/date", Content: "Today's date: 2026-07-15", Available: true,
+	}})
+	sess.AddMessage(UserMessage("hello"))
+	sess.PrepareInstructionContext([]InstructionSource{{
+		Key:            "core/date",
+		Content:        "Today's date: 2026-07-16",
+		ChangedContent: "Today's date is now: 2026-07-16",
+		Available:      true,
+	}})
+
+	messages := sess.GetMessages(a)
+	require.Len(t, messages, 4)
+	assert.Contains(t, messages[3].Content, "Today's date is now: 2026-07-16")
+	assert.NotContains(t, messages[3].Content, "turn-start")
+	assert.NotContains(t, messages[3].Content, "context under")
+}
+
+func TestInstructionContextUpdatesOnlyChangedGroupMember(t *testing.T) {
+	sess := New()
+	a := agent.New("test", "base prompt")
+	initial := []InstructionSource{
+		{Key: "core/prompt-file-a", Group: "core/prompt-files", Content: "Instructions from: /a\na1", RemovedContent: "removed /a", CompleteGroup: true, Available: true},
+		{Key: "core/prompt-file-b", Group: "core/prompt-files", Content: "Instructions from: /b\nb1", RemovedContent: "removed /b", Available: true},
+	}
+	sess.PrepareInstructionContext(initial)
+	sess.AddMessage(UserMessage("hello"))
+	sess.PrepareInstructionContext([]InstructionSource{
+		{Key: "core/prompt-file-a", Group: "core/prompt-files", Content: "Instructions from: /a\na2", ChangedContent: "changed /a", RemovedContent: "removed /a", CompleteGroup: true, Available: true},
+		{Key: "core/prompt-file-b", Group: "core/prompt-files", Content: "Instructions from: /b\nb1", RemovedContent: "removed /b", Available: true},
+	})
+
+	messages := sess.GetMessages(a)
+	update := messages[len(messages)-1].Content
+	assert.Contains(t, update, "changed /a")
+	assert.NotContains(t, update, "Instructions from: /b")
+
+	sess.AddMessage(NewAgentMessage("test", &chat.Message{Role: chat.MessageRoleAssistant, Content: "reply"}))
+	sess.PrepareInstructionContext([]InstructionSource{
+		{Key: "core/prompt-file-a", Group: "core/prompt-files", Content: "Instructions from: /a\na2", ChangedContent: "changed /a", RemovedContent: "removed /a", CompleteGroup: true, Available: true},
+	})
+	messages = sess.GetMessages(a)
+	assert.Contains(t, messages[len(messages)-1].Content, "removed /b")
+	assert.NotContains(t, messages[len(messages)-1].Content, "Instructions from: /a")
+}
+
+func TestInstructionContextAdvancesEpochAfterCompaction(t *testing.T) {
+	sess := New()
+	a := agent.New("test", "base prompt")
+	sess.AddMessage(UserMessage("first"))
+	sess.PrepareInstructionContext([]InstructionSource{{Key: "core/value", Content: "old", Available: true}})
+	sess.AddMessage(NewAgentMessage("test", &chat.Message{Role: chat.MessageRoleAssistant, Content: "reply"}))
+	sess.PrepareInstructionContext([]InstructionSource{{Key: "core/value", Content: "new", Available: true}})
+
+	sess.ApplyCompaction(0, 0, Item{Summary: "summary"})
+	require.True(t, sess.PrepareInstructionContext([]InstructionSource{{Key: "core/value", Content: "new", Available: true}}))
+	messages := sess.GetMessages(a)
+
+	require.GreaterOrEqual(t, len(messages), 3)
+	assert.Equal(t, "new", messages[1].Content)
+	for _, message := range messages {
+		assert.NotContains(t, message.Content, "<system-update>")
+	}
+}
+
+func TestInstructionContextUnavailableReadKeepsCurrentValue(t *testing.T) {
+	sess := New()
+	sess.PrepareInstructionContext([]InstructionSource{{Key: "core/value", Content: "known", Available: true}})
+
+	assert.False(t, sess.PrepareInstructionContext([]InstructionSource{{Key: "core/value", Available: false}}))
+	assert.Equal(t, "known", sess.InstructionContext.Current["core/value"].Content)
+	assert.Empty(t, sess.InstructionContext.Updates)
+}
+
+func TestGetMessagesWithoutInstructionContextUsesLegacyExtras(t *testing.T) {
+	sess := New()
+	a := agent.New("test", "base prompt")
+	sess.PrepareInstructionContext([]InstructionSource{{Key: "core/date", Content: "old date", Available: true}})
+	sess.AddMessage(UserMessage("hello"))
+
+	messages := sess.GetMessagesWithoutInstructionContext(a, chat.Message{
+		Role: chat.MessageRoleSystem, Content: "current date",
+	})
+	require.Len(t, messages, 3)
+	assert.Equal(t, "base prompt", messages[0].Content)
+	assert.Equal(t, "current date", messages[1].Content)
+	assert.Equal(t, "hello", messages[2].Content)
+}
+
+func TestInstructionContextPersistsInSQLite(t *testing.T) {
+	store, err := NewSQLiteSessionStore(t.Context(), filepath.Join(t.TempDir(), "sessions.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	sess := New(WithID("instruction-context"))
+	sess.PrepareInstructionContext([]InstructionSource{{Key: "core/value", Content: "old", Available: true}})
+	sess.AddMessage(UserMessage("hello"))
+	sess.PrepareInstructionContext([]InstructionSource{{Key: "core/value", Content: "new", Available: true}})
+	require.NoError(t, store.AddSession(t.Context(), sess))
+
+	loaded, err := store.GetSession(t.Context(), sess.ID)
+	require.NoError(t, err)
+	require.NotNil(t, loaded.InstructionContext)
+	assert.Equal(t, "old", loaded.InstructionContext.Initial["core/value"].Content)
+	assert.Equal(t, "new", loaded.InstructionContext.Current["core/value"].Content)
+	require.Len(t, loaded.InstructionContext.Updates, 1)
+	assert.Equal(t, 1, loaded.InstructionContext.Updates[0].Position)
+}

--- a/pkg/session/migrations.go
+++ b/pkg/session/migrations.go
@@ -401,6 +401,12 @@ func getAllMigrations() []Migration {
 			Description: "Add first_kept_entry column to session_items for compaction-preserved messages",
 			UpSQL:       `ALTER TABLE session_items ADD COLUMN first_kept_entry INTEGER DEFAULT 0`,
 		},
+		{
+			ID:          22,
+			Name:        "022_add_instruction_context_column",
+			Description: "Persist cache-stable instruction snapshots and chronological updates",
+			UpSQL:       `ALTER TABLE sessions ADD COLUMN instruction_context TEXT DEFAULT ''`,
+		},
 	}
 }
 

--- a/pkg/session/migrations_pinned_test.go
+++ b/pkg/session/migrations_pinned_test.go
@@ -39,7 +39,7 @@ func TestMigrationCatalogIsContentPinned(t *testing.T) {
 
 	got := digestMigrationCatalog(getAllMigrations())
 
-	const wantDigest = "0c6d5df46b970104cf49988ee3931e33643d5db85c68dd41b74b639d0094cec9"
+	const wantDigest = "7b8a0fe3b0c0446da69d09ac6c78e0da0df07dd70c5b3ca97e01bca56dbd22d4"
 	if got != wantDigest {
 		t.Fatalf(`migration catalogue content has changed.
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -2,8 +2,11 @@ package session
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"log/slog"
+	"maps"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -261,10 +264,52 @@ type Session struct {
 	// within the parent session's Messages array.
 	ParentID string `json:"-"`
 
+	// InstructionContext keeps the cache-stable snapshot and chronological
+	// updates for dynamic system context.
+	InstructionContext *InstructionContextState `json:"instruction_context,omitempty"`
+
 	// MessageUsageHistory stores per-message usage data for remote mode.
 	// In remote mode, messages are managed server-side, so we track usage separately.
 	// This is not persisted (json:"-") as it's only needed for the current session display.
 	MessageUsageHistory []MessageUsageRecord `json:"-"`
+}
+
+// InstructionSource is one independently changing piece of trusted context.
+type InstructionSource struct {
+	Key            string
+	Group          string
+	Label          string
+	Content        string
+	ChangedContent string
+	RemovedContent string
+	Removed        bool
+	Available      bool
+	CompleteGroup  bool
+	SetMarker      bool
+}
+
+// InstructionValue is a content-addressed instruction value.
+type InstructionValue struct {
+	Hash           string `json:"hash"`
+	Group          string `json:"group,omitempty"`
+	Label          string `json:"label,omitempty"`
+	Content        string `json:"content"`
+	RemovedContent string `json:"removed_content,omitempty"`
+}
+
+// InstructionUpdate records an append-only context change at a session item boundary.
+type InstructionUpdate struct {
+	Position int    `json:"position"`
+	Content  string `json:"content"`
+}
+
+// InstructionContextState separates the frozen epoch snapshot from current values.
+type InstructionContextState struct {
+	EpochStart int                         `json:"epoch_start"`
+	Order      []string                    `json:"order,omitempty"`
+	Initial    map[string]InstructionValue `json:"initial,omitempty"`
+	Current    map[string]InstructionValue `json:"current,omitempty"`
+	Updates    []InstructionUpdate         `json:"updates,omitempty"`
 }
 
 // MessageUsageRecord stores usage data for a single assistant message.
@@ -636,6 +681,164 @@ func (s *Session) ApplyCompaction(inputTokens, outputTokens int64, item Item) {
 	s.InputTokens = inputTokens
 	s.OutputTokens = outputTokens
 	s.Messages = append(s.Messages, item)
+}
+
+// PrepareInstructionContext observes dynamic context before a model call. The
+// initial snapshot remains frozen until compaction; later changes become
+// append-only wrapped-user updates at the current history position.
+func (s *Session) PrepareInstructionContext(sources []InstructionSource) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.InstructionContext == nil {
+		for _, source := range sources {
+			if !source.Available {
+				return false
+			}
+		}
+		state := &InstructionContextState{
+			EpochStart: -1,
+			Initial:    make(map[string]InstructionValue),
+			Current:    make(map[string]InstructionValue),
+		}
+		for _, source := range sources {
+			if !source.Available || source.SetMarker || source.Removed || strings.TrimSpace(source.Content) == "" {
+				continue
+			}
+			value := instructionValue(source)
+			state.Order = append(state.Order, source.Key)
+			state.Initial[source.Key] = value
+			state.Current[source.Key] = value
+		}
+		s.InstructionContext = state
+		return true
+	}
+
+	state := s.InstructionContext
+	latestSummary := -1
+	for i := range slices.Backward(s.Messages) {
+		if s.Messages[i].Summary != "" {
+			latestSummary = i
+			break
+		}
+	}
+	changed := false
+	if latestSummary > state.EpochStart {
+		state.EpochStart = latestSummary
+		state.Initial = cloneInstructionValues(state.Current)
+		state.Updates = nil
+		changed = true
+	}
+
+	completeGroups := make(map[string]bool)
+	observedKeys := make(map[string]bool)
+	for _, source := range sources {
+		if source.Available && source.CompleteGroup && source.Group != "" {
+			completeGroups[source.Group] = true
+		}
+		if source.Available && !source.SetMarker && source.Key != "" {
+			observedKeys[source.Key] = true
+		}
+	}
+
+	var rendered []string
+	for _, source := range sources {
+		if !source.Available || source.SetMarker || source.Key == "" {
+			continue
+		}
+		previous, existed := state.Current[source.Key]
+		if source.Removed || strings.TrimSpace(source.Content) == "" {
+			if !existed {
+				continue
+			}
+			delete(state.Current, source.Key)
+			if source.RemovedContent != "" {
+				rendered = append(rendered, source.RemovedContent)
+			} else {
+				rendered = append(rendered, "The context under \""+sourceLabel(source)+"\" no longer applies. Disregard it.")
+			}
+			continue
+		}
+
+		current := instructionValue(source)
+		if existed && previous.Hash == current.Hash {
+			continue
+		}
+		switch {
+		case !existed:
+			state.Order = appendMissing(state.Order, source.Key)
+			rendered = append(rendered, "Additional context is now available under \""+sourceLabel(source)+"\":\n\n"+source.Content)
+		case source.ChangedContent != "":
+			rendered = append(rendered, source.ChangedContent)
+		default:
+			rendered = append(rendered, "The context under \""+sourceLabel(source)+"\" changed and supersedes the previous value:\n\n"+source.Content)
+		}
+		state.Current[source.Key] = current
+	}
+	for _, key := range state.Order {
+		previous, exists := state.Current[key]
+		if !exists || previous.Group == "" || !completeGroups[previous.Group] || observedKeys[key] {
+			continue
+		}
+		delete(state.Current, key)
+		if previous.RemovedContent != "" {
+			rendered = append(rendered, previous.RemovedContent)
+		} else {
+			rendered = append(rendered, "The context under \""+previous.Label+"\" no longer applies. Disregard it.")
+		}
+	}
+	if len(rendered) == 0 {
+		return changed
+	}
+
+	state.Updates = append(state.Updates, InstructionUpdate{
+		Position: len(s.Messages),
+		Content:  "<system-update>\n" + strings.Join(rendered, "\n\n") + "\n</system-update>",
+	})
+	return true
+}
+
+func instructionValue(source InstructionSource) InstructionValue {
+	encoded, _ := json.Marshal(source.Content)
+	sum := sha256.Sum256(encoded)
+	return InstructionValue{
+		Hash:           hex.EncodeToString(sum[:]),
+		Group:          source.Group,
+		Label:          sourceLabel(source),
+		Content:        source.Content,
+		RemovedContent: source.RemovedContent,
+	}
+}
+
+func sourceLabel(source InstructionSource) string {
+	if source.Label != "" {
+		return source.Label
+	}
+	return source.Key
+}
+
+func cloneInstructionValues(values map[string]InstructionValue) map[string]InstructionValue {
+	return maps.Clone(values)
+}
+
+func appendMissing(values []string, value string) []string {
+	if !slices.Contains(values, value) {
+		return append(values, value)
+	}
+	return values
+}
+
+func cloneInstructionContext(state *InstructionContextState) *InstructionContextState {
+	if state == nil {
+		return nil
+	}
+	return &InstructionContextState{
+		EpochStart: state.EpochStart,
+		Order:      slices.Clone(state.Order),
+		Initial:    cloneInstructionValues(state.Initial),
+		Current:    cloneInstructionValues(state.Current),
+		Updates:    slices.Clone(state.Updates),
+	}
 }
 
 // AddSubSession adds a sub-session to the session
@@ -1434,7 +1637,47 @@ func (s *Session) CompactionInput() ([]chat.Message, []int, int) {
 	return messages, sessIndices, len(items)
 }
 
+// ClearInstructionContext removes a previously prepared cache-stable snapshot.
+// It returns whether persisted session metadata changed.
+func (s *Session) ClearInstructionContext() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.InstructionContext == nil {
+		return false
+	}
+	s.InstructionContext = nil
+	return true
+}
+
+func (s *Session) instructionMessages() ([]chat.Message, []InstructionUpdate) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.InstructionContext == nil {
+		return nil, nil
+	}
+
+	initial := make([]chat.Message, 0, len(s.InstructionContext.Initial))
+	for _, key := range s.InstructionContext.Order {
+		value, ok := s.InstructionContext.Initial[key]
+		if !ok || strings.TrimSpace(value.Content) == "" {
+			continue
+		}
+		initial = append(initial, chat.Message{Role: chat.MessageRoleSystem, Content: value.Content})
+	}
+	return initial, slices.Clone(s.InstructionContext.Updates)
+}
+
 func (s *Session) GetMessages(a *agent.Agent, extraSystemMessages ...chat.Message) []chat.Message {
+	return s.getMessages(a, true, extraSystemMessages...)
+}
+
+// GetMessagesWithoutInstructionContext assembles the legacy prompt where
+// dynamic context is supplied directly as extra system messages.
+func (s *Session) GetMessagesWithoutInstructionContext(a *agent.Agent, extraSystemMessages ...chat.Message) []chat.Message {
+	return s.getMessages(a, false, extraSystemMessages...)
+}
+
+func (s *Session) getMessages(a *agent.Agent, includeInstructionContext bool, extraSystemMessages ...chat.Message) []chat.Message {
 	slog.Debug("Getting messages for agent", "agent", a.Name(), "session_id", s.ID)
 
 	// Build invariant system messages (cacheable across sessions/users/projects)
@@ -1444,12 +1687,19 @@ func (s *Session) GetMessages(a *agent.Agent, extraSystemMessages ...chat.Messag
 	// Take a snapshot of Messages under the lock, copying Message structs
 	// to avoid racing with UpdateMessage which may modify the pointed-to objects.
 	items := s.snapshotItems()
+	var instructionInitial []chat.Message
+	var instructionUpdates []InstructionUpdate
+	if includeInstructionContext {
+		instructionInitial, instructionUpdates = s.instructionMessages()
+	}
 
 	// Build session summary messages (vary per session)
 	summaryMessages, startIndex := s.buildSessionSummaryMessages(items)
 
 	var messages []chat.Message
 	messages = append(messages, invariantMessages...)
+	messages = append(messages, instructionInitial...)
+	markLastMessageAsCacheControl(messages)
 	// extraSystemMessages are caller-supplied transient system messages
 	// (e.g. turn_start hook output) inserted after the invariant cache
 	// checkpoint and before the conversation. The last extra carries a
@@ -1465,11 +1715,22 @@ func (s *Session) GetMessages(a *agent.Agent, extraSystemMessages ...chat.Messag
 	}
 	messages = append(messages, summaryMessages...)
 
-	// Begin adding conversation messages
-	for i := startIndex; i < len(items); i++ {
-		item := items[i]
-		if item.IsMessage() {
-			messages = append(messages, item.Message.Message)
+	// Begin adding conversation messages, interleaving instruction changes at
+	// the history position where they were observed.
+	updateIndex := 0
+	for updateIndex < len(instructionUpdates) && instructionUpdates[updateIndex].Position < startIndex {
+		updateIndex++
+	}
+	for i := startIndex; i <= len(items); i++ {
+		for updateIndex < len(instructionUpdates) && instructionUpdates[updateIndex].Position == i {
+			messages = append(messages, chat.Message{
+				Role:    chat.MessageRoleUser,
+				Content: instructionUpdates[updateIndex].Content,
+			})
+			updateIndex++
+		}
+		if i < len(items) && items[i].IsMessage() {
+			messages = append(messages, items[i].Message.Message)
 		}
 	}
 

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -236,6 +236,7 @@ func (s *InMemorySessionStore) UpdateSession(_ context.Context, session *Session
 		Permissions:         session.Permissions.Clone(),
 		AgentModelOverrides: cloneStringMap(session.AgentModelOverrides),
 		CustomModelsUsed:    cloneStringSlice(session.CustomModelsUsed),
+		InstructionContext:  cloneInstructionContext(session.InstructionContext),
 		AttachedFiles:       slices.Clone(session.AttachedFiles),
 		ParentID:            session.ParentID,
 	}
@@ -374,7 +375,7 @@ type SQLiteSessionStore struct {
 // sessionSelectColumns is the canonical SELECT list for the sessions table.
 // The column order matches what scanSession expects; all read paths use this
 // constant so that adding a column requires updating exactly one place.
-const sessionSelectColumns = `id, tools_approved, input_tokens, output_tokens, title, cost, send_user_message, max_iterations, working_dir, created_at, starred, permissions, agent_model_overrides, custom_models_used, thinking, parent_id`
+const sessionSelectColumns = `id, tools_approved, input_tokens, output_tokens, title, cost, send_user_message, max_iterations, working_dir, created_at, starred, permissions, agent_model_overrides, custom_models_used, thinking, parent_id, instruction_context`
 
 // sessionPersistedFields holds the encoded form of a Session's JSON-bearing
 // columns plus the SQL representation of parent_id (nil for the empty
@@ -383,6 +384,7 @@ type sessionPersistedFields struct {
 	PermissionsJSON         string
 	AgentModelOverridesJSON string
 	CustomModelsUsedJSON    string
+	InstructionContextJSON  string
 	ParentID                any // string or nil
 }
 
@@ -417,6 +419,14 @@ func sessionPersistedFieldsOf(session *Session) (sessionPersistedFields, error) 
 			return f, err
 		}
 		f.CustomModelsUsedJSON = string(customBytes)
+	}
+
+	if session.InstructionContext != nil {
+		contextBytes, err := json.Marshal(session.InstructionContext)
+		if err != nil {
+			return f, err
+		}
+		f.InstructionContextJSON = string(contextBytes)
 	}
 
 	// Use NULL for empty parent_id to avoid foreign key constraint issues.
@@ -636,12 +646,12 @@ func (s *SQLiteSessionStore) AddSession(ctx context.Context, session *Session) e
 		`INSERT INTO sessions (
 			id, tools_approved, input_tokens, output_tokens, title, cost, send_user_message,
 			max_iterations, working_dir, created_at, permissions, agent_model_overrides,
-			custom_models_used, thinking, parent_id
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			custom_models_used, thinking, parent_id, instruction_context
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		session.ID, session.ToolsApproved, session.InputTokens, session.OutputTokens, session.Title,
 		session.Cost, session.SendUserMessage, session.MaxIterations, session.WorkingDir,
 		session.CreatedAt.Format(time.RFC3339), fields.PermissionsJSON, fields.AgentModelOverridesJSON,
-		fields.CustomModelsUsedJSON, false, fields.ParentID)
+		fields.CustomModelsUsedJSON, false, fields.ParentID, fields.InstructionContextJSON)
 	if err != nil {
 		return err
 	}
@@ -671,6 +681,7 @@ func scanSession(scanner interface {
 		parentID                sql.NullString
 		agentModelOverridesJSON string
 		customModelsUsedJSON    string
+		instructionContextJSON  sql.NullString
 		createdAtStr            string
 		thinking                bool // discarded
 	)
@@ -679,7 +690,7 @@ func scanSession(scanner interface {
 		&sess.ID, &sess.ToolsApproved, &sess.InputTokens, &sess.OutputTokens,
 		&sess.Title, &sess.Cost, &sess.SendUserMessage, &sess.MaxIterations,
 		&workingDir, &createdAtStr, &sess.Starred, &permissionsJSON,
-		&agentModelOverridesJSON, &customModelsUsedJSON, &thinking, &parentID,
+		&agentModelOverridesJSON, &customModelsUsedJSON, &thinking, &parentID, &instructionContextJSON,
 	)
 	if err != nil {
 		return nil, err
@@ -704,6 +715,13 @@ func scanSession(scanner interface {
 
 	if customModelsUsedJSON != "" && customModelsUsedJSON != "[]" {
 		if err := json.Unmarshal([]byte(customModelsUsedJSON), &sess.CustomModelsUsed); err != nil {
+			return nil, err
+		}
+	}
+
+	if instructionContextJSON.Valid && instructionContextJSON.String != "" {
+		sess.InstructionContext = &InstructionContextState{}
+		if err := json.Unmarshal([]byte(instructionContextJSON.String), sess.InstructionContext); err != nil {
 			return nil, err
 		}
 	}
@@ -958,6 +976,7 @@ func (s *SQLiteSessionStore) UpdateSession(ctx context.Context, session *Session
 		Permissions:         session.Permissions.Clone(),
 		AgentModelOverrides: cloneStringMap(session.AgentModelOverrides),
 		CustomModelsUsed:    cloneStringSlice(session.CustomModelsUsed),
+		InstructionContext:  cloneInstructionContext(session.InstructionContext),
 		ParentID:            session.ParentID,
 	}
 	session.mu.RUnlock()
@@ -979,9 +998,9 @@ func (s *SQLiteSessionStore) UpdateSession(ctx context.Context, session *Session
 		`INSERT INTO sessions (
 			id, tools_approved, input_tokens, output_tokens, title, cost, send_user_message,
 			max_iterations, working_dir, created_at, starred, permissions, agent_model_overrides,
-			custom_models_used, thinking, parent_id
+			custom_models_used, thinking, parent_id, instruction_context
 		)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(id) DO UPDATE SET
 		   title = excluded.title,
 		   tools_approved = excluded.tools_approved,
@@ -996,11 +1015,12 @@ func (s *SQLiteSessionStore) UpdateSession(ctx context.Context, session *Session
 		   agent_model_overrides = excluded.agent_model_overrides,
 		   custom_models_used = excluded.custom_models_used,
 		   thinking = excluded.thinking,
-		   parent_id = excluded.parent_id`,
+		   parent_id = excluded.parent_id,
+		   instruction_context = excluded.instruction_context`,
 		snapshot.ID, snapshot.ToolsApproved, snapshot.InputTokens, snapshot.OutputTokens,
 		snapshot.Title, snapshot.Cost, snapshot.SendUserMessage, snapshot.MaxIterations, snapshot.WorkingDir,
 		snapshot.CreatedAt.Format(time.RFC3339), snapshot.Starred, fields.PermissionsJSON, fields.AgentModelOverridesJSON,
-		fields.CustomModelsUsedJSON, false, fields.ParentID)
+		fields.CustomModelsUsedJSON, false, fields.ParentID, fields.InstructionContextJSON)
 	if err != nil {
 		return err
 	}
@@ -1147,14 +1167,14 @@ func (s *SQLiteSessionStore) addSessionTx(ctx context.Context, tx *sql.Tx, sessi
 		`INSERT INTO sessions (
 			id, tools_approved, input_tokens, output_tokens, title, cost, send_user_message,
 			max_iterations, working_dir, created_at, starred, permissions, agent_model_overrides,
-			custom_models_used, thinking, parent_id
+			custom_models_used, thinking, parent_id, instruction_context
 		)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		session.ID, session.ToolsApproved, session.InputTokens, session.OutputTokens,
 		session.Title, session.Cost, session.SendUserMessage, session.MaxIterations,
 		session.WorkingDir, session.CreatedAt.Format(time.RFC3339), session.Starred,
 		fields.PermissionsJSON, fields.AgentModelOverridesJSON, fields.CustomModelsUsedJSON, false,
-		fields.ParentID)
+		fields.ParentID, fields.InstructionContextJSON)
 	return err
 }
 

--- a/pkg/tui/dialog/settings.go
+++ b/pkg/tui/dialog/settings.go
@@ -51,6 +51,7 @@ const (
 	rowYOLO
 	rowRestoreTabs
 	rowSnapshot
+	rowCacheStablePrompts
 	rowLean
 	rowTabTitleLength
 	behaviorRowCount
@@ -253,6 +254,8 @@ func (d *settingsDialog) changeValue(delta int) tea.Cmd {
 			d.current.RestoreTabs = !d.current.RestoreTabs
 		case rowSnapshot:
 			d.current.Snapshot = !d.current.Snapshot
+		case rowCacheStablePrompts:
+			d.current.CacheStablePrompts = !d.current.CacheStablePrompts
 		case rowLean:
 			d.current.Lean = !d.current.Lean
 		case rowTabTitleLength:
@@ -367,6 +370,7 @@ func (d *settingsDialog) renderBehaviorTab(content *Content, inner int) {
 		AddContent(d.renderToggleRow(rowYOLO, "Auto-approve tools by default", d.current.YOLO)).
 		AddContent(d.renderToggleRow(rowRestoreTabs, "Restore tabs on launch", d.current.RestoreTabs)).
 		AddContent(d.renderToggleRow(rowSnapshot, "Automatic snapshots", d.current.Snapshot)).
+		AddContent(d.renderToggleRow(rowCacheStablePrompts, "Cache-stable dynamic prompts", d.current.CacheStablePrompts)).
 		AddContent(d.renderToggleRow(rowLean, "Lean UI by default", d.current.Lean)).
 		AddContent(d.renderStepperRow(rowTabTitleLength, "Tab title max length", d.current.TabTitleMaxLength, "chars", inner, false))
 	if d.confirmYOLO {

--- a/pkg/tui/dialog/settings_test.go
+++ b/pkg/tui/dialog/settings_test.go
@@ -189,6 +189,19 @@ func TestSettingsDialogTogglesSendModeWithoutPreview(t *testing.T) {
 	assert.Equal(t, messages.SendModeSteer, d.current.SendMode, "cycling wraps around")
 }
 
+func TestSettingsDialogTogglesCacheStablePrompts(t *testing.T) {
+	t.Parallel()
+
+	d := newTestSettingsDialog(t, messages.LayoutSettings{})
+	d.tab = tabBehavior
+	d.selected[tabBehavior] = rowCacheStablePrompts
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+	assert.Nil(t, cmd)
+	assert.True(t, d.current.CacheStablePrompts)
+	assert.Contains(t, ansi.Strip(d.View()), "Cache-stable dynamic prompts")
+}
+
 func TestSettingsDialogApplyEmitsApplySettings(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -876,18 +876,19 @@ func (m *appModel) handleThemeFileChanged(themeRef string) (tea.Model, tea.Cmd) 
 func (m *appModel) handleOpenSettingsDialog() (tea.Model, tea.Cmd) {
 	settings := userconfig.Get()
 	preferences := messages.Preferences{
-		Layout:            m.layoutSettings,
-		SendMode:          m.sendMode,
-		SplitDiffView:     settings.GetSplitDiffView(),
-		ExpandThinking:    settings.GetExpandThinking(),
-		HideToolResults:   settings.HideToolResults,
-		YOLO:              settings.YOLO,
-		RestoreTabs:       settings.GetRestoreTabs(),
-		Snapshot:          settings.SnapshotsEnabled(),
-		Lean:              settings.Lean,
-		TabTitleMaxLength: settings.GetTabTitleMaxLength(),
-		Sound:             settings.GetSound(),
-		SoundThreshold:    settings.GetSoundThreshold(),
+		Layout:             m.layoutSettings,
+		SendMode:           m.sendMode,
+		SplitDiffView:      settings.GetSplitDiffView(),
+		ExpandThinking:     settings.GetExpandThinking(),
+		HideToolResults:    settings.HideToolResults,
+		YOLO:               settings.YOLO,
+		RestoreTabs:        settings.GetRestoreTabs(),
+		Snapshot:           settings.SnapshotsEnabled(),
+		CacheStablePrompts: settings.CacheStablePromptsEnabled(),
+		Lean:               settings.Lean,
+		TabTitleMaxLength:  settings.GetTabTitleMaxLength(),
+		Sound:              settings.GetSound(),
+		SoundThreshold:     settings.GetSoundThreshold(),
 	}
 	return m, core.CmdHandler(dialog.OpenDialogMsg{
 		Model: dialog.NewSettingsDialog(preferences, !m.hideSidebar),
@@ -968,6 +969,7 @@ func savePreferences(p messages.Preferences) error {
 		s.ExpandThinking = boolPreference(p.ExpandThinking, false)
 		s.RestoreTabs = boolPreference(p.RestoreTabs, false)
 		s.Snapshot = boolPreference(p.Snapshot, false)
+		s.CacheStablePrompts = boolPreference(p.CacheStablePrompts, false)
 		s.HideToolResults = p.HideToolResults
 		s.YOLO = p.YOLO
 		s.Lean = p.Lean
@@ -1020,7 +1022,8 @@ func saveSettingsToUserConfig(layout messages.LayoutSettings, mode messages.Send
 		Layout: layout, SendMode: mode, SplitDiffView: settings.GetSplitDiffView(),
 		ExpandThinking: settings.GetExpandThinking(), HideToolResults: settings.HideToolResults,
 		YOLO: settings.YOLO, RestoreTabs: settings.GetRestoreTabs(), Snapshot: settings.SnapshotsEnabled(),
-		Lean: settings.Lean, TabTitleMaxLength: settings.GetTabTitleMaxLength(),
+		CacheStablePrompts: settings.CacheStablePromptsEnabled(),
+		Lean:               settings.Lean, TabTitleMaxLength: settings.GetTabTitleMaxLength(),
 		Sound: settings.GetSound(), SoundThreshold: settings.GetSoundThreshold(),
 	})
 }

--- a/pkg/tui/messages/settings.go
+++ b/pkg/tui/messages/settings.go
@@ -103,18 +103,19 @@ func ParseSendMode(raw string) SendMode {
 
 // Preferences contains the persistent values managed by the settings dialog.
 type Preferences struct {
-	Layout            LayoutSettings
-	SendMode          SendMode
-	SplitDiffView     bool
-	ExpandThinking    bool
-	HideToolResults   bool
-	YOLO              bool
-	RestoreTabs       bool
-	Snapshot          bool
-	Lean              bool
-	TabTitleMaxLength int
-	Sound             bool
-	SoundThreshold    int
+	Layout             LayoutSettings
+	SendMode           SendMode
+	SplitDiffView      bool
+	ExpandThinking     bool
+	HideToolResults    bool
+	YOLO               bool
+	RestoreTabs        bool
+	Snapshot           bool
+	CacheStablePrompts bool
+	Lean               bool
+	TabTitleMaxLength  int
+	Sound              bool
+	SoundThreshold     int
 }
 
 // Settings dialog messages.

--- a/pkg/tui/settings_persistence_test.go
+++ b/pkg/tui/settings_persistence_test.go
@@ -116,17 +116,18 @@ func TestSavePreferences_RoundTripAndPreservesExtra(t *testing.T) {
 			SectionSpacing:  messages.SpacingCompact,
 			HideAgents:      true,
 		},
-		SendMode:          messages.SendModeQueue,
-		SplitDiffView:     false,
-		ExpandThinking:    true,
-		HideToolResults:   true,
-		YOLO:              true,
-		RestoreTabs:       true,
-		Snapshot:          true,
-		Lean:              true,
-		TabTitleMaxLength: 42,
-		Sound:             true,
-		SoundThreshold:    17,
+		SendMode:           messages.SendModeQueue,
+		SplitDiffView:      false,
+		ExpandThinking:     true,
+		HideToolResults:    true,
+		YOLO:               true,
+		RestoreTabs:        true,
+		Snapshot:           true,
+		CacheStablePrompts: true,
+		Lean:               true,
+		TabTitleMaxLength:  42,
+		Sound:              true,
+		SoundThreshold:     17,
 	}
 	require.NoError(t, savePreferences(preferences))
 
@@ -139,6 +140,7 @@ func TestSavePreferences_RoundTripAndPreservesExtra(t *testing.T) {
 	assert.Equal(t, preferences.YOLO, settings.YOLO)
 	assert.Equal(t, preferences.RestoreTabs, settings.GetRestoreTabs())
 	assert.Equal(t, preferences.Snapshot, settings.SnapshotsEnabled())
+	assert.Equal(t, preferences.CacheStablePrompts, settings.CacheStablePromptsEnabled())
 	assert.Equal(t, preferences.Lean, settings.Lean)
 	assert.Equal(t, preferences.TabTitleMaxLength, settings.GetTabTitleMaxLength())
 	assert.Equal(t, preferences.Sound, settings.GetSound())
@@ -150,14 +152,15 @@ func TestSavePreferences_DefaultsClearEntries(t *testing.T) {
 	setupSettingsConfigTest(t)
 
 	require.NoError(t, savePreferences(messages.Preferences{
-		Layout:            messages.LayoutSettings{SidebarPosition: messages.SidebarLeft},
-		SendMode:          messages.SendModeQueue,
-		SplitDiffView:     false,
-		ExpandThinking:    true,
-		RestoreTabs:       true,
-		Snapshot:          true,
-		TabTitleMaxLength: 40,
-		SoundThreshold:    40,
+		Layout:             messages.LayoutSettings{SidebarPosition: messages.SidebarLeft},
+		SendMode:           messages.SendModeQueue,
+		SplitDiffView:      false,
+		ExpandThinking:     true,
+		RestoreTabs:        true,
+		Snapshot:           true,
+		CacheStablePrompts: true,
+		TabTitleMaxLength:  40,
+		SoundThreshold:     40,
 	}))
 	require.NoError(t, savePreferences(messages.Preferences{
 		Layout:            messages.LayoutSettings{SidebarPosition: messages.SidebarRight, SectionSpacing: messages.SpacingNormal},
@@ -177,6 +180,7 @@ func TestSavePreferences_DefaultsClearEntries(t *testing.T) {
 	assert.Nil(t, settings.ExpandThinking)
 	assert.Nil(t, settings.RestoreTabs)
 	assert.Nil(t, settings.Snapshot)
+	assert.Nil(t, settings.CacheStablePrompts)
 	assert.Zero(t, settings.TabTitleMaxLength)
 	assert.Zero(t, settings.SoundThreshold)
 }

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -80,6 +80,9 @@ type Settings struct {
 	SoundThreshold int `yaml:"sound_threshold,omitempty"`
 	// Snapshot enables automatic shadow-git snapshots globally when true.
 	Snapshot *bool `yaml:"snapshot,omitempty"`
+	// CacheStablePrompts keeps changing trusted context out of the frozen system
+	// prefix and appends chronological updates instead. Defaults to false.
+	CacheStablePrompts *bool `yaml:"cache_stable_prompts,omitempty"`
 	// Permissions defines global permission patterns applied across all sessions
 	// and agents. These act as user-wide defaults; session-level and agent-level
 	// permissions override them.
@@ -211,6 +214,11 @@ func (s *Settings) GetRestoreTabs() bool {
 // SnapshotsEnabled returns whether global snapshot auto-injection is enabled.
 func (s *Settings) SnapshotsEnabled() bool {
 	return s != nil && s.Snapshot != nil && *s.Snapshot
+}
+
+// CacheStablePromptsEnabled reports whether chronological instruction updates are enabled.
+func (s *Settings) CacheStablePromptsEnabled() bool {
+	return s != nil && s.CacheStablePrompts != nil && *s.CacheStablePrompts
 }
 
 // GlobalHooks returns the user-level hooks config, if configured. Invalid

--- a/pkg/userconfig/userconfig_test.go
+++ b/pkg/userconfig/userconfig_test.go
@@ -979,6 +979,15 @@ func TestSettings_GetSound(t *testing.T) {
 	}
 }
 
+func TestSettings_CacheStablePromptsEnabled(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, (*Settings)(nil).CacheStablePromptsEnabled())
+	assert.False(t, (&Settings{}).CacheStablePromptsEnabled())
+	assert.True(t, (&Settings{CacheStablePrompts: new(true)}).CacheStablePromptsEnabled())
+	assert.False(t, (&Settings{CacheStablePrompts: new(false)}).CacheStablePromptsEnabled())
+}
+
 func TestSettings_SnapshotsEnabled(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Persist frozen instruction snapshots and append chronological updates when trusted context changes without invalidating the cached prompt prefix.

Track dates, individual prompt files, git status, git diffs, recent commits, and directory listings as independent sources. Advance snapshots after compaction and preserve legacy transient system prompts when disabled.

Add the cache_stable_prompts user setting and expose it in the settings dialog.

This is disabled by default, we should test it more, it adds more context when things change but it doesn't bust the cache.

Before and after, a session where I ask an agent to update AGENTS.md

<img width="698" height="500" alt="Screenshot 2026-07-15 at 16 31 10" src="https://github.com/user-attachments/assets/5a39e4f5-12fb-47ca-9968-a09c3bd441d7" />

<img width="698" height="498" alt="Screenshot 2026-07-15 at 16 32 09" src="https://github.com/user-attachments/assets/ce24a6d1-94de-4daf-befd-7ae7f3b48414" />
