### PR TITLE
fix(config): add scheduler toolset to agent-schema.json type enum

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -2019,6 +2019,7 @@
             "open_url",
             "model_picker",
             "background_agents",
+            "scheduler",
             "rag"
           ]
         },
@@ -2354,7 +2355,8 @@
                 "lsp",
                 "user_prompt",
                 "model_picker",
-                "background_agents"
+                "background_agents",
+                "scheduler"
               ]
             }
           }


### PR DESCRIPTION
## Summary

PR #3632 added the `scheduler` builtin toolset and registered it in the Go runtime (`pkg/teamloader/toolsets/catalog.go`, `pkg/teamloader/toolsets/toolsets.go`) and docs (`docs/tools/scheduler/index.md`), but never added it to the toolset `type` enum in `agent-schema.json`. Because that enum is enforced at config-load time via `gojsonschema`, **any agent config using `type: scheduler` was rejected**, making the new feature unusable. It also broke `TestDocYAMLSnippetsAreValid` in `pkg/config` (the scheduler doc snippet fails schema validation).

## Fix

Add `"scheduler"` to the two places the toolset type is validated in `agent-schema.json`:
- the primary toolset `type` enum, and
- the `anyOf` branch that permits types requiring no extra fields (alongside `background_agents`).

The `anyOf` edit is required in addition to the enum: adding `scheduler` only to the primary enum still failed validation with `Must validate at least one schema (anyOf)`, because `scheduler` (like `background_agents`) needs no extra required fields and so must also appear in that branch.

Scope kept minimal — this does not touch the unrelated pre-existing omissions of `openapi`/`open_url`/`rag` from the same `anyOf` branch.

## Testing

- `go test ./pkg/config/...` — all pass (including `TestDocYAMLSnippetsAreValid`)
- `agent-schema.json` validated as well-formed JSON

## Regression

Introduced by: #3632 (merge commit `9076342925eaade1da2bed8ba63a0df7604e25a7`) cc @dwin-gharibi 
