### PR TITLE
fix(server): surface background elicitations over API

### DIFF
--- a/docs/features/api-server/index.md
+++ b/docs/features/api-server/index.md
@@ -46,7 +46,7 @@ All endpoints are under the `/api` prefix.
 | `GET`    | `/api/sessions/:id`                 | Get a session by ID (messages, tokens, permissions)     |
 | `GET`    | `/api/sessions/:id/status`          | Lightweight runtime state (streaming, title, agent, tokens). Requires an attached runtime. |
 | `GET`    | `/api/sessions/:id/snapshot`        | Full state in one call (stored fields + runtime state + `last_event_seq`) for gapless resync — see [Reconnecting without gaps](#reconnecting-without-gaps). |
-| `GET`    | `/api/sessions/:id/events`          | Live session event stream (SSE) with sequence numbers and replay. Available for a run attached via [`--listen`](#listen). |
+| `GET`    | `/api/sessions/:id/events`          | Live session event stream (SSE) with sequence numbers and replay. Available for a run attached via [`--listen`](#listen), or once a session has raised at least one out-of-band event (e.g. a background job's elicitation, answered via `POST .../elicitation`), which creates a session-scoped event log on demand carrying such out-of-band events — see [Session event stream](#session-event-stream-and-reconnection) for what each kind of log contains. |
 | `DELETE` | `/api/sessions/:id`                 | Delete a session                                        |
 | `PATCH`  | `/api/sessions/:id/title`           | Update session title                                    |
 | `PATCH`  | `/api/sessions/:id/permissions`     | Update session permissions                              |
@@ -55,7 +55,7 @@ All endpoints are under the `/api` prefix.
 | `PATCH`  | `/api/sessions/:id/messages/:msg_id` | Update an existing message by ID. Returns `409 Conflict` while the session has an active run. |
 | `POST`   | `/api/sessions/:id/resume`          | Resume a paused session (after tool confirmation)       |
 | `POST`   | `/api/sessions/:id/tools/toggle`    | Toggle auto-approve (YOLO) mode                         |
-| `POST`   | `/api/sessions/:id/elicitation`     | Respond to an MCP tool elicitation request              |
+| `POST`   | `/api/sessions/:id/elicitation`     | Respond to an MCP tool elicitation request. Pass the `elicitation_id` from the `elicitation_request` event to target a specific concurrent request; omitted, it resolves the sole pending one. |
 | `POST`   | `/api/sessions/:id/steer`           | Inject messages into a running turn (pre-empts current) |
 | `POST`   | `/api/sessions/:id/followup`        | Enqueue messages to run after the current turn finishes (supports an `Idempotency-Key` — see [Idempotent follow-ups](#idempotent-follow-ups)). |
 | `GET`    | `/api/sessions/:id/models`          | List available models for the session's current agent   |
@@ -257,7 +257,16 @@ session's runtime events — `stream_started`, `agent_choice`, `tool_call`,
 per-request stream returned by the agent-execution endpoint, it is
 session-scoped and survives across turns, so a client can watch a session for
 its whole lifetime. It is available for a run attached via
-[`--listen`](#listen).
+[`--listen`](#listen), and — since a session-scoped event log is created on
+demand the first time a session raises an out-of-band event, such as an
+`elicitation_request` from a background job — for any API-created session
+that has produced at least one (see the
+[Sessions endpoint table](#sessions) above). The two kinds of log differ in
+coverage: a `--listen` run feeds its full runtime event stream into the log,
+while an on-demand log for an API-created session carries the session's
+out-of-band events — not necessarily all ordinary turn events, which flow on
+the per-request SSE stream of the [agent-execution](#agent-execution)
+request that runs the turn.
 
 Each event carries a monotonic **sequence number** in the SSE `id:` field, and
 the server buffers recent events. This makes the stream resumable:

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -56,6 +56,24 @@ type SessionManager struct {
 
 	mux sync.Mutex
 
+	// eventLogsMu serialises event-log lifecycle transitions: on-demand
+	// creation (ensureEventLog), source attachment (RegisterEventSource) and
+	// teardown (dropEventLog), together with deletedEventLogs. Reads of
+	// eventLogs stay lock-free. It is a leaf lock: sm.mux may be held when
+	// acquiring it (DeleteSession/BatchDeleteSessions), never the reverse —
+	// ensureEventLog runs on runtime goroutines (elicitation sink callbacks)
+	// and must not need sm.mux.
+	eventLogsMu sync.Mutex
+
+	// deletedEventLogs tombstones the IDs of deleted sessions so a stale
+	// elicitation-sink closure — held by an in-flight or detached background
+	// elicitation that outlives DeleteSession — cannot lazily recreate an
+	// event log for a session that no longer exists (#3584 review). Entries
+	// are permanent: session IDs are never reused, and one string per deleted
+	// session is far cheaper than the leaked event log it prevents. Guarded
+	// by eventLogsMu.
+	deletedEventLogs map[string]struct{}
+
 	// sessionReady is closed once the first session is attached or created,
 	// signalling that the server is ready to accept session-scoped requests.
 	sessionReady     chan struct{}
@@ -95,6 +113,7 @@ func NewSessionManager(ctx context.Context, sources config.Sources, sessionStore
 		runtimeSessions:   concurrent.NewMap[string, *activeRuntimes](),
 		deletedSessions:   concurrent.NewMap[string, *activeRuntimes](),
 		eventLogs:         concurrent.NewMap[string, *pumpedEventLog](),
+		deletedEventLogs:  make(map[string]struct{}),
 		followUpInjectors: concurrent.NewMap[string, FollowUpInjector](),
 		followUpKeys:      concurrent.NewMap[string, *idempotencyCache](),
 		sessionStore:      sessionStore,
@@ -129,6 +148,11 @@ func (sm *SessionManager) WaitReady(ctx context.Context) error {
 type pumpedEventLog struct {
 	log    *eventLog
 	cancel context.CancelFunc
+
+	// lazy marks a log created on demand by ensureEventLog: ring buffer
+	// only, no pump goroutine. RegisterEventSource adopts such a log (see
+	// there) instead of clobbering it.
+	lazy bool
 }
 
 // RegisterEventSource attaches an event source for sessionID and immediately
@@ -140,10 +164,38 @@ type pumpedEventLog struct {
 // The pump runs for the session's lifetime (until DeleteSession or the source
 // returns), buffering events even when no client is connected, so a client
 // that connects or reconnects later can replay what it missed.
+//
+// A lazily-created log (see ensureEventLog) that already exists for
+// sessionID — because an out-of-band event beat the source registration —
+// is adopted rather than replaced: its buffered events, sequence numbers
+// and connected listeners all survive, and only the lifetime owner changes.
+// The adopted entry's cancel becomes the pump cancel, whose deferred close
+// below ends the log — the exact same contract a brand-new attached source
+// gets. The lazy entry's old cancel closure held nothing but the log, so
+// dropping it leaks nothing.
+//
+// Registering for a deleted session is a no-op: like ensureEventLog, the
+// registration is serialised with dropEventLog under eventLogsMu and gated
+// on the deletedEventLogs tombstone, so a registration racing
+// DeleteSession/BatchDeleteSessions can neither store a log nobody will ever
+// tear down nor start a pump for a session that is gone — src is never
+// invoked. The pump context is only created after the tombstone check, so a
+// rejected registration leaves nothing behind to clean up.
 func (sm *SessionManager) RegisterEventSource(sessionID string, src EventSource) {
+	sm.eventLogsMu.Lock()
+	if _, deleted := sm.deletedEventLogs[sessionID]; deleted {
+		sm.eventLogsMu.Unlock()
+		return
+	}
+	var log *eventLog
+	if pe, ok := sm.eventLogs.Load(sessionID); ok && pe.lazy {
+		log = pe.log
+	} else {
+		log = newEventLog(defaultEventLogCapacity)
+	}
 	pumpCtx, cancel := context.WithCancel(context.Background())
-	log := newEventLog(defaultEventLogCapacity)
 	sm.eventLogs.Store(sessionID, &pumpedEventLog{log: log, cancel: cancel})
+	sm.eventLogsMu.Unlock()
 
 	go func() {
 		defer log.close("session ended")
@@ -155,6 +207,102 @@ func (sm *SessionManager) RegisterEventSource(sessionID string, src EventSource)
 func (sm *SessionManager) HasEventSource(sessionID string) bool {
 	_, ok := sm.eventLogs.Load(sessionID)
 	return ok
+}
+
+// ensureEventLog returns sessionID's [pumpedEventLog], creating a bare one —
+// ring buffer only, no pump goroutine — if none is registered yet. An
+// existing log (e.g. one attached via RegisterEventSource) is always reused,
+// never replaced. Used by appendSessionEvent to give a session a replayable
+// event route even when it was never attached via RegisterEventSource (the
+// common case for a session created directly by the API server rather than
+// by an external embedder like the TUI).
+//
+// Returns nil — and creates nothing — once the session has been deleted:
+// creation is serialised with dropEventLog under eventLogsMu and gated on
+// the deletedEventLogs tombstone, so a stale elicitation-sink closure that
+// fires after DeleteSession cannot resurrect a log for a session whose
+// runtime is gone (its events would be permanently unanswerable) or leak
+// one nobody will ever tear down (#3584 review). The lock-free fast path is
+// safe without the tombstone check: a log that deletion is concurrently
+// tearing down is closed before it is removed, and appends to a closed log
+// are no-ops.
+//
+// cancel closes the log (delivering session_exited and disconnecting any
+// live listener) instead of being a no-op: there is no external source pump
+// to stop, but DeleteSession/BatchDeleteSessions call pe.cancel()
+// unconditionally expecting it to end the log's lifetime. A no-op here would
+// leave a connected GET /api/sessions/:id/events request on a lazily-created
+// log blocked forever after deletion — it would never see session_exited and
+// never close, contradicting the end-of-session contract documented on
+// Server.sessionEvents.
+func (sm *SessionManager) ensureEventLog(sessionID string) *pumpedEventLog {
+	if pe, ok := sm.eventLogs.Load(sessionID); ok {
+		return pe
+	}
+
+	sm.eventLogsMu.Lock()
+	defer sm.eventLogsMu.Unlock()
+	if _, deleted := sm.deletedEventLogs[sessionID]; deleted {
+		return nil
+	}
+	if pe, ok := sm.eventLogs.Load(sessionID); ok {
+		return pe
+	}
+	log := newEventLog(defaultEventLogCapacity)
+	pe := &pumpedEventLog{log: log, cancel: func() { log.close("session ended") }, lazy: true}
+	sm.eventLogs.Store(sessionID, pe)
+	return pe
+}
+
+// dropEventLog tombstones sessionID and tears down its event log, if any.
+// Serialised with ensureEventLog/RegisterEventSource under eventLogsMu so
+// that once it returns, no event log for sessionID exists or can ever be
+// created again — neither lazily nor via a source registration. Callers may
+// hold sm.mux (see eventLogsMu's lock ordering note).
+func (sm *SessionManager) dropEventLog(sessionID string) {
+	sm.eventLogsMu.Lock()
+	defer sm.eventLogsMu.Unlock()
+	sm.deletedEventLogs[sessionID] = struct{}{}
+	if pe, ok := sm.eventLogs.Load(sessionID); ok {
+		pe.cancel()
+		sm.eventLogs.Delete(sessionID)
+	}
+}
+
+// appendSessionEvent appends event to sessionID's event log, creating the
+// log on demand (see ensureEventLog) if this is the first out-of-band event
+// the session has ever produced. Events for a deleted session are dropped.
+func (sm *SessionManager) appendSessionEvent(sessionID string, event any) {
+	if pe := sm.ensureEventLog(sessionID); pe != nil {
+		pe.log.append(event)
+	}
+}
+
+// sessionElicitationSink returns the OnElicitationRequest handler that
+// runtimeForSession registers on every API/server-created runtime: it
+// appends the event to sessionID's (lazily created) event log, giving
+// out-of-band elicitations — chiefly from detached background jobs — a
+// session-scoped route to any client streaming GET /api/sessions/:id/events,
+// instead of the runtime treating an absent sink as "no UI" and
+// auto-declining (#3584). Split out as its own method so the exact wiring is
+// unit-testable without spinning up a real runtime/team.
+func (sm *SessionManager) sessionElicitationSink(sessionID string) func(runtime.Event) {
+	return func(ev runtime.Event) {
+		sm.appendSessionEvent(sessionID, ev)
+	}
+}
+
+// elicitationSinkMirror is the optional capability marking a runtime whose
+// OnElicitationRequest sink is the exactly-once delivery point for
+// elicitation requests even though the same event is ALSO best-effort
+// mirrored onto its RunStream channel (see
+// [runtime.LocalRuntime.MirrorsElicitationOnRunStream]). Consumers that copy
+// RunStream events into the session event log must skip that mirror copy or
+// the log would carry the same request twice. Runtimes without the
+// capability (e.g. RemoteRuntime, whose OnElicitationRequest is a no-op)
+// deliver ONLY via RunStream, so their copy must never be skipped.
+type elicitationSinkMirror interface {
+	MirrorsElicitationOnRunStream()
 }
 
 // LastEventSeq returns the most recent event sequence number for sessionID,
@@ -550,6 +698,16 @@ func (sm *SessionManager) DeleteSession(ctx context.Context, sessionID string) e
 	}
 
 	if sessionRuntime, ok := sm.runtimeSessions.Load(sess.ID); ok {
+		// Server-owned runtimes (done == nil) carry the manager's own
+		// elicitation sink (see runtimeForSession); clear it so a detached
+		// background job that elicits after this point hits the runtime's
+		// headless fast-decline path ("no sink means no UI") and terminates,
+		// instead of parking a waiter forever on a request nobody can answer
+		// or route anymore. Attached runtimes' sinks belong to their embedder
+		// (pkg/app) and outlive this session, so they are left alone.
+		if sessionRuntime.done == nil {
+			sessionRuntime.runtime.OnElicitationRequest(nil)
+		}
 		if sessionRuntime.cancel != nil {
 			sessionRuntime.cancel()
 		}
@@ -580,10 +738,7 @@ func (sm *SessionManager) DeleteSession(ctx context.Context, sessionID string) e
 			}
 		}()
 	}
-	if pe, ok := sm.eventLogs.Load(sess.ID); ok {
-		pe.cancel()
-		sm.eventLogs.Delete(sess.ID)
-	}
+	sm.dropEventLog(sess.ID)
 	sm.followUpInjectors.Delete(sess.ID)
 	sm.followUpKeys.Delete(sess.ID)
 
@@ -911,11 +1066,19 @@ func (sm *SessionManager) recallSession(ctx context.Context, sessionID string, m
 	}
 	sm.mux.Unlock()
 
+	_, skipMirroredElicitation := rt.runtime.(elicitationSinkMirror)
 	go func() {
 		defer rt.streaming.Unlock()
 		defer runCancel()
 		stream := rt.runtime.RunStream(runCtx, sess)
 		for event := range stream {
+			// Already appended exactly once via the OnElicitationRequest
+			// sink (see runtimeForSession); skip the best-effort RunStream
+			// mirror copy so the event log doesn't carry the same request
+			// twice (#3584).
+			if _, isElicitation := event.(*runtime.ElicitationRequestEvent); isElicitation && skipMirroredElicitation {
+				continue
+			}
 			if pe, ok := sm.eventLogs.Load(sessionID); ok {
 				pe.log.append(event)
 			}
@@ -1122,6 +1285,20 @@ func (sm *SessionManager) runtimeForSession(ctx context.Context, sess *session.S
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// Give this session an out-of-band, session-scoped route for
+	// elicitations raised while nobody is synchronously reading this
+	// specific RunSession call's stream — most notably background jobs
+	// (run_background_agent) that outlive the request that started them.
+	// Without a sink, elicitationHandler's headless fast-decline path ("no
+	// sink means no UI") fires for every background elicitation raised
+	// through the API even though an HTTP client CAN answer it via POST
+	// /api/sessions/:id/elicitation. Appending to this session's event log
+	// makes the request replayable via GET /api/sessions/:id/events (lazily
+	// creating the log if this session was never attached with
+	// RegisterEventSource) and answerable through the existing elicitation
+	// route (#3584).
+	run.OnElicitationRequest(sm.sessionElicitationSink(sess.ID))
 
 	// Apply any stored per-agent model overrides so that a session
 	// resumed (or freshly created with overrides via CreateSession) uses
@@ -1603,13 +1780,18 @@ func (sm *SessionManager) BatchDeleteSessions(ctx context.Context, sessionIDs []
 		} else {
 			deleted++
 			if sessionRuntime, ok := sm.runtimeSessions.Load(sessionID); ok {
-				sessionRuntime.cancel()
+				// Same as DeleteSession: silence the manager-registered
+				// elicitation sink on server-owned runtimes so post-delete
+				// background elicitations fast-decline instead of parking.
+				if sessionRuntime.done == nil {
+					sessionRuntime.runtime.OnElicitationRequest(nil)
+				}
+				if sessionRuntime.cancel != nil {
+					sessionRuntime.cancel()
+				}
 				sm.runtimeSessions.Delete(sessionID)
 			}
-			if pe, ok := sm.eventLogs.Load(sessionID); ok {
-				pe.cancel()
-				sm.eventLogs.Delete(sessionID)
-			}
+			sm.dropEventLog(sessionID)
 			sm.followUpInjectors.Delete(sessionID)
 			sm.followUpKeys.Delete(sessionID)
 		}

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -73,13 +73,17 @@ func (f *fakeRuntime) ResumeElicitation(_ context.Context, _ tools.ElicitationAc
 	return nil
 }
 
+// OnElicitationRequest is a no-op: DeleteSession/BatchDeleteSessions call it
+// (with nil) on server-owned runtimes to silence the manager's sink.
+func (f *fakeRuntime) OnElicitationRequest(func(runtime.Event)) {}
+
 func (f *fakeRuntime) CurrentAgentName(context.Context) string { return "root" }
 
 // SupportsModelSwitching reports false by default. Tests that exercise
 // the /models endpoints embed fakeRuntime and override this.
 func (f *fakeRuntime) SupportsModelSwitching() bool { return false }
 
-func newTestSessionManager(t *testing.T, sess *session.Session, fake *fakeRuntime) *SessionManager {
+func newTestSessionManager(t *testing.T, sess *session.Session, fake runtime.Runtime) *SessionManager {
 	t.Helper()
 
 	ctx := t.Context()
@@ -90,6 +94,7 @@ func newTestSessionManager(t *testing.T, sess *session.Session, fake *fakeRuntim
 		runtimeSessions:   concurrent.NewMap[string, *activeRuntimes](),
 		deletedSessions:   concurrent.NewMap[string, *activeRuntimes](),
 		eventLogs:         concurrent.NewMap[string, *pumpedEventLog](),
+		deletedEventLogs:  make(map[string]struct{}),
 		followUpInjectors: concurrent.NewMap[string, FollowUpInjector](),
 		followUpKeys:      concurrent.NewMap[string, *idempotencyCache](),
 		sessionStore:      store,
@@ -1003,4 +1008,975 @@ func storedToolResultContent(t *testing.T, sess *session.Session, toolCallID str
 
 	require.Failf(t, "tool result not found", "tool_call_id=%s", toolCallID)
 	return ""
+}
+
+// --- #3584: session-scoped elicitation sink for API/server-created runtimes ---
+
+// scriptedStreamRuntime is a fakeRuntime whose RunStream replays a fixed
+// list of events and closes.
+type scriptedStreamRuntime struct {
+	fakeRuntime
+
+	events []runtime.Event
+}
+
+func (s *scriptedStreamRuntime) RunStream(context.Context, *session.Session) <-chan runtime.Event {
+	ch := make(chan runtime.Event, len(s.events))
+	for _, ev := range s.events {
+		ch <- ev
+	}
+	close(ch)
+	return ch
+}
+
+// mirroredScriptedStreamRuntime additionally declares — like LocalRuntime —
+// that its OnElicitationRequest sink is the exactly-once delivery point and
+// any elicitation copy on RunStream is a best-effort mirror.
+type mirroredScriptedStreamRuntime struct {
+	scriptedStreamRuntime
+}
+
+func (m *mirroredScriptedStreamRuntime) MirrorsElicitationOnRunStream() {}
+
+// waitSessionIdle blocks until sessionID's streaming lock is free, i.e. the
+// recall/run pump goroutine has fully finished appending to the event log.
+func waitSessionIdle(t *testing.T, sm *SessionManager, sessionID string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		rt, ok := sm.runtimeSessions.Load(sessionID)
+		if !ok {
+			return false
+		}
+		if !rt.streaming.TryLock() {
+			return false
+		}
+		rt.streaming.Unlock()
+		return true
+	}, 2*time.Second, time.Millisecond)
+}
+
+// replaySessionEvents streams sessionID's event log until want events have
+// been received (replay first, then live tail), then returns them in order.
+func replaySessionEvents(t *testing.T, sm *SessionManager, sessionID string, want int) []any {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	var mu sync.Mutex
+	var events []any
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ok := sm.StreamEvents(ctx, sessionID, nil, func(_ uint64, event any) {
+			mu.Lock()
+			defer mu.Unlock()
+			events = append(events, event)
+		})
+		assert.True(t, ok, "expected an event log for session %s", sessionID)
+	}()
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(events) >= want
+	}, 2*time.Second, time.Millisecond)
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	return append([]any(nil), events...)
+}
+
+// TestSessionElicitationSink_MakesSessionEventSourceReplayable pins the fix
+// for #3584 on the server side: before it, only pkg/app (the TUI) ever
+// registered an OnElicitationRequest sink, so every API/server-created
+// runtime had none — elicitationHandler's headless fast-decline path ("no
+// sink means no UI") therefore fired for every background elicitation raised
+// through the API, even though an HTTP client could otherwise answer it.
+// runtimeForSession registers sessionElicitationSink on every runtime it
+// builds; this exercises that exact closure (without needing a full
+// runtime/team) and confirms the session gains a replayable event source it
+// didn't have before.
+func TestSessionElicitationSink_MakesSessionEventSourceReplayable(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	sm := NewSessionManager(ctx, config.Sources{}, session.NewInMemorySessionStore(), 0, &config.RuntimeConfig{})
+
+	require.False(t, sm.HasEventSource("sess-1"),
+		"a session that was never attached and produced no out-of-band event must have no event source")
+
+	sink := sm.sessionElicitationSink("sess-1")
+	ev := runtime.ElicitationRequest("need input", "form", nil, "", "eid-1", "", "bg-child", nil, "agent")
+	sink(ev)
+
+	require.True(t, sm.HasEventSource("sess-1"),
+		"the sink must lazily create a session-scoped event source on first use")
+
+	replayed := replaySessionEvents(t, sm, "sess-1", 1)
+	require.Len(t, replayed, 1)
+	assert.Same(t, ev, replayed[0], "the elicitation event must be replayable via GET .../events")
+}
+
+// TestSessionElicitationSink_AccumulatesAcrossCalls verifies repeated sink
+// invocations append to one session-scoped log — each event exactly once, in
+// order — rather than each invocation overwriting the log.
+func TestSessionElicitationSink_AccumulatesAcrossCalls(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	sm := NewSessionManager(ctx, config.Sources{}, session.NewInMemorySessionStore(), 0, &config.RuntimeConfig{})
+
+	sink := sm.sessionElicitationSink("sess-2")
+	first := runtime.ElicitationRequest("first", "form", nil, "", "eid-1", "", "bg-child-1", nil, "agent")
+	second := runtime.ElicitationRequest("second", "form", nil, "", "eid-2", "", "bg-child-2", nil, "agent")
+	sink(first)
+	sink(second)
+
+	seq, ok := sm.LastEventSeq("sess-2")
+	require.True(t, ok)
+	assert.Equal(t, uint64(2), seq, "both sink deliveries must land in the same event log")
+
+	replayed := replaySessionEvents(t, sm, "sess-2", 2)
+	require.Len(t, replayed, 2)
+	assert.Same(t, first, replayed[0])
+	assert.Same(t, second, replayed[1])
+}
+
+// TestSessionElicitationSink_ReusesAttachedEventLog verifies the sink never
+// clobbers a log that RegisterEventSource already attached (the --listen
+// case): the elicitation must continue that log's sequence instead of
+// replacing it — replacing would silently drop the attached pump's buffered
+// events and detach its cancel.
+func TestSessionElicitationSink_ReusesAttachedEventLog(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	sm := NewSessionManager(ctx, config.Sources{}, session.NewInMemorySessionStore(), 0, &config.RuntimeConfig{})
+
+	pumped := make(chan struct{})
+	sm.RegisterEventSource("sess-3", func(ctx context.Context, send func(any)) {
+		send("attached-event")
+		close(pumped)
+		<-ctx.Done() // keep the source alive so the pump doesn't close the log
+	})
+	// The pump ctx is detached from t.Context(); stop it explicitly.
+	t.Cleanup(func() {
+		if pe, ok := sm.eventLogs.Load("sess-3"); ok {
+			pe.cancel()
+		}
+	})
+	<-pumped
+
+	attached, ok := sm.eventLogs.Load("sess-3")
+	require.True(t, ok)
+
+	ev := runtime.ElicitationRequest("need input", "form", nil, "", "eid-1", "", "bg-child", nil, "agent")
+	sm.sessionElicitationSink("sess-3")(ev)
+
+	current, ok := sm.eventLogs.Load("sess-3")
+	require.True(t, ok)
+	assert.Same(t, attached, current, "the sink must reuse the attached event log, not overwrite it")
+
+	seq, ok := sm.LastEventSeq("sess-3")
+	require.True(t, ok)
+	assert.Equal(t, uint64(2), seq, "the elicitation must continue the attached log's sequence")
+
+	replayed := replaySessionEvents(t, sm, "sess-3", 2)
+	require.Len(t, replayed, 2)
+	assert.Equal(t, "attached-event", replayed[0])
+	assert.Same(t, ev, replayed[1])
+}
+
+// TestRuntimeForSession_RegistersSessionScopedElicitationSink is an
+// end-to-end check that runtimeForSession actually wires
+// sessionElicitationSink onto every runtime it builds (not just that the
+// sink mechanics work in isolation, per the tests above). It uses a
+// harness-backed agent (harness: type: claude-code) so no model provider or
+// API key is needed — runtime construction only requires *a* valid agent,
+// per LocalRuntime's "has no valid model" guard.
+//
+// Crucially, this drives the sink through the RETURNED runtime itself (via
+// EmitElicitationRequestForTesting) rather than reconstructing a fresh
+// sm.sessionElicitationSink(...) closure and calling that in isolation: the
+// latter would keep passing even if runtimeForSession's
+// `run.OnElicitationRequest(...)` registration were deleted, since it never
+// exercises what got wired onto `run`.
+func TestRuntimeForSession_RegistersSessionScopedElicitationSink(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cfg := []byte(`agents:
+  root:
+    description: Test agent
+    instruction: Be helpful.
+    harness:
+      type: claude-code
+`)
+	store := session.NewInMemorySessionStore()
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	sources := config.Sources{"agent.yaml": config.NewBytesSource("agent.yaml", cfg)}
+	sm := NewSessionManager(ctx, sources, store, 0, &config.RuntimeConfig{})
+
+	require.False(t, sm.HasEventSource(sess.ID))
+
+	run, _, err := sm.runtimeForSession(ctx, sess, "agent.yaml", "", &config.RuntimeConfig{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = run.Close() })
+
+	lr, ok := run.(*runtime.LocalRuntime)
+	require.True(t, ok, "runtimeForSession is expected to build a *runtime.LocalRuntime, got %T", run)
+
+	// Simulate what elicitationHandler does when it raises a background
+	// elicitation, but through the sink runtimeForSession actually registered
+	// on this specific runtime instance, not a freshly built one.
+	lr.EmitElicitationRequestForTesting(runtime.ElicitationRequest("need input", "form", nil, "", "eid-1", "", sess.ID, nil, "root"))
+	require.True(t, sm.HasEventSource(sess.ID),
+		"runtimeForSession must leave the session able to surface out-of-band elicitations")
+}
+
+// elicitationRecordingRuntime records ResumeElicitation calls so tests can
+// assert exactly what the elicitation endpoint routed to a session's runtime.
+type elicitationRecordingRuntime struct {
+	fakeRuntime
+
+	mu    sync.Mutex
+	calls []recordedElicitationResume
+}
+
+type recordedElicitationResume struct {
+	action  tools.ElicitationAction
+	content map[string]any
+	id      string
+}
+
+func (e *elicitationRecordingRuntime) ResumeElicitation(_ context.Context, action tools.ElicitationAction, content map[string]any, elicitationID ...string) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	var id string
+	if len(elicitationID) > 0 {
+		id = elicitationID[0]
+	}
+	e.calls = append(e.calls, recordedElicitationResume{action: action, content: content, id: id})
+	return nil
+}
+
+func (e *elicitationRecordingRuntime) recordedCalls() []recordedElicitationResume {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]recordedElicitationResume(nil), e.calls...)
+}
+
+// TestElicitationEndpoint_RoutesAnswerToSessionRuntime pins the server half
+// of the #3584 answer path: POST /api/sessions/:id/elicitation must hand the
+// client's action, content and elicitation_id verbatim to the session's
+// runtime via ResumeElicitation. Together with pkg/runtime's
+// TestElicitationHandler_BackgroundWithSinkStillWaitsForResponse — which
+// proves a runtime with a wired OnElicitationRequest sink parks a background
+// elicitation until ResumeElicitation(elicitation_id) delivers the answer —
+// and TestRuntimeForSession_RegistersSessionScopedElicitationSink above,
+// this closes the end-to-end loop without a package-crossing test seam into
+// the unexported elicitationHandler.
+func TestElicitationEndpoint_RoutesAnswerToSessionRuntime(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	sess := session.New()
+	fake := &elicitationRecordingRuntime{}
+	sm := newTestSessionManager(t, sess, fake)
+	srv := NewWithManager(sm, "")
+
+	body, err := json.Marshal(api.ResumeElicitationRequest{
+		Action:        "accept",
+		Content:       map[string]any{"confirmed": true},
+		ElicitationID: "eid-42",
+	})
+	require.NoError(t, err)
+
+	e := echo.New()
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/api/sessions/"+sess.ID+"/elicitation", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(sess.ID)
+	require.NoError(t, srv.elicitation(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	calls := fake.recordedCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, tools.ElicitationActionAccept, calls[0].action)
+	assert.Equal(t, map[string]any{"confirmed": true}, calls[0].content)
+	assert.Equal(t, "eid-42", calls[0].id, "the elicitation_id must reach the runtime for per-request routing")
+}
+
+// TestRecallSession_SkipsMirroredElicitationOnRunStream guards the
+// exactly-once contract of the event log now that the OnElicitationRequest
+// sink appends elicitation requests to it: LocalRuntime ALSO best-effort
+// mirrors the same event onto RunStream (for out-of-process RunStream
+// consumers), so recallSession's pump — which copies RunStream events into
+// the same log — must skip that mirror copy for runtimes that declare it
+// (MirrorsElicitationOnRunStream), mirroring pkg/app's dedupe.
+func TestRecallSession_SkipsMirroredElicitationOnRunStream(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	sess := session.New()
+	elicit := runtime.ElicitationRequest("need input", "form", nil, "", "eid-1", "", "bg-child", nil, "root")
+	other := runtime.Warning("heads up", "root")
+	fake := &mirroredScriptedStreamRuntime{scriptedStreamRuntime{events: []runtime.Event{elicit, other}}}
+	sm := newTestSessionManager(t, sess, fake)
+
+	// Reliable path: the sink already delivered the request exactly once.
+	sm.sessionElicitationSink(sess.ID)(elicit)
+
+	require.NoError(t, sm.recallSession(ctx, sess.ID, runtime.QueuedMessage{Content: "wake up"}))
+	waitSessionIdle(t, sm, sess.ID)
+
+	seq, ok := sm.LastEventSeq(sess.ID)
+	require.True(t, ok)
+	require.Equal(t, uint64(2), seq,
+		"the RunStream mirror copy of an elicitation must not be appended a second time")
+
+	replayed := replaySessionEvents(t, sm, sess.ID, 2)
+	assert.Same(t, elicit, replayed[0], "the sink-delivered elicitation must be first")
+	assert.Same(t, other, replayed[1], "non-elicitation stream events must still be pumped")
+}
+
+// TestRecallSession_KeepsElicitationFromNonMirroringRuntime is the
+// counterpart guard: a runtime that does NOT declare
+// MirrorsElicitationOnRunStream (e.g. RemoteRuntime, whose
+// OnElicitationRequest is a no-op) delivers elicitations ONLY via RunStream,
+// so that sole copy must reach the event log unfiltered.
+func TestRecallSession_KeepsElicitationFromNonMirroringRuntime(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	sess := session.New()
+	elicit := runtime.ElicitationRequest("need input", "form", nil, "", "eid-1", "", "bg-child", nil, "root")
+	fake := &scriptedStreamRuntime{events: []runtime.Event{elicit}}
+	sm := newTestSessionManager(t, sess, fake)
+
+	// Pre-create the session's event log (as an attached session would have).
+	sm.ensureEventLog(sess.ID)
+
+	require.NoError(t, sm.recallSession(ctx, sess.ID, runtime.QueuedMessage{Content: "wake up"}))
+	waitSessionIdle(t, sm, sess.ID)
+
+	seq, ok := sm.LastEventSeq(sess.ID)
+	require.True(t, ok)
+	require.Equal(t, uint64(1), seq,
+		"a non-mirroring runtime's RunStream copy is the only delivery and must not be skipped")
+
+	replayed := replaySessionEvents(t, sm, sess.ID, 1)
+	assert.Same(t, elicit, replayed[0])
+}
+
+// TestDeleteSession_ClosesLazyElicitationEventLog guards ensureEventLog's
+// cancel contract: DeleteSession calls pe.cancel() unconditionally, expecting
+// it to end the log's lifetime. Were the lazily-created log's cancel a no-op,
+// a client already streaming GET /api/sessions/:id/events for such a session
+// would never receive the terminal session_exited event and never see its
+// stream close, contradicting the end-of-session contract documented on
+// Server.sessionEvents. This proves the lazily-created log is actually
+// closed on deletion: session_exited is delivered and the blocked
+// StreamEvents call returns.
+func TestDeleteSession_ClosesLazyElicitationEventLog(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	// Lazily create the session's event log the way runtimeForSession's
+	// sessionElicitationSink does for a background job's elicitation — no
+	// runtime/RegisterEventSource pump is ever registered for this session.
+	sm.sessionElicitationSink(sess.ID)(runtime.ElicitationRequest("need input", "form", nil, "", "eid-1", "", sess.ID, nil, "root"))
+	require.True(t, sm.HasEventSource(sess.ID))
+
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	defer cancelStream()
+	var mu sync.Mutex
+	var received []any
+	streamDone := make(chan struct{})
+	go func() {
+		defer close(streamDone)
+		sm.StreamEvents(streamCtx, sess.ID, nil, func(_ uint64, event any) {
+			mu.Lock()
+			defer mu.Unlock()
+			received = append(received, event)
+		})
+	}()
+
+	// Wait for the replay of the elicitation event so the stream is known to
+	// be actively connected (not merely about to start) before we delete.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(received) == 1
+	}, 2*time.Second, time.Millisecond)
+
+	require.NoError(t, sm.DeleteSession(ctx, sess.ID))
+
+	select {
+	case <-streamDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StreamEvents must return once the session is deleted; a no-op cancel on the lazily-created event log leaves connected /events streams blocked forever")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, received, 2, "expected the elicitation event followed by a terminal session_exited event")
+	exited, ok := received[1].(sessionExitedEvent)
+	require.True(t, ok, "expected sessionExitedEvent, got %T", received[1])
+	assert.Equal(t, "session_exited", exited.Type)
+}
+
+// TestBatchDeleteSessions_ClosesLazyElicitationEventLog is the batch variant
+// of the above: BatchDeleteSessions goes through the same pe.cancel() call
+// per session, so it must uphold the same contract.
+func TestBatchDeleteSessions_ClosesLazyElicitationEventLog(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	sm.sessionElicitationSink(sess.ID)(runtime.ElicitationRequest("need input", "form", nil, "", "eid-1", "", sess.ID, nil, "root"))
+	require.True(t, sm.HasEventSource(sess.ID))
+
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	defer cancelStream()
+	var mu sync.Mutex
+	var received []any
+	streamDone := make(chan struct{})
+	go func() {
+		defer close(streamDone)
+		sm.StreamEvents(streamCtx, sess.ID, nil, func(_ uint64, event any) {
+			mu.Lock()
+			defer mu.Unlock()
+			received = append(received, event)
+		})
+	}()
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(received) == 1
+	}, 2*time.Second, time.Millisecond)
+
+	deleted, failed := sm.BatchDeleteSessions(ctx, []string{sess.ID})
+	assert.Equal(t, 1, deleted)
+	assert.Empty(t, failed)
+
+	select {
+	case <-streamDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StreamEvents must return once the session is batch-deleted; a no-op cancel on the lazily-created event log leaves connected /events streams blocked forever")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, received, 2, "expected the elicitation event followed by a terminal session_exited event")
+	exited, ok := received[1].(sessionExitedEvent)
+	require.True(t, ok, "expected sessionExitedEvent, got %T", received[1])
+	assert.Equal(t, "session_exited", exited.Type)
+}
+
+// --- #3584 review: deletion vs. lazy event-log creation race ---
+
+// TestDeleteSession_StaleSinkAfterDeleteCannotResurrectEventLog pins the
+// tombstone gate on ensureEventLog: the elicitation sink closure that
+// runtimeForSession registered keeps existing after DeleteSession (a
+// detached background elicitation may already hold it), and before the gate
+// its next invocation silently recreated a permanent event log for the
+// deleted session — an entry nobody would ever tear down again (session IDs
+// are never reused) carrying a request nobody could answer (the runtime
+// registration is gone). Both the "log existed and was torn down" and the
+// "log never existed" orderings must refuse to (re)create one.
+func TestDeleteSession_StaleSinkAfterDeleteCannotResurrectEventLog(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	// The exact closure runtimeForSession registers on the runtime; deletion
+	// cannot revoke copies already held by in-flight elicitations.
+	sink := sm.sessionElicitationSink(sess.ID)
+	ev := runtime.ElicitationRequest("need input", "form", nil, "", "eid-1", "", sess.ID, nil, "root")
+	sink(ev)
+	require.True(t, sm.HasEventSource(sess.ID))
+
+	require.NoError(t, sm.DeleteSession(ctx, sess.ID))
+	require.False(t, sm.HasEventSource(sess.ID))
+
+	sink(ev)
+	assert.False(t, sm.HasEventSource(sess.ID),
+		"a stale sink invocation after DeleteSession must not resurrect the event log")
+
+	// Never-had-a-log ordering: delete first, sink fires afterwards.
+	other := session.New()
+	require.NoError(t, store.AddSession(ctx, other))
+	lateSink := sm.sessionElicitationSink(other.ID)
+	require.NoError(t, sm.DeleteSession(ctx, other.ID))
+
+	lateSink(ev)
+	assert.False(t, sm.HasEventSource(other.ID),
+		"a stale sink invocation must not create an event log for a session deleted before its first event")
+}
+
+// TestBatchDeleteSessions_StaleSinkAfterDeleteCannotResurrectEventLog is the
+// BatchDeleteSessions counterpart of the test above: batch deletion goes
+// through the same tombstone + teardown, so both orderings must hold there
+// too.
+func TestBatchDeleteSessions_StaleSinkAfterDeleteCannotResurrectEventLog(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+
+	withLog := session.New()
+	withoutLog := session.New()
+	require.NoError(t, store.AddSession(ctx, withLog))
+	require.NoError(t, store.AddSession(ctx, withoutLog))
+
+	sinkWithLog := sm.sessionElicitationSink(withLog.ID)
+	sinkWithoutLog := sm.sessionElicitationSink(withoutLog.ID)
+	ev := runtime.ElicitationRequest("need input", "form", nil, "", "eid-1", "", withLog.ID, nil, "root")
+	sinkWithLog(ev)
+	require.True(t, sm.HasEventSource(withLog.ID))
+
+	deleted, failed := sm.BatchDeleteSessions(ctx, []string{withLog.ID, withoutLog.ID})
+	assert.Equal(t, 2, deleted)
+	assert.Empty(t, failed)
+
+	sinkWithLog(ev)
+	sinkWithoutLog(ev)
+	assert.False(t, sm.HasEventSource(withLog.ID),
+		"a stale sink invocation after BatchDeleteSessions must not resurrect the event log")
+	assert.False(t, sm.HasEventSource(withoutLog.ID),
+		"a stale sink invocation must not create an event log for a batch-deleted session that never had one")
+}
+
+// testConcurrentSinkVsDelete races continuous elicitation-sink invocations
+// against del on a live session, then makes the deterministic check: once
+// deletion has completed and every racing goroutine has stopped, one more
+// stale invocation must find the tombstone and create nothing. Run with
+// -race this also proves the create-vs-teardown paths are properly
+// synchronised.
+func testConcurrentSinkVsDelete(t *testing.T, del func(*SessionManager, *session.Session)) {
+	t.Helper()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	sink := sm.sessionElicitationSink(sess.ID)
+	ev := runtime.ElicitationRequest("need input", "form", nil, "", "eid-1", "", sess.ID, nil, "root")
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					sink(ev)
+				}
+			}
+		})
+	}
+
+	del(sm, sess)
+	close(stop)
+	wg.Wait()
+
+	sink(ev)
+	assert.False(t, sm.HasEventSource(sess.ID),
+		"no sink invocation concurrent with or after deletion may leave an event log behind")
+}
+
+func TestDeleteSession_ConcurrentSinkInvocationsCannotResurrectEventLog(t *testing.T) {
+	t.Parallel()
+
+	testConcurrentSinkVsDelete(t, func(sm *SessionManager, sess *session.Session) {
+		require.NoError(t, sm.DeleteSession(t.Context(), sess.ID))
+	})
+}
+
+func TestBatchDeleteSessions_ConcurrentSinkInvocationsCannotResurrectEventLog(t *testing.T) {
+	t.Parallel()
+
+	testConcurrentSinkVsDelete(t, func(sm *SessionManager, sess *session.Session) {
+		deleted, failed := sm.BatchDeleteSessions(t.Context(), []string{sess.ID})
+		assert.Equal(t, 1, deleted)
+		assert.Empty(t, failed)
+	})
+}
+
+// sinkRegistrationRecordingRuntime records every OnElicitationRequest
+// registration so tests can observe deletion clearing (or leaving alone) a
+// runtime's elicitation sink.
+type sinkRegistrationRecordingRuntime struct {
+	fakeRuntime
+
+	mu    sync.Mutex
+	sinks []func(runtime.Event)
+}
+
+func (s *sinkRegistrationRecordingRuntime) OnElicitationRequest(handler func(runtime.Event)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sinks = append(s.sinks, handler)
+}
+
+func (s *sinkRegistrationRecordingRuntime) registrations() []func(runtime.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]func(runtime.Event), len(s.sinks))
+	copy(out, s.sinks)
+	return out
+}
+
+// TestDeleteSession_ClearsElicitationSinkOnServerOwnedRuntimeOnly verifies
+// the runtime-side half of the deletion fix: DeleteSession must clear (set
+// to nil) the elicitation sink of a server-owned runtime — so a later
+// background elicitation hits the runtime's headless fast-decline path (see
+// pkg/runtime's TestElicitationHandler_HeadlessBackgroundFastDeclines)
+// instead of parking a waiter forever — while leaving an attached runtime's
+// sink alone: that one is registered and owned by the embedder (pkg/app) and
+// serves the embedder beyond this session's lifetime.
+func TestDeleteSession_ClearsElicitationSinkOnServerOwnedRuntimeOnly(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+
+	owned := session.New()
+	require.NoError(t, store.AddSession(ctx, owned))
+	ownedRT := &sinkRegistrationRecordingRuntime{}
+	// Register the runtime the way RunSession does for a server-created
+	// session: no done channel marks the entry as server-owned.
+	sm.runtimeSessions.Store(owned.ID, &activeRuntimes{runtime: ownedRT, cancel: func() {}, session: owned})
+
+	require.NoError(t, sm.DeleteSession(ctx, owned.ID))
+	regs := ownedRT.registrations()
+	require.Len(t, regs, 1, "DeleteSession must clear the server-registered sink")
+	assert.Nil(t, regs[0], "the clearing registration must be nil so the runtime fast-declines background elicitations")
+
+	attached := session.New()
+	require.NoError(t, store.AddSession(ctx, attached))
+	attachedRT := &sinkRegistrationRecordingRuntime{}
+	sm.AttachRuntime(ctx, attached.ID, attachedRT, attached)
+
+	require.NoError(t, sm.DeleteSession(ctx, attached.ID))
+	assert.Empty(t, attachedRT.registrations(),
+		"DeleteSession must not touch an attached runtime's embedder-owned sink")
+}
+
+// TestBatchDeleteSessions_ClearsElicitationSinkOnServerOwnedRuntimeOnly is
+// the batch counterpart of the test above.
+func TestBatchDeleteSessions_ClearsElicitationSinkOnServerOwnedRuntimeOnly(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+
+	owned := session.New()
+	attached := session.New()
+	require.NoError(t, store.AddSession(ctx, owned))
+	require.NoError(t, store.AddSession(ctx, attached))
+
+	ownedRT := &sinkRegistrationRecordingRuntime{}
+	sm.runtimeSessions.Store(owned.ID, &activeRuntimes{runtime: ownedRT, cancel: func() {}, session: owned})
+	attachedRT := &sinkRegistrationRecordingRuntime{}
+	sm.AttachRuntime(ctx, attached.ID, attachedRT, attached)
+
+	deleted, failed := sm.BatchDeleteSessions(ctx, []string{owned.ID, attached.ID})
+	assert.Equal(t, 2, deleted)
+	assert.Empty(t, failed)
+
+	regs := ownedRT.registrations()
+	require.Len(t, regs, 1, "BatchDeleteSessions must clear the server-registered sink")
+	assert.Nil(t, regs[0])
+	assert.Empty(t, attachedRT.registrations(),
+		"BatchDeleteSessions must not touch an attached runtime's embedder-owned sink")
+}
+
+// TestDeleteSession_SilencesLiveRuntimeElicitationDelivery replays the
+// reviewer's #3584 deletion scenario end to end against a real
+// *runtime.LocalRuntime built by runtimeForSession: after DeleteSession, an
+// elicitation emission from that (still live, e.g. held by a detached
+// background job) runtime must go nowhere — the sink is cleared and the
+// tombstone blocks recreation — instead of resurrecting an event log for the
+// deleted session.
+func TestDeleteSession_SilencesLiveRuntimeElicitationDelivery(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cfg := []byte(`agents:
+  root:
+    description: Test agent
+    instruction: Be helpful.
+    harness:
+      type: claude-code
+`)
+	store := session.NewInMemorySessionStore()
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+
+	sources := config.Sources{"agent.yaml": config.NewBytesSource("agent.yaml", cfg)}
+	sm := NewSessionManager(ctx, sources, store, 0, &config.RuntimeConfig{})
+
+	run, _, err := sm.runtimeForSession(ctx, sess, "agent.yaml", "", &config.RuntimeConfig{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = run.Close() })
+	lr, ok := run.(*runtime.LocalRuntime)
+	require.True(t, ok, "runtimeForSession is expected to build a *runtime.LocalRuntime, got %T", run)
+
+	// Register the runtime as RunSession would (server-owned: no done
+	// channel), then delete the session out from under it.
+	sm.runtimeSessions.Store(sess.ID, &activeRuntimes{runtime: run, cancel: func() {}, session: sess})
+	require.NoError(t, sm.DeleteSession(ctx, sess.ID))
+
+	lr.EmitElicitationRequestForTesting(runtime.ElicitationRequest("need input", "form", nil, "", "eid-1", "", sess.ID, nil, "root"))
+	assert.False(t, sm.HasEventSource(sess.ID),
+		"an elicitation raised through the deleted session's runtime must not recreate its event log")
+}
+
+// TestRegisterEventSource_AdoptsLazyEventLog covers the reverse of
+// TestSessionElicitationSink_ReusesAttachedEventLog: the lazily-created log
+// exists first (an out-of-band elicitation arrived before the embedder
+// attached), then RegisterEventSource runs. It must adopt that log — same
+// log identity, buffered events and connected listeners intact, sequence
+// numbers continuing — rather than clobber it, and the registered entry's
+// cancel must take over the attached-source lifecycle: stop the pump, whose
+// deferred close then ends the log with session_exited.
+func TestRegisterEventSource_AdoptsLazyEventLog(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	sm := NewSessionManager(ctx, config.Sources{}, session.NewInMemorySessionStore(), 0, &config.RuntimeConfig{})
+
+	ev := runtime.ElicitationRequest("need input", "form", nil, "", "eid-1", "", "bg-child", nil, "agent")
+	sm.sessionElicitationSink("sess-adopt")(ev)
+
+	lazyPE, ok := sm.eventLogs.Load("sess-adopt")
+	require.True(t, ok)
+
+	// Connect a listener before the source attaches; it must survive the
+	// attachment and keep receiving on the same stream.
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	defer cancelStream()
+	var mu sync.Mutex
+	var received []any
+	streamDone := make(chan struct{})
+	go func() {
+		defer close(streamDone)
+		sm.StreamEvents(streamCtx, "sess-adopt", nil, func(_ uint64, event any) {
+			mu.Lock()
+			defer mu.Unlock()
+			received = append(received, event)
+		})
+	}()
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(received) == 1
+	}, 2*time.Second, time.Millisecond)
+
+	pumped := make(chan struct{})
+	sm.RegisterEventSource("sess-adopt", func(ctx context.Context, send func(any)) {
+		send("source-event")
+		close(pumped)
+		<-ctx.Done()
+	})
+	<-pumped
+
+	current, ok := sm.eventLogs.Load("sess-adopt")
+	require.True(t, ok)
+	assert.Same(t, lazyPE.log, current.log,
+		"RegisterEventSource must adopt the lazily-created log, not replace it")
+
+	seq, ok := sm.LastEventSeq("sess-adopt")
+	require.True(t, ok)
+	assert.Equal(t, uint64(2), seq, "the source's events must continue the adopted log's sequence")
+
+	// Cancelling the registered entry must stop the pump; its deferred close
+	// then delivers session_exited and disconnects the listener — the same
+	// lifecycle a brand-new attached source has.
+	current.cancel()
+	select {
+	case <-streamDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancelling the adopted source must close the log and end connected streams")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, received, 3)
+	assert.Same(t, ev, received[0], "the buffered out-of-band event must survive the adoption")
+	assert.Equal(t, "source-event", received[1])
+	exited, ok := received[2].(sessionExitedEvent)
+	require.True(t, ok, "expected sessionExitedEvent, got %T", received[2])
+	assert.Equal(t, "session_exited", exited.Type)
+}
+
+// --- #3584 review cycle 2: deletion vs. RegisterEventSource race ---
+
+// testRegisterEventSourceAfterDelete pins RegisterEventSource's tombstone
+// gate: registering an event source for a session already deleted via del
+// must be a complete no-op — no event log stored (session IDs are never
+// reused, so nobody would ever tear it down again) and no pump goroutine
+// launched (src must never run). Covers both the session whose lazy log the
+// deletion tore down and the one that never had a log at all.
+func testRegisterEventSourceAfterDelete(t *testing.T, del func(sm *SessionManager, ids []string)) {
+	t.Helper()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+
+	hadLog := session.New()
+	neverHadLog := session.New()
+	require.NoError(t, store.AddSession(ctx, hadLog))
+	require.NoError(t, store.AddSession(ctx, neverHadLog))
+
+	// Give one session a lazily-created log so the deletion also exercises
+	// the torn-down-then-register ordering, not just register-after-nothing.
+	sm.sessionElicitationSink(hadLog.ID)(runtime.ElicitationRequest("need input", "form", nil, "", "eid-1", "", hadLog.ID, nil, "root"))
+	require.True(t, sm.HasEventSource(hadLog.ID))
+
+	del(sm, []string{hadLog.ID, neverHadLog.ID})
+	require.False(t, sm.HasEventSource(hadLog.ID))
+
+	started := make(chan string, 2)
+	for _, id := range []string{hadLog.ID, neverHadLog.ID} {
+		sm.RegisterEventSource(id, func(context.Context, func(any)) {
+			started <- id
+		})
+		// The log entry is stored synchronously before RegisterEventSource
+		// returns, so this check deterministically catches a resurrection.
+		assert.False(t, sm.HasEventSource(id),
+			"RegisterEventSource after deletion must not resurrect the event log for %s", id)
+	}
+
+	// A rejected registration launches no pump goroutine at all, so this
+	// bounded wait never fires on correct code; on a regression it also
+	// catches the pump the HasEventSource asserts above already flagged.
+	select {
+	case id := <-started:
+		t.Fatalf("the source callback for %s must never be started for a deleted session", id)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestDeleteSession_RegisterEventSourceAfterDeleteIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	testRegisterEventSourceAfterDelete(t, func(sm *SessionManager, ids []string) {
+		for _, id := range ids {
+			require.NoError(t, sm.DeleteSession(t.Context(), id))
+		}
+	})
+}
+
+func TestBatchDeleteSessions_RegisterEventSourceAfterDeleteIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	testRegisterEventSourceAfterDelete(t, func(sm *SessionManager, ids []string) {
+		deleted, failed := sm.BatchDeleteSessions(t.Context(), ids)
+		assert.Equal(t, len(ids), deleted)
+		assert.Empty(t, failed)
+	})
+}
+
+// TestRegisterEventSource_RacingDeleteNeverLeavesEventLogBehind races
+// RegisterEventSource against DeleteSession on the same session. eventLogsMu
+// linearises the two: either the registration lands first and the deletion
+// tears its log (and pump) down, or the deletion's tombstone lands first and
+// the registration is rejected outright. In every interleaving, once both
+// calls have returned no event log may remain, and any pump that did start
+// must have been cancelled.
+func TestRegisterEventSource_RacingDeleteNeverLeavesEventLogBehind(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+
+	for range 50 {
+		sess := session.New()
+		require.NoError(t, store.AddSession(ctx, sess))
+
+		var pumpStarted atomic.Bool
+		pumpStopped := make(chan struct{}, 1)
+		var delErr error
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			sm.RegisterEventSource(sess.ID, func(ctx context.Context, _ func(any)) {
+				pumpStarted.Store(true)
+				<-ctx.Done()
+				pumpStopped <- struct{}{}
+			})
+		})
+		wg.Go(func() {
+			delErr = sm.DeleteSession(ctx, sess.ID)
+		})
+		wg.Wait()
+
+		require.NoError(t, delErr)
+		assert.False(t, sm.HasEventSource(sess.ID),
+			"no interleaving of RegisterEventSource and DeleteSession may leave an event log behind")
+		if pumpStarted.Load() {
+			select {
+			case <-pumpStopped:
+			case <-time.After(2 * time.Second):
+				t.Fatal("a pump that won the race must be cancelled by the deletion")
+			}
+		}
+	}
+}
+
+// TestBatchDeleteSessions_ToleratesNilRuntimeCancel mirrors DeleteSession's
+// nil-guard on the runtime entry's cancel: an entry registered without one
+// (as newTestSessionManager does) must not panic batch deletion and must
+// still be deregistered.
+func TestBatchDeleteSessions_ToleratesNilRuntimeCancel(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	store := session.NewInMemorySessionStore()
+	sm := NewSessionManager(ctx, config.Sources{}, store, 0, &config.RuntimeConfig{})
+
+	sess := session.New()
+	require.NoError(t, store.AddSession(ctx, sess))
+	sm.runtimeSessions.Store(sess.ID, &activeRuntimes{runtime: &fakeRuntime{}, session: sess})
+
+	deleted, failed := sm.BatchDeleteSessions(ctx, []string{sess.ID})
+	assert.Equal(t, 1, deleted)
+	assert.Empty(t, failed)
+	_, ok := sm.runtimeSessions.Load(sess.ID)
+	assert.False(t, ok, "the runtime entry must still be deregistered")
 }


### PR DESCRIPTION
## Summary

Complete the server/API portion of #3584 so elicitation requests raised by concurrent background jobs are replayable and answerable instead of being auto-declined when no per-request stream is active.

This supersedes #3625 with the same core session-scoped sink plus the lifecycle and concurrency hardening found during review.

## Issue expectations

| Expectation | Implementation |
|---|---|
| Display concurrent background elicitations | API-created runtimes append each request to a session-scoped `/events` log |
| Route responses to the correct job | `elicitation_id` is preserved through `POST /api/sessions/:id/elicitation` |
| Avoid silent drops | Event logs are created on demand and retain multiple requests in order |
| Avoid duplicate requests | Mirrored `RunStream` copies are skipped when the reliable sink already delivered the event |
| Handle session lifecycle safely | Single and batch deletion close lazy logs, clear server-owned sinks, and tombstone deleted IDs |
| Cover concurrency under the race detector | Regression tests exercise concurrent delivery, deletion, source registration, replay, and response routing |

## Implementation

- Register a per-session `OnElicitationRequest` sink for API/server-created runtimes.
- Create replayable event logs lazily for out-of-band events.
- Reuse existing attached logs rather than replacing buffered events or listeners.
- Serialize creation, source registration, and deletion to prevent stale callbacks from resurrecting leaked logs.
- Preserve exactly-once delivery when local runtimes mirror elicitation events onto `RunStream`.
- Document API event-log coverage and correlated responses.

## Validation

- `go test ./...`
- `go test -race ./pkg/server ./pkg/runtime/...`
- `go build ./...`
- `go vet ./pkg/server/... ./pkg/runtime/...`
- `golangci-lint run ./pkg/server/... ./pkg/runtime/...`
- `markdownlint-cli2 docs/features/api-server/index.md`

All checks pass. The full test suite was run with workspace proxy variables unset because the injected proxy intercepts the private-address SSRF tests.

Closes #3584
