### PR TITLE
ci: bump golangci-lint-action to v9.3.0 and fix DeferMutexUnlock lint offense

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.12.2
 

--- a/pkg/tools/builtin/scheduler/scheduler.go
+++ b/pkg/tools/builtin/scheduler/scheduler.go
@@ -155,8 +155,8 @@ func (t *ToolSet) signalWake() {
 
 func (t *ToolSet) setRuntime(rt tools.Runtime) {
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	t.rt = rt
-	t.mu.Unlock()
 }
 
 func (t *ToolSet) runtime() tools.Runtime {


### PR DESCRIPTION
Bumps `golangci/golangci-lint-action` from v9.2.0 to v9.3.0 in the CI workflow, with the action SHA pinned to match. golangci-lint itself is already at the latest v2.12.2 so no tool version change was needed.

The bump surfaced a `DeferMutexUnlock` offense in the scheduler's `setRuntime` method, where `mu.Unlock()` was called directly rather than via `defer`. The fix moves the unlock to a deferred call, which is the safer and idiomatic pattern — it guarantees the lock is released even if a panic occurs, and eliminates the lint warning cleanly.

Additional linters evaluated during this pass (including `forcetypeassert`, `nilerr`, `nilnil`, `spancheck`, `errchkjson`, `canonicalheader`, `dupword`, `musttag`, `tagalign`, `godot`, `gosmopolitan`, and others) were not enabled: hits were either false positives, intentional patterns, or stylistic churn with no correctness benefit.