### PR TITLE
fix(teamloader): preserve deferred toolset instructions

### DIFF
--- a/pkg/teamloader/filter.go
+++ b/pkg/teamloader/filter.go
@@ -81,3 +81,33 @@ func (f *filterTools) Tools(ctx context.Context) ([]tools.Tool, error) {
 
 	return filtered, nil
 }
+
+// WithNoToolsFilter creates a toolset that exposes no tools but preserves all other
+// capabilities (like Instructions) of the inner toolset.
+func WithNoToolsFilter(inner tools.ToolSet) tools.ToolSet {
+	return &noToolsFilter{ToolSet: inner}
+}
+
+type noToolsFilter struct {
+	tools.ToolSet
+}
+
+// Verify interface compliance
+var (
+	_ tools.Instructable = (*noToolsFilter)(nil)
+	_ tools.Unwrapper    = (*noToolsFilter)(nil)
+)
+
+// Unwrap implements tools.Unwrapper.
+func (f *noToolsFilter) Unwrap() tools.ToolSet {
+	return f.ToolSet
+}
+
+// Instructions implements tools.Instructable by delegating to the inner toolset.
+func (f *noToolsFilter) Instructions() string {
+	return tools.GetInstructions(f.ToolSet)
+}
+
+func (f *noToolsFilter) Tools(ctx context.Context) ([]tools.Tool, error) {
+	return nil, nil
+}

--- a/pkg/teamloader/filter_test.go
+++ b/pkg/teamloader/filter_test.go
@@ -178,3 +178,49 @@ func TestWithToolsFilter_NonInstructableInner(t *testing.T) {
 	instructions := tools.GetInstructions(wrapped)
 	assert.Empty(t, instructions)
 }
+
+func TestWithNoToolsFilter_HidesAllTools(t *testing.T) {
+	t.Parallel()
+	inner := &mockToolSet{
+		toolsFunc: func(context.Context) ([]tools.Tool, error) {
+			return []tools.Tool{{Name: "tool1"}, {Name: "tool2"}}, nil
+		},
+	}
+
+	wrapped := WithNoToolsFilter(inner)
+
+	result, err := wrapped.Tools(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestWithNoToolsFilter_PreservesInstructions(t *testing.T) {
+	t.Parallel()
+	inner := &instructableToolSet{
+		mockToolSet: mockToolSet{
+			toolsFunc: func(context.Context) ([]tools.Tool, error) {
+				return []tools.Tool{{Name: "tool1"}}, nil
+			},
+		},
+		instructions: "Test instructions for the toolset",
+	}
+
+	wrapped := WithNoToolsFilter(inner)
+
+	instructions := tools.GetInstructions(wrapped)
+	assert.Equal(t, "Test instructions for the toolset", instructions)
+}
+
+func TestWithNoToolsFilter_NonInstructableInner(t *testing.T) {
+	t.Parallel()
+	inner := &mockToolSet{
+		toolsFunc: func(context.Context) ([]tools.Tool, error) {
+			return []tools.Tool{{Name: "tool1"}}, nil
+		},
+	}
+
+	wrapped := WithNoToolsFilter(inner)
+
+	instructions := tools.GetInstructions(wrapped)
+	assert.Empty(t, instructions)
+}

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -759,9 +759,7 @@ func getToolsForAgent(ctx context.Context, a *latest.AgentConfig, parentDir stri
 		if !toolset.Defer.IsEmpty() {
 			deferredToolset.AddSource(wrapped, toolset.Defer.DeferAll, toolset.Defer.Tools)
 			if toolset.Defer.DeferAll {
-				// Don't add the wrapped toolset to toolSets - all its tools are deferred
-				// TODO: maybe we _do_ want to add this toolset since it has instructions?
-				continue
+				wrapped = WithNoToolsFilter(wrapped)
 			} else {
 				wrapped = WithToolsExcludeFilter(wrapped, toolset.Defer.Tools...)
 			}


### PR DESCRIPTION
### Description
This pull request fixes a logic bug in the teamloader where setting `defer_all: true` on a toolset would cause the entire toolset to be dropped from the agent's context.

Dropping the toolset had the unintended side effect of permanently deleting the toolset's custom `Instructions`, leaving the LLM completely unaware of when or how to ask for the deferred tools to be loaded.

### Changes Made
* Implemented `WithNoToolsFilter` in `pkg/teamloader/filter.go` to wrap toolsets.
* This new filter intercepts all tool requests and returns an empty slice, guaranteeing the agent sees zero tools.
* The filter safely delegates to the wrapped toolset for `Instructions`, ensuring the instructions are seamlessly preserved in the agent's system prompt.
* Replaced the destructive `continue` block in `pkg/teamloader/teamloader.go` with the new filter.
* Added comprehensive unit tests in `pkg/teamloader/filter_test.go`.

### Verification
* Ran `go test` and verified all unit tests pass.
* Verified no formatting or linting regressions with `go fmt` and `go vet`.
