### PR TITLE
feat(run): autodiscover project agent config

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -48,6 +48,8 @@ import (
 // cobra's optional-value flags the two are indistinguishable by design.
 const worktreeAutoName = "auto"
 
+var projectDefaultAgentFiles = []string{"docker-agent.yaml", "docker-agent.yml"}
+
 type runExecFlags struct {
 	agentName         string
 	autoApprove       bool
@@ -327,10 +329,7 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 		}
 	}()
 
-	var agentFileName string
-	if len(args) > 0 {
-		agentFileName = args[0]
-	}
+	agentFileName := f.resolveRunAgentFileName(args)
 
 	// Apply global user settings first (lowest priority)
 	// User settings only apply if the flag wasn't explicitly set by the user
@@ -528,6 +527,32 @@ func (f *runExecFlags) runOrExec(ctx context.Context, out *cli.Printer, args []s
 		f.cleanupWorktree(context.WithoutCancel(ctx), out, createdWorktree)
 	}
 	return nil
+}
+
+func (f *runExecFlags) resolveRunAgentFileName(args []string) string {
+	if len(args) > 0 {
+		return args[0]
+	}
+	if f.remoteAddress != "" {
+		return ""
+	}
+	if agentFileName, ok := discoverProjectDefaultAgentFile(); ok {
+		return agentFileName
+	}
+	return ""
+}
+
+func discoverProjectDefaultAgentFile() (string, bool) {
+	for _, name := range projectDefaultAgentFiles {
+		info, err := os.Stat(name)
+		if err == nil && !info.IsDir() {
+			return name, true
+		}
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return name, true
+		}
+	}
+	return "", false
 }
 
 // loadTeamInWorktree creates the requested worktree (if any) and then loads

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -121,7 +121,7 @@ func newRunCmd() *cobra.Command {
 		Long:  "Run an agent with the specified configuration and prompt",
 		Example: `  docker-agent run ./agent.yaml
   docker-agent run ./team.yaml --agent root
-  docker-agent run # built-in default agent
+  docker-agent run # project config or built-in default agent
   docker-agent run coder # built-in coding agent
   docker-agent run ./echo.yaml "INSTRUCTIONS"
   docker-agent run ./echo.yaml "First question" "Follow-up question"
@@ -277,6 +277,9 @@ func (f *runExecFlags) runRunCommand(cmd *cobra.Command, args []string) (command
 		args = prependAgentRef(chosen, args)
 	}
 
+	var discoveredProjectConfig bool
+	args, discoveredProjectConfig = f.discoverRunAgentArgs(args)
+
 	// Resolve alias / runtime-declared sandbox opt-in before dispatch.
 	// An explicit --sandbox=<bool> on the CLI always wins, so we only
 	// consult the lower-priority sources when the flag wasn't set.
@@ -287,6 +290,11 @@ func (f *runExecFlags) runRunCommand(cmd *cobra.Command, args []string) (command
 			agentRef = args[0]
 		}
 		f.sandbox, agentCfg = resolveSandboxDefault(ctx, agentRef, f.sandbox)
+	}
+
+	out := cli.NewPrinter(cmd.OutOrStdout())
+	if discoveredProjectConfig {
+		out.Println("Using project config: " + args[0])
 	}
 
 	if f.sandbox {
@@ -306,8 +314,6 @@ func (f *runExecFlags) runRunCommand(cmd *cobra.Command, args []string) (command
 	if f.worktreeBase != "" && !f.worktree {
 		return errors.New("--worktree-base requires --worktree")
 	}
-
-	out := cli.NewPrinter(cmd.OutOrStdout())
 
 	// When an interactive run cannot find any usable model, offer the setup
 	// wizard instead of leaving the user alone with the error.
@@ -533,13 +539,17 @@ func (f *runExecFlags) resolveRunAgentFileName(args []string) string {
 	if len(args) > 0 {
 		return args[0]
 	}
-	if f.remoteAddress != "" {
-		return ""
-	}
-	if agentFileName, ok := discoverProjectDefaultAgentFile(); ok {
-		return agentFileName
-	}
 	return ""
+}
+
+func (f *runExecFlags) discoverRunAgentArgs(args []string) ([]string, bool) {
+	if len(args) > 0 || f.remoteAddress != "" {
+		return args, false
+	}
+	if name, ok := discoverProjectDefaultAgentFile(); ok {
+		return prependAgentRef(name, args), true
+	}
+	return args, false
 }
 
 func discoverProjectDefaultAgentFile() (string, bool) {
@@ -549,6 +559,8 @@ func discoverProjectDefaultAgentFile() (string, bool) {
 			return name, true
 		}
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			// Surface unreadable or otherwise broken project configs instead of
+			// silently falling through to a later candidate or the built-in default.
 			return name, true
 		}
 	}

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -48,7 +48,7 @@ import (
 // cobra's optional-value flags the two are indistinguishable by design.
 const worktreeAutoName = "auto"
 
-var projectDefaultAgentFiles = []string{"docker-agent.yaml", "docker-agent.yml"}
+var projectDefaultAgentFiles = []string{"docker-agent.yaml", "docker-agent.yml", "docker-agent.hcl"}
 
 type runExecFlags struct {
 	agentName         string

--- a/cmd/root/run_autodiscovery_test.go
+++ b/cmd/root/run_autodiscovery_test.go
@@ -1,0 +1,66 @@
+package root
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveRunAgentFileName(t *testing.T) {
+	t.Run("explicit argument wins", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		require.NoError(t, os.WriteFile("docker-agent.yaml", []byte("agents: {}\n"), 0o644))
+
+		got := (&runExecFlags{}).resolveRunAgentFileName([]string{"custom.yaml"})
+
+		assert.Equal(t, "custom.yaml", got)
+	})
+
+	t.Run("discovers docker-agent yaml before yml", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		require.NoError(t, os.WriteFile("docker-agent.yaml", []byte("agents: {}\n"), 0o644))
+		require.NoError(t, os.WriteFile("docker-agent.yml", []byte("agents: {}\n"), 0o644))
+
+		got := (&runExecFlags{}).resolveRunAgentFileName(nil)
+
+		assert.Equal(t, "docker-agent.yaml", got)
+	})
+
+	t.Run("discovers docker-agent yml", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		require.NoError(t, os.WriteFile("docker-agent.yml", []byte("agents: {}\n"), 0o644))
+
+		got := (&runExecFlags{}).resolveRunAgentFileName(nil)
+
+		assert.Equal(t, "docker-agent.yml", got)
+	})
+
+	t.Run("ignores directories", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		require.NoError(t, os.Mkdir("docker-agent.yaml", 0o755))
+		require.NoError(t, os.WriteFile("docker-agent.yml", []byte("agents: {}\n"), 0o644))
+
+		got := (&runExecFlags{}).resolveRunAgentFileName(nil)
+
+		assert.Equal(t, "docker-agent.yml", got)
+	})
+
+	t.Run("falls back to built-in default", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+
+		got := (&runExecFlags{}).resolveRunAgentFileName(nil)
+
+		assert.Empty(t, got)
+	})
+
+	t.Run("remote run keeps server-side default", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		require.NoError(t, os.WriteFile("docker-agent.yaml", []byte("agents: {}\n"), 0o644))
+
+		got := (&runExecFlags{remoteAddress: "http://127.0.0.1:8080"}).resolveRunAgentFileName(nil)
+
+		assert.Empty(t, got)
+	})
+}

--- a/cmd/root/run_autodiscovery_test.go
+++ b/cmd/root/run_autodiscovery_test.go
@@ -2,20 +2,22 @@ package root
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestResolveRunAgentFileName(t *testing.T) {
+func TestDiscoverRunAgentArgs(t *testing.T) {
 	t.Run("explicit argument wins", func(t *testing.T) {
 		t.Chdir(t.TempDir())
 		require.NoError(t, os.WriteFile("docker-agent.yaml", []byte("agents: {}\n"), 0o644))
 
-		got := (&runExecFlags{}).resolveRunAgentFileName([]string{"custom.yaml"})
+		got, discovered := (&runExecFlags{}).discoverRunAgentArgs([]string{"custom.yaml"})
 
-		assert.Equal(t, "custom.yaml", got)
+		assert.Equal(t, []string{"custom.yaml"}, got)
+		assert.False(t, discovered)
 	})
 
 	t.Run("discovers docker-agent yaml before yml", func(t *testing.T) {
@@ -24,18 +26,20 @@ func TestResolveRunAgentFileName(t *testing.T) {
 		require.NoError(t, os.WriteFile("docker-agent.yml", []byte("agents: {}\n"), 0o644))
 		require.NoError(t, os.WriteFile("docker-agent.hcl", []byte("agent \"root\" {}\n"), 0o644))
 
-		got := (&runExecFlags{}).resolveRunAgentFileName(nil)
+		got, discovered := (&runExecFlags{}).discoverRunAgentArgs(nil)
 
-		assert.Equal(t, "docker-agent.yaml", got)
+		assert.Equal(t, []string{"docker-agent.yaml"}, got)
+		assert.True(t, discovered)
 	})
 
 	t.Run("discovers docker-agent yml", func(t *testing.T) {
 		t.Chdir(t.TempDir())
 		require.NoError(t, os.WriteFile("docker-agent.yml", []byte("agents: {}\n"), 0o644))
 
-		got := (&runExecFlags{}).resolveRunAgentFileName(nil)
+		got, discovered := (&runExecFlags{}).discoverRunAgentArgs(nil)
 
-		assert.Equal(t, "docker-agent.yml", got)
+		assert.Equal(t, []string{"docker-agent.yml"}, got)
+		assert.True(t, discovered)
 	})
 
 	t.Run("discovers docker-agent hcl last", func(t *testing.T) {
@@ -43,18 +47,20 @@ func TestResolveRunAgentFileName(t *testing.T) {
 		require.NoError(t, os.WriteFile("docker-agent.yml", []byte("agents: {}\n"), 0o644))
 		require.NoError(t, os.WriteFile("docker-agent.hcl", []byte("agent \"root\" {}\n"), 0o644))
 
-		got := (&runExecFlags{}).resolveRunAgentFileName(nil)
+		got, discovered := (&runExecFlags{}).discoverRunAgentArgs(nil)
 
-		assert.Equal(t, "docker-agent.yml", got)
+		assert.Equal(t, []string{"docker-agent.yml"}, got)
+		assert.True(t, discovered)
 	})
 
 	t.Run("discovers docker-agent hcl", func(t *testing.T) {
 		t.Chdir(t.TempDir())
 		require.NoError(t, os.WriteFile("docker-agent.hcl", []byte("agent \"root\" {}\n"), 0o644))
 
-		got := (&runExecFlags{}).resolveRunAgentFileName(nil)
+		got, discovered := (&runExecFlags{}).discoverRunAgentArgs(nil)
 
-		assert.Equal(t, "docker-agent.hcl", got)
+		assert.Equal(t, []string{"docker-agent.hcl"}, got)
+		assert.True(t, discovered)
 	})
 
 	t.Run("ignores directories", func(t *testing.T) {
@@ -62,25 +68,56 @@ func TestResolveRunAgentFileName(t *testing.T) {
 		require.NoError(t, os.Mkdir("docker-agent.yaml", 0o755))
 		require.NoError(t, os.WriteFile("docker-agent.yml", []byte("agents: {}\n"), 0o644))
 
-		got := (&runExecFlags{}).resolveRunAgentFileName(nil)
+		got, discovered := (&runExecFlags{}).discoverRunAgentArgs(nil)
 
-		assert.Equal(t, "docker-agent.yml", got)
+		assert.Equal(t, []string{"docker-agent.yml"}, got)
+		assert.True(t, discovered)
 	})
 
 	t.Run("falls back to built-in default", func(t *testing.T) {
 		t.Chdir(t.TempDir())
 
-		got := (&runExecFlags{}).resolveRunAgentFileName(nil)
+		got, discovered := (&runExecFlags{}).discoverRunAgentArgs(nil)
 
 		assert.Empty(t, got)
+		assert.False(t, discovered)
 	})
 
 	t.Run("remote run keeps server-side default", func(t *testing.T) {
 		t.Chdir(t.TempDir())
 		require.NoError(t, os.WriteFile("docker-agent.yaml", []byte("agents: {}\n"), 0o644))
 
-		got := (&runExecFlags{remoteAddress: "http://127.0.0.1:8080"}).resolveRunAgentFileName(nil)
+		got, discovered := (&runExecFlags{remoteAddress: "http://127.0.0.1:8080"}).discoverRunAgentArgs(nil)
 
 		assert.Empty(t, got)
+		assert.False(t, discovered)
+	})
+
+	t.Run("discovered config participates in sandbox default resolution", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		require.NoError(t, os.WriteFile("docker-agent.yaml",
+			[]byte("runtime:\n  sandbox: true\nagents:\n  root:\n    model: openai/gpt-4o\n    description: t\n    instruction: t\n"),
+			0o644))
+
+		args, discovered := (&runExecFlags{}).discoverRunAgentArgs(nil)
+		got, cfg := resolveSandboxDefault(t.Context(), args[0], false)
+
+		assert.True(t, discovered)
+		assert.True(t, got)
+		assert.NotNil(t, cfg)
+	})
+
+	t.Run("stat errors shadow later candidates", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("self-referential symlink behavior is platform-specific")
+		}
+		t.Chdir(t.TempDir())
+		require.NoError(t, os.Symlink("docker-agent.yaml", "docker-agent.yaml"))
+		require.NoError(t, os.WriteFile("docker-agent.yml", []byte("agents: {}\n"), 0o644))
+
+		got, ok := discoverProjectDefaultAgentFile()
+
+		assert.True(t, ok)
+		assert.Equal(t, "docker-agent.yaml", got)
 	})
 }

--- a/cmd/root/run_autodiscovery_test.go
+++ b/cmd/root/run_autodiscovery_test.go
@@ -22,6 +22,7 @@ func TestResolveRunAgentFileName(t *testing.T) {
 		t.Chdir(t.TempDir())
 		require.NoError(t, os.WriteFile("docker-agent.yaml", []byte("agents: {}\n"), 0o644))
 		require.NoError(t, os.WriteFile("docker-agent.yml", []byte("agents: {}\n"), 0o644))
+		require.NoError(t, os.WriteFile("docker-agent.hcl", []byte("agent \"root\" {}\n"), 0o644))
 
 		got := (&runExecFlags{}).resolveRunAgentFileName(nil)
 
@@ -35,6 +36,25 @@ func TestResolveRunAgentFileName(t *testing.T) {
 		got := (&runExecFlags{}).resolveRunAgentFileName(nil)
 
 		assert.Equal(t, "docker-agent.yml", got)
+	})
+
+	t.Run("discovers docker-agent hcl last", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		require.NoError(t, os.WriteFile("docker-agent.yml", []byte("agents: {}\n"), 0o644))
+		require.NoError(t, os.WriteFile("docker-agent.hcl", []byte("agent \"root\" {}\n"), 0o644))
+
+		got := (&runExecFlags{}).resolveRunAgentFileName(nil)
+
+		assert.Equal(t, "docker-agent.yml", got)
+	})
+
+	t.Run("discovers docker-agent hcl", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		require.NoError(t, os.WriteFile("docker-agent.hcl", []byte("agent \"root\" {}\n"), 0o644))
+
+		got := (&runExecFlags{}).resolveRunAgentFileName(nil)
+
+		assert.Equal(t, "docker-agent.hcl", got)
 	})
 
 	t.Run("ignores directories", func(t *testing.T) {

--- a/docs/concepts/agents/index.md
+++ b/docs/concepts/agents/index.md
@@ -97,10 +97,10 @@ Commands support environment variable interpolation using JavaScript template li
 
 ## Default Agent
 
-Running `docker agent run` without a config file uses a built-in default agent. This is a capable general-purpose agent for quick tasks without needing any configuration.
+Running `docker agent run` without a config argument uses `docker-agent.yaml` or `docker-agent.yml` from the current directory when present. Otherwise, it uses a capable built-in default agent for quick tasks without needing any configuration.
 
 ```bash
-# Use the default agent
+# Use the project config or built-in default agent
 $ docker agent run
 
 # Override the default with an alias

--- a/docs/concepts/agents/index.md
+++ b/docs/concepts/agents/index.md
@@ -97,7 +97,7 @@ Commands support environment variable interpolation using JavaScript template li
 
 ## Default Agent
 
-Running `docker agent run` without a config argument uses `docker-agent.yaml` or `docker-agent.yml` from the current directory when present. Otherwise, it uses a capable built-in default agent for quick tasks without needing any configuration.
+Running `docker agent run` without a config argument uses `docker-agent.yaml`, `docker-agent.yml`, or `docker-agent.hcl` from the current directory when present. Otherwise, it uses a capable built-in default agent for quick tasks without needing any configuration.
 
 ```bash
 # Use the project config or built-in default agent

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -627,7 +627,7 @@ Commands that accept a config support multiple reference types:
 | OCI registry  | `docker.io/username/agent:latest`           |
 | Agent catalog | `agentcatalog/pirate`                       |
 | Alias         | `pirate` (after `docker agent alias add`)   |
-| Default       | (no argument) — uses built-in default agent |
+| Default       | (no argument) — uses project config or built-in default agent |
 
 > [!NOTE]
 > **Debugging**

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -13,7 +13,7 @@ _Complete reference for all docker-agent command-line commands and flags._
 > [!TIP]
 > **No config needed**
 >
-> Running `docker agent run` without a config argument uses `docker-agent.yaml` or `docker-agent.yml` from the current directory when present. Otherwise, it uses a built-in default agent that is perfect for quick experimentation.
+> Running `docker agent run` without a config argument uses `docker-agent.yaml`, `docker-agent.yml`, or `docker-agent.hcl` from the current directory when present. Otherwise, it uses a built-in default agent that is perfect for quick experimentation.
 
 ## Commands
 

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -13,7 +13,7 @@ _Complete reference for all docker-agent command-line commands and flags._
 > [!TIP]
 > **No config needed**
 >
-> Running `docker agent run` without a config file uses a built-in default agent. Perfect for quick experimentation.
+> Running `docker agent run` without a config argument uses `docker-agent.yaml` or `docker-agent.yml` from the current directory when present. Otherwise, it uses a built-in default agent that is perfect for quick experimentation.
 
 ## Commands
 

--- a/docs/guides/tips/index.md
+++ b/docs/guides/tips/index.md
@@ -375,7 +375,7 @@ settings:
   default_model: anthropic/claude-sonnet-4-5
 ```
 
-This model is used when you run `docker agent run` without a config file.
+This model is used by the built-in default agent when you run `docker agent run` without a config argument and no project-level `docker-agent.yaml` or `docker-agent.yml` exists.
 
 ### Get Desktop Notifications with Hooks
 

--- a/docs/guides/tips/index.md
+++ b/docs/guides/tips/index.md
@@ -375,7 +375,7 @@ settings:
   default_model: anthropic/claude-sonnet-4-5
 ```
 
-This model is used by the built-in default agent when you run `docker agent run` without a config argument and no project-level `docker-agent.yaml` or `docker-agent.yml` exists.
+This model is used by the built-in default agent when you run `docker agent run` without a config argument and no project-level `docker-agent.yaml`, `docker-agent.yml`, or `docker-agent.hcl` exists.
 
 ### Get Desktop Notifications with Hooks
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -274,7 +274,7 @@ Docker Agent follows a simple loop:
 The fastest way to try it — no config file needed:
 
 ```bash
-# Run the built-in default agent
+# Run the project config or built-in default agent
 $ docker agent run
 ```
 

--- a/docs/providers/mistral/index.md
+++ b/docs/providers/mistral/index.md
@@ -70,7 +70,7 @@ Check the [Mistral Models documentation](https://docs.mistral.ai/getting-started
 
 ## Auto-Detection
 
-When you run `docker agent run` without specifying a config and no project-level `docker-agent.yaml` or `docker-agent.yml` exists, docker-agent automatically detects available providers. If `MISTRAL_API_KEY` is set and higher-priority providers (OpenAI, Anthropic, Google) are not available, Mistral will be used with `mistral-small-latest` as the default model.
+When you run `docker agent run` without specifying a config and no project-level `docker-agent.yaml`, `docker-agent.yml`, or `docker-agent.hcl` exists, docker-agent automatically detects available providers. If `MISTRAL_API_KEY` is set and higher-priority providers (OpenAI, Anthropic, Google) are not available, Mistral will be used with `mistral-small-latest` as the default model.
 
 ## Extended Thinking
 

--- a/docs/providers/mistral/index.md
+++ b/docs/providers/mistral/index.md
@@ -70,7 +70,7 @@ Check the [Mistral Models documentation](https://docs.mistral.ai/getting-started
 
 ## Auto-Detection
 
-When you run `docker agent run` without specifying a config, docker-agent automatically detects available providers. If `MISTRAL_API_KEY` is set and higher-priority providers (OpenAI, Anthropic, Google) are not available, Mistral will be used with `mistral-small-latest` as the default model.
+When you run `docker agent run` without specifying a config and no project-level `docker-agent.yaml` or `docker-agent.yml` exists, docker-agent automatically detects available providers. If `MISTRAL_API_KEY` is set and higher-priority providers (OpenAI, Anthropic, Google) are not available, Mistral will be used with `mistral-small-latest` as the default model.
 
 ## Extended Thinking
 


### PR DESCRIPTION
Refs #2435

## Summary
- autodiscover `docker-agent.yaml` / `docker-agent.yml` / `docker-agent.hcl` for no-argument local `docker agent run`
- normalize discovered project configs before sandbox selection so `runtime.sandbox: true` is honored the same as explicit config paths
- keep explicit config arguments and `--remote` runs unchanged
- update user-facing docs for the new project-file-before-built-in-default behavior

## Why
Repositories can now check in a conventional project-level agent config and let developers run `docker agent run` without remembering a file path. This keeps the first slice focused on autodiscovery and leaves native `docker agent new` scaffolding for a follow-up.

## Testing
- `gofmt`
- `git diff --check`
- `go test -p=1 ./cmd/root -run TestDiscoverRunAgentArgs -count=1` in `golang:1.26.5`
- `go test -p=1 ./cmd/root -count=1` in `golang:1.26.5`
- `./scripts/build.sh` in `golang:1.26.5`
- `go mod tidy --diff` in `golang:1.26.5`
- `go run ./lint .` in `golang:1.26.5`
- `golangci-lint run --concurrency=2` with v2.12.2 in `golang:1.26.5`
