### PR TITLE
Centralize Anthropic cache control

### DIFF
--- a/benchmarks/compaction/main.go
+++ b/benchmarks/compaction/main.go
@@ -236,7 +236,6 @@ func buildCompactionMessages(sess *session.Session) []chat.Message {
 	messages, _, _ := sess.CompactionInput()
 	for i := range messages {
 		messages[i].Cost = 0
-		messages[i].CacheControl = false
 	}
 
 	splitIdx := compaction.SplitIndexForKeep(messages, min(maxKeepTokens, contextLimit/5))

--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -49,6 +49,13 @@ type MessageImageURL struct {
 	Detail ImageURLDetail `json:"detail,omitempty"`
 }
 
+type PromptSection string
+
+const (
+	PromptSectionInvariant PromptSection = "invariant"
+	PromptSectionContext   PromptSection = "context"
+)
+
 type Message struct {
 	Role         MessageRole   `json:"role"`
 	Content      string        `json:"content"`
@@ -96,8 +103,9 @@ type Message struct {
 	// Only set for assistant messages.
 	FinishReason FinishReason `json:"finish_reason,omitempty"`
 
-	// CacheControl indicates whether this message is a cached message (only used by anthropic)
-	CacheControl bool `json:"cache_control,omitempty"`
+	// PromptSection describes system-prompt provenance for provider-level caching.
+	// It is request metadata and is never persisted with conversation history.
+	PromptSection PromptSection `json:"-"`
 }
 
 // MessageFile is the legacy file attachment shape kept for stored sessions.

--- a/pkg/model/provider/anthropic/beta_client.go
+++ b/pkg/model/provider/anthropic/beta_client.go
@@ -67,6 +67,7 @@ func (c *Client) createBetaStream(
 		Tools:     allTools,
 		Betas:     betas,
 	}
+	applyBetaPromptCacheControl(messages, requestTools, &params)
 
 	// Apply structured output configuration
 	if structuredOutput := c.ModelOptions.StructuredOutput(); structuredOutput != nil {

--- a/pkg/model/provider/anthropic/beta_converter.go
+++ b/pkg/model/provider/anthropic/beta_converter.go
@@ -137,9 +137,6 @@ func (c *Client) convertBetaMessagesWithDeferred(ctx context.Context, messages [
 		}
 	}
 
-	// Add ephemeral cache to last 2 messages' last content block
-	applyBetaMessageCacheControl(betaMessages)
-
 	return betaMessages, nil
 }
 
@@ -330,14 +327,6 @@ func extractBetaSystemBlocks(messages []chat.Message) []anthropic.BetaTextBlockP
 	betaBlocks := make([]anthropic.BetaTextBlockParam, len(regularBlocks))
 	for i, block := range regularBlocks {
 		betaBlocks[i] = anthropic.BetaTextBlockParam{Text: block.Text}
-
-		// Copy over cache control from regular blocks (already set on first 2)
-		if block.CacheControl.Type != "" {
-			betaBlocks[i].CacheControl = anthropic.BetaCacheControlEphemeralParam{
-				Type: block.CacheControl.Type,
-				TTL:  anthropic.BetaCacheControlEphemeralTTL(block.CacheControl.TTL),
-			}
-		}
 	}
 
 	return betaBlocks
@@ -345,8 +334,7 @@ func extractBetaSystemBlocks(messages []chat.Message) []anthropic.BetaTextBlockP
 
 // convertBetaTools converts tools to Beta API format
 func convertBetaTools(t []tools.Tool) ([]anthropic.BetaToolUnionParam, error) {
-	hasDeferredTools := containsDeferredTool(t)
-	t, immediateCount := orderToolsForDeferredLoading(t)
+	t = orderToolsForDeferredLoading(t)
 	betaTools := make([]anthropic.BetaToolUnionParam, 0, len(t))
 
 	for _, tool := range t {
@@ -370,39 +358,10 @@ func convertBetaTools(t []tools.Tool) ([]anthropic.BetaToolUnionParam, error) {
 		if tool.Deferred {
 			betaTool.DeferLoading = param.NewOpt(true)
 		}
-		if hasDeferredTools && len(betaTools) == immediateCount-1 {
-			betaTool.CacheControl = anthropic.NewBetaCacheControlEphemeralParam()
-		}
 		betaTools = append(betaTools, anthropic.BetaToolUnionParam{OfTool: betaTool})
 	}
 
 	return betaTools, nil
-}
-
-// applyBetaMessageCacheControl adds ephemeral cache control to the last content block
-// of the last 2 messages for prompt caching.
-func applyBetaMessageCacheControl(messages []anthropic.BetaMessageParam) {
-	for i := len(messages) - 1; i >= 0 && i >= len(messages)-2; i-- {
-		msg := &messages[i]
-		if len(msg.Content) == 0 {
-			continue
-		}
-		lastIdx := len(msg.Content) - 1
-		block := &msg.Content[lastIdx]
-		cacheCtrl := anthropic.NewBetaCacheControlEphemeralParam()
-		switch {
-		case block.OfText != nil:
-			block.OfText.CacheControl = cacheCtrl
-		case block.OfToolUse != nil:
-			block.OfToolUse.CacheControl = cacheCtrl
-		case block.OfToolResult != nil:
-			block.OfToolResult.CacheControl = cacheCtrl
-		case block.OfImage != nil:
-			block.OfImage.CacheControl = cacheCtrl
-		case block.OfDocument != nil:
-			block.OfDocument.CacheControl = cacheCtrl
-		}
-	}
 }
 
 // stdBlocksToBeta converts standard Anthropic SDK content blocks to their Beta

--- a/pkg/model/provider/anthropic/cache_control.go
+++ b/pkg/model/provider/anthropic/cache_control.go
@@ -1,0 +1,162 @@
+package anthropic
+
+import (
+	"slices"
+	"strings"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+const maxCacheControlBreakpoints = 4
+
+// applyPromptCacheControl is the single policy point for cache breakpoints in
+// standard Anthropic requests. Conversion functions deliberately leave cache
+// control unset so a complete request cannot accumulate markers implicitly.
+func applyPromptCacheControl(source []chat.Message, requestTools []tools.Tool, params *anthropic.MessageNewParams) {
+	remaining := maxCacheControlBreakpoints
+	for _, index := range systemCacheBreakpoints(source) {
+		if remaining == 0 {
+			return
+		}
+		if index < len(params.System) {
+			params.System[index].CacheControl = anthropic.NewCacheControlEphemeralParam()
+			remaining--
+		}
+	}
+
+	if index, ok := toolCacheBreakpoint(requestTools); ok && remaining > 0 && index < len(params.Tools) && params.Tools[index].OfTool != nil {
+		params.Tools[index].OfTool.CacheControl = anthropic.NewCacheControlEphemeralParam()
+		remaining--
+	}
+
+	for i, marked := len(params.Messages)-1, 0; i >= 0 && remaining > 0 && marked < 2; i-- {
+		if setMessageCacheControl(&params.Messages[i]) {
+			remaining--
+			marked++
+		}
+	}
+}
+
+// applyBetaPromptCacheControl mirrors applyPromptCacheControl for the SDK's
+// beta request types. Keep all beta marker translation here rather than in the
+// individual system, message, and tool converters.
+func applyBetaPromptCacheControl(source []chat.Message, requestTools []tools.Tool, params *anthropic.BetaMessageNewParams) {
+	remaining := maxCacheControlBreakpoints
+	for _, index := range systemCacheBreakpoints(source) {
+		if remaining == 0 {
+			return
+		}
+		if index < len(params.System) {
+			params.System[index].CacheControl = anthropic.NewBetaCacheControlEphemeralParam()
+			remaining--
+		}
+	}
+
+	if index, ok := toolCacheBreakpoint(requestTools); ok && remaining > 0 && index < len(params.Tools) && params.Tools[index].OfTool != nil {
+		params.Tools[index].OfTool.CacheControl = anthropic.NewBetaCacheControlEphemeralParam()
+		remaining--
+	}
+
+	for i, marked := len(params.Messages)-1, 0; i >= 0 && remaining > 0 && marked < 2; i-- {
+		if setBetaMessageCacheControl(&params.Messages[i]) {
+			remaining--
+			marked++
+		}
+	}
+}
+
+func systemCacheBreakpoints(messages []chat.Message) []int {
+	lastBySection := make(map[chat.PromptSection]int)
+	blockCount := 0
+	for _, msg := range messages {
+		if msg.Role != chat.MessageRoleSystem {
+			continue
+		}
+
+		before := blockCount
+		if len(msg.MultiContent) > 0 {
+			for _, part := range msg.MultiContent {
+				if part.Type == chat.MessagePartTypeText && strings.TrimSpace(part.Text) != "" {
+					blockCount++
+				}
+			}
+		} else if strings.TrimSpace(msg.Content) != "" {
+			blockCount++
+		}
+		if msg.PromptSection != "" && blockCount > before {
+			lastBySection[msg.PromptSection] = blockCount - 1
+		}
+	}
+
+	indices := make([]int, 0, len(lastBySection))
+	for _, index := range lastBySection {
+		indices = append(indices, index)
+	}
+	slices.Sort(indices)
+	return indices
+}
+
+func toolCacheBreakpoint(requestTools []tools.Tool) (int, bool) {
+	if !containsDeferredTool(requestTools) {
+		return 0, false
+	}
+	immediateCount := 0
+	for _, tool := range requestTools {
+		if !tool.Deferred {
+			immediateCount++
+		}
+	}
+	if immediateCount == 0 {
+		return len(requestTools) - 1, len(requestTools) > 0
+	}
+	return immediateCount - 1, true
+}
+
+func setMessageCacheControl(msg *anthropic.MessageParam) bool {
+	if len(msg.Content) == 0 {
+		return false
+	}
+	block := &msg.Content[len(msg.Content)-1]
+	cacheControl := anthropic.NewCacheControlEphemeralParam()
+	switch {
+	case block.OfText != nil:
+		block.OfText.CacheControl = cacheControl
+	case block.OfToolUse != nil:
+		block.OfToolUse.CacheControl = cacheControl
+	case block.OfToolResult != nil:
+		block.OfToolResult.CacheControl = cacheControl
+	case block.OfImage != nil:
+		block.OfImage.CacheControl = cacheControl
+	case block.OfDocument != nil:
+		block.OfDocument.CacheControl = cacheControl
+	default:
+		return false
+	}
+	return true
+}
+
+func setBetaMessageCacheControl(msg *anthropic.BetaMessageParam) bool {
+	if len(msg.Content) == 0 {
+		return false
+	}
+	block := &msg.Content[len(msg.Content)-1]
+	cacheControl := anthropic.NewBetaCacheControlEphemeralParam()
+	switch {
+	case block.OfText != nil:
+		block.OfText.CacheControl = cacheControl
+	case block.OfToolUse != nil:
+		block.OfToolUse.CacheControl = cacheControl
+	case block.OfToolResult != nil:
+		block.OfToolResult.CacheControl = cacheControl
+	case block.OfImage != nil:
+		block.OfImage.CacheControl = cacheControl
+	case block.OfDocument != nil:
+		block.OfDocument.CacheControl = cacheControl
+	default:
+		return false
+	}
+	return true
+}

--- a/pkg/model/provider/anthropic/cache_control_test.go
+++ b/pkg/model/provider/anthropic/cache_control_test.go
@@ -1,0 +1,136 @@
+package anthropic
+
+import (
+	"testing"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+func TestPromptCacheControlHonorsBreakpointLimit(t *testing.T) {
+	t.Parallel()
+
+	source := []chat.Message{
+		{Role: chat.MessageRoleSystem, Content: "invariant", PromptSection: chat.PromptSectionInvariant},
+		{Role: chat.MessageRoleSystem, Content: "context", PromptSection: chat.PromptSectionContext},
+	}
+	requestTools := []tools.Tool{
+		{Name: "immediate", Parameters: map[string]any{"type": "object"}},
+		{Name: "deferred", Parameters: map[string]any{"type": "object"}, Deferred: true},
+	}
+	convertedTools, err := convertTools(requestTools)
+	require.NoError(t, err)
+	params := anthropic.MessageNewParams{
+		System: []anthropic.TextBlockParam{{Text: "invariant"}, {Text: "context"}},
+		Tools:  convertedTools,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock("older")),
+			anthropic.NewAssistantMessage(anthropic.NewTextBlock("latest")),
+		},
+	}
+
+	applyPromptCacheControl(source, requestTools, &params)
+
+	assert.Equal(t, maxCacheControlBreakpoints, countCacheControlBreakpoints(params))
+	assert.Empty(t, string(params.Messages[0].Content[0].OfText.CacheControl.Type))
+	assert.Equal(t, "ephemeral", string(params.Messages[1].Content[0].OfText.CacheControl.Type))
+
+	convertedBetaTools, err := convertBetaTools(requestTools)
+	require.NoError(t, err)
+	betaParams := anthropic.BetaMessageNewParams{
+		System: []anthropic.BetaTextBlockParam{{Text: "invariant"}, {Text: "context"}},
+		Tools:  convertedBetaTools,
+		Messages: []anthropic.BetaMessageParam{
+			betaTextMessage(anthropic.BetaMessageParamRoleUser, "older"),
+			betaTextMessage(anthropic.BetaMessageParamRoleAssistant, "latest"),
+		},
+	}
+
+	applyBetaPromptCacheControl(source, requestTools, &betaParams)
+
+	assert.Equal(t, maxCacheControlBreakpoints, countBetaCacheControlBreakpoints(betaParams))
+	assert.Empty(t, string(betaParams.Messages[0].Content[0].OfText.CacheControl.Type))
+	assert.Equal(t, "ephemeral", string(betaParams.Messages[1].Content[0].OfText.CacheControl.Type))
+}
+
+func TestPromptCacheControlMarksTwoRecentMessagesWhenBudgetAllows(t *testing.T) {
+	t.Parallel()
+
+	source := []chat.Message{{
+		Role:          chat.MessageRoleSystem,
+		Content:       "invariant",
+		PromptSection: chat.PromptSectionInvariant,
+	}}
+	params := anthropic.MessageNewParams{
+		System: []anthropic.TextBlockParam{{Text: "invariant"}},
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock("oldest")),
+			anthropic.NewAssistantMessage(anthropic.NewTextBlock("older")),
+			anthropic.NewUserMessage(anthropic.NewTextBlock("latest")),
+		},
+	}
+
+	applyPromptCacheControl(source, nil, &params)
+
+	assert.Equal(t, 3, countCacheControlBreakpoints(params))
+	assert.Empty(t, string(params.Messages[0].Content[0].OfText.CacheControl.Type))
+	assert.Equal(t, "ephemeral", string(params.Messages[1].Content[0].OfText.CacheControl.Type))
+	assert.Equal(t, "ephemeral", string(params.Messages[2].Content[0].OfText.CacheControl.Type))
+}
+
+func betaTextMessage(role anthropic.BetaMessageParamRole, text string) anthropic.BetaMessageParam {
+	return anthropic.BetaMessageParam{
+		Role: role,
+		Content: []anthropic.BetaContentBlockParamUnion{{
+			OfText: &anthropic.BetaTextBlockParam{Text: text},
+		}},
+	}
+}
+
+func countCacheControlBreakpoints(params anthropic.MessageNewParams) int {
+	count := 0
+	for _, block := range params.System {
+		if block.CacheControl.Type != "" {
+			count++
+		}
+	}
+	for _, tool := range params.Tools {
+		if tool.OfTool != nil && tool.OfTool.CacheControl.Type != "" {
+			count++
+		}
+	}
+	for _, message := range params.Messages {
+		for _, block := range message.Content {
+			if block.OfText != nil && block.OfText.CacheControl.Type != "" {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func countBetaCacheControlBreakpoints(params anthropic.BetaMessageNewParams) int {
+	count := 0
+	for _, block := range params.System {
+		if block.CacheControl.Type != "" {
+			count++
+		}
+	}
+	for _, tool := range params.Tools {
+		if tool.OfTool != nil && tool.OfTool.CacheControl.Type != "" {
+			count++
+		}
+	}
+	for _, message := range params.Messages {
+		for _, block := range message.Content {
+			if block.OfText != nil && block.OfText.CacheControl.Type != "" {
+				count++
+			}
+		}
+	}
+	return count
+}

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -226,6 +226,7 @@ func (c *Client) CreateChatCompletionStream(
 		Messages:  converted,
 		Tools:     allTools,
 	}
+	applyPromptCacheControl(messages, requestTools, &params)
 
 	// Apply thinking budget first, as it affects whether we can set temperature
 	thinkingEnabled := c.applyThinkingConfig(&params, maxTokens)
@@ -439,9 +440,6 @@ func (c *Client) convertMessagesWithDeferred(ctx context.Context, messages []cha
 		}
 	}
 
-	// Add ephemeral cache to last 2 messages' last content block
-	applyMessageCacheControl(anthropicMessages)
-
 	return anthropicMessages, nil
 }
 
@@ -623,32 +621,6 @@ func (c *Client) convertUserMultiContent(ctx context.Context, parts []chat.Messa
 	return contentBlocks, nil
 }
 
-// applyMessageCacheControl adds ephemeral cache control to the last content block
-// of the last 2 messages for prompt caching.
-func applyMessageCacheControl(messages []anthropic.MessageParam) {
-	for i := len(messages) - 1; i >= 0 && i >= len(messages)-2; i-- {
-		msg := &messages[i]
-		if len(msg.Content) == 0 {
-			continue
-		}
-		lastIdx := len(msg.Content) - 1
-		block := &msg.Content[lastIdx]
-		cacheCtrl := anthropic.NewCacheControlEphemeralParam()
-		switch {
-		case block.OfText != nil:
-			block.OfText.CacheControl = cacheCtrl
-		case block.OfToolUse != nil:
-			block.OfToolUse.CacheControl = cacheCtrl
-		case block.OfToolResult != nil:
-			block.OfToolResult.CacheControl = cacheCtrl
-		case block.OfImage != nil:
-			block.OfImage.CacheControl = cacheCtrl
-		case block.OfDocument != nil:
-			block.OfDocument.CacheControl = cacheCtrl
-		}
-	}
-}
-
 // extractSystemBlocks converts any system-role messages into Anthropic system text blocks
 // to be set on the top-level MessageNewParams.System field.
 func extractSystemBlocks(messages []chat.Message) []anthropic.TextBlockParam {
@@ -673,10 +645,6 @@ func extractSystemBlocks(messages []chat.Message) []anthropic.TextBlockParam {
 			systemBlocks = append(systemBlocks, anthropic.TextBlockParam{
 				Text: txt,
 			})
-		}
-
-		if msg.CacheControl && len(systemBlocks) > 0 {
-			systemBlocks[len(systemBlocks)-1].CacheControl = anthropic.NewCacheControlEphemeralParam()
 		}
 	}
 
@@ -704,8 +672,7 @@ func (c *Client) toolsWithSupportedDeferral(requestTools []tools.Tool) []tools.T
 }
 
 func convertTools(tooles []tools.Tool) ([]anthropic.ToolUnionParam, error) {
-	hasDeferredTools := containsDeferredTool(tooles)
-	tooles, immediateCount := orderToolsForDeferredLoading(tooles)
+	tooles = orderToolsForDeferredLoading(tooles)
 	toolParams := make([]anthropic.ToolParam, len(tooles))
 
 	for i, tool := range tooles {
@@ -721,9 +688,6 @@ func convertTools(tooles []tools.Tool) ([]anthropic.ToolUnionParam, error) {
 		}
 		if tool.Deferred {
 			toolParams[i].DeferLoading = param.NewOpt(true)
-		}
-		if hasDeferredTools && i == immediateCount-1 {
-			toolParams[i].CacheControl = anthropic.NewCacheControlEphemeralParam()
 		}
 	}
 	anthropicTools := make([]anthropic.ToolUnionParam, len(toolParams))
@@ -743,7 +707,7 @@ func containsDeferredTool(requestTools []tools.Tool) bool {
 	return false
 }
 
-func orderToolsForDeferredLoading(requestTools []tools.Tool) ([]tools.Tool, int) {
+func orderToolsForDeferredLoading(requestTools []tools.Tool) []tools.Tool {
 	ordered := make([]tools.Tool, 0, len(requestTools))
 	for _, tool := range requestTools {
 		if !tool.Deferred {
@@ -756,14 +720,14 @@ func orderToolsForDeferredLoading(requestTools []tools.Tool) ([]tools.Tool, int)
 		for i := range ordered {
 			ordered[i].Deferred = false
 		}
-		return ordered, len(ordered)
+		return ordered
 	}
 	for _, tool := range requestTools {
 		if tool.Deferred {
 			ordered = append(ordered, tool)
 		}
 	}
-	return ordered, immediateCount
+	return ordered
 }
 
 // ConvertParametersToSchema converts parameters to Anthropic Schema format

--- a/pkg/model/provider/anthropic/client_test.go
+++ b/pkg/model/provider/anthropic/client_test.go
@@ -509,64 +509,57 @@ func TestExtractSystemBlocks_MultiContent(t *testing.T) {
 	assert.Equal(t, "Part 2", blocks[1].Text)
 }
 
-func TestExtractSystemBlocksCacheControl(t *testing.T) {
+func TestPromptCacheControlMarksLastSystemBlock(t *testing.T) {
 	t.Parallel()
 	msgs := []chat.Message{
 		{
-			Role:    chat.MessageRoleSystem,
-			Content: "instructions",
+			Role:          chat.MessageRoleSystem,
+			Content:       "instructions",
+			PromptSection: chat.PromptSectionInvariant,
 		},
 		{
-			Role:         chat.MessageRoleSystem,
-			Content:      "tools",
-			CacheControl: true,
+			Role:          chat.MessageRoleSystem,
+			Content:       "tools",
+			PromptSection: chat.PromptSectionInvariant,
 		},
 		{
-			Role:    chat.MessageRoleSystem,
-			Content: "date",
+			Role:          chat.MessageRoleSystem,
+			Content:       "date",
+			PromptSection: chat.PromptSectionContext,
 		},
 		{
-			Role:         chat.MessageRoleSystem,
-			Content:      "last",
-			CacheControl: true,
+			Role:          chat.MessageRoleSystem,
+			Content:       "last",
+			PromptSection: chat.PromptSectionContext,
 		},
 	}
 
-	blocks := extractSystemBlocks(msgs)
+	params := anthropic.MessageNewParams{System: extractSystemBlocks(msgs)}
+	applyPromptCacheControl(msgs, nil, &params)
 
-	require.Len(t, blocks, 4)
-	assert.Equal(t, "instructions", blocks[0].Text)
-	assert.Empty(t, string(blocks[0].CacheControl.Type))
-	assert.Empty(t, string(blocks[0].CacheControl.TTL))
+	require.Len(t, params.System, 4)
+	assert.Equal(t, "instructions", params.System[0].Text)
+	assert.Empty(t, string(params.System[0].CacheControl.Type))
+	assert.Empty(t, string(params.System[0].CacheControl.TTL))
 
-	assert.Equal(t, "tools", blocks[1].Text)
-	assert.Equal(t, "ephemeral", string(blocks[1].CacheControl.Type))
-	assert.Empty(t, string(blocks[1].CacheControl.TTL))
+	assert.Equal(t, "tools", params.System[1].Text)
+	assert.Equal(t, "ephemeral", string(params.System[1].CacheControl.Type))
+	assert.Empty(t, string(params.System[1].CacheControl.TTL))
 
-	assert.Equal(t, "date", blocks[2].Text)
-	assert.Empty(t, string(blocks[2].CacheControl.Type))
-	assert.Empty(t, string(blocks[2].CacheControl.TTL))
+	assert.Equal(t, "date", params.System[2].Text)
+	assert.Empty(t, string(params.System[2].CacheControl.Type))
+	assert.Empty(t, string(params.System[2].CacheControl.TTL))
 
-	assert.Equal(t, "last", blocks[3].Text)
-	assert.Equal(t, "ephemeral", string(blocks[3].CacheControl.Type))
-	assert.Empty(t, string(blocks[3].CacheControl.TTL))
+	assert.Equal(t, "last", params.System[3].Text)
+	assert.Equal(t, "ephemeral", string(params.System[3].CacheControl.Type))
+	assert.Empty(t, string(params.System[3].CacheControl.TTL))
 }
 
-func TestExtractSystemBlocks_EmptyContentWithCacheControl(t *testing.T) {
+func TestExtractSystemBlocks_EmptyContent(t *testing.T) {
 	t.Parallel()
 
-	// An empty system message with CacheControl must not panic.
-	// Since extractSystemBlocks now trims system content, an empty/whitespace-only
-	// message produces no block, so CacheControl has nothing to apply to.
-	msgs := []chat.Message{
-		{
-			Role:         chat.MessageRoleSystem,
-			Content:      "",
-			CacheControl: true,
-		},
-	}
+	msgs := []chat.Message{{Role: chat.MessageRoleSystem, Content: ""}}
 
-	// Must not panic; the empty block is skipped.
 	blocks := extractSystemBlocks(msgs)
 	assert.Empty(t, blocks)
 }

--- a/pkg/model/provider/anthropic/tool_deferrals_test.go
+++ b/pkg/model/provider/anthropic/tool_deferrals_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	anthropic "github.com/anthropics/anthropic-sdk-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -31,19 +32,23 @@ func TestConvertToolsMarksOnlyDeferredTools(t *testing.T) {
 
 	standard, err := convertTools(requestTools)
 	require.NoError(t, err)
-	require.Len(t, standard, 2)
-	assert.False(t, standard[0].OfTool.DeferLoading.Valid())
-	assert.Equal(t, "ephemeral", string(standard[0].OfTool.CacheControl.Type))
-	require.True(t, standard[1].OfTool.DeferLoading.Valid())
-	assert.True(t, standard[1].OfTool.DeferLoading.Value)
+	standardParams := anthropic.MessageNewParams{Tools: standard}
+	applyPromptCacheControl(nil, requestTools, &standardParams)
+	require.Len(t, standardParams.Tools, 2)
+	assert.False(t, standardParams.Tools[0].OfTool.DeferLoading.Valid())
+	assert.Equal(t, "ephemeral", string(standardParams.Tools[0].OfTool.CacheControl.Type))
+	require.True(t, standardParams.Tools[1].OfTool.DeferLoading.Valid())
+	assert.True(t, standardParams.Tools[1].OfTool.DeferLoading.Value)
 
 	beta, err := convertBetaTools(requestTools)
 	require.NoError(t, err)
-	require.Len(t, beta, 2)
-	assert.False(t, beta[0].OfTool.DeferLoading.Valid())
-	assert.Equal(t, "ephemeral", string(beta[0].OfTool.CacheControl.Type))
-	require.True(t, beta[1].OfTool.DeferLoading.Valid())
-	assert.True(t, beta[1].OfTool.DeferLoading.Value)
+	betaParams := anthropic.BetaMessageNewParams{Tools: beta}
+	applyBetaPromptCacheControl(nil, requestTools, &betaParams)
+	require.Len(t, betaParams.Tools, 2)
+	assert.False(t, betaParams.Tools[0].OfTool.DeferLoading.Valid())
+	assert.Equal(t, "ephemeral", string(betaParams.Tools[0].OfTool.CacheControl.Type))
+	require.True(t, betaParams.Tools[1].OfTool.DeferLoading.Valid())
+	assert.True(t, betaParams.Tools[1].OfTool.DeferLoading.Value)
 }
 
 func TestDeferredToolsAreReferencedAtTheirLoadPoint(t *testing.T) {

--- a/pkg/runtime/compactor/compactor.go
+++ b/pkg/runtime/compactor/compactor.go
@@ -262,10 +262,7 @@ func ComputeFirstKeptEntry(sess *session.Session, contextLimit int64) int {
 // Cost is per-message bookkeeping already accumulated into
 // sess.TotalCost(); leaving it set would double-count when the
 // summarization session reports its own TotalCost back through
-// [Result.Cost]. CacheControl pins a provider cache checkpoint
-// (Anthropic prompt caching, etc.); pinning it inside the
-// summarization sub-call would associate the cache point with the
-// throwaway compaction conversation rather than the parent session.
+// [Result.Cost].
 //
 // The reconstruction work — surfacing a synthetic "Session Summary"
 // message when a prior summary exists, picking the right start index
@@ -282,7 +279,6 @@ func gatherCompactionInput(sess *session.Session) (messages []chat.Message, sess
 	messages, sessIndices, itemCount = sess.CompactionInput()
 	for i := range messages {
 		messages[i].Cost = 0
-		messages[i].CacheControl = false
 	}
 	return messages, sessIndices, itemCount
 }

--- a/pkg/runtime/compactor/compactor_test.go
+++ b/pkg/runtime/compactor/compactor_test.go
@@ -102,14 +102,13 @@ func TestExtractMessages(t *testing.T) {
 			wantConversationMsgCount: 1,
 		},
 		{
-			name: "cost and cache control are cleared",
+			name: "cost is cleared",
 			messages: []session.Item{
 				session.NewMessageItem(&session.Message{
 					Message: chat.Message{
-						Role:         chat.MessageRoleUser,
-						Content:      "hello",
-						Cost:         1.5,
-						CacheControl: true,
+						Role:    chat.MessageRoleUser,
+						Content: "hello",
+						Cost:    1.5,
 					},
 				}),
 			},
@@ -140,10 +139,9 @@ func TestExtractMessages(t *testing.T) {
 			// Conversation messages are all except first (system) and last (user prompt)
 			assert.Len(t, result[1:len(result)-1], tt.wantConversationMsgCount)
 
-			// Verify cost and cache control are cleared on conversation messages
+			// Verify cost is cleared on conversation messages.
 			for i := 1; i < len(result)-1; i++ {
 				assert.Zero(t, result[i].Cost)
-				assert.False(t, result[i].CacheControl)
 			}
 		})
 	}

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1516,12 +1516,6 @@ func New(opts ...Opt) *Session {
 	return s
 }
 
-func markLastMessageAsCacheControl(messages []chat.Message) {
-	if len(messages) > 0 {
-		messages[len(messages)-1].CacheControl = true
-	}
-}
-
 // buildInvariantSystemMessages builds system messages that are identical
 // for all users of a given agent configuration. These messages can be
 // cached efficiently as they don't change between sessions, users, or projects.
@@ -1686,8 +1680,8 @@ func (s *Session) buildSessionSummaryMessages(items []Item) ([]chat.Message, int
 //
 // This method intentionally bypasses GetMessages's agent-level
 // transformations — invariant system prompts, NumHistoryItems
-// trimming, old-tool-content truncation, whitespace normalization,
-// orphan-tool-call sanitization, and cache_control marking. None of
+// trimming, old-tool-content truncation, whitespace normalization, and
+// orphan-tool-call sanitization. None of
 // those belong in compaction input: the compactor needs the full,
 // untrimmed history (so the LLM can summarize what trimming would
 // have hidden), supplies its own system/user prompt, and runs through
@@ -1785,6 +1779,14 @@ func (s *Session) instructionMessages() ([]chat.Message, []InstructionUpdate) {
 	return initial, slices.Clone(s.InstructionContext.Updates)
 }
 
+func setPromptSection(messages []chat.Message, section chat.PromptSection) {
+	for i := range messages {
+		if messages[i].Role == chat.MessageRoleSystem {
+			messages[i].PromptSection = section
+		}
+	}
+}
+
 func (s *Session) GetMessages(a *agent.Agent, extraSystemMessages ...chat.Message) []chat.Message {
 	return s.getMessages(a, true, extraSystemMessages...)
 }
@@ -1800,7 +1802,7 @@ func (s *Session) getMessages(a *agent.Agent, includeInstructionContext bool, ex
 
 	// Build invariant system messages (cacheable across sessions/users/projects)
 	invariantMessages := buildInvariantSystemMessages(a)
-	markLastMessageAsCacheControl(invariantMessages)
+	setPromptSection(invariantMessages, chat.PromptSectionInvariant)
 
 	// Take a snapshot of Messages under the lock, copying Message structs
 	// to avoid racing with UpdateMessage which may modify the pointed-to objects.
@@ -1809,6 +1811,7 @@ func (s *Session) getMessages(a *agent.Agent, includeInstructionContext bool, ex
 	var instructionUpdates []InstructionUpdate
 	if includeInstructionContext {
 		instructionInitial, instructionUpdates = s.instructionMessages()
+		setPromptSection(instructionInitial, chat.PromptSectionContext)
 	}
 
 	// Build session summary messages (vary per session)
@@ -1817,20 +1820,11 @@ func (s *Session) getMessages(a *agent.Agent, includeInstructionContext bool, ex
 	var messages []chat.Message
 	messages = append(messages, invariantMessages...)
 	messages = append(messages, instructionInitial...)
-	markLastMessageAsCacheControl(messages)
 	// extraSystemMessages are caller-supplied transient system messages
-	// (e.g. turn_start hook output) inserted after the invariant cache
-	// checkpoint and before the conversation. The last extra carries a
-	// cache_control marker so that stable per-session/per-day extras
-	// (AddPromptFiles, AddEnvironmentInfo) participate in prompt caching.
-	// Volatile extras (the daily date) live behind the same marker, which
-	// is acceptable: the cache simply rotates when the date rolls over,
-	// matching the behavior of the previous inline
-	// buildContextSpecificSystemMessages path.
-	if len(extraSystemMessages) > 0 {
-		messages = append(messages, extraSystemMessages...)
-		markLastMessageAsCacheControl(messages[len(messages)-len(extraSystemMessages):])
-	}
+	// (e.g. turn_start hook output) inserted before the conversation.
+	extraStart := len(messages)
+	messages = append(messages, extraSystemMessages...)
+	setPromptSection(messages[extraStart:], chat.PromptSectionContext)
 	messages = append(messages, summaryMessages...)
 
 	// Begin adding conversation messages, interleaving instruction changes at

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -221,71 +221,25 @@ func TestGetMessages_Instructions(t *testing.T) {
 
 	assert.Len(t, messages, 1)
 	assert.Equal(t, "instructions", messages[0].Content)
-	assert.True(t, messages[0].CacheControl)
 }
 
-func TestGetMessages_CacheControl(t *testing.T) {
+func TestGetMessages_SystemMessageOrder(t *testing.T) {
 	t.Parallel()
 
 	testAgent := agent.New("root", "instructions", agent.WithToolSets(todoToolSet(t)))
-
-	s := New()
-	messages := s.GetMessages(testAgent)
-
-	assert.Len(t, messages, 2)
-	assert.Equal(t, "instructions", messages[0].Content)
-	assert.False(t, messages[0].CacheControl)
-
-	assert.Contains(t, messages[1].Content, "Todo Tools")
-	assert.True(t, messages[1].CacheControl)
-}
-
-func TestGetMessages_CacheControlWithSummary(t *testing.T) {
-	t.Parallel()
-
-	// Caching contract pinned by this test:
-	//
-	//   - The last invariant system message gets a cache-control marker.
-	//   - The last caller-supplied extra (typically turn_start hook output)
-	//     ALSO gets a cache-control marker so stable per-session/per-day
-	//     extras (AddPromptFiles, AddEnvironmentInfo) participate in
-	//     prompt caching. This matches the prior
-	//     buildContextSpecificSystemMessages caching behavior.
-	//   - Summary and conversation messages are not cache-controlled.
-	testAgent := agent.New("root", "instructions",
-		agent.WithToolSets(todoToolSet(t)),
-	)
-
 	s := New()
 	s.Messages = append(s.Messages, Item{Summary: "Test summary"})
+	extra := chat.Message{Role: chat.MessageRoleSystem, Content: "Today's date: 2026-04-25"}
 
-	extra := chat.Message{
-		Role:    chat.MessageRoleSystem,
-		Content: "Today's date: 2026-04-25",
-	}
 	messages := s.GetMessages(testAgent, extra)
 
-	var checkpointIndices []int
-	for i, msg := range messages {
-		if msg.Role == chat.MessageRoleSystem && msg.CacheControl {
-			checkpointIndices = append(checkpointIndices, i)
-		}
-	}
-
-	require.Len(t, checkpointIndices, 2,
-		"invariant and last-extra messages should each be cache-controlled")
-
-	// Checkpoint #1: last invariant message (toolset instructions).
-	assert.Contains(t, messages[checkpointIndices[0]].Content, "Todo Tools",
-		"checkpoint #1 must land on the last invariant message")
-
-	// Checkpoint #2: last extra (the date system message).
-	assert.Equal(t, extra.Content, messages[checkpointIndices[1]].Content,
-		"checkpoint #2 must land on the last extra system message")
-
-	// The extra must come AFTER the invariant block.
-	assert.Greater(t, checkpointIndices[1], checkpointIndices[0],
-		"extras must come AFTER the invariant cache checkpoint")
+	require.Len(t, messages, 4)
+	assert.Equal(t, "instructions", messages[0].Content)
+	assert.Contains(t, messages[1].Content, "Todo Tools")
+	assert.Equal(t, extra.Role, messages[2].Role)
+	assert.Equal(t, extra.Content, messages[2].Content)
+	assert.Equal(t, chat.PromptSectionContext, messages[2].PromptSection)
+	assert.Equal(t, SummaryMessageContent("Test summary"), messages[3].Content)
 }
 
 func TestGetLastUserMessages(t *testing.T) {
@@ -932,10 +886,9 @@ func TestCompactionInput(t *testing.T) {
 		t.Parallel()
 		sess := New(WithMessages([]Item{
 			NewMessageItem(&Message{Message: chat.Message{
-				Role:         chat.MessageRoleUser,
-				Content:      "hello",
-				Cost:         1.5,
-				CacheControl: true,
+				Role:    chat.MessageRoleUser,
+				Content: "hello",
+				Cost:    1.5,
 			}}),
 		}))
 
@@ -943,11 +896,9 @@ func TestCompactionInput(t *testing.T) {
 		require.Len(t, messages, 1)
 
 		messages[0].Cost = 0
-		messages[0].CacheControl = false
 		messages[0].Content = "mutated"
 
 		assert.InDelta(t, 1.5, sess.Messages[0].Message.Message.Cost, 0)
-		assert.True(t, sess.Messages[0].Message.Message.CacheControl)
 		assert.Equal(t, "hello", sess.Messages[0].Message.Message.Content)
 	})
 }


### PR DESCRIPTION
 The centralized policy marks:

 1. The final system block
 2. The immediate/deferred tool boundary, when applicable
 3. The final two conversation messages