### PR TITLE
docs(agents): fix stale command syntax and sub_agents claim in Named Commands

### DIFF
--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -339,8 +339,8 @@ agents:
       
       # Advanced format with agent switching
       plan:
-        agent: planner  # Switch to the 'planner' sub-agent
-        instruction: "Create a detailed plan for: $1"  # Optional: send this prompt after switching
+        agent: planner  # Switch to the 'planner' agent
+        instruction: "Create a detailed plan for: ${args.join(\" \")}"  # Optional: send this prompt after switching
       
       # Agent switching without instruction - forwards remaining text as prompt
       review:
@@ -366,8 +366,8 @@ Commands support three formats:
 
    ```yaml
    plan:
-     agent: planner           # Required: name of sub-agent to switch to
-     instruction: "Plan: $1"  # Optional: prompt to send after switching
+     agent: planner  # Required: name of any agent defined in the team
+     instruction: "Plan: ${args.join(\" \")}"  # Optional: prompt to send after switching
      description: "Switch to planning mode"  # Optional: shown in help text
    ```
 
@@ -379,7 +379,7 @@ Commands support three formats:
      description: "Open the documentation"  # Optional: shown in help text
    ```
 
-When `agent` is set without `instruction`, any text typed after the slash command (e.g., `/plan build a web app`) is forwarded as a prompt to the target agent. The target agent must be listed in the current agent's `sub_agents` array.
+When `agent` is set without `instruction`, any text typed after the slash command (e.g., `/plan build a web app`) is forwarded as a prompt to the target agent. The target agent can be **any agent defined in the team configuration** — it does not need to be listed in the current agent's `sub_agents` array.
 
 ### Agent-Switching Commands
 
@@ -396,7 +396,7 @@ agents:
       # Switch to planner with a pre-filled prompt
       plan:
         agent: planner
-        instruction: "Create a detailed plan for: $1"
+        instruction: "Create a detailed plan for: ${args.join(\" \")}"
       # Switch to reviewer; any text after /review is forwarded
       review:
         agent: reviewer

--- a/docs/configuration/agents/index.md
+++ b/docs/configuration/agents/index.md
@@ -381,6 +381,15 @@ Commands support three formats:
 
 When `agent` is set without `instruction`, any text typed after the slash command (e.g., `/plan build a web app`) is forwarded as a prompt to the target agent. The target agent can be **any agent defined in the team configuration** — it does not need to be listed in the current agent's `sub_agents` array.
 
+**Argument and expansion syntax**
+
+An `instruction` string can reference the command's arguments and expand tool calls:
+
+- `${args[0]}`, `${args[1]}`, … — individual positional arguments, in the order the user typed them after the command
+- `${args.join(" ")}` — all arguments joined into a single string
+- `${tool_name({...})}` — calls a tool and inlines its return value (any tool available to the agent)
+- `!tool_name(key=value)` — legacy tool-call form: calls a tool with plain `key=value` arguments and inlines its output
+
 ### Agent-Switching Commands
 
 Commands with an `agent` field switch the active agent for that command's scope. This is useful for building workflow shortcuts where `/plan`, `/review`, `/deploy` each route the user to the appropriate specialist.


### PR DESCRIPTION
## What

Fixes two pre-existing factual errors in the "Named Commands" section of `docs/configuration/agents/index.md`:

1. **Command argument syntax** — replaces the non-working `$1` / `$2` placeholders with the actually-supported forms: `${args[0]}`, `${args.join(" ")}`, `${tool_name({...})}`, and the legacy `!tool_name(key=value)` form. Adds a concise "Argument and expansion syntax" explanation.
2. **Agent-switching target scope** — corrects the false claim that a command's target agent must be listed in the current agent's `sub_agents`; the target can be any agent defined in the team.

## Notes

Docs-only. Verified against `pkg/runtime/commands.go`, `pkg/runtime/agent_router.go`, `pkg/team/team.go`, `agent-schema.json`, and the runtime/js tests. Passes canonical check + markdownlint.

> [!NOTE]
> This PR (#3684) and #3683 both touch `docs/configuration/agents/index.md`. Whichever merges second will need a trivial rebase.
