### PR TITLE
feat: add prompt cache miss warnings

### DIFF
--- a/pkg/runtime/harness.go
+++ b/pkg/runtime/harness.go
@@ -375,6 +375,9 @@ func (r *LocalRuntime) recordHarnessAssistantMessage(sess *session.Session, a *a
 	usageEvent := SessionUsage(sess, 0, a.CompactionThreshold())
 	usageEvent.LastMessage = msgUsage
 	events.Emit(NewTokenUsageEvent(sess.ID, a.Name(), usageEvent))
+	if shouldWarnOnCacheMiss(sess, msgUsage) {
+		events.Emit(Warning("This agent turn did not use the prompt cache.", a.Name()))
+	}
 }
 
 func harnessPromptFromMessages(messages []chat.Message) string {

--- a/pkg/runtime/loop.go
+++ b/pkg/runtime/loop.go
@@ -34,6 +34,7 @@ import (
 	"github.com/docker/docker-agent/pkg/tools/builtin/skills"
 	"github.com/docker/docker-agent/pkg/tools/builtin/transfertask"
 	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
+	"github.com/docker/docker-agent/pkg/userconfig"
 )
 
 // registerDefaultTools wires up the built-in tool handlers (delegation,
@@ -842,6 +843,9 @@ func (r *LocalRuntime) runTurn(
 	usage := SessionUsage(sess, contextLimit, a.CompactionThreshold())
 	usage.LastMessage = msgUsage
 	events.Emit(NewTokenUsageEvent(sess.ID, a.Name(), usage))
+	if shouldWarnOnCacheMiss(sess, msgUsage) {
+		events.Emit(Warning("This agent turn did not use the prompt cache.", a.Name()))
+	}
 
 	// Record the message count before tool calls so we can
 	// measure how much content was added by tool results.
@@ -1052,6 +1056,27 @@ func computeMessageCost(usage *chat.Usage, m *modelsdev.Model) *float64 {
 		float64(usage.CachedInputTokens)*m.Cost.CacheRead +
 		float64(usage.CacheWriteTokens)*m.Cost.CacheWrite) / 1e6
 	return &cost
+}
+
+func shouldWarnOnCacheMiss(sess *session.Session, usage *MessageUsage) bool {
+	if !userconfig.Get().CacheMissWarningsEnabled() || usage == nil || usage.CachedInputTokens > 0 {
+		return false
+	}
+	if usage.InputTokens == 0 && usage.CacheWriteTokens == 0 {
+		return false
+	}
+
+	assistantMessages := 0
+	for _, message := range sess.OwnMessages() {
+		if message.Message.Role != chat.MessageRoleAssistant {
+			continue
+		}
+		assistantMessages++
+		if assistantMessages > 1 {
+			return true
+		}
+	}
+	return false
 }
 
 // recordAssistantMessage adds the model's response to the session and returns

--- a/pkg/tui/dialog/settings.go
+++ b/pkg/tui/dialog/settings.go
@@ -60,6 +60,7 @@ const (
 const (
 	rowSound = iota
 	rowSoundThreshold
+	rowWarnOnCacheMiss
 	notificationsRowCount
 )
 
@@ -272,6 +273,8 @@ func (d *settingsDialog) changeValue(delta int) tea.Cmd {
 			if d.current.Sound {
 				d.current.SoundThreshold = stepValue(d.current.SoundThreshold, delta, 1, 1, 300)
 			}
+		case rowWarnOnCacheMiss:
+			d.current.WarnOnCacheMiss = !d.current.WarnOnCacheMiss
 		}
 	}
 	return nil
@@ -382,7 +385,8 @@ func (d *settingsDialog) renderBehaviorTab(content *Content, inner int) {
 func (d *settingsDialog) renderNotificationsTab(content *Content, inner int) {
 	content.AddSpace().
 		AddContent(d.renderToggleRow(rowSound, "Sound on task completion", d.current.Sound)).
-		AddContent(d.renderStepperRow(rowSoundThreshold, "Sound threshold", d.current.SoundThreshold, "seconds", inner, !d.current.Sound))
+		AddContent(d.renderStepperRow(rowSoundThreshold, "Sound threshold", d.current.SoundThreshold, "seconds", inner, !d.current.Sound)).
+		AddContent(d.renderToggleRow(rowWarnOnCacheMiss, "Warn when a turn misses the cache", d.current.WarnOnCacheMiss))
 }
 
 func (d *settingsDialog) renderSendModeOption(opt sendModeOption) string {

--- a/pkg/tui/dialog/settings_test.go
+++ b/pkg/tui/dialog/settings_test.go
@@ -371,10 +371,23 @@ func TestSettingsDialogSoundThresholdDisabledWhenSoundOff(t *testing.T) {
 	d := newTestSettingsDialog(t, messages.LayoutSettings{})
 	d.tab = tabNotifications
 	d.moveSelection(1)
-	assert.Equal(t, rowSound, d.selected[tabNotifications], "disabled threshold is skipped")
+	assert.Equal(t, rowWarnOnCacheMiss, d.selected[tabNotifications], "disabled threshold is skipped")
+	d.selected[tabNotifications] = rowSound
 	d.Update(tea.KeyPressMsg{Code: tea.KeySpace})
 	d.moveSelection(1)
 	assert.Equal(t, rowSoundThreshold, d.selected[tabNotifications])
+}
+
+func TestSettingsDialogTogglesCacheMissWarning(t *testing.T) {
+	t.Parallel()
+
+	d := newTestSettingsDialog(t, messages.LayoutSettings{})
+	d.tab = tabNotifications
+	d.selected[tabNotifications] = rowWarnOnCacheMiss
+	d.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+
+	assert.True(t, d.current.WarnOnCacheMiss)
+	assert.Contains(t, ansi.Strip(d.View()), "Warn when a turn misses the cache")
 }
 
 func TestRenderLayoutPreviewReflectsSections(t *testing.T) {

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -885,6 +885,7 @@ func (m *appModel) handleOpenSettingsDialog() (tea.Model, tea.Cmd) {
 		RestoreTabs:        settings.GetRestoreTabs(),
 		Snapshot:           settings.SnapshotsEnabled(),
 		CacheStablePrompts: settings.CacheStablePromptsEnabled(),
+		WarnOnCacheMiss:    settings.CacheMissWarningsEnabled(),
 		Lean:               settings.Lean,
 		TabTitleMaxLength:  settings.GetTabTitleMaxLength(),
 		Sound:              settings.GetSound(),
@@ -970,6 +971,7 @@ func savePreferences(p messages.Preferences) error {
 		s.RestoreTabs = boolPreference(p.RestoreTabs, false)
 		s.Snapshot = boolPreference(p.Snapshot, false)
 		s.CacheStablePrompts = boolPreference(p.CacheStablePrompts, false)
+		s.WarnOnCacheMiss = boolPreference(p.WarnOnCacheMiss, false)
 		s.HideToolResults = p.HideToolResults
 		s.YOLO = p.YOLO
 		s.Lean = p.Lean
@@ -1023,6 +1025,7 @@ func saveSettingsToUserConfig(layout messages.LayoutSettings, mode messages.Send
 		ExpandThinking: settings.GetExpandThinking(), HideToolResults: settings.HideToolResults,
 		YOLO: settings.YOLO, RestoreTabs: settings.GetRestoreTabs(), Snapshot: settings.SnapshotsEnabled(),
 		CacheStablePrompts: settings.CacheStablePromptsEnabled(),
+		WarnOnCacheMiss:    settings.CacheMissWarningsEnabled(),
 		Lean:               settings.Lean, TabTitleMaxLength: settings.GetTabTitleMaxLength(),
 		Sound: settings.GetSound(), SoundThreshold: settings.GetSoundThreshold(),
 	})

--- a/pkg/tui/messages/settings.go
+++ b/pkg/tui/messages/settings.go
@@ -112,6 +112,7 @@ type Preferences struct {
 	RestoreTabs        bool
 	Snapshot           bool
 	CacheStablePrompts bool
+	WarnOnCacheMiss    bool
 	Lean               bool
 	TabTitleMaxLength  int
 	Sound              bool

--- a/pkg/tui/settings_persistence_test.go
+++ b/pkg/tui/settings_persistence_test.go
@@ -124,6 +124,7 @@ func TestSavePreferences_RoundTripAndPreservesExtra(t *testing.T) {
 		RestoreTabs:        true,
 		Snapshot:           true,
 		CacheStablePrompts: true,
+		WarnOnCacheMiss:    true,
 		Lean:               true,
 		TabTitleMaxLength:  42,
 		Sound:              true,
@@ -141,6 +142,7 @@ func TestSavePreferences_RoundTripAndPreservesExtra(t *testing.T) {
 	assert.Equal(t, preferences.RestoreTabs, settings.GetRestoreTabs())
 	assert.Equal(t, preferences.Snapshot, settings.SnapshotsEnabled())
 	assert.Equal(t, preferences.CacheStablePrompts, settings.CacheStablePromptsEnabled())
+	assert.Equal(t, preferences.WarnOnCacheMiss, settings.CacheMissWarningsEnabled())
 	assert.Equal(t, preferences.Lean, settings.Lean)
 	assert.Equal(t, preferences.TabTitleMaxLength, settings.GetTabTitleMaxLength())
 	assert.Equal(t, preferences.Sound, settings.GetSound())
@@ -159,6 +161,7 @@ func TestSavePreferences_DefaultsClearEntries(t *testing.T) {
 		RestoreTabs:        true,
 		Snapshot:           true,
 		CacheStablePrompts: true,
+		WarnOnCacheMiss:    true,
 		TabTitleMaxLength:  40,
 		SoundThreshold:     40,
 	}))
@@ -181,6 +184,7 @@ func TestSavePreferences_DefaultsClearEntries(t *testing.T) {
 	assert.Nil(t, settings.RestoreTabs)
 	assert.Nil(t, settings.Snapshot)
 	assert.Nil(t, settings.CacheStablePrompts)
+	assert.Nil(t, settings.WarnOnCacheMiss)
 	assert.Zero(t, settings.TabTitleMaxLength)
 	assert.Zero(t, settings.SoundThreshold)
 }

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -83,6 +83,9 @@ type Settings struct {
 	// CacheStablePrompts keeps changing trusted context out of the frozen system
 	// prefix and appends chronological updates instead. Defaults to false.
 	CacheStablePrompts *bool `yaml:"cache_stable_prompts,omitempty"`
+	// WarnOnCacheMiss shows a warning when a model call after the first one in
+	// a session reports no cached input tokens. Defaults to false.
+	WarnOnCacheMiss *bool `yaml:"warn_on_cache_miss,omitempty"`
 	// Permissions defines global permission patterns applied across all sessions
 	// and agents. These act as user-wide defaults; session-level and agent-level
 	// permissions override them.
@@ -219,6 +222,11 @@ func (s *Settings) SnapshotsEnabled() bool {
 // CacheStablePromptsEnabled reports whether chronological instruction updates are enabled.
 func (s *Settings) CacheStablePromptsEnabled() bool {
 	return s != nil && s.CacheStablePrompts != nil && *s.CacheStablePrompts
+}
+
+// CacheMissWarningsEnabled reports whether cache-miss notifications are enabled.
+func (s *Settings) CacheMissWarningsEnabled() bool {
+	return s != nil && s.WarnOnCacheMiss != nil && *s.WarnOnCacheMiss
 }
 
 // GlobalHooks returns the user-level hooks config, if configured. Invalid


### PR DESCRIPTION
## Summary
- add an opt-in `warn_on_cache_miss` user setting
- expose the setting in the Notifications tab of `/settings`
- emit warning notifications when model turns after the first session response report no cached input tokens
- support both regular model calls and coding harness responses

## Validation
- `task build` ✅
- `go test ./pkg/runtime ./pkg/tui/page/chat` ✅
- `go test ./pkg/tui/dialog ./pkg/tui/page/chat ./pkg/tui ./pkg/userconfig` ✅
- `task test` ⚠️ unrelated existing failures in the scheduler docs schema snippet and live Moonshot provider test
- `task lint` ⚠️ unrelated existing `Lint/DeferMutexUnlock` offense in `pkg/tools/builtin/scheduler/scheduler.go`
