### PR TITLE
fix: repair CI workflow YAML and failing AgentsMd e2e test on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-        go-version-file: go.mod
-        cache-dependency-path: go.sum
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
 
       - name: Lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0

--- a/e2e/testdata/cassettes/TestExec_Anthropic_AgentsMd.yaml
+++ b/e2e/testdata/cassettes/TestExec_Anthropic_AgentsMd.yaml
@@ -8,7 +8,7 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.anthropic.com
-        body: '{"max_tokens":64000,"messages":[{"content":[{"text":"What''s 2+2?","cache_control":{"type":"ephemeral"},"type":"text"}],"role":"user"}],"model":"claude-sonnet-4-0","system":[{"text":"You are a knowledgeable assistant that helps users with various tasks.\nBe helpful, accurate, and concise in your responses.","cache_control":{"type":"ephemeral"},"type":"text"},{"text":"This is a test agents.md file.","cache_control":{"type":"ephemeral"},"type":"text"}],"tools":[],"stream":true}'
+        body: '{"max_tokens":64000,"messages":[{"content":[{"text":"What''s 2+2?","cache_control":{"type":"ephemeral"},"type":"text"}],"role":"user"}],"model":"claude-sonnet-4-0","system":[{"text":"You are a knowledgeable assistant that helps users with various tasks.\nBe helpful, accurate, and concise in your responses.","cache_control":{"type":"ephemeral"},"type":"text"},{"text":"Instructions from: FILE\nThis is a test agents.md file.","cache_control":{"type":"ephemeral"},"type":"text"}],"tools":[],"stream":true}'
         url: https://api.anthropic.com/v1/messages
         method: POST
       response:

--- a/pkg/fake/proxy.go
+++ b/pkg/fake/proxy.go
@@ -292,6 +292,8 @@ func DefaultMatcher(onError func(err error)) recorder.MatcherFunc {
 	// strict gateways (LiteLLM) accept the request, but older cassettes were
 	// recorded without it.
 	toolChoiceRegex := regexp.MustCompile(`"tool_choice":"[^"]*",?`)
+	// Normalize prompt-file paths (they are machine-specific absolute paths).
+	promptFileRegex := regexp.MustCompile(`Instructions from: [^\\"]+`)
 
 	return func(r *http.Request, i cassette.Request) bool {
 		if r.Body == nil || r.Body == http.NoBody {
@@ -322,11 +324,13 @@ func DefaultMatcher(onError func(err error)) recorder.MatcherFunc {
 		normalizedReq = thinkingConfigRegex.ReplaceAllString(normalizedReq, "")
 		normalizedReq = reasoningRegex.ReplaceAllString(normalizedReq, "")
 		normalizedReq = toolChoiceRegex.ReplaceAllString(normalizedReq, "")
+		normalizedReq = promptFileRegex.ReplaceAllString(normalizedReq, "Instructions from: FILE")
 		normalizedCassette := callIDRegex.ReplaceAllString(i.Body, "call_ID")
 		normalizedCassette = maxTokensRegex.ReplaceAllString(normalizedCassette, "")
 		normalizedCassette = thinkingConfigRegex.ReplaceAllString(normalizedCassette, "")
 		normalizedCassette = reasoningRegex.ReplaceAllString(normalizedCassette, "")
 		normalizedCassette = toolChoiceRegex.ReplaceAllString(normalizedCassette, "")
+		normalizedCassette = promptFileRegex.ReplaceAllString(normalizedCassette, "Instructions from: FILE")
 
 		return normalizedReq == normalizedCassette
 	}


### PR DESCRIPTION
This PR fixes two independent breakages on `main`.

## 1. CI workflow YAML parse failure

When the lint job's "Set up Go" step was last modified, the `go-version-file` and `cache-dependency-path` keys were left at the wrong indentation level — they sat as siblings of `uses:` rather than as children of `with:`. GitHub Actions could not parse the resulting YAML, so every CI run failed instantly with a "workflow file issue" error before a single job could start.

The fix re-indents those two keys so they are correctly nested under `with:`. No logic changes — the values are unchanged. Validated with `actionlint` and `scripts/workflow-lint.sh`.

## 2. Failing `TestExec_Anthropic_AgentsMd` e2e test

Commit `2e6951c6d` (cache-stable dynamic prompts) changed `add_prompt_files` to prefix prompt-file content with `Instructions from: <absolute path>`, but the VCR cassette for this test predated that change, so the recorded Anthropic request no longer matched and the test failed with "requested interaction not found".

Fix:
- `pkg/fake/proxy.go`: the VCR `DefaultMatcher` now normalizes machine-specific `Instructions from: <path>` prefixes to a stable `Instructions from: FILE` placeholder, keeping cassettes portable across machines and CI.
- `e2e/testdata/cassettes/TestExec_Anthropic_AgentsMd.yaml`: the recorded request body now includes the new prefix.

Validated with `task test`, `task lint`, and `task build` — all green.