### PR TITLE
fix(session): keep cost monotonic across compaction

### DIFF
--- a/pkg/acp/runagent_test.go
+++ b/pkg/acp/runagent_test.go
@@ -87,7 +87,7 @@ func (f *fakeRuntime) Run(context.Context, *session.Session) ([]session.Message,
 	return nil, nil
 }
 
-func (f *fakeRuntime) ResumeElicitation(context.Context, tools.ElicitationAction, map[string]any) error {
+func (f *fakeRuntime) ResumeElicitation(context.Context, tools.ElicitationAction, map[string]any, ...string) error {
 	return nil
 }
 func (f *fakeRuntime) SessionStore() session.Store { return nil }
@@ -127,6 +127,7 @@ func (f *fakeRuntime) AvailableModels(context.Context) []runtime.ModelChoice { r
 func (f *fakeRuntime) SupportsModelSwitching() bool                          { return false }
 func (f *fakeRuntime) OnToolsChanged(func(runtime.Event))                    {}
 func (f *fakeRuntime) OnBackgroundEvent(func(runtime.Event))                 {}
+func (f *fakeRuntime) OnElicitationRequest(func(runtime.Event))              {}
 func (f *fakeRuntime) Close() error                                          { return nil }
 
 // captureWriter is a goroutine-safe sink for the connection's outbound

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -230,8 +230,9 @@ type UpdateMessageRequest struct {
 
 // AddSummaryRequest represents a request to add a summary to a session
 type AddSummaryRequest struct {
-	Summary string `json:"summary"`
-	Tokens  int    `json:"tokens,omitempty"`
+	Summary string  `json:"summary"`
+	Tokens  int     `json:"tokens,omitempty"`
+	Cost    float64 `json:"cost,omitempty"`
 }
 
 // UpdateSessionTokensRequest represents a request to update session token counts

--- a/pkg/leantui/status_test.go
+++ b/pkg/leantui/status_test.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/leantui/ui"
 	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
 )
 
 func TestAgentInfoContextLimitShownBeforeUsage(t *testing.T) {
@@ -95,6 +97,71 @@ func TestEmptySessionUsageDoesNotOverrideSessionScopedUsage(t *testing.T) {
 
 	assert.Equal(t, int64(3_000), m.status.Tokens)
 	assert.InDelta(t, 0.10, m.status.Cost, 0.0001)
+}
+
+// leantuiCostItem returns an assistant-message item carrying the given cost.
+func leantuiCostItem(agentName string, cost float64) session.Item {
+	return session.Item{Message: &session.Message{
+		AgentName: agentName,
+		Message:   chat.Message{Role: chat.MessageRoleAssistant, Content: "done", Cost: cost},
+	}}
+}
+
+// TestRestoredSessionCostDoesNotDecreaseAfterCompaction is a regression test
+// for the footer total dropping after a session restore: the startup usage
+// event carries the restored total (own + embedded sub-session costs), and
+// the next root event — compaction emits one right away — used to replace it
+// with an own-cost-only snapshot, shrinking the total.
+func TestRestoredSessionCostDoesNotDecreaseAfterCompaction(t *testing.T) {
+	t.Parallel()
+	m := bareModel(24)
+
+	// Restored session: $0.10 direct + $0.05 embedded sub-session.
+	sess := session.New()
+	sess.InputTokens = 800
+	sess.OutputTokens = 200
+	sess.Messages = append(sess.Messages, leantuiCostItem("root", 0.10))
+	sub := session.New(session.WithParentID(sess.ID))
+	sub.Messages = append(sub.Messages, leantuiCostItem("developer", 0.05))
+	sess.Messages = append(sess.Messages, session.Item{SubSession: sub})
+
+	// Session restore: EmitStartupInfo emits the restored session's usage.
+	m.handleEvent(t.Context(), runtime.NewTokenUsageEvent(sess.ID, "root", runtime.SessionUsage(sess, 10_000)))
+	assert.InDelta(t, 0.15, m.status.Cost, 0.0001)
+
+	// Compaction appends a $0.01 summary and immediately emits the session's
+	// usage (see compactWithReason).
+	sess.ApplyCompaction(100, 0, session.Item{Summary: "summary", Cost: 0.01})
+	m.handleEvent(t.Context(), runtime.NewTokenUsageEvent(sess.ID, "root", runtime.SessionUsage(sess, 10_000)))
+	assert.InDelta(t, 0.16, m.status.Cost, 0.0001,
+		"the total must keep the embedded sub-session cost and gain the summary cost")
+}
+
+// TestLiveSubSessionCostNotDoubleCounted drives the live delegation flow
+// through the runtime's own usage snapshots: the child reports its own cost
+// while it runs, and once it completes and attaches to the root the root's
+// next event must not fold the child in again.
+func TestLiveSubSessionCostNotDoubleCounted(t *testing.T) {
+	t.Parallel()
+	m := bareModel(24)
+
+	root := session.New()
+	root.Messages = append(root.Messages, leantuiCostItem("root", 0.10))
+	m.handleEvent(t.Context(), runtime.StreamStarted(root.ID, "root"))
+	m.handleEvent(t.Context(), runtime.NewTokenUsageEvent(root.ID, "root", runtime.SessionUsage(root, 10_000)))
+
+	child := session.New(session.WithParentID(root.ID))
+	child.Messages = append(child.Messages, leantuiCostItem("developer", 0.05))
+	m.handleEvent(t.Context(), runtime.StreamStarted(child.ID, "developer"))
+	m.handleEvent(t.Context(), runtime.NewTokenUsageEvent(child.ID, "developer", runtime.SessionUsage(child, 10_000)))
+	assert.InDelta(t, 0.15, m.status.Cost, 0.0001)
+
+	// Child completes: its stream stops and it is attached to the root.
+	m.handleEvent(t.Context(), runtime.StreamStopped(child.ID, "developer", "normal"))
+	root.AddLiveSubSession(child)
+
+	m.handleEvent(t.Context(), runtime.NewTokenUsageEvent(root.ID, "root", runtime.SessionUsage(root, 10_000)))
+	assert.InDelta(t, 0.15, m.status.Cost, 0.0001, "root own + child own, not double-counted")
 }
 
 // TestSessionCompactionDrivesGaugeState verifies the status line adopts the

--- a/pkg/runtime/agent_delegation.go
+++ b/pkg/runtime/agent_delegation.go
@@ -314,7 +314,7 @@ func (r *LocalRuntime) runForwarding(ctx context.Context, parent *session.Sessio
 	// transcript is the most valuable artifact for debugging. The persistence
 	// pipeline relies on SubSessionCompleted to write the sub-session's
 	// messages to the store; without this emission they are silently dropped.
-	parent.AddSubSession(s)
+	parent.AddLiveSubSession(s)
 	evts.Emit(SubSessionCompleted(parent.ID, s, callerAgent.Name()))
 
 	if subSessionErr != nil {
@@ -388,10 +388,31 @@ func (r *LocalRuntime) runCollecting(ctx context.Context, parent *session.Sessio
 	for range events {
 	}
 
+	// The loop above stops forwarding on ctx cancellation / first ErrorEvent,
+	// so the drain can discard TokenUsageEvents carrying the child's latest
+	// recorded usage. Emit one authoritative final snapshot before the child
+	// is attached: AddLiveSubSession marks it live-attached, so the parent's
+	// own events will never fold this cost back in. UI snapshots replace by
+	// session ID, which makes the duplicate on the clean path harmless.
+	// A child that failed before recording any usage or cost gets no
+	// snapshot at all: a zero-usage event would only add an empty
+	// sub-session row to the UI and clobber per-agent context accounting.
+	// Check that before resolving the context limit — the model lookup is
+	// pure overhead for a snapshot that is never emitted.
+	finalUsage := SessionUsage(s, 0, child.CompactionThreshold())
+	usageCtx := context.WithoutCancel(ctx)
+	if finalUsage.ContextLength > 0 || finalUsage.Cost > 0 {
+		// usageCtx: the context-limit lookup must still resolve for a
+		// cancelled task.
+		finalUsage.ContextLimit = r.contextLimitForAgentModel(usageCtx, child, r.getEffectiveModelID(usageCtx, child))
+		r.emitBackgroundEvent(NewTokenUsageEvent(s.ID, cfg.AgentName, finalUsage))
+	}
+
 	// Persist the sub-session unconditionally — the partial transcript is
 	// the most valuable artifact for debugging a failed background agent.
-	// AddSubSession records it in-memory on both the success and error paths.
-	parent.AddSubSession(s)
+	// AddLiveSubSession records it in-memory on both the success and error
+	// paths.
+	parent.AddLiveSubSession(s)
 
 	// Mirror runForwarding's persistence, but write to the store directly
 	// instead of emitting SubSessionCompleted: runCollecting runs on a
@@ -399,9 +420,10 @@ func (r *LocalRuntime) runCollecting(ctx context.Context, parent *session.Sessio
 	// chain would race the parent's live RunStream (the PersistenceObserver
 	// keeps unsynchronised streaming state). Without this the background
 	// sub-session never reaches the store — its tokens and cost are recorded
-	// as $0 and escape any spend accounting that reads the store. Use
-	// WithoutCancel so a cancelled/stopped task still persists its transcript.
-	r.persistBackgroundSubSession(context.WithoutCancel(ctx), parent.ID, s)
+	// as $0 and escape any spend accounting that reads the store. usageCtx is
+	// already detached, so a cancelled/stopped task still persists its
+	// transcript.
+	r.persistBackgroundSubSession(usageCtx, parent.ID, s)
 
 	if errMsg != "" {
 		return &agenttool.RunResult{ErrMsg: errMsg}

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -687,9 +687,9 @@ func (c *Client) UpdateMessage(ctx context.Context, sessionID, msgID string, msg
 }
 
 // AddSummary adds a summary to a session.
-func (c *Client) AddSummary(ctx context.Context, sessionID, summary string, tokens int) error {
+func (c *Client) AddSummary(ctx context.Context, sessionID, summary string, tokens int, cost float64) error {
 	endpoint := fmt.Sprintf("/api/sessions/%s/summaries", sessionID)
-	req := api.AddSummaryRequest{Summary: summary, Tokens: tokens}
+	req := api.AddSummaryRequest{Summary: summary, Tokens: tokens, Cost: cost}
 	return c.doRequest(ctx, http.MethodPost, endpoint, req, nil)
 }
 

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -400,16 +400,22 @@ func NewTokenUsageEvent(sessionID, agentName string, usage *Usage) Event {
 func (e *TokenUsageEvent) GetSessionID() string { return e.SessionID }
 
 // SessionUsage builds a Usage from the session's current token counts, the
-// model's context limit, and the session's own cost. The optional
-// compactionThreshold is the agent's configured auto-compaction trigger
-// fraction (0 or omitted when unknown), passed along verbatim for UI gauges.
+// model's context limit, and the session's cost. The reported cost is the
+// session's own cost plus the cost of sub-sessions embedded at load time
+// (restored or branched history), which never emit events of their own.
+// Sub-sessions attached during a live run are excluded: they report their
+// own cost through separate per-session events, and folding them in here
+// would double count in UIs that aggregate per-session entries. The
+// optional compactionThreshold is the agent's configured auto-compaction
+// trigger fraction (0 or omitted when unknown), passed along verbatim for
+// UI gauges.
 func SessionUsage(sess *session.Session, contextLimit int64, compactionThreshold ...float64) *Usage {
 	u := &Usage{
 		InputTokens:   sess.InputTokens,
 		OutputTokens:  sess.OutputTokens,
 		ContextLength: sess.InputTokens + sess.OutputTokens,
 		ContextLimit:  contextLimit,
-		Cost:          sess.OwnCost(),
+		Cost:          sess.OwnCost() + sess.EmbeddedSubSessionCost(),
 	}
 	if len(compactionThreshold) > 0 {
 		u.CompactionThreshold = compactionThreshold[0]
@@ -461,18 +467,23 @@ func (e *SessionPlanUpdatedEvent) GetSessionID() string { return e.SessionID }
 type SessionSummaryEvent struct {
 	AgentContext
 
-	Type           string `json:"type"`
-	SessionID      string `json:"session_id"`
-	Summary        string `json:"summary"`
-	FirstKeptEntry int    `json:"first_kept_entry,omitempty"`
+	Type           string  `json:"type"`
+	SessionID      string  `json:"session_id"`
+	Summary        string  `json:"summary"`
+	FirstKeptEntry int     `json:"first_kept_entry,omitempty"`
+	Cost           float64 `json:"cost,omitempty"`
 }
 
-func SessionSummary(sessionID, summary, agentName string, firstKeptEntry int) Event {
+// SessionSummary builds the event announcing an applied compaction summary.
+// cost is the dollar cost of producing the summary; 0 when nothing was
+// billed (hook-supplied summaries, status-only remote notifications).
+func SessionSummary(sessionID, summary, agentName string, firstKeptEntry int, cost float64) Event {
 	return &SessionSummaryEvent{
 		Type:           "session_summary",
 		SessionID:      sessionID,
 		Summary:        summary,
 		FirstKeptEntry: firstKeptEntry,
+		Cost:           cost,
 		AgentContext:   newAgentContext(agentName),
 	}
 }

--- a/pkg/runtime/event_test.go
+++ b/pkg/runtime/event_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/session"
 )
 
@@ -22,4 +23,52 @@ func TestSessionUsageCarriesCompactionThreshold(t *testing.T) {
 	assert.InDelta(t, 0.75, u.CompactionThreshold, 0.0001)
 	assert.Equal(t, int64(100_000), u.ContextLimit)
 	assert.Equal(t, int64(1_000), u.ContextLength)
+}
+
+// costItem returns an assistant-message item carrying the given cost.
+func costItem(agentName string, cost float64) session.Item {
+	return session.Item{Message: &session.Message{
+		AgentName: agentName,
+		Message:   chat.Message{Role: chat.MessageRoleAssistant, Content: "done", Cost: cost},
+	}}
+}
+
+// TestSessionUsageCostIncludesEmbeddedSubSessions reproduces the restored
+// session shape: the root's direct cost plus an embedded sub-session that
+// will never emit its own events. The emitted cost must include both, and a
+// post-compaction emission (see compactWithReason) must increase it by the
+// summary cost instead of dropping back to the root's own cost.
+func TestSessionUsageCostIncludesEmbeddedSubSessions(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sess.Messages = append(sess.Messages, costItem("root", 0.10))
+	sub := session.New(session.WithParentID(sess.ID))
+	sub.Messages = append(sub.Messages, costItem("developer", 0.05))
+	sess.Messages = append(sess.Messages, session.Item{SubSession: sub})
+
+	u := SessionUsage(sess, 100_000)
+	assert.InDelta(t, 0.15, u.Cost, 1e-9, "restored total = own + embedded sub-session cost")
+
+	sess.ApplyCompaction(100, 0, session.Item{Summary: "summary", Cost: 0.01})
+	u = SessionUsage(sess, 100_000)
+	assert.InDelta(t, 0.16, u.Cost, 1e-9, "compaction increases the emitted total")
+}
+
+// TestSessionUsageCostExcludesLiveSubSessions pins the live aggregation
+// contract: a sub-session that ran during this process reported its own cost
+// through its own events, so attaching it to the parent must not inflate the
+// parent's emitted cost.
+func TestSessionUsageCostExcludesLiveSubSessions(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sess.Messages = append(sess.Messages, costItem("root", 0.10))
+
+	child := session.New(session.WithParentID(sess.ID))
+	child.Messages = append(child.Messages, costItem("developer", 0.05))
+	assert.InDelta(t, 0.05, SessionUsage(child, 100_000).Cost, 1e-9, "the child emits its own cost")
+
+	sess.AddLiveSubSession(child)
+	assert.InDelta(t, 0.10, SessionUsage(sess, 100_000).Cost, 1e-9, "the parent keeps emitting only its own cost")
 }

--- a/pkg/runtime/persistence_observer.go
+++ b/pkg/runtime/persistence_observer.go
@@ -119,7 +119,7 @@ func (p *PersistenceObserver) OnEvent(ctx context.Context, sess *session.Session
 		}
 
 	case *SessionSummaryEvent:
-		if err := p.store.AddSummary(ctx, e.SessionID, e.Summary, e.FirstKeptEntry); err != nil {
+		if err := p.store.AddSummary(ctx, e.SessionID, e.Summary, e.FirstKeptEntry, e.Cost); err != nil {
 			slog.WarnContext(ctx, "Failed to persist summary", "session_id", e.SessionID, "error", err)
 		}
 

--- a/pkg/runtime/persistence_observer_summary_test.go
+++ b/pkg/runtime/persistence_observer_summary_test.go
@@ -1,0 +1,34 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+// TestPersistenceObserver_PersistsSummaryCost verifies the cost carried by a
+// SessionSummaryEvent reaches the persisted summary item. Without it, a
+// reloaded session under-reports TotalCost by everything compaction billed.
+func TestPersistenceObserver_PersistsSummaryCost(t *testing.T) {
+	t.Parallel()
+
+	store := session.NewInMemorySessionStore()
+	obs := newPersistenceObserver(store)
+	require.NotNil(t, obs)
+
+	sess := session.New(session.WithID("s1"), session.WithUserMessage("hi"))
+	require.NoError(t, store.AddSession(t.Context(), sess))
+
+	obs.OnEvent(t.Context(), sess, SessionSummary(sess.ID, "the summary", "root", 1, 0.002))
+
+	reloaded, err := store.GetSession(t.Context(), sess.ID)
+	require.NoError(t, err)
+
+	last := reloaded.Messages[len(reloaded.Messages)-1]
+	require.Equal(t, "the summary", last.Summary)
+	assert.Equal(t, 1, last.FirstKeptEntry)
+	assert.InDelta(t, 0.002, last.Cost, 1e-9, "the event's cost must land on the summary item")
+}

--- a/pkg/runtime/remote_client.go
+++ b/pkg/runtime/remote_client.go
@@ -97,7 +97,7 @@ type RemoteClient interface {
 	UpdateMessage(ctx context.Context, sessionID, msgID string, msg *session.Message) error
 
 	// AddSummary adds a summary to a session
-	AddSummary(ctx context.Context, sessionID, summary string, tokens int) error
+	AddSummary(ctx context.Context, sessionID, summary string, tokens int, cost float64) error
 
 	// UpdateSessionTokens updates token counts for a session
 	UpdateSessionTokens(ctx context.Context, sessionID string, inputTokens, outputTokens int64, cost float64) error

--- a/pkg/runtime/remote_contract_test.go
+++ b/pkg/runtime/remote_contract_test.go
@@ -137,7 +137,7 @@ func (s *stubRemoteClient) UpdateMessage(context.Context, string, string, *sessi
 	return nil
 }
 
-func (s *stubRemoteClient) AddSummary(context.Context, string, string, int) error {
+func (s *stubRemoteClient) AddSummary(context.Context, string, string, int, float64) error {
 	return nil
 }
 

--- a/pkg/runtime/remote_runtime.go
+++ b/pkg/runtime/remote_runtime.go
@@ -366,15 +366,15 @@ func (r *RemoteRuntime) Resume(ctx context.Context, req ResumeRequest) {
 // Summarize generates a summary for the session by compacting it server-side.
 func (r *RemoteRuntime) Summarize(ctx context.Context, sess *session.Session, _ string, sink EventSink) {
 	if r.sessionID == "" {
-		sink.Emit(SessionSummary(sess.ID, "No active session to summarize", r.currentAgent, 0))
+		sink.Emit(SessionSummary(sess.ID, "No active session to summarize", r.currentAgent, 0, 0))
 		return
 	}
 	if err := r.client.CompactSession(ctx, r.sessionID); err != nil {
 		slog.WarnContext(ctx, "Failed to compact session", "error", err)
-		sink.Emit(SessionSummary(sess.ID, fmt.Sprintf("Compaction failed: %v", err), r.currentAgent, 0))
+		sink.Emit(SessionSummary(sess.ID, fmt.Sprintf("Compaction failed: %v", err), r.currentAgent, 0, 0))
 		return
 	}
-	sink.Emit(SessionSummary(sess.ID, "Session compacted successfully", r.currentAgent, 0))
+	sink.Emit(SessionSummary(sess.ID, "Session compacted successfully", r.currentAgent, 0, 0))
 }
 
 func (r *RemoteRuntime) convertSessionMessages(sess *session.Session) []api.Message {
@@ -752,11 +752,11 @@ func (r *RemoteRuntime) UpdateSessionMessage(ctx context.Context, msgID string, 
 }
 
 // AddSessionSummary adds a summary to the current session on the remote server.
-func (r *RemoteRuntime) AddSessionSummary(ctx context.Context, summary string, tokens int) error {
+func (r *RemoteRuntime) AddSessionSummary(ctx context.Context, summary string, tokens int, cost float64) error {
 	if r.sessionID == "" {
 		return errors.New("no active session")
 	}
-	return r.client.AddSummary(ctx, r.sessionID, summary, tokens)
+	return r.client.AddSummary(ctx, r.sessionID, summary, tokens, cost)
 }
 
 // UpdateSessionTokens updates token counts for the current session on the remote server.
@@ -836,7 +836,7 @@ func (s *RemoteSessionStore) AddSubSession(context.Context, string, *session.Ses
 	return fmt.Errorf("add sub session: %w", ErrUnsupported)
 }
 
-func (s *RemoteSessionStore) AddSummary(context.Context, string, string, int) error {
+func (s *RemoteSessionStore) AddSummary(context.Context, string, string, int, float64) error {
 	return fmt.Errorf("add summary: %w", ErrUnsupported)
 }
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1566,13 +1566,12 @@ func (r *LocalRuntime) EmitStartupInfo(ctx context.Context, sess *session.Sessio
 	// The context limit comes from the model definition (models.dev), which
 	// is a model property — not persisted in the session.
 	//
-	// Use TotalCost (not OwnCost) because this is a restore/branch context:
-	// sub-sessions won't emit their own events, so the parent must include
-	// their costs.
+	// SessionUsage folds embedded sub-session costs into the parent's cost,
+	// which is what a restore/branch context needs: those sub-sessions
+	// won't emit their own events.
 	if sess != nil && (sess.InputTokens > 0 || sess.OutputTokens > 0) {
 		contextLimit := r.contextLimitForAgentModel(ctx, a, modelID)
 		usage := SessionUsage(sess, contextLimit, a.CompactionThreshold())
-		usage.Cost = sess.TotalCost()
 
 		// Reconstruct LastMessage from the parent session's last assistant
 		// message so that FinishReason (and other per-message fields) are

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -4272,11 +4272,75 @@ func TestRunAgentPersistsSubSessionOnError(t *testing.T) {
 		"parent session must record the sub-session even when the background agent errored")
 }
 
+// TestRunAgentImmediateFailureEmitsNoZeroUsageEvent guards runCollecting's
+// final authoritative snapshot: a background child that fails before
+// recording any usage or cost (here the provider errors on stream creation)
+// must not surface a zero-usage TokenUsageEvent — it would add an empty
+// sub-session row to the UI and clobber per-agent context accounting. The
+// guard keys off the child's recorded usage alone and skips the event — and
+// the context-limit lookup — before any model resolution; the model store
+// still resolves a real limit so a wrongly emitted event would carry one.
+func TestRunAgentImmediateFailureEmitsNoZeroUsageEvent(t *testing.T) {
+	t.Parallel()
+
+	parentProv := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	failingProv := &mockProviderWithError{id: "test/mock-model"}
+
+	worker := agent.New("worker", "Worker agent", agent.WithModel(failingProv))
+	root := agent.New("root", "Root agent", agent.WithModel(parentProv))
+	agent.WithSubAgents(worker)(root)
+
+	rt, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root, worker)),
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStoreWithCostAndLimit{limit: 100_000, cost: modelsdev.Cost{Input: 10, Output: 20}}))
+	require.NoError(t, err)
+
+	var forwarded []Event
+	rt.OnBackgroundEvent(func(event Event) { forwarded = append(forwarded, event) })
+
+	sess := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))
+	result := rt.RunAgent(t.Context(), agenttool.RunParams{
+		AgentName:     "worker",
+		Task:          "do something",
+		ParentSession: sess,
+	})
+	require.NotEmpty(t, result.ErrMsg, "RunAgent should surface the sub-session error")
+
+	assert.Empty(t, forwarded,
+		"a child that failed before any billed work must not emit a zero-usage snapshot")
+}
+
+// mockModelStoreWithCostAndLimit prices tokens so usage snapshots carry a
+// nonzero cost, in addition to a resolvable context limit.
+type mockModelStoreWithCostAndLimit struct {
+	ModelStore
+
+	limit int
+	cost  modelsdev.Cost
+}
+
+func (m mockModelStoreWithCostAndLimit) GetModel(_ context.Context, _ modelsdev.ID) (*modelsdev.Model, error) {
+	return &modelsdev.Model{Limit: modelsdev.Limit{Context: m.limit}, Cost: &m.cost}, nil
+}
+
+// lastAttachedSubSession returns the most recent sub-session recorded on sess.
+func lastAttachedSubSession(sess *session.Session) *session.Session {
+	var sub *session.Session
+	for _, item := range sess.Messages {
+		if item.SubSession != nil {
+			sub = item.SubSession
+		}
+	}
+	return sub
+}
+
 // TestRunAgentForwardsTokenUsageOutOfBand verifies runCollecting surfaces the
 // background sub-session's TokenUsageEvents through OnBackgroundEvent — the
 // out-of-band path that lets the TUI keep per-agent context accounting for
 // background agents — tagged with the sub-session id and the worker's name,
-// and forwards nothing else.
+// and forwards nothing else. The last event is the authoritative final
+// snapshot runCollecting emits before attaching the child, and must match
+// the child's final recorded state.
 func TestRunAgentForwardsTokenUsageOutOfBand(t *testing.T) {
 	t.Parallel()
 
@@ -4289,7 +4353,8 @@ func TestRunAgentForwardsTokenUsageOutOfBand(t *testing.T) {
 	agent.WithSubAgents(worker)(root)
 
 	tm := team.New(team.WithAgents(root, worker))
-	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false), WithModelStore(mockModelStore{}))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithSessionCompaction(false),
+		WithModelStore(mockModelStoreWithCostAndLimit{limit: 100_000, cost: modelsdev.Cost{Input: 10, Output: 20}}))
 	require.NoError(t, err)
 
 	var forwarded []Event
@@ -4311,9 +4376,109 @@ func TestRunAgentForwardsTokenUsageOutOfBand(t *testing.T) {
 		assert.NotEqual(t, sess.ID, usage.SessionID, "usage carries the sub-session id, not the parent's")
 		assert.NotEmpty(t, usage.SessionID)
 	}
+
+	// Once attached, the child is live-attached and the parent's own events
+	// exclude its cost, so the last out-of-band snapshot must already carry
+	// the child's final accounting: cumulative tokens, cost (100×$10 +
+	// 50×$20 per 1M tokens), and the resolved context limit.
+	sub := lastAttachedSubSession(sess)
+	require.NotNil(t, sub)
 	last := forwarded[len(forwarded)-1].(*TokenUsageEvent)
 	require.NotNil(t, last.Usage)
+	assert.Equal(t, sub.ID, last.SessionID)
 	assert.Equal(t, int64(150), last.Usage.ContextLength, "final snapshot carries the worker's cumulative usage")
+	assert.InDelta(t, 0.002, last.Usage.Cost, 1e-9, "final snapshot carries the worker's final cost")
+	assert.InDelta(t, sub.OwnCost()+sub.EmbeddedSubSessionCost(), last.Usage.Cost, 1e-9,
+		"the snapshot's cost is exactly what the attached child reports for itself")
+	assert.Equal(t, int64(100_000), last.Usage.ContextLimit, "final snapshot resolves the worker's context limit")
+}
+
+// TestRunAgentEmitsFinalUsageOnCancellation is the regression test for the
+// background cancellation accounting gap: when the task's context is
+// cancelled, runCollecting's forwarding loop breaks and blindly drains the
+// remaining events — including the TokenUsageEvent carrying the child's
+// recorded usage. Because the child is then attached live to the parent
+// (excluded from the parent's own snapshots), nothing would ever surface its
+// cost. runCollecting must emit one final authoritative snapshot before
+// attaching the child.
+func TestRunAgentEmitsFinalUsageOnCancellation(t *testing.T) {
+	t.Parallel()
+
+	// The worker streams content, then calls a tool that cancels the task
+	// context — strictly after the turn's usage was recorded and its
+	// TokenUsageEvent buffered. onContent (below) blocks until the
+	// cancellation is visible, so the forwarding loop deterministically
+	// breaks before reaching that TokenUsageEvent.
+	ctx, cancel := context.WithCancel(t.Context())
+	contentSeen := make(chan struct{})
+	cancelled := make(chan struct{})
+
+	workerTools := []tools.Tool{{
+		Name:       "cancel_task",
+		Parameters: map[string]any{},
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
+			<-contentSeen
+			cancel()
+			close(cancelled)
+			return tools.ResultSuccess("cancelling"), nil
+		},
+	}}
+	workerStream := newStreamBuilder().
+		AddContent("partial").
+		AddToolCallName("call-1", "cancel_task").
+		AddToolCallArguments("call-1", "{}").
+		AddToolCallStopWithUsage(100, 50).
+		Build()
+
+	worker := agent.New("worker", "Worker agent",
+		agent.WithModel(&mockProvider{id: "test/mock-model", stream: workerStream}),
+		agent.WithToolSets(newStubToolSet(nil, workerTools, nil)),
+	)
+	root := agent.New("root", "Root agent", agent.WithModel(&mockProvider{id: "test/mock-model", stream: &mockStream{}}))
+	agent.WithSubAgents(worker)(root)
+
+	rt, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root, worker)),
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStoreWithCostAndLimit{limit: 100_000, cost: modelsdev.Cost{Input: 10, Output: 20}}))
+	require.NoError(t, err)
+
+	var forwarded []*TokenUsageEvent
+	rt.OnBackgroundEvent(func(event Event) {
+		if usage, ok := event.(*TokenUsageEvent); ok {
+			forwarded = append(forwarded, usage)
+		}
+	})
+
+	sess := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))
+	var once sync.Once
+	rt.RunAgent(ctx, agenttool.RunParams{
+		AgentName:     "worker",
+		Task:          "do something",
+		ParentSession: sess,
+		OnContent: func(string) {
+			once.Do(func() {
+				close(contentSeen)
+				<-cancelled
+			})
+		},
+	})
+
+	// The cancelled child still attached with the turn it completed.
+	sub := lastAttachedSubSession(sess)
+	require.NotNil(t, sub, "the cancelled child must still be attached to the parent")
+	require.Equal(t, int64(150), sub.InputTokens+sub.OutputTokens, "the child recorded the turn before cancellation")
+
+	require.NotEmpty(t, forwarded,
+		"a final authoritative snapshot must be emitted even though the loop broke on cancellation")
+	last := forwarded[len(forwarded)-1]
+	require.NotNil(t, last.Usage)
+	assert.Equal(t, sub.ID, last.SessionID)
+	assert.Equal(t, "worker", last.AgentName)
+	assert.Equal(t, int64(150), last.Usage.ContextLength, "final snapshot carries the usage recorded before cancellation")
+	assert.InDelta(t, sub.OwnCost()+sub.EmbeddedSubSessionCost(), last.Usage.Cost, 1e-9,
+		"the snapshot's cost is exactly what the attached child reports for itself")
+	assert.Positive(t, last.Usage.Cost, "cost is mandatory on the final snapshot")
+	assert.Equal(t, int64(100_000), last.Usage.ContextLimit, "context limit resolves even after cancellation")
 }
 
 // TestReasoningOnlyTurnEmitsWarning is a regression test for

--- a/pkg/runtime/session_compaction.go
+++ b/pkg/runtime/session_compaction.go
@@ -138,7 +138,7 @@ func (r *LocalRuntime) doCompact(ctx context.Context, sess *session.Session, a *
 	_ = r.sessionStore.UpdateSession(ctx, sess)
 
 	slog.DebugContext(ctx, "Generated session summary", "session_id", sess.ID, "summary_length", len(result.Summary))
-	events.Emit(SessionSummary(sess.ID, result.Summary, a.Name(), result.FirstKeptEntry))
+	events.Emit(SessionSummary(sess.ID, result.Summary, a.Name(), result.FirstKeptEntry, result.Cost))
 
 	// after_compaction: observational. Fired only when a summary was
 	// actually applied to the session. The hook receives the
@@ -276,9 +276,14 @@ func providerContextLimit(p provider.Provider) int64 {
 // runCompactionAgent runs an agent against a sub-session for compaction.
 // It is the runtime-side glue [pkg/runtime/compactor] invokes via callback,
 // which avoids creating an import cycle on [pkg/runtime].
+//
+// The sub-runtime inherits the parent's model store so the summary call is
+// priced from the same catalogue as every other call — otherwise the
+// compaction cost recorded on the summary item would silently be 0 whenever
+// the default lazy store cannot price the model the configured store can.
 func (r *LocalRuntime) runCompactionAgent(ctx context.Context, a *agent.Agent, sess *session.Session) error {
 	t := team.New(team.WithAgents(a))
-	rt, err := New(ctx, t, WithSessionCompaction(false))
+	rt, err := New(ctx, t, WithSessionCompaction(false), WithModelStore(r.modelsStore))
 	if err != nil {
 		return err
 	}

--- a/pkg/runtime/session_compaction_test.go
+++ b/pkg/runtime/session_compaction_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/modelsdev"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/team"
 )
@@ -222,6 +223,8 @@ func TestDoCompactBeforeHookSuppliesSummary(t *testing.T) {
 		"the session must record the hook-supplied summary as its last item")
 	assert.InDelta(t, 0.0, last.Cost, 0.0001,
 		"hook-supplied summaries cost nothing — no LLM was called")
+	assert.InDelta(t, 0.0, summaryEvent.Cost, 0.0001,
+		"the summary event carries the same zero cost")
 }
 
 // TestDoCompactAfterHookFires verifies that after_compaction fires
@@ -336,4 +339,49 @@ func TestDoCompactNoHooksMatchesPriorBehavior(t *testing.T) {
 	assert.Equal(t, 1, doneCount, "expected exactly one completed event")
 	require.NotNil(t, summaryEvent, "expected a SessionSummary event from the LLM path")
 	assert.Equal(t, "summary", summaryEvent.Summary)
+}
+
+// TestDoCompactSummaryEventCarriesCost pins the cost plumbing of the LLM
+// compaction path: the summarization stream's billed cost
+// (compactor.Result.Cost) must land on the applied summary item and on the
+// emitted SessionSummaryEvent — the value the persistence observer stores.
+// The compaction sub-runtime inherits the parent's model store, which is
+// what prices the summary call here.
+func TestDoCompactSummaryEventCarriesCost(t *testing.T) {
+	t.Parallel()
+
+	summaryStream := newStreamBuilder().AddContent("the summary").AddStopWithUsage(100, 50).Build()
+	prov := &queueProvider{id: "test/mock-model", streams: []chat.MessageStream{summaryStream}}
+	root := agent.New("root", "test", agent.WithModel(prov))
+
+	rt, err := NewLocalRuntime(t.Context(), team.New(team.WithAgents(root)),
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStoreWithCostAndLimit{limit: 100_000, cost: modelsdev.Cost{Input: 10, Output: 20}}),
+	)
+	require.NoError(t, err)
+
+	sess := session.New(session.WithMessages([]session.Item{
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "hi"}}),
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "hello"}}),
+	}))
+
+	events := make(chan Event, 32)
+	rt.compactWithReason(t.Context(), sess, "", compactionReasonManual, NewChannelSink(events))
+	close(events)
+
+	var summaryEvent *SessionSummaryEvent
+	for ev := range events {
+		if e, ok := ev.(*SessionSummaryEvent); ok {
+			summaryEvent = e
+		}
+	}
+	require.NotNil(t, summaryEvent, "expected a SessionSummary event from the LLM path")
+
+	// The summary stream billed 100 input × $10/M + 50 output × $20/M = $0.002.
+	last := sess.Messages[len(sess.Messages)-1]
+	require.Equal(t, "the summary", last.Summary)
+	assert.InDelta(t, 0.002, last.Cost, 1e-9,
+		"the summary item records the summarization stream's cost")
+	assert.InDelta(t, last.Cost, summaryEvent.Cost, 1e-9,
+		"the emitted event must carry the same cost that was applied to the session")
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -781,7 +781,7 @@ func (s *Server) addSummary(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "summary is required")
 	}
 
-	if err := s.sm.AddSummary(c.Request().Context(), sessionID, req.Summary, req.Tokens); err != nil {
+	if err := s.sm.AddSummary(c.Request().Context(), sessionID, req.Summary, req.Tokens, req.Cost); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to add summary: %v", err))
 	}
 

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -1345,11 +1345,11 @@ func (sm *SessionManager) UpdateMessage(ctx context.Context, sessionID, msgID st
 }
 
 // AddSummary adds a summary to a session.
-func (sm *SessionManager) AddSummary(ctx context.Context, sessionID, summary string, tokens int) error {
+func (sm *SessionManager) AddSummary(ctx context.Context, sessionID, summary string, tokens int, cost float64) error {
 	sm.mux.Lock()
 	defer sm.mux.Unlock()
 
-	return sm.sessionStore.AddSummary(ctx, sessionID, summary, tokens)
+	return sm.sessionStore.AddSummary(ctx, sessionID, summary, tokens, cost)
 }
 
 // UpdateSessionTokens updates the token counts for a session.

--- a/pkg/session/branch_test.go
+++ b/pkg/session/branch_test.go
@@ -459,3 +459,45 @@ func TestForkSession(t *testing.T) {
 		assert.Equal(t, 4000, forked.MaxToolResultTokens)
 	})
 }
+
+// TestBranchSession_LiveSubSessionBecomesEmbedded pins sub-session cost
+// provenance across a branch/fork. On the parent, a child attached live via
+// AddLiveSubSession is excluded from EmbeddedSubSessionCost because it
+// reported its own cost through its own TokenUsageEvents. A branched/forked
+// session is newly minted: its sub-session items are embedded history that
+// will never emit events, so the same child's cost must fold into the new
+// session's own usage reporting (own + embedded, the accounting SessionUsage
+// emits).
+func TestBranchSession_LiveSubSessionBecomesEmbedded(t *testing.T) {
+	t.Parallel()
+
+	parent := New()
+	parent.AddMessage(UserMessage("hi"))
+	child := New(WithParentID(parent.ID))
+	child.AddMessage(&Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "done", Cost: 0.05}})
+	parent.AddLiveSubSession(child)
+	require.Zero(t, parent.EmbeddedSubSessionCost(), "the live-attached child is excluded on the parent")
+
+	tests := []struct {
+		name string
+		mint func(*Session, int) (*Session, error)
+	}{
+		{name: "branch", mint: BranchSession},
+		{name: "fork", mint: ForkSession},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			minted, err := tt.mint(parent, 2)
+			require.NoError(t, err)
+			require.Len(t, minted.Messages, 2)
+			require.True(t, minted.Messages[1].IsSubSession())
+
+			assert.InDelta(t, 0.05, minted.EmbeddedSubSessionCost(), 1e-9,
+				"the minted session embeds the child, so its cost is included")
+			assert.InDelta(t, 0.05, minted.OwnCost()+minted.EmbeddedSubSessionCost(), 1e-9,
+				"own + embedded — what SessionUsage emits — must carry the child's cost")
+		})
+	}
+}

--- a/pkg/session/clone_test.go
+++ b/pkg/session/clone_test.go
@@ -189,10 +189,11 @@ func TestClone_PreservesSubSessionAndSummary(t *testing.T) {
 	t.Parallel()
 	sub := New()
 	sub.AddMessage(UserMessage("sub message"))
+	sub.AddMessage(&Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "done", Cost: 0.05}})
 
 	orig := New()
 	orig.AddMessage(UserMessage("first"))
-	orig.AddSubSession(sub)
+	orig.AddLiveSubSession(sub)
 	orig.Messages = append(orig.Messages, Item{Summary: "a summary", Cost: 0.25})
 
 	clone := orig.Clone()
@@ -204,6 +205,15 @@ func TestClone_PreservesSubSessionAndSummary(t *testing.T) {
 	assert.Equal(t, "sub message", clone.Messages[1].SubSession.GetLastUserMessageContent())
 	assert.Equal(t, "a summary", clone.Messages[2].Summary)
 	assert.InEpsilon(t, 0.25, clone.Messages[2].Cost, 1e-9)
+
+	// Clone preserves identity, including the live-attached provenance of an
+	// AddLiveSubSession child: the child reported its own cost through its own
+	// TokenUsageEvents, so the clone must keep excluding it from the embedded
+	// roll-up — same ID, same live identity, same accounting.
+	assert.Equal(t, sub.ID, clone.Messages[1].SubSession.ID)
+	assert.Zero(t, clone.EmbeddedSubSessionCost(),
+		"a live-attached child must stay excluded from the clone's embedded cost")
+	assert.InDelta(t, 0.30, clone.TotalCost(), 1e-9, "the total still counts the live child")
 }
 
 // TestClone_PreservesItemValueFields guards against a clone that rebuilds

--- a/pkg/session/migrations.go
+++ b/pkg/session/migrations.go
@@ -401,6 +401,12 @@ func getAllMigrations() []Migration {
 			Description: "Add first_kept_entry column to session_items for compaction-preserved messages",
 			UpSQL:       `ALTER TABLE session_items ADD COLUMN first_kept_entry INTEGER DEFAULT 0`,
 		},
+		{
+			ID:          22,
+			Name:        "022_add_cost_to_session_items",
+			Description: "Add cost column to session_items so compaction summary costs survive reload",
+			UpSQL:       `ALTER TABLE session_items ADD COLUMN cost REAL NOT NULL DEFAULT 0`,
+		},
 	}
 }
 

--- a/pkg/session/migrations_pinned_test.go
+++ b/pkg/session/migrations_pinned_test.go
@@ -39,7 +39,7 @@ func TestMigrationCatalogIsContentPinned(t *testing.T) {
 
 	got := digestMigrationCatalog(getAllMigrations())
 
-	const wantDigest = "0c6d5df46b970104cf49988ee3931e33643d5db85c68dd41b74b639d0094cec9"
+	const wantDigest = "072d24a6f9737e47319443cfd12ce09a1d40a754f3ec31e4c1c38ce8b3bd5309"
 	if got != wantDigest {
 		t.Fatalf(`migration catalogue content has changed.
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -82,6 +82,13 @@ type Item struct {
 	// Cost tracks the cost of operations associated with this item that
 	// don't produce a regular message (e.g., compaction/summarization).
 	Cost float64 `json:"cost,omitempty"`
+
+	// liveAttached marks a sub-session item appended by AddLiveSubSession
+	// in this process, i.e. a sub-session that ran live and reported its
+	// own cost through its own TokenUsageEvents. Deliberately unexported
+	// and not persisted: after a reload the sub-session no longer emits
+	// events, so it must count as embedded (see EmbeddedSubSessionCost).
+	liveAttached bool
 }
 
 // IsMessage returns true if this item contains a message
@@ -626,11 +633,26 @@ func (s *Session) ApplyCompaction(inputTokens, outputTokens int64, item Item) {
 	s.Messages = append(s.Messages, item)
 }
 
-// AddSubSession adds a sub-session to the session
+// AddSubSession adds a sub-session to the session as embedded history,
+// e.g. when a store hydrates a parent with its children. Its cost counts
+// as embedded (see EmbeddedSubSessionCost); use AddLiveSubSession for a
+// sub-session that ran live in this process.
 func (s *Session) AddSubSession(subSession *Session) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.Messages = append(s.Messages, NewSubSessionItem(subSession))
+}
+
+// AddLiveSubSession adds a sub-session that ran live in this process: it
+// has its own TokenUsageEvent entry, having reported its own cost through
+// its own events, so EmbeddedSubSessionCost skips it to avoid double
+// counting in per-session aggregations.
+func (s *Session) AddLiveSubSession(subSession *Session) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	item := NewSubSessionItem(subSession)
+	item.liveAttached = true
+	s.Messages = append(s.Messages, item)
 }
 
 // AddError appends a recorded error to the session so it survives reload and
@@ -1089,6 +1111,25 @@ func (s *Session) OwnCost() float64 {
 			cost += item.Message.Message.Cost
 		}
 		cost += item.Cost
+	}
+	return cost
+}
+
+// EmbeddedSubSessionCost returns the total cost of sub-sessions that were
+// already embedded when this session was loaded (restored or branched
+// history), excluding sub-sessions attached live via AddLiveSubSession.
+// Embedded sub-sessions never emit their own TokenUsageEvents, so live
+// cost reporting must fold their cost into this session's own cost;
+// live sub-sessions report theirs through separate per-session events.
+func (s *Session) EmbeddedSubSessionCost() float64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var cost float64
+	for _, item := range s.Messages {
+		if item.IsSubSession() && !item.liveAttached {
+			cost += item.SubSession.TotalCost()
+		}
 	}
 	return cost
 }

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -951,3 +951,35 @@ func TestCompactionInput(t *testing.T) {
 		assert.Equal(t, "hello", sess.Messages[0].Message.Message.Content)
 	})
 }
+
+// TestEmbeddedSubSessionCost distinguishes sub-sessions embedded at load time
+// (hydrated items carry no live-attached marker) from sub-sessions attached
+// live via AddLiveSubSession: only the former count, because live
+// sub-sessions report their own cost through their own TokenUsageEvents.
+func TestEmbeddedSubSessionCost(t *testing.T) {
+	t.Parallel()
+
+	costItem := func(cost float64) Item {
+		return Item{Message: &Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Cost: cost}}}
+	}
+
+	sess := New()
+	sess.Messages = append(sess.Messages, costItem(0.10))
+
+	// Restored shape: hydration appends sub-session items directly.
+	embedded := New(WithParentID(sess.ID))
+	embedded.Messages = append(embedded.Messages, costItem(0.05))
+	nested := New(WithParentID(embedded.ID))
+	nested.Messages = append(nested.Messages, costItem(0.01))
+	embedded.Messages = append(embedded.Messages, Item{SubSession: nested})
+	sess.Messages = append(sess.Messages, Item{SubSession: embedded})
+
+	// Live shape: the sub-session completed during this process.
+	live := New(WithParentID(sess.ID))
+	live.Messages = append(live.Messages, costItem(0.02))
+	sess.AddLiveSubSession(live)
+
+	assert.InDelta(t, 0.06, sess.EmbeddedSubSessionCost(), 1e-9, "embedded sub-sessions count recursively")
+	assert.InDelta(t, 0.10, sess.OwnCost(), 1e-9)
+	assert.InDelta(t, 0.18, sess.TotalCost(), 1e-9, "TotalCost counts embedded and live sub-sessions")
+}

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -115,7 +115,8 @@ type Store interface {
 
 	// AddSummary adds a summary item to a session at the next position.
 	// firstKeptEntry is the index of the first message kept verbatim during compaction.
-	AddSummary(ctx context.Context, sessionID, summary string, firstKeptEntry int) error
+	// cost is the dollar cost of producing the summary (0 when nothing was billed).
+	AddSummary(ctx context.Context, sessionID, summary string, firstKeptEntry int, cost float64) error
 
 	// AddError appends a recorded error item to a session at the next position.
 	// Persisting failures lets them survive a reload and travel with a JSON export.
@@ -331,7 +332,7 @@ func (s *InMemorySessionStore) AddSubSession(_ context.Context, parentSessionID 
 }
 
 // AddSummary adds a summary item to a session at the next position.
-func (s *InMemorySessionStore) AddSummary(_ context.Context, sessionID, summary string, firstKeptEntry int) error {
+func (s *InMemorySessionStore) AddSummary(_ context.Context, sessionID, summary string, firstKeptEntry int, cost float64) error {
 	if sessionID == "" {
 		return ErrEmptyID
 	}
@@ -341,7 +342,7 @@ func (s *InMemorySessionStore) AddSummary(_ context.Context, sessionID, summary 
 	}
 	session.mu.Lock()
 	defer session.mu.Unlock()
-	session.Messages = append(session.Messages, Item{Summary: summary, FirstKeptEntry: firstKeptEntry})
+	session.Messages = append(session.Messages, Item{Summary: summary, FirstKeptEntry: firstKeptEntry, Cost: cost})
 	return nil
 }
 
@@ -729,6 +730,7 @@ type sessionItemRow struct {
 	subsessionID   sql.NullString
 	summaryText    sql.NullString
 	firstKeptEntry int
+	cost           float64
 }
 
 // loadSessionItems loads all items for a session from session_items.
@@ -736,7 +738,7 @@ type sessionItemRow struct {
 // loadSession when resolving sub-sessions inside a transaction.
 func (s *SQLiteSessionStore) loadSessionItems(ctx context.Context, q querier, sessionID string) ([]Item, error) {
 	rows, err := q.QueryContext(ctx,
-		`SELECT position, item_type, agent_name, message_json, implicit, subsession_id, summary_text, COALESCE(first_kept_entry, 0)
+		`SELECT position, item_type, agent_name, message_json, implicit, subsession_id, summary_text, COALESCE(first_kept_entry, 0), cost
 		 FROM session_items WHERE session_id = ? ORDER BY position`, sessionID)
 	if err != nil {
 		return nil, err
@@ -748,7 +750,7 @@ func (s *SQLiteSessionStore) loadSessionItems(ctx context.Context, q querier, se
 	var rawRows []sessionItemRow
 	for rows.Next() {
 		var row sessionItemRow
-		if err := rows.Scan(&row.position, &row.itemType, &row.agentName, &row.messageJSON, &row.implicit, &row.subsessionID, &row.summaryText, &row.firstKeptEntry); err != nil {
+		if err := rows.Scan(&row.position, &row.itemType, &row.agentName, &row.messageJSON, &row.implicit, &row.subsessionID, &row.summaryText, &row.firstKeptEntry, &row.cost); err != nil {
 			return nil, err
 		}
 		rawRows = append(rawRows, row)
@@ -798,7 +800,7 @@ func (s *SQLiteSessionStore) loadSessionItems(ctx context.Context, q querier, se
 			items = append(items, Item{SubSession: subSession})
 
 		case "summary":
-			items = append(items, Item{Summary: row.summaryText.String, FirstKeptEntry: row.firstKeptEntry})
+			items = append(items, Item{Summary: row.summaryText.String, FirstKeptEntry: row.firstKeptEntry, Cost: row.cost})
 
 		case "error":
 			var e Error
@@ -1195,9 +1197,9 @@ func (s *SQLiteSessionStore) addItemTx(ctx context.Context, tx *sql.Tx, sessionI
 
 	case item.Summary != "":
 		_, err := tx.ExecContext(ctx,
-			`INSERT INTO session_items (session_id, position, item_type, summary_text, first_kept_entry)
-			 VALUES (?, ?, 'summary', ?, ?)`,
-			sessionID, position, item.Summary, item.FirstKeptEntry)
+			`INSERT INTO session_items (session_id, position, item_type, summary_text, first_kept_entry, cost)
+			 VALUES (?, ?, 'summary', ?, ?, ?)`,
+			sessionID, position, item.Summary, item.FirstKeptEntry, item.Cost)
 		return err
 
 	case item.Error != nil:
@@ -1217,15 +1219,15 @@ func (s *SQLiteSessionStore) addItemTx(ctx context.Context, tx *sql.Tx, sessionI
 }
 
 // AddSummary adds a summary item to a session at the next position.
-func (s *SQLiteSessionStore) AddSummary(ctx context.Context, sessionID, summary string, firstKeptEntry int) error {
+func (s *SQLiteSessionStore) AddSummary(ctx context.Context, sessionID, summary string, firstKeptEntry int, cost float64) error {
 	if sessionID == "" {
 		return ErrEmptyID
 	}
 
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO session_items (session_id, position, item_type, summary_text, first_kept_entry)
-		 VALUES (?, (SELECT COALESCE(MAX(position), -1) + 1 FROM session_items WHERE session_id = ?), 'summary', ?, ?)`,
-		sessionID, sessionID, summary, firstKeptEntry)
+		`INSERT INTO session_items (session_id, position, item_type, summary_text, first_kept_entry, cost)
+		 VALUES (?, (SELECT COALESCE(MAX(position), -1) + 1 FROM session_items WHERE session_id = ?), 'summary', ?, ?, ?)`,
+		sessionID, sessionID, summary, firstKeptEntry, cost)
 	if err != nil {
 		return err
 	}

--- a/pkg/session/store_memory_test.go
+++ b/pkg/session/store_memory_test.go
@@ -75,3 +75,43 @@ func TestNewSQLiteSessionStoreFromDB_RoundTripWithMessages(t *testing.T) {
 	assert.Equal(t, "hello", got.Messages[0].Message.Message.Content)
 	assert.Equal(t, "world", got.Messages[1].Message.Message.Content)
 }
+
+// TestMigration22_LegacySummaryRowsReadAsZeroCost simulates a database
+// created before migration 022 (no cost column on session_items, summary
+// rows written without one): opening the store applies the migration and
+// the legacy summary must hydrate with cost 0 — historical summary costs
+// cannot be reconstructed.
+func TestMigration22_LegacySummaryRowsReadAsZeroCost(t *testing.T) {
+	t.Parallel()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+	ctx := t.Context()
+
+	// Bootstrap schema plus migrations 1..21 only — the pre-cost layout.
+	_, err = db.ExecContext(ctx, `CREATE TABLE sessions (id TEXT PRIMARY KEY, messages TEXT, created_at TEXT)`)
+	require.NoError(t, err)
+	all := getAllMigrations()
+	require.NoError(t, NewMigrationManagerWithMigrations(db, all[:len(all)-1]).InitializeMigrations(ctx))
+
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO sessions (id, created_at) VALUES ('legacy', '2024-01-01T00:00:00Z')`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO session_items (session_id, position, item_type, summary_text, first_kept_entry)
+		 VALUES ('legacy', 0, 'summary', 'old summary', 2)`)
+	require.NoError(t, err)
+
+	store, err := NewSQLiteSessionStoreFromDB(ctx, db)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	got, err := store.GetSession(ctx, "legacy")
+	require.NoError(t, err)
+	require.Len(t, got.Messages, 1)
+	assert.Equal(t, "old summary", got.Messages[0].Summary)
+	assert.Equal(t, 2, got.Messages[0].FirstKeptEntry)
+	assert.Zero(t, got.Messages[0].Cost, "legacy summary rows must read as cost 0")
+}

--- a/pkg/session/store_test.go
+++ b/pkg/session/store_test.go
@@ -1049,6 +1049,81 @@ func TestAddError_NotFound(t *testing.T) {
 	require.ErrorIs(t, err, ErrNotFound)
 }
 
+// TestAddSubSession_InMemoryChildIsEmbedded pins sub-session cost provenance
+// in the in-memory store: AddSubSession records store history, not a live
+// runtime attachment, so a parent fetched via GetSession must report the
+// child's cost through EmbeddedSubSessionCost — the component live usage
+// reporting folds into the parent's own cost. A live-attached child would be
+// skipped there, leaving the fetched parent's usage ($0.10) short of its
+// TotalCost ($0.15).
+func TestAddSubSession_InMemoryChildIsEmbedded(t *testing.T) {
+	t.Parallel()
+
+	store := NewInMemorySessionStore()
+
+	root := New(WithID("cost-root"))
+	root.AddMessage(&Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "done", Cost: 0.10}})
+	require.NoError(t, store.AddSession(t.Context(), root))
+
+	child := New()
+	child.AddMessage(&Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "done", Cost: 0.05}})
+	require.NoError(t, store.AddSubSession(t.Context(), root.ID, child))
+
+	got, err := store.GetSession(t.Context(), root.ID)
+	require.NoError(t, err)
+	assert.InDelta(t, 0.05, got.EmbeddedSubSessionCost(), 1e-9,
+		"a store-attached child is embedded history, not a live attachment")
+	assert.InDelta(t, 0.15, got.TotalCost(), 1e-9)
+	assert.InDelta(t, got.TotalCost(), got.OwnCost()+got.EmbeddedSubSessionCost(), 1e-9,
+		"own + embedded — what live usage reporting emits — must equal the total")
+}
+
+// TestSQLiteStore_CostsSurviveReload proves the full cost surface of a
+// session round-trips through the on-disk schema: a normal message cost, a
+// compaction summary cost written through the real AddSummary route, and an
+// embedded sub-session's costs (persisted via addItemTx, including its own
+// summary item). TotalCost must be identical before and after closing and
+// reopening the store.
+func TestSQLiteStore_CostsSurviveReload(t *testing.T) {
+	t.Parallel()
+
+	tempDB := filepath.Join(t.TempDir(), "test_cost_roundtrip.db")
+
+	store, err := NewSQLiteSessionStore(t.Context(), tempDB)
+	require.NoError(t, err)
+
+	root := New(WithID("cost-roundtrip-root"))
+	root.AddMessage(&Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "done", Cost: 0.10}})
+
+	child := New(WithParentID(root.ID))
+	child.AddMessage(&Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "child done", Cost: 0.05}})
+	child.Messages = append(child.Messages, Item{Summary: "child summary", Cost: 0.02})
+	root.AddSubSession(child)
+
+	require.NoError(t, store.AddSession(t.Context(), root))
+	require.NoError(t, store.AddSummary(t.Context(), root.ID, "root summary", 1, 0.01))
+	// Mirror AddSummary in memory so the pre-reload total includes it.
+	root.Messages = append(root.Messages, Item{Summary: "root summary", FirstKeptEntry: 1, Cost: 0.01})
+
+	want := root.TotalCost()
+	require.InDelta(t, 0.18, want, 1e-9)
+	require.NoError(t, store.(*SQLiteSessionStore).Close())
+
+	reopened, err := NewSQLiteSessionStore(t.Context(), tempDB)
+	require.NoError(t, err)
+	defer reopened.(*SQLiteSessionStore).Close()
+
+	got, err := reopened.GetSession(t.Context(), root.ID)
+	require.NoError(t, err)
+
+	last := got.Messages[len(got.Messages)-1]
+	require.Equal(t, "root summary", last.Summary)
+	assert.Equal(t, 1, last.FirstKeptEntry)
+	assert.InDelta(t, 0.01, last.Cost, 1e-9, "the summary item's cost must survive persistence")
+	assert.InDelta(t, want, got.TotalCost(), 1e-9,
+		"TotalCost must be identical after closing and reopening the store")
+}
+
 func TestIsRelativeSessionRef(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/components/sidebar/token_usage_test.go
+++ b/pkg/tui/components/sidebar/token_usage_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tui/service"
@@ -226,4 +227,83 @@ func TestTokenUsageTab_ShowsTokenGlyph(t *testing.T) {
 	out := ansi.Strip(m.tokenUsage(40))
 	assert.Contains(t, out, styles.TokenGlyph)
 	assert.Contains(t, out, "8.0K")
+}
+
+// sidebarCostItem returns an assistant-message item carrying the given cost.
+func sidebarCostItem(agentName string, cost float64) session.Item {
+	return session.Item{Message: &session.Message{
+		AgentName: agentName,
+		Message:   chat.Message{Role: chat.MessageRoleAssistant, Content: "done", Cost: cost},
+	}}
+}
+
+// TestComputeUsageStats_RestoredCostDoesNotDecreaseAfterCompaction is a
+// regression test for the displayed total dropping after a session restore:
+// LoadFromSession seeds the root entry with the restored total (own +
+// embedded sub-session costs), and the next live TokenUsageEvent for the
+// root — compaction emits one right away — used to replace it with an
+// own-cost-only snapshot, shrinking the total.
+func TestComputeUsageStats_RestoredCostDoesNotDecreaseAfterCompaction(t *testing.T) {
+	t.Parallel()
+
+	// Restored session: $0.10 direct + $0.05 embedded sub-session.
+	sess := session.New()
+	sess.InputTokens = 800
+	sess.OutputTokens = 200
+	sess.Messages = append(sess.Messages, sidebarCostItem("root", 0.10))
+	sub := session.New(session.WithParentID(sess.ID))
+	sub.Messages = append(sub.Messages, sidebarCostItem("developer", 0.05))
+	sess.Messages = append(sess.Messages, session.Item{SubSession: sub})
+
+	m := newTestSidebar(t)
+	m.LoadFromSession(sess)
+	assert.InDelta(t, 0.15, m.computeUsageStats().totalCost, 1e-9)
+
+	// Compaction appends a $0.01 summary and immediately emits the session's
+	// usage (see compactWithReason).
+	sess.ApplyCompaction(100, 0, session.Item{Summary: "summary", Cost: 0.01})
+	m.SetTokenUsage(&runtime.TokenUsageEvent{
+		SessionID:    sess.ID,
+		AgentContext: runtime.AgentContext{AgentName: "root"},
+		Usage:        runtime.SessionUsage(sess, 100_000),
+	})
+	assert.InDelta(t, 0.16, m.computeUsageStats().totalCost, 1e-9,
+		"the total must keep the embedded sub-session cost and gain the summary cost")
+}
+
+// TestComputeUsageStats_LiveSubSessionNotDoubleCounted drives the live
+// delegation flow through the runtime's own usage snapshots: the child
+// reports its own cost while it runs, and once it completes and attaches to
+// the root the root's next event must not fold the child in again.
+func TestComputeUsageStats_LiveSubSessionNotDoubleCounted(t *testing.T) {
+	t.Parallel()
+
+	usageEvent := func(sessionID, agentName string, sess *session.Session) *runtime.TokenUsageEvent {
+		return &runtime.TokenUsageEvent{
+			SessionID:    sessionID,
+			AgentContext: runtime.AgentContext{AgentName: agentName},
+			Usage:        runtime.SessionUsage(sess, 100_000),
+		}
+	}
+
+	root := session.New()
+	root.Messages = append(root.Messages, sidebarCostItem("root", 0.10))
+
+	m := newTestSidebar(t)
+	m.startStream(root.ID, "root")
+	m.SetTokenUsage(usageEvent(root.ID, "root", root))
+
+	child := session.New(session.WithParentID(root.ID))
+	child.Messages = append(child.Messages, sidebarCostItem("developer", 0.05))
+	m.startStream(child.ID, "developer")
+	m.SetTokenUsage(usageEvent(child.ID, "developer", child))
+	assert.InDelta(t, 0.15, m.computeUsageStats().totalCost, 1e-9)
+
+	// Child completes: its stream stops and it is attached to the root.
+	m.stopStream()
+	root.AddLiveSubSession(child)
+
+	m.SetTokenUsage(usageEvent(root.ID, "root", root))
+	assert.InDelta(t, 0.15, m.computeUsageStats().totalCost, 1e-9,
+		"$root own + $child own, not double-counted")
 }


### PR DESCRIPTION
## Summary

Fix session cost snapshots that can drop after compaction, for example from `$49` to `$12`, when restored sub-session costs are replaced by a live root-only usage event.

- distinguish restored or embedded sub-session costs from live sub-session entries
- emit authoritative final usage snapshots for detached background sub-sessions
- persist compaction summary costs through runtime events, stores, HTTP transport, and SQLite migration 023
- preserve cost accounting across reload, branch, fork, clone, cancellation, and failed delegation paths

## Root cause and behavior

| stage | before | after |
|---|---|---|
| restored parent usage | total cost, including historical sub-sessions | unchanged |
| next live usage event | root `OwnCost()` replaces the restored total and can display a large drop | root cost plus embedded historical sub-session cost |
| live delegation | parent plus child can double-count if `TotalCost()` is used globally | child remains a separate usage entry |
| SQLite reload after compaction | summary item cost is lost | summary cost survives reload |

Compaction did not remove billed messages. It emitted the next token-usage snapshot, exposing the mismatch between restore-time `TotalCost()` and live `OwnCost()` accounting.

## Implementation

- add explicit live sub-session provenance with `AddLiveSubSession`
- include only embedded or restored sub-session costs in `SessionUsage`
- emit a final non-empty background-agent usage snapshot before live attachment
- add `session_items.cost` with append-only migration `023_add_cost_to_session_items`
- carry summary cost through `SessionSummaryEvent`, `PersistenceObserver`, `Store.AddSummary`, and the remote HTTP API
- reuse the configured model store when pricing compaction summaries

## Regression coverage

- restored session followed by compaction in full and lean TUI usage trackers
- live delegation without double counting
- in-memory store hydration provenance
- clone, branch, and fork semantics
- background success, error, and cancellation snapshots
- compaction event cost propagation
- SQLite message, summary, and embedded sub-session cost round-trip
- legacy pre-migration summary rows defaulting to zero cost

## Validation

- `task build`
- `task lint`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy task test`
- `go test -race -count=1 ./pkg/session ./pkg/runtime ./pkg/acp ./pkg/tui/components/sidebar ./pkg/leantui/...`
- cancellation and compaction regressions repeated 20 times

The latest full-suite run has one recording-proxy fixture failure in `TestExec_Anthropic_AgentsMd` (`requested interaction not found`), reproduced unchanged on `origin/main`; all other packages pass. A full suite on the same patch before the upstream recording fixture changed passed completely.
