### PR TITLE
perf: parallelize toolset startup and prefetch MCP catalog

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -524,9 +524,22 @@ func (a *Agent) ToolSets() []tools.ToolSet {
 // not surface a "now available" notice (the OAuth dialog completing or
 // the model just using the tool already makes a successful start
 // obvious; a follow-up notification just reads as a spurious warning).
+//
+// Starts run concurrently so one slow toolset (e.g. an MCP server
+// handshake) doesn't delay the others; Start() is single-flight per
+// toolset and warnings are recorded in configuration order afterwards.
 func (a *Agent) ensureToolSetsAreStarted(ctx context.Context) {
-	for _, toolSet := range a.toolsets {
-		err := toolSet.Start(ctx)
+	errs := make([]error, len(a.toolsets))
+	var wg sync.WaitGroup
+	for i, toolSet := range a.toolsets {
+		wg.Go(func() {
+			errs[i] = toolSet.Start(ctx)
+		})
+	}
+	wg.Wait()
+
+	for i, toolSet := range a.toolsets {
+		err := errs[i]
 		if err == nil {
 			continue
 		}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -544,10 +544,25 @@ func (a *Agent) ToolSets() []tools.ToolSet {
 // Starts run concurrently so one slow toolset (e.g. an MCP server
 // handshake) doesn't delay the others; Start() is single-flight per
 // toolset and warnings are recorded in configuration order afterwards.
+// Peer-dependent toolsets (e.g. the deferred aggregator, whose Start
+// lists its source toolsets' tools) start in a second wave, after the
+// toolsets they depend on have settled.
 func (a *Agent) ensureToolSetsAreStarted(ctx context.Context) {
-	errs := concurrent.MapSlice(a.toolsets, func(toolSet *tools.StartableToolSet) error {
-		return toolSet.Start(ctx)
-	})
+	var independent, dependent []int
+	for i, toolSet := range a.toolsets {
+		if _, ok := tools.As[tools.PeerDependent](toolSet); ok {
+			dependent = append(dependent, i)
+		} else {
+			independent = append(independent, i)
+		}
+	}
+
+	errs := make([]error, len(a.toolsets))
+	for _, wave := range [][]int{independent, dependent} {
+		concurrent.ForEach(wave, func(i int) {
+			errs[i] = a.toolsets[i].Start(ctx)
+		})
+	}
 
 	for i, toolSet := range a.toolsets {
 		err := errs[i]

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/docker/docker-agent/pkg/cache"
+	"github.com/docker/docker-agent/pkg/concurrent"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/config/types"
 	"github.com/docker/docker-agent/pkg/model/provider"
@@ -444,19 +445,13 @@ func (a *Agent) collectTools(ctx context.Context) ([]tools.Tool, error) {
 		err     error
 		started bool
 	}
-	results := make([]listResult, len(a.toolsets))
-	var wg sync.WaitGroup
-	for i, toolSet := range a.toolsets {
+	results := concurrent.MapSlice(a.toolsets, func(toolSet *tools.StartableToolSet) listResult {
 		if !toolSet.IsStarted() {
-			continue
+			return listResult{}
 		}
-		results[i].started = true
-		wg.Go(func() {
-			results[i].tools, results[i].err = toolSet.Tools(ctx)
-		})
-	}
-	wg.Wait()
-
+		ts, err := toolSet.Tools(ctx)
+		return listResult{tools: ts, err: err, started: true}
+	})
 	for i, toolSet := range a.toolsets {
 		if !results[i].started {
 			// Toolset not started; skip it
@@ -550,14 +545,9 @@ func (a *Agent) ToolSets() []tools.ToolSet {
 // handshake) doesn't delay the others; Start() is single-flight per
 // toolset and warnings are recorded in configuration order afterwards.
 func (a *Agent) ensureToolSetsAreStarted(ctx context.Context) {
-	errs := make([]error, len(a.toolsets))
-	var wg sync.WaitGroup
-	for i, toolSet := range a.toolsets {
-		wg.Go(func() {
-			errs[i] = toolSet.Start(ctx)
-		})
-	}
-	wg.Wait()
+	errs := concurrent.MapSlice(a.toolsets, func(toolSet *tools.StartableToolSet) error {
+		return toolSet.Start(ctx)
+	})
 
 	for i, toolSet := range a.toolsets {
 		err := errs[i]

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -436,12 +436,33 @@ func (a *Agent) collectTools(ctx context.Context) ([]tools.Tool, error) {
 		}
 	}
 
-	for _, toolSet := range a.toolsets {
+	// List every started toolset concurrently — a remote MCP tools/list is a
+	// network round-trip — then merge in configuration order so dedup
+	// ("first toolset in config wins") and warning semantics are unchanged.
+	type listResult struct {
+		tools   []tools.Tool
+		err     error
+		started bool
+	}
+	results := make([]listResult, len(a.toolsets))
+	var wg sync.WaitGroup
+	for i, toolSet := range a.toolsets {
 		if !toolSet.IsStarted() {
+			continue
+		}
+		results[i].started = true
+		wg.Go(func() {
+			results[i].tools, results[i].err = toolSet.Tools(ctx)
+		})
+	}
+	wg.Wait()
+
+	for i, toolSet := range a.toolsets {
+		if !results[i].started {
 			// Toolset not started; skip it
 			continue
 		}
-		ta, err := toolSet.Tools(ctx)
+		ta, err := results[i].tools, results[i].err
 		if err != nil {
 			desc := tools.DescribeToolSet(toolSet)
 			// Route through the once-per-streak guard so a toolset stuck

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -5,7 +5,10 @@ import (
 	"errors"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -595,6 +598,62 @@ func TestAgentReProbeRecoveryDoesNotEmitNotice(t *testing.T) {
 
 // TestAgentNoDuplicateStartWarnings verifies that repeated failures generate
 // only one warning (on the first failure), not one per retry.
+// slowToolSet blocks in Start until release is closed, recording completion.
+type slowToolSet struct {
+	stubToolSet
+
+	release chan struct{}
+	done    atomic.Bool
+}
+
+func (s *slowToolSet) Start(context.Context) error {
+	<-s.release
+	s.done.Store(true)
+	return nil
+}
+
+// peerDependentToolSet implements tools.PeerDependent and records whether
+// its peer had finished starting when its own Start ran.
+type peerDependentToolSet struct {
+	stubToolSet
+
+	peer        *slowToolSet
+	peerStarted atomic.Bool
+}
+
+var _ tools.PeerDependent = (*peerDependentToolSet)(nil)
+
+func (p *peerDependentToolSet) StartsAfterPeers() {}
+
+func (p *peerDependentToolSet) Start(context.Context) error {
+	p.peerStarted.Store(p.peer.done.Load())
+	return nil
+}
+
+// A peer-dependent toolset (e.g. the deferred aggregator) must only start
+// once every other toolset has settled, even though starts run concurrently
+// — its Start reads from its peers.
+func TestEnsureToolSetsAreStartedPeerDependentStartsLast(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		slow := &slowToolSet{release: make(chan struct{})}
+		dep := &peerDependentToolSet{peer: slow}
+		// The dependent is listed first on purpose: order in config must not matter.
+		a := New("root", "test", WithToolSets(dep, slow))
+
+		// In the bubble the sleep only fires once every other goroutine is
+		// blocked, so a buggy concurrent dep.Start deterministically runs
+		// (and records slow.done == false) before the release.
+		go func() {
+			time.Sleep(50 * time.Millisecond) //nolint:forbidigo // fake time inside the synctest bubble
+			close(slow.release)
+		}()
+
+		_, err := a.Tools(t.Context())
+		require.NoError(t, err)
+		assert.True(t, dep.peerStarted.Load(), "peer-dependent toolset started before its peers settled")
+	})
+}
+
 func TestAgentNoDuplicateStartWarnings(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/concurrent/mapslice.go
+++ b/pkg/concurrent/mapslice.go
@@ -20,3 +20,15 @@ func MapSlice[T, R any](items []T, f func(T) R) []R {
 	wg.Wait()
 	return results
 }
+
+// ForEach calls f on every element of items concurrently and blocks until
+// every call has returned. Same parallelism caveats as [MapSlice].
+func ForEach[T any](items []T, f func(T)) {
+	var wg sync.WaitGroup
+	for _, item := range items {
+		wg.Go(func() {
+			f(item)
+		})
+	}
+	wg.Wait()
+}

--- a/pkg/concurrent/mapslice.go
+++ b/pkg/concurrent/mapslice.go
@@ -1,0 +1,22 @@
+package concurrent
+
+import "sync"
+
+// MapSlice applies f to every element of items concurrently and returns the
+// results in input order (results[i] = f(items[i])). It blocks until every
+// call has returned.
+//
+// f must be safe to call concurrently. There is no bound on parallelism: one
+// goroutine is spawned per element, which suits the small fan-outs this is
+// meant for (toolsets, hooks, tool calls) — not thousands of items.
+func MapSlice[T, R any](items []T, f func(T) R) []R {
+	results := make([]R, len(items))
+	var wg sync.WaitGroup
+	for i, item := range items {
+		wg.Go(func() {
+			results[i] = f(item)
+		})
+	}
+	wg.Wait()
+	return results
+}

--- a/pkg/concurrent/mapslice_test.go
+++ b/pkg/concurrent/mapslice_test.go
@@ -1,0 +1,42 @@
+package concurrent
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapSlice(t *testing.T) {
+	t.Parallel()
+
+	got := MapSlice([]int{1, 2, 3, 4}, func(v int) int { return v * v })
+	assert.Equal(t, []int{1, 4, 9, 16}, got)
+}
+
+func TestMapSlice_Empty(t *testing.T) {
+	t.Parallel()
+
+	got := MapSlice(nil, func(int) int { t.Fatal("f must not be called"); return 0 })
+	assert.Empty(t, got)
+}
+
+func TestMapSlice_RunsConcurrently(t *testing.T) {
+	t.Parallel()
+
+	const n = 8
+	var running atomic.Int32
+	start := make(chan struct{})
+
+	// Every call blocks until all n are running; the test deadlocks (and
+	// times out) if MapSlice were sequential.
+	got := MapSlice(make([]struct{}, n), func(struct{}) int {
+		if running.Add(1) == n {
+			close(start)
+		}
+		<-start
+		return 1
+	})
+
+	assert.Len(t, got, n)
+}

--- a/pkg/concurrent/mapslice_test.go
+++ b/pkg/concurrent/mapslice_test.go
@@ -3,6 +3,7 @@ package concurrent
 import (
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -28,15 +29,30 @@ func TestMapSlice_RunsConcurrently(t *testing.T) {
 	var running atomic.Int32
 	start := make(chan struct{})
 
-	// Every call blocks until all n are running; the test deadlocks (and
-	// times out) if MapSlice were sequential.
+	// Every call blocks until all n are running — only possible if MapSlice
+	// is concurrent. The timeout makes a sequential regression fail fast
+	// instead of hanging until the package deadline.
+	timeout := time.After(10 * time.Second)
 	got := MapSlice(make([]struct{}, n), func(struct{}) int {
 		if running.Add(1) == n {
 			close(start)
 		}
-		<-start
-		return 1
+		select {
+		case <-start:
+			return 1
+		case <-timeout:
+			t.Error("MapSlice did not run all calls concurrently")
+			return 0
+		}
 	})
 
 	assert.Len(t, got, n)
+}
+
+func TestForEach(t *testing.T) {
+	t.Parallel()
+
+	var sum atomic.Int32
+	ForEach([]int32{1, 2, 3, 4}, func(v int32) { sum.Add(v) })
+	assert.Equal(t, int32(10), sum.Load())
 }

--- a/pkg/gateway/catalog.go
+++ b/pkg/gateway/catalog.go
@@ -62,6 +62,14 @@ func ParseServerRef(ref string) string {
 	return strings.TrimPrefix(ref, "docker:")
 }
 
+// Prefetch starts resolving the catalog in the background so a later
+// ServerSpec call finds the result memoized (or the fetch already in flight)
+// instead of paying the network round-trip on the caller's critical path.
+func Prefetch(ctx context.Context) {
+	loader := loaderFrom(ctx)
+	go func() { _, _ = loader.load(ctx) }()
+}
+
 // cachedCatalog is the on-disk cache format.
 type cachedCatalog struct {
 	Catalog Catalog `json:"catalog"`

--- a/pkg/hooks/executor.go
+++ b/pkg/hooks/executor.go
@@ -9,13 +9,13 @@ import (
 	"maps"
 	"regexp"
 	"strings"
-	"sync"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/docker/docker-agent/pkg/concurrent"
 	"github.com/docker/docker-agent/pkg/telemetry/genai"
 )
 
@@ -215,12 +215,9 @@ func (e *Executor) Dispatch(ctx context.Context, event EventType, input *Input) 
 		return nil, fmt.Errorf("failed to serialize hook input: %w", err)
 	}
 
-	results := make([]hookResult, len(hooks))
-	var wg sync.WaitGroup
-	for i, hook := range hooks {
-		wg.Go(func() { results[i] = e.runHook(ctx, hook, inputJSON) })
-	}
-	wg.Wait()
+	results := concurrent.MapSlice(hooks, func(hook Hook) hookResult {
+		return e.runHook(ctx, hook, inputJSON)
+	})
 
 	final := aggregate(results, event)
 	annotateHookSpan(span, event, final)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/chat"
-	"github.com/docker/docker-agent/pkg/concurrent"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/config/types"
 	"github.com/docker/docker-agent/pkg/effort"
@@ -1674,15 +1673,35 @@ func (r *LocalRuntime) emitToolsProgressively(ctx context.Context, a *agent.Agen
 	// Start every toolset concurrently so one slow start (e.g. an MCP server
 	// pulling an image) doesn't delay the others; the context is already
 	// non-interactive here so no start can block on a user-driven flow. Each
-	// start keeps its own bounded timeout. Results are then processed in
-	// configuration order so progress events and warnings are deterministic.
-	startErrs := concurrent.MapSlice(toolsets, func(toolset tools.ToolSet) error {
+	// start keeps its own bounded timeout, and outcomes are consumed in
+	// configuration order below so an early fast toolset is listed (and
+	// counted) without waiting for a slow later one. Peer-dependent toolsets
+	// (e.g. the deferred aggregator, whose Start lists its source toolsets'
+	// tools) start in a second wave, after the others have settled.
+	starts := make([]chan error, totalToolsets)
+	var independents sync.WaitGroup
+	var dependents []int
+	for i, toolset := range toolsets {
 		startable, ok := toolset.(*tools.StartableToolSet)
 		if !ok {
-			return nil
+			continue
 		}
-		return startToolsetWithTimeout(ctx, startable, r.toolStartTimeout)
-	})
+		starts[i] = make(chan error, 1)
+		if _, ok := tools.As[tools.PeerDependent](startable); ok {
+			dependents = append(dependents, i)
+			continue
+		}
+		independents.Go(func() {
+			starts[i] <- startToolsetWithTimeout(ctx, startable, r.toolStartTimeout)
+		})
+	}
+	for _, i := range dependents {
+		startable := toolsets[i].(*tools.StartableToolSet)
+		go func() {
+			independents.Wait()
+			starts[i] <- startToolsetWithTimeout(ctx, startable, r.toolStartTimeout)
+		}()
+	}
 
 	// Load tools from each toolset and emit progress
 	var totalTools int
@@ -1700,7 +1719,7 @@ func (r *LocalRuntime) emitToolsProgressively(ctx context.Context, a *agent.Agen
 		// can fire the targeted re-auth notice. Start() is a no-op when the
 		// toolset is already healthy, so calling it unconditionally is safe.
 		if startable, ok := toolset.(*tools.StartableToolSet); ok {
-			if err := startErrs[i]; err != nil {
+			if err := <-starts[i]; err != nil {
 				desc := tools.DescribeToolSet(startable.ToolSet)
 				// A start that outlived its deadline (e.g. an MCP container
 				// stuck behind a wedged Docker daemon) is reported directly:

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/concurrent"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/config/types"
 	"github.com/docker/docker-agent/pkg/effort"
@@ -1675,18 +1676,13 @@ func (r *LocalRuntime) emitToolsProgressively(ctx context.Context, a *agent.Agen
 	// non-interactive here so no start can block on a user-driven flow. Each
 	// start keeps its own bounded timeout. Results are then processed in
 	// configuration order so progress events and warnings are deterministic.
-	startErrs := make([]error, totalToolsets)
-	var wg sync.WaitGroup
-	for i, toolset := range toolsets {
+	startErrs := concurrent.MapSlice(toolsets, func(toolset tools.ToolSet) error {
 		startable, ok := toolset.(*tools.StartableToolSet)
 		if !ok {
-			continue
+			return nil
 		}
-		wg.Go(func() {
-			startErrs[i] = startToolsetWithTimeout(ctx, startable, r.toolStartTimeout)
-		})
-	}
-	wg.Wait()
+		return startToolsetWithTimeout(ctx, startable, r.toolStartTimeout)
+	})
 
 	// Load tools from each toolset and emit progress
 	var totalTools int

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1670,6 +1670,24 @@ func (r *LocalRuntime) emitToolsProgressively(ctx context.Context, a *agent.Agen
 		return
 	}
 
+	// Start every toolset concurrently so one slow start (e.g. an MCP server
+	// pulling an image) doesn't delay the others; the context is already
+	// non-interactive here so no start can block on a user-driven flow. Each
+	// start keeps its own bounded timeout. Results are then processed in
+	// configuration order so progress events and warnings are deterministic.
+	startErrs := make([]error, totalToolsets)
+	var wg sync.WaitGroup
+	for i, toolset := range toolsets {
+		startable, ok := toolset.(*tools.StartableToolSet)
+		if !ok {
+			continue
+		}
+		wg.Go(func() {
+			startErrs[i] = startToolsetWithTimeout(ctx, startable, r.toolStartTimeout)
+		})
+	}
+	wg.Wait()
+
 	// Load tools from each toolset and emit progress
 	var totalTools int
 	for i, toolset := range toolsets {
@@ -1680,13 +1698,13 @@ func (r *LocalRuntime) emitToolsProgressively(ctx context.Context, a *agent.Agen
 
 		isLast := i == totalToolsets-1
 
-		// Start the toolset if needed, including recovery: a previously-started
+		// Handle the start outcome, including recovery: a previously-started
 		// toolset whose inner connection died (e.g. background invalid_token)
-		// must have its recovery Start() called here so ShouldReportRecoveryFailure
+		// had its recovery Start() called above so ShouldReportRecoveryFailure
 		// can fire the targeted re-auth notice. Start() is a no-op when the
 		// toolset is already healthy, so calling it unconditionally is safe.
 		if startable, ok := toolset.(*tools.StartableToolSet); ok {
-			if err := startToolsetWithTimeout(ctx, startable, r.toolStartTimeout); err != nil {
+			if err := startErrs[i]; err != nil {
 				desc := tools.DescribeToolSet(startable.ToolSet)
 				// A start that outlived its deadline (e.g. an MCP container
 				// stuck behind a wedged Docker daemon) is reported directly:

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1423,6 +1423,67 @@ func TestEmitStartupInfo_SkipsToolsetWhoseStartHangs(t *testing.T) {
 	assert.Contains(t, warning.Message, "taking too long to start")
 }
 
+// TestEmitStartupInfo_EmitsProgressWhileSlowToolsetStarts guards the
+// progressive contract of emitToolsProgressively: an early fast toolset must
+// be counted in a ToolsetInfo event while a later toolset is still starting,
+// not only after every start has settled.
+func TestEmitStartupInfo_EmitsProgressWhileSlowToolsetStarts(t *testing.T) {
+	t.Parallel()
+
+	prov := &mockProvider{id: "test/startup-model", stream: &mockStream{}}
+
+	release := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	fast := newStubToolSet(nil, []tools.Tool{{Name: "ready"}}, nil)
+	slow := &blockingStartToolSet{release: release}
+
+	root := agent.New("root", "agent",
+		agent.WithModel(prov),
+		agent.WithToolSets(fast, slow),
+	)
+	tm := team.New(team.WithAgents(root))
+
+	rt, err := NewLocalRuntime(t.Context(), tm,
+		WithCurrentAgent("root"),
+		WithModelStore(mockModelStore{}),
+	)
+	require.NoError(t, err)
+
+	events := make(chan Event, 32)
+	go func() {
+		rt.EmitStartupInfo(t.Context(), nil, NewChannelSink(events))
+		close(events)
+	}()
+
+	// The fast toolset's count must arrive while the slow start is still
+	// blocked (release is not closed yet).
+	timeout := time.After(5 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			ti, ok := e.(*ToolsetInfoEvent)
+			if !ok {
+				continue
+			}
+			if ti.AvailableTools == 1 && ti.Loading {
+				close(release)
+				for range events { // drain so EmitStartupInfo finishes
+				}
+				return
+			}
+		case <-timeout:
+			t.Fatal("no progress event for the fast toolset arrived while the slow toolset was starting")
+		}
+	}
+}
+
 // TestEmitStartupInfo_AuthRequiredIsSilent verifies that when a toolset's
 // Start() returns an mcptools.IsAuthorizationRequired error — the runtime
 // deliberately deferred OAuth until the user is interacting — the user

--- a/pkg/runtime/toolexec/dispatcher.go
+++ b/pkg/runtime/toolexec/dispatcher.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/concurrent"
 	"github.com/docker/docker-agent/pkg/hooks"
 	"github.com/docker/docker-agent/pkg/permissions"
 	"github.com/docker/docker-agent/pkg/session"
@@ -209,23 +210,18 @@ func (d *Dispatcher) Process(ctx context.Context, sess *session.Session, calls [
 	batchCtx, cancelBatch := context.WithCancelCause(ctx)
 	defer cancelBatch(nil)
 
-	outcomes := make([]CallOutcome, len(calls))
 	var stopOnce sync.Once
-	var wg sync.WaitGroup
-	for i, tc := range calls {
-		wg.Go(func() {
-			c := d.newCall(sess, em, a, tc, toolByName)
-			outcome := c.run(batchCtx)
-			outcomes[i] = outcome
-			switch {
-			case outcome.Canceled:
-				stopOnce.Do(func() { cancelBatch(errBatchCanceledByUser) })
-			case outcome.StopRun:
-				stopOnce.Do(func() { cancelBatch(errBatchStoppedByHook) })
-			}
-		})
-	}
-	wg.Wait()
+	outcomes := concurrent.MapSlice(calls, func(tc tools.ToolCall) CallOutcome {
+		c := d.newCall(sess, em, a, tc, toolByName)
+		outcome := c.run(batchCtx)
+		switch {
+		case outcome.Canceled:
+			stopOnce.Do(func() { cancelBatch(errBatchCanceledByUser) })
+		case outcome.StopRun:
+			stopOnce.Do(func() { cancelBatch(errBatchStoppedByHook) })
+		}
+		return outcome
+	})
 
 	for _, outcome := range outcomes {
 		if outcome.StopRun {

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker-agent/pkg/agent"
 	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/gateway"
 	"github.com/docker/docker-agent/pkg/js"
 	"github.com/docker/docker-agent/pkg/model/provider"
 	"github.com/docker/docker-agent/pkg/model/provider/dmr"
@@ -170,6 +171,14 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 			attribute.Int("cagent.teamloader.agent_count", len(cfg.Agents)),
 			attribute.Int("cagent.teamloader.model_count", len(cfg.Models)),
 		)
+	}
+
+	// Toolsets referencing an MCP catalog server (ref: docker:...) need the
+	// catalog to be built. Kick the fetch off now so its network round-trip
+	// overlaps model and environment resolution instead of stalling toolset
+	// creation later in this load.
+	if configUsesCatalogRefs(cfg) {
+		gateway.Prefetch(ctx)
 	}
 
 	// Merge user-level provider definitions (seeded into the runtime config
@@ -913,6 +922,28 @@ func filterSkillsByName(loaded []skills.Skill, include []string) []skills.Skill 
 		}
 	}
 	return filtered
+}
+
+// configUsesCatalogRefs reports whether any toolset in the config references
+// an MCP catalog server (ref: docker:...), i.e. whether loading the team will
+// need the MCP catalog.
+func configUsesCatalogRefs(cfg *latest.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	for i := range cfg.Agents {
+		for _, ts := range cfg.Agents[i].Toolsets {
+			if ts.Ref != "" {
+				return true
+			}
+		}
+	}
+	for _, ts := range cfg.Toolsets {
+		if ts.Ref != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // configNameFromSource extracts a clean config name from a source name.

--- a/pkg/tools/builtin/deferred/deferred.go
+++ b/pkg/tools/builtin/deferred/deferred.go
@@ -33,10 +33,11 @@ type ToolSet struct {
 
 // Verify interface compliance
 var (
-	_ tools.ToolSet      = (*ToolSet)(nil)
-	_ tools.Startable    = (*ToolSet)(nil)
-	_ tools.Instructable = (*ToolSet)(nil)
-	_ tools.Named        = (*ToolSet)(nil)
+	_ tools.ToolSet       = (*ToolSet)(nil)
+	_ tools.Startable     = (*ToolSet)(nil)
+	_ tools.Instructable  = (*ToolSet)(nil)
+	_ tools.Named         = (*ToolSet)(nil)
+	_ tools.PeerDependent = (*ToolSet)(nil)
 )
 
 type deferredSource struct {
@@ -56,6 +57,10 @@ func New() *ToolSet {
 func (d *ToolSet) Name() string {
 	return "deferred"
 }
+
+// StartsAfterPeers implements tools.PeerDependent: Start lists the source
+// toolsets' tools, so they must be started first.
+func (d *ToolSet) StartsAfterPeers() {}
 
 func (d *ToolSet) AddSource(toolset tools.ToolSet, deferAll bool, toolNames []string) {
 	d.mu.Lock()

--- a/pkg/tools/capabilities.go
+++ b/pkg/tools/capabilities.go
@@ -13,6 +13,15 @@ type Startable interface {
 	Stop(ctx context.Context) error
 }
 
+// PeerDependent is implemented by toolsets whose Start reads from the
+// agent's other toolsets (e.g. the deferred aggregator lists its source
+// toolsets' tools). Callers that start an agent's toolsets concurrently
+// must start these only after every other toolset has settled, or their
+// Start would race the very toolsets it depends on.
+type PeerDependent interface {
+	StartsAfterPeers()
+}
+
 // Statable is implemented by toolsets that expose a lifecycle state
 // snapshot (Stopped/Starting/Ready/Degraded/Restarting/Failed) plus the
 // most recent error and restart count. The TUI uses this to render

--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -460,6 +460,14 @@ func (t *oauthTransport) handleServerRejectedToken(ctx context.Context, prev *OA
 	return t.startInteractiveFlowLocked(ctx, t.baseURL, wwwAuth)
 }
 
+// interactiveOAuthMu serializes interactive OAuth flows across transports
+// (per-toolset oauthFlowMu only serializes flows for one server). Toolsets
+// now start concurrently, so two OAuth-requiring servers could otherwise
+// prompt the user at the same time and race to bind a fixed callback port.
+// One flow at a time restores the sequential-start behavior; queued flows
+// run as soon as the user finishes (or cancels) the current one.
+var interactiveOAuthMu sync.Mutex
+
 // startInteractiveFlowLocked runs the interactive OAuth flow while oauthFlowMu
 // is already held. It enforces the sticky-decline guard: a prior user cancel
 // short-circuits immediately and returns OAuthDeclinedError, and a new cancel
@@ -477,6 +485,12 @@ func (t *oauthTransport) startInteractiveFlowLocked(ctx context.Context, authSer
 		slog.DebugContext(ctx, "OAuth flow short-circuited: user already declined on this transport", "url", t.baseURL)
 		return &OAuthDeclinedError{URL: t.baseURL}
 	}
+
+	// Queue behind other transports' flows only after the cheap decline
+	// short-circuit; flows on this transport are already serialized by
+	// oauthFlowMu, so the latch cannot change while we wait here.
+	interactiveOAuthMu.Lock()
+	defer interactiveOAuthMu.Unlock()
 
 	err := t.handleOAuthFlow(ctx, authServer, wwwAuth)
 	if err != nil {


### PR DESCRIPTION
Profiling `examples/gopher.yaml` on Apple Silicon revealed that agent startup blocked sequentially on MCP handshakes: every toolset was started one after another, so total startup time was the *sum* of all handshake latencies. For a sub-agent like `librarian` that reaches three MCP servers, that summed to around 5.2 s on a warm cache.

This PR attacks that sequential work at every layer. `gateway.Prefetch()` kicks off the memoized catalog fetch in the background as soon as a config with `ref:` toolsets is loaded, so the network round-trip overlaps model and environment resolution instead of blocking `LoadTeam`. Inside `EmitStartupInfo`, `agent.Run`, and `tools/list`, toolsets are now started and queried concurrently using a new `concurrent.MapSlice` fan-out helper that replaces five hand-rolled results-slice + `WaitGroup` patterns (including pre-existing ones in `pkg/hooks/executor.go` and `pkg/runtime/toolexec/dispatcher.go`). Merged tool lists remain in configuration order so dedup, collision detection, and warning semantics are unchanged.

Two correctness fixes accompany the parallelism. The `deferred` aggregator implements a new `tools.PeerDependent` marker so it is started only after all its peer toolsets have settled — preserving the ordering invariant that existed before when startup was sequential. A process-wide mutex in `pkg/tools/mcp/oauth.go` serializes interactive OAuth flows so concurrent starts cannot race on the fixed callback port, issue simultaneous prompts, or confuse legacy MCP clients that answer elicitations without an `elicitation_id`.

Measured on Apple Silicon, warm caches: `LoadTeam` drops from ~150–190 ms to ~130–145 ms; gopher root-agent tools ready in 1.34 s (from 1.47 s, now bound by the inherent ~1.3 s `gopls` MCP handshake); librarian sub-agent first turn drops from 5.2 s to ~3.4 s. The single-flight guarantee on `Start` is preserved, configuration-order warnings and dedup are preserved, and the deferred toolset ordering invariant is preserved.