### PR TITLE
feat: custom base_url implies bypass_models_gateway

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -1515,7 +1515,7 @@
         },
         "bypass_models_gateway": {
           "type": "boolean",
-          "description": "When true, this model connects directly to its provider, ignoring any configured models gateway (--models-gateway / CAGENT_MODELS_GATEWAY). The model then authenticates with the provider's own credentials (e.g. OPENAI_API_KEY, ANTHROPIC_API_KEY, or token_key) instead of routing through the gateway."
+          "description": "When true, this model connects directly to its provider, ignoring any configured models gateway (--models-gateway / CAGENT_MODELS_GATEWAY). The model then authenticates with the provider's own credentials (e.g. OPENAI_API_KEY, ANTHROPIC_API_KEY, or token_key) instead of routing through the gateway. A custom base_url (set on the model or inherited from a custom provider definition) implies this bypass even when the flag is false."
         },
         "provider_opts": {
           "type": "object",

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -42,7 +42,7 @@ models:
     title_model: string # Optional: model used for session-title generation
     compaction_model: string # Optional: model used for session-compaction (summary generation)
     compaction_threshold: float # Optional: context-window fraction that triggers auto-compaction (0–1, default: 0.9)
-    bypass_models_gateway: boolean # Optional: skip the models gateway for this model
+    bypass_models_gateway: boolean # Optional: skip the models gateway for this model (implied by a custom base_url)
 ```
 
 ## Properties Reference
@@ -69,7 +69,7 @@ models:
 | `title_model`         | string     | ✗        | Model used for session-title generation. Can be a named model from the `models:` section or an inline `provider/model` string. When omitted, the agent's primary model generates titles. Cannot be combined with `first_available`. |
 | `compaction_model`    | string     | ✗        | Model used for session compaction (summary generation). Can be a named model or an inline `provider/model` string. When omitted, the primary model compacts. Cannot be combined with `first_available`. See [Delegating Session Compaction](#delegating-session-compaction). |
 | `compaction_threshold` | float     | ✗        | Fraction of the context window at which proactive auto-compaction triggers for agents running this model. Must be greater than `0` and at most `1`. Takes precedence over the agent-level `compaction_threshold`. Cannot be combined with `first_available`. Default: `0.9`. |
-| `bypass_models_gateway` | boolean  | ✗        | When `true`, this model connects directly to its provider even when a models gateway (`--models-gateway` / `CAGENT_MODELS_GATEWAY`) is configured. See [Gateway Bypass](#gateway-bypass). |
+| `bypass_models_gateway` | boolean  | ✗        | When `true`, this model connects directly to its provider even when a models gateway (`--models-gateway` / `CAGENT_MODELS_GATEWAY`) is configured. Implied by a custom `base_url`. See [Gateway Bypass](#gateway-bypass). |
 
 ## Attachment Capability Overrides
 

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -185,8 +185,9 @@ for complete examples.
 ## Gateway Bypass
 
 When a models gateway (`--models-gateway` / `CAGENT_MODELS_GATEWAY`) is configured,
-all models route through it by default. Set `bypass_models_gateway: true` on a
-specific model to make it connect directly to its provider instead:
+models without a custom `base_url` route through it by default. Set
+`bypass_models_gateway: true` on a specific model to make it connect directly
+to its provider instead:
 
 ```yaml
 models:

--- a/docs/providers/custom/index.md
+++ b/docs/providers/custom/index.md
@@ -302,3 +302,9 @@ When you reference a provider:
 3. All model-level defaults (temperature, max_tokens, thinking_budget, etc.) are inherited (model settings take precedence)
 4. For OpenAI-compatible providers, the `api_type` is stored in `provider_opts.api_type`
 5. The model is used with the appropriate API client
+
+A provider with a `base_url` implies `bypass_models_gateway: true` for every
+model that references it: user-chosen endpoints are never routed through a
+configured models gateway, and such models authenticate with the provider's
+own credentials (`token_key`). See
+[Gateway Bypass](../../configuration/models/index.md#gateway-bypass).

--- a/examples/bypass_models_gateway.yaml
+++ b/examples/bypass_models_gateway.yaml
@@ -10,6 +10,10 @@
 # A bypassed model authenticates with the provider's own credentials
 # (OPENAI_API_KEY, ANTHROPIC_API_KEY, or an explicit token_key) rather than the
 # gateway's short-lived token.
+#
+# A custom base_url (on the model or inherited from a named provider
+# definition) implies the bypass automatically — user-chosen endpoints are
+# never routed through the models gateway.
 models:
   # Routed through the gateway when one is configured.
   gateway-model:
@@ -22,6 +26,12 @@ models:
     provider: anthropic
     model: claude-sonnet-4-5
     bypass_models_gateway: true
+
+  # A custom base_url implies the bypass; no flag needed.
+  proxied-model:
+    provider: openai
+    model: gpt-4o
+    base_url: https://proxy.internal.example.com/v1
 
 agents:
   root:

--- a/examples/bypass_models_gateway.yaml
+++ b/examples/bypass_models_gateway.yaml
@@ -38,3 +38,9 @@ agents:
     model: direct-model
     description: Assistant whose model bypasses the models gateway
     instruction: You are a helpful assistant.
+    sub_agents: [proxied]
+
+  proxied:
+    model: proxied-model
+    description: Assistant whose custom endpoint implies the gateway bypass
+    instruction: You are a helpful assistant.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -374,6 +374,67 @@ func TestCheckRequiredEnvVars_BypassModelsGateway(t *testing.T) {
 	assert.Equal(t, []string{"ANTHROPIC_API_KEY"}, reqErr.Missing)
 }
 
+func TestCheckRequiredEnvVars_CustomBaseURLImpliesBypass(t *testing.T) {
+	t.Parallel()
+
+	env := &fakeEnvProvider{vars: map[string]string{
+		environment.DockerDesktopTokenEnv: "some-jwt-token",
+	}}
+
+	t.Run("model base_url requires its token_key", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &latest.Config{
+			Agents: []latest.AgentConfig{{Name: "root", Model: "proxied"}},
+			Models: map[string]latest.ModelConfig{
+				"proxied": {Provider: "openai", Model: "gpt-4o", BaseURL: "https://proxy.example.com/v1", TokenKey: "PROXY_KEY"},
+			},
+		}
+
+		// A custom base_url implies the gateway bypass, so the model dials its
+		// endpoint directly and needs its own credentials.
+		err := CheckRequiredEnvVars(t.Context(), cfg, "https://models.docker.com", env)
+		require.Error(t, err)
+		var reqErr *environment.RequiredEnvError
+		require.ErrorAs(t, err, &reqErr)
+		assert.Equal(t, []string{"PROXY_KEY"}, reqErr.Missing)
+	})
+
+	t.Run("custom provider base_url requires its token_key", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &latest.Config{
+			Agents: []latest.AgentConfig{{Name: "root", Model: "custom"}},
+			Providers: map[string]latest.ProviderConfig{
+				"my_endpoint": {BaseURL: "https://llm.internal.example.com/v1", TokenKey: "MY_TOKEN"},
+			},
+			Models: map[string]latest.ModelConfig{
+				"custom": {Provider: "my_endpoint", Model: "llama-3"},
+			},
+		}
+
+		err := CheckRequiredEnvVars(t.Context(), cfg, "https://models.docker.com", env)
+		require.Error(t, err)
+		var reqErr *environment.RequiredEnvError
+		require.ErrorAs(t, err, &reqErr)
+		assert.Equal(t, []string{"MY_TOKEN"}, reqErr.Missing)
+	})
+
+	t.Run("no base_url still relies on the gateway", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &latest.Config{
+			Agents: []latest.AgentConfig{{Name: "root", Model: "routed"}},
+			Models: map[string]latest.ModelConfig{
+				"routed": {Provider: "anthropic", Model: "claude-sonnet-4-5"},
+			},
+		}
+
+		err := CheckRequiredEnvVars(t.Context(), cfg, "https://models.docker.com", env)
+		require.NoError(t, err)
+	})
+}
+
 func TestCheckRequiredEnvVars_BypassModelsGatewayRouting(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -433,6 +433,77 @@ func TestCheckRequiredEnvVars_CustomBaseURLImpliesBypass(t *testing.T) {
 		err := CheckRequiredEnvVars(t.Context(), cfg, "https://models.docker.com", env)
 		require.NoError(t, err)
 	})
+
+	t.Run("router-level base_url does not bypass the fallback", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &latest.Config{
+			Agents: []latest.AgentConfig{{Name: "root", Model: "router"}},
+			Models: map[string]latest.ModelConfig{
+				"router": {
+					Provider: "anthropic",
+					Model:    "claude-sonnet-4-5",
+					BaseURL:  "https://proxy.example.com/v1",
+					TokenKey: "PROXY_KEY",
+					Routing:  []latest.RoutingRule{{Model: "openai/gpt-5", Examples: []string{"code"}}},
+				},
+			},
+		}
+
+		// The runtime rebuilds a router's fallback from its "provider/model"
+		// spec, dropping the router-level base_url/token_key, so the whole
+		// subtree still routes through the gateway.
+		err := CheckRequiredEnvVars(t.Context(), cfg, "https://models.docker.com", env)
+		require.NoError(t, err)
+	})
+
+	t.Run("router on a custom provider bypasses the fallback", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &latest.Config{
+			Agents: []latest.AgentConfig{{Name: "root", Model: "router"}},
+			Providers: map[string]latest.ProviderConfig{
+				"my_endpoint": {BaseURL: "https://llm.internal.example.com/v1", TokenKey: "MY_TOKEN"},
+			},
+			Models: map[string]latest.ModelConfig{
+				"router": {
+					Provider: "my_endpoint",
+					Model:    "llama-3",
+					Routing:  []latest.RoutingRule{{Model: "openai/gpt-5", Examples: []string{"code"}}},
+				},
+			},
+		}
+
+		// The provider name survives the fallback rebuild, so the custom
+		// provider's base_url still implies the bypass for the fallback leaf.
+		err := CheckRequiredEnvVars(t.Context(), cfg, "https://models.docker.com", env)
+		require.Error(t, err)
+		var reqErr *environment.RequiredEnvError
+		require.ErrorAs(t, err, &reqErr)
+		assert.Equal(t, []string{"MY_TOKEN"}, reqErr.Missing)
+	})
+
+	t.Run("env refs in inherited provider base_url are required", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &latest.Config{
+			Agents: []latest.AgentConfig{{Name: "root", Model: "custom"}},
+			Providers: map[string]latest.ProviderConfig{
+				"proxy": {BaseURL: "${env.PROXY_URL}", TokenKey: "MY_TOKEN"},
+			},
+			Models: map[string]latest.ModelConfig{
+				"custom": {Provider: "proxy", Model: "llama-3"},
+			},
+		}
+
+		// The provider-level base_url is merged and expanded at runtime, so
+		// its ${env.X} references must be preflighted too.
+		err := CheckRequiredEnvVars(t.Context(), cfg, "https://models.docker.com", env)
+		require.Error(t, err)
+		var reqErr *environment.RequiredEnvError
+		require.ErrorAs(t, err, &reqErr)
+		assert.Equal(t, []string{"MY_TOKEN", "PROXY_URL"}, reqErr.Missing)
+	})
 }
 
 func TestCheckRequiredEnvVars_BypassModelsGatewayRouting(t *testing.T) {

--- a/pkg/config/first_available.go
+++ b/pkg/config/first_available.go
@@ -234,9 +234,11 @@ func validateCandidateProvider(cfg *latest.Config, ref, provider string) error {
 // not configured in the environment. Models that require no env vars (e.g.
 // local dmr/ollama providers) have no missing credentials and are considered
 // available. When a gateway is configured, credentials are supplied by the
-// gateway.
+// gateway — except for candidates that bypass it (explicit
+// bypass_models_gateway or a custom base_url, which implies the bypass) and
+// therefore still need their own credentials.
 func modelMissingCredentials(ctx context.Context, cfg *latest.Config, model *latest.ModelConfig, modelsGateway string, env environment.Provider) ([]string, error) {
-	if modelsGateway != "" {
+	if modelsGateway != "" && !model.BypassModelsGateway && !latest.HasCustomBaseURL(*model, cfg.Providers) {
 		return nil, nil
 	}
 

--- a/pkg/config/first_available_test.go
+++ b/pkg/config/first_available_test.go
@@ -160,6 +160,59 @@ func TestResolveFirstAvailableModels_GatewaySelectsFirst(t *testing.T) {
 	assert.Equal(t, "claude-sonnet-4-6", got.Model)
 }
 
+func TestResolveFirstAvailableModels_GatewaySkipsBypassingCandidateWithMissingCredentials(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Providers: map[string]latest.ProviderConfig{
+			"my_endpoint": {BaseURL: "https://llm.internal.example.com/v1", TokenKey: "MY_TOKEN"},
+		},
+		Models: map[string]latest.ModelConfig{
+			"direct": {Provider: "anthropic", Model: "claude-sonnet-4-6", BypassModelsGateway: true},
+			"smart": {
+				FirstAvailable: []string{
+					"my_endpoint/llama-3", // custom base_url implies the bypass; MY_TOKEN unset
+					"direct",              // explicit bypass; ANTHROPIC_API_KEY unset
+					"openai/gpt-5",        // gateway supplies credentials
+				},
+			},
+		},
+	}
+
+	// Bypassing candidates dial their endpoint directly even under a gateway,
+	// so they need their own credentials to be selected.
+	require.NoError(t, ResolveFirstAvailableModels(t.Context(), cfg, "gateway:8080", environment.NewNoEnvProvider()))
+
+	got := cfg.Models["smart"]
+	assert.Equal(t, "openai", got.Provider)
+	assert.Equal(t, "gpt-5", got.Model)
+}
+
+func TestResolveFirstAvailableModels_GatewaySelectsBypassingCandidateWithCredentials(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Providers: map[string]latest.ProviderConfig{
+			"my_endpoint": {BaseURL: "https://llm.internal.example.com/v1", TokenKey: "MY_TOKEN"},
+		},
+		Models: map[string]latest.ModelConfig{
+			"smart": {
+				FirstAvailable: []string{
+					"my_endpoint/llama-3",
+					"openai/gpt-5",
+				},
+			},
+		},
+	}
+
+	env := environment.NewMapEnvProvider(map[string]string{"MY_TOKEN": "test-key"})
+	require.NoError(t, ResolveFirstAvailableModels(t.Context(), cfg, "gateway:8080", env))
+
+	got := cfg.Models["smart"]
+	assert.Equal(t, "my_endpoint", got.Provider)
+	assert.Equal(t, "llama-3", got.Model)
+}
+
 func TestResolveFirstAvailableModels_NoCandidateAvailable(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/gather.go
+++ b/pkg/config/gather.go
@@ -109,8 +109,10 @@ func gatherEnvVarsForModel(ctx context.Context, cfg *latest.Config, modelName st
 	rootBypassed := model.BypassModelsGateway
 
 	// The model's own provider/model is a leaf: either the model itself or, for
-	// a router, its fallback model. It bypasses iff the model bypasses.
-	if !bypassOnly || rootBypassed {
+	// a router, its fallback model. It bypasses iff the model bypasses. A custom
+	// base_url implies the bypass: such endpoints are never routed through the
+	// models gateway (see createDirectProvider).
+	if !bypassOnly || rootBypassed || hasCustomBaseURL(&model, cfg.Providers) {
 		addEnvVarsForModelConfig(ctx, &model, cfg.Providers, requiredEnv, env)
 	}
 
@@ -119,16 +121,17 @@ func gatherEnvVarsForModel(ctx context.Context, cfg *latest.Config, modelName st
 		ruleModelName := rule.Model
 		if ruleModel, exists := cfg.Models[ruleModelName]; exists {
 			// Named model reference. A routed target bypasses when the router
-			// does (propagation) or when it sets its own flag.
-			if !bypassOnly || rootBypassed || ruleModel.BypassModelsGateway {
+			// does (propagation), when it sets its own flag, or when it dials a
+			// custom base_url (implied bypass).
+			if !bypassOnly || rootBypassed || ruleModel.BypassModelsGateway || hasCustomBaseURL(&ruleModel, cfg.Providers) {
 				addEnvVarsForModelConfig(ctx, &ruleModel, cfg.Providers, requiredEnv, env)
 			}
 		} else if providerName, _, ok := strings.Cut(ruleModelName, "/"); ok {
 			// Inline spec (e.g., "openai/gpt-4o") - infer env vars from provider.
-			// Inline specs carry no flag of their own; they bypass only via the
-			// router's propagated bypass.
-			if !bypassOnly || rootBypassed {
-				inlineModel := latest.ModelConfig{Provider: providerName}
+			// Inline specs carry no flag of their own; they bypass via the
+			// router's propagated bypass or a custom provider's base_url.
+			inlineModel := latest.ModelConfig{Provider: providerName}
+			if !bypassOnly || rootBypassed || hasCustomBaseURL(&inlineModel, cfg.Providers) {
 				addEnvVarsForModelConfig(ctx, &inlineModel, cfg.Providers, requiredEnv, env)
 			}
 		}

--- a/pkg/config/gather.go
+++ b/pkg/config/gather.go
@@ -109,11 +109,18 @@ func gatherEnvVarsForModel(ctx context.Context, cfg *latest.Config, modelName st
 	rootBypassed := model.BypassModelsGateway
 
 	// The model's own provider/model is a leaf: either the model itself or, for
-	// a router, its fallback model. It bypasses iff the model bypasses. A custom
-	// base_url implies the bypass: such endpoints are never routed through the
-	// models gateway (see createDirectProvider).
-	if !bypassOnly || rootBypassed || hasCustomBaseURL(&model, cfg.Providers) {
-		addEnvVarsForModelConfig(ctx, &model, cfg.Providers, requiredEnv, env)
+	// a router, its fallback. The runtime rebuilds a router's fallback from its
+	// "provider/model" spec (see rulebased.NewClient), resolving it as a named
+	// model when one exists and keeping only provider/model otherwise; mirror
+	// that here so router-level base_url/token_key are not misattributed to the
+	// fallback. A custom base_url implies the bypass: such endpoints are never
+	// routed through the models gateway (see createDirectProvider).
+	leaf := model
+	if len(model.Routing) > 0 {
+		leaf = routerFallbackLeaf(cfg, model)
+	}
+	if !bypassOnly || rootBypassed || leaf.BypassModelsGateway || hasCustomBaseURL(&leaf, cfg.Providers) {
+		addEnvVarsForModelConfig(ctx, &leaf, cfg.Providers, requiredEnv, env)
 	}
 
 	// If the model has routing rules, also check all referenced models.
@@ -138,6 +145,18 @@ func gatherEnvVarsForModel(ctx context.Context, cfg *latest.Config, modelName st
 	}
 }
 
+// routerFallbackLeaf mirrors how the runtime resolves a router's fallback
+// (see rulebased.NewClient): the "provider/model" spec is looked up as a
+// named model first, otherwise reparsed inline, which keeps only the
+// provider and model fields.
+func routerFallbackLeaf(cfg *latest.Config, router latest.ModelConfig) latest.ModelConfig {
+	spec := router.Provider + "/" + router.Model
+	if fallback, exists := cfg.Models[spec]; exists {
+		return fallback
+	}
+	return latest.ModelConfig{Provider: router.Provider, Model: router.Model}
+}
+
 // addEnvVarsForModelConfig adds required environment variables for a model config.
 // It checks custom providers first, then built-in aliases, then hardcoded fallbacks.
 func addEnvVarsForModelConfig(ctx context.Context, model *latest.ModelConfig, customProviders map[string]latest.ProviderConfig, requiredEnv map[string]bool, env environment.Provider) {
@@ -148,6 +167,16 @@ func addEnvVarsForModelConfig(ctx context.Context, model *latest.ModelConfig, cu
 	for _, field := range []string{model.Model, model.BaseURL} {
 		for _, name := range environment.Refs(field) {
 			requiredEnv[name] = true
+		}
+	}
+	// A provider-level base_url is merged into the model at runtime when the
+	// model does not override it (see mergeFromProviderConfig), so its ${env.X}
+	// references must be resolvable too.
+	if model.BaseURL == "" {
+		if provCfg, exists := customProviders[model.Provider]; exists {
+			for _, name := range environment.Refs(provCfg.BaseURL) {
+				requiredEnv[name] = true
+			}
 		}
 	}
 

--- a/pkg/config/latest/base_url.go
+++ b/pkg/config/latest/base_url.go
@@ -1,0 +1,17 @@
+package latest
+
+// HasCustomBaseURL reports whether m targets a user-supplied endpoint: a
+// base_url set directly on the model or inherited from a custom provider
+// definition. It must be evaluated on the raw config — after provider
+// defaults are applied a built-in alias default base URL is indistinguishable
+// from a custom one.
+//
+// A custom base_url implies bypass_models_gateway: such endpoints are never
+// routed through a configured models gateway.
+func HasCustomBaseURL(m ModelConfig, providers map[string]ProviderConfig) bool {
+	if m.BaseURL != "" {
+		return true
+	}
+	p, exists := providers[m.Provider]
+	return exists && p.BaseURL != ""
+}

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -966,11 +966,15 @@ type ModelConfig struct {
 	// the provider's own credentials (e.g. OPENAI_API_KEY, ANTHROPIC_API_KEY, or
 	// token_key) instead of routing through the gateway.
 	//
+	// A custom base_url (set on the model or inherited from a custom provider
+	// definition) implies the bypass even when this flag is false: user-chosen
+	// endpoints are never routed through the models gateway.
+	//
 	// Security note: a model that bypasses the gateway sends the provider's
-	// ambient credentials directly to its endpoint. Combined with a custom
-	// base_url this lets a config exfiltrate those credentials to an arbitrary
-	// host, so only enable it on configs you trust. For a router model the
-	// bypass propagates to its fallback and every routed target.
+	// ambient credentials directly to its endpoint. A malicious base_url thus
+	// lets a config exfiltrate those credentials to an arbitrary host, so only
+	// run configs you trust. For a router model the bypass propagates to its
+	// fallback and every routed target.
 	BypassModelsGateway bool `json:"bypass_models_gateway,omitempty"`
 	// ProviderOpts allows provider-specific options.
 	ProviderOpts map[string]any `json:"provider_opts,omitempty"`

--- a/pkg/config/model_alias.go
+++ b/pkg/config/model_alias.go
@@ -57,17 +57,5 @@ func isInlineModelEntry(name string, modelCfg latest.ModelConfig) bool {
 // hasCustomBaseURL checks if a model config has a custom base_url, either directly
 // or through a referenced provider definition.
 func hasCustomBaseURL(modelCfg *latest.ModelConfig, providers map[string]latest.ProviderConfig) bool {
-	// Check if the model has a direct base_url
-	if modelCfg.BaseURL != "" {
-		return true
-	}
-
-	// Check if the model references a provider with a base_url
-	if providers != nil && modelCfg.Provider != "" {
-		if providerCfg, exists := providers[modelCfg.Provider]; exists {
-			return providerCfg.BaseURL != ""
-		}
-	}
-
-	return false
+	return latest.HasCustomBaseURL(*modelCfg, providers)
 }

--- a/pkg/model/provider/defaults.go
+++ b/pkg/model/provider/defaults.go
@@ -177,6 +177,19 @@ func applyAliasFallbacks(dst *latest.ModelConfig, alias Alias) {
 	}
 }
 
+// hasCustomBaseURL reports whether cfg targets a user-supplied endpoint: a
+// base_url set directly on the model or inherited from a custom provider
+// definition. Must be called on the pre-defaults config — after
+// applyProviderDefaults a built-in alias default base URL is indistinguishable
+// from a custom one.
+func hasCustomBaseURL(cfg *latest.ModelConfig, customProviders map[string]latest.ProviderConfig) bool {
+	if cfg.BaseURL != "" {
+		return true
+	}
+	providerCfg, exists := customProviders[cfg.Provider]
+	return exists && providerCfg.BaseURL != ""
+}
+
 // setIfNil assigns src to *dst when *dst is nil. It centralises the repetitive
 // "only fill in if unset" pattern used when merging provider-level defaults.
 func setIfNil[T any](dst **T, src *T) {

--- a/pkg/model/provider/defaults.go
+++ b/pkg/model/provider/defaults.go
@@ -177,19 +177,6 @@ func applyAliasFallbacks(dst *latest.ModelConfig, alias Alias) {
 	}
 }
 
-// hasCustomBaseURL reports whether cfg targets a user-supplied endpoint: a
-// base_url set directly on the model or inherited from a custom provider
-// definition. Must be called on the pre-defaults config — after
-// applyProviderDefaults a built-in alias default base URL is indistinguishable
-// from a custom one.
-func hasCustomBaseURL(cfg *latest.ModelConfig, customProviders map[string]latest.ProviderConfig) bool {
-	if cfg.BaseURL != "" {
-		return true
-	}
-	providerCfg, exists := customProviders[cfg.Provider]
-	return exists && providerCfg.BaseURL != ""
-}
-
 // setIfNil assigns src to *dst when *dst is nil. It centralises the repetitive
 // "only fill in if unset" pattern used when merging provider-level defaults.
 func setIfNil[T any](dst **T, src *T) {

--- a/pkg/model/provider/factory.go
+++ b/pkg/model/provider/factory.go
@@ -92,7 +92,12 @@ func (r *Registry) createDirectProvider(ctx context.Context, cfg *latest.ModelCo
 	// A model may opt out of the models gateway and dial its provider directly.
 	// Clearing the gateway option makes the leaf provider take its direct-auth
 	// path (provider API key / token_key) instead of the gateway path.
-	if enhancedCfg.BypassModelsGateway && globalOptions.Gateway() != "" {
+	// A custom base_url (set on the model or inherited from a custom provider
+	// definition) implies the bypass: the endpoint was explicitly chosen by the
+	// user and is not one the gateway serves. Checked on the pre-defaults cfg so
+	// built-in alias default base URLs don't count.
+	bypass := enhancedCfg.BypassModelsGateway || hasCustomBaseURL(cfg, globalOptions.Providers())
+	if bypass && globalOptions.Gateway() != "" {
 		slog.DebugContext(ctx, "Bypassing models gateway for model", "provider", enhancedCfg.Provider, "model", enhancedCfg.Model)
 		opts = append(opts, options.WithGateway(""))
 	}

--- a/pkg/model/provider/factory.go
+++ b/pkg/model/provider/factory.go
@@ -96,7 +96,7 @@ func (r *Registry) createDirectProvider(ctx context.Context, cfg *latest.ModelCo
 	// definition) implies the bypass: the endpoint was explicitly chosen by the
 	// user and is not one the gateway serves. Checked on the pre-defaults cfg so
 	// built-in alias default base URLs don't count.
-	bypass := enhancedCfg.BypassModelsGateway || hasCustomBaseURL(cfg, globalOptions.Providers())
+	bypass := enhancedCfg.BypassModelsGateway || latest.HasCustomBaseURL(*cfg, globalOptions.Providers())
 	if bypass && globalOptions.Gateway() != "" {
 		slog.DebugContext(ctx, "Bypassing models gateway for model", "provider", enhancedCfg.Provider, "model", enhancedCfg.Model)
 		opts = append(opts, options.WithGateway(""))

--- a/pkg/model/provider/factory_test.go
+++ b/pkg/model/provider/factory_test.go
@@ -218,6 +218,81 @@ func TestCreateDirectProvider_BypassModelsGateway(t *testing.T) {
 	}
 }
 
+// TestCreateDirectProvider_CustomBaseURLImpliesGatewayBypass verifies that a
+// custom base_url — set directly on the model or inherited from a custom
+// provider definition — implies bypass_models_gateway: the gateway option is
+// cleared before the leaf factory runs. Built-in alias default base URLs and
+// custom providers without a base_url keep the gateway.
+func TestCreateDirectProvider_CustomBaseURLImpliesGatewayBypass(t *testing.T) {
+	t.Parallel()
+
+	const gateway = "https://gateway.example.com"
+
+	customProviders := map[string]latest.ProviderConfig{
+		"my_endpoint": {
+			APIType:  "openai",
+			BaseURL:  "https://llm.internal.example.com/v1",
+			TokenKey: "MY_TOKEN",
+		},
+		"my_anthropic": {
+			Provider: "anthropic",
+			TokenKey: "MY_ANTHROPIC_KEY",
+		},
+	}
+
+	tests := []struct {
+		name        string
+		cfg         *latest.ModelConfig
+		wantGateway string
+	}{
+		{
+			name:        "model base_url bypasses gateway",
+			cfg:         &latest.ModelConfig{Provider: "openai", Model: "gpt-4o", BaseURL: "http://localhost:8000/v1"},
+			wantGateway: "",
+		},
+		{
+			name:        "custom provider base_url bypasses gateway",
+			cfg:         &latest.ModelConfig{Provider: "my_endpoint", Model: "llama-3"},
+			wantGateway: "",
+		},
+		{
+			name:        "custom provider without base_url keeps gateway",
+			cfg:         &latest.ModelConfig{Provider: "my_anthropic", Model: "claude-sonnet-4-5"},
+			wantGateway: gateway,
+		},
+		{
+			name:        "alias default base_url keeps gateway",
+			cfg:         &latest.ModelConfig{Provider: "mistral", Model: "mistral-large-latest"},
+			wantGateway: gateway,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var gotOpts options.ModelOptions
+			leaf := func(_ context.Context, _ *latest.ModelConfig, _ environment.Provider, opts ...options.Opt) (Provider, error) {
+				for _, opt := range opts {
+					opt(&gotOpts)
+				}
+				return &fakeProvider{id: modelsdev.NewID("test", "captured")}, nil
+			}
+			r := NewRegistry(map[string]providerFactory{
+				"openai":    leaf,
+				"anthropic": leaf,
+			})
+
+			_, err := r.createDirectProvider(
+				t.Context(), tt.cfg, environment.NewNoEnvProvider(),
+				options.WithGateway(gateway),
+				options.WithProviders(customProviders),
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantGateway, gotOpts.Gateway())
+		})
+	}
+}
+
 // TestNewWithModels_BypassModelsGatewayRouting verifies that a routing model
 // with bypass_models_gateway propagates the bypass to its fallback and routed
 // targets (the router itself makes no HTTP calls).


### PR DESCRIPTION
When a model is configured with a custom `base_url` — either set directly on the model or inherited from a named entry in the `providers:` section — it is clearly meant to reach a specific endpoint that is not the default for that provider. Routing such a model through a configured models gateway serves no purpose and often breaks things, yet until now callers had to remember to also set `bypass_models_gateway: true` explicitly.

This change makes the implication automatic. A custom (non-default) `base_url` now sets `bypass_models_gateway: true` at config resolution time, so the model dials its endpoint directly. Built-in provider alias defaults are unaffected. The predicate that decides whether a URL is "custom" is consolidated into `latest.HasCustomBaseURL` so the logic lives in one place. The env-var preflight now correctly requires direct credentials for these models even when a gateway is configured, and also expands `${env.X}` refs that come from an inherited provider-level `base_url`. `first_available` candidates that bypass the gateway — whether via the explicit flag or the new implied path — are credential-checked against the direct endpoint rather than being selected blindly.

No breaking change to existing configs: anyone who already sets `bypass_models_gateway: true` alongside `base_url` will see identical behavior.