### PR TITLE
fix: limit anthropic cache control markers

### DIFF
--- a/e2e/testdata/cassettes/TestDebug_Title/Anthropic.yaml
+++ b/e2e/testdata/cassettes/TestDebug_Title/Anthropic.yaml
@@ -8,7 +8,7 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.anthropic.com
-        body: '{"max_tokens":20,"messages":[{"content":[{"text":"Based on the following recent user messages from a conversation with an AI assistant, generate a short, descriptive title (maximum 50 characters) that captures the main topic or purpose of the conversation. Return ONLY the title text on a single line, nothing else. Do not include any newlines, explanations, or formatting.\n\nRecent user messages:\n1. What can you do?\n\n\n","cache_control":{"type":"ephemeral"},"type":"text"}],"role":"user"}],"model":"claude-haiku-4-5","system":[{"text":"You are a helpful AI assistant that generates concise, descriptive titles for conversations. You will be given up to 2 recent user messages and asked to create a single-line title that captures the main topic. Never use newlines or line breaks in your response.","type":"text"}],"tools":[],"stream":true}'
+        body: '{"max_tokens":256,"messages":[{"content":[{"text":"Based on the following recent user messages from a conversation with an AI assistant, generate a short, descriptive title (maximum 50 characters) that captures the main topic or purpose of the conversation. Return ONLY the title text on a single line, nothing else. Do not include any newlines, explanations, or formatting.\n\nRecent user messages:\n1. What can you do?\n\n\n","type":"text"}],"role":"user"}],"model":"claude-haiku-4-5","system":[{"text":"You are a helpful AI assistant that generates concise, descriptive titles for conversations. You will be given up to 2 recent user messages and asked to create a single-line title that captures the main topic. Never use newlines or line breaks in your response.","type":"text"}],"tools":[],"stream":true}'
         url: https://api.anthropic.com/v1/messages
         method: POST
       response:
@@ -19,28 +19,25 @@ interactions:
         uncompressed: true
         body: |+
             event: message_start
-            data: {"type":"message_start","message":{"model":"claude-haiku-4-5-20251001","id":"msg_01DxmYVWEFxiicUjBNkDkEiY","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":142,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"not_available"}} }
+            data: {"type":"message_start","message":{"model":"claude-haiku-4-5-20251001","id":"msg_011Cd5zLZEquGTrDC9uhMhLq","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":142,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"not_available"}}    }
 
             event: content_block_start
-            data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}              }
+            data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}       }
 
             event: ping
             data: {"type": "ping"}
 
             event: content_block_delta
-            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"AI"}            }
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"AI"}  }
 
             event: content_block_delta
-            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" Assistant"}  }
-
-            event: content_block_delta
-            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" Capabilities Overview"}             }
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" Assistant Capabilities Overview"} }
 
             event: content_block_stop
-            data: {"type":"content_block_stop","index":0 }
+            data: {"type":"content_block_stop","index":0              }
 
             event: message_delta
-            data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":142,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":8}       }
+            data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":142,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":8}    }
 
             event: message_stop
             data: {"type":"message_stop" }
@@ -48,4 +45,4 @@ interactions:
         headers: {}
         status: 200 OK
         code: 200
-        duration: 646.247542ms
+        duration: 743.844542ms

--- a/e2e/testdata/cassettes/TestDebug_Title/Anthropic_Opus46.yaml
+++ b/e2e/testdata/cassettes/TestDebug_Title/Anthropic_Opus46.yaml
@@ -8,7 +8,7 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.anthropic.com
-        body: '{"max_tokens":20,"messages":[{"content":[{"text":"Based on the following recent user messages from a conversation with an AI assistant, generate a short, descriptive title (maximum 50 characters) that captures the main topic or purpose of the conversation. Return ONLY the title text on a single line, nothing else. Do not include any newlines, explanations, or formatting.\n\nRecent user messages:\n1. What can you do?\n\n\n","cache_control":{"type":"ephemeral"},"type":"text"}],"role":"user"}],"model":"claude-opus-4-6","system":[{"text":"You are a helpful AI assistant that generates concise, descriptive titles for conversations. You will be given up to 2 recent user messages and asked to create a single-line title that captures the main topic. Never use newlines or line breaks in your response.","type":"text"}],"tools":[],"stream":true}'
+        body: '{"max_tokens":256,"messages":[{"content":[{"text":"Based on the following recent user messages from a conversation with an AI assistant, generate a short, descriptive title (maximum 50 characters) that captures the main topic or purpose of the conversation. Return ONLY the title text on a single line, nothing else. Do not include any newlines, explanations, or formatting.\n\nRecent user messages:\n1. What can you do?\n\n\n","type":"text"}],"role":"user"}],"model":"claude-opus-4-6","system":[{"text":"You are a helpful AI assistant that generates concise, descriptive titles for conversations. You will be given up to 2 recent user messages and asked to create a single-line title that captures the main topic. Never use newlines or line breaks in your response.","type":"text"}],"tools":[],"stream":true}'
         url: https://api.anthropic.com/v1/messages
         method: POST
       response:
@@ -19,36 +19,30 @@ interactions:
         uncompressed: true
         body: |+
             event: message_start
-            data: {"type":"message_start","message":{"model":"claude-opus-4-6","id":"msg_012MvFeESDXT7zfGLkERzcmY","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":143,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"global"}}             }
+            data: {"type":"message_start","message":{"model":"claude-opus-4-6","id":"msg_011Cd5zLZtYAx7NhWJHoLW4U","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":143,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"global"}} }
 
             event: content_block_start
-            data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}          }
+            data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}   }
 
             event: ping
             data: {"type": "ping"}
 
             event: content_block_delta
-            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"AI"}}
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"AI"}             }
 
             event: content_block_delta
-            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" Assistant"}     }
-
-            event: content_block_delta
-            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" Capabilities"}   }
-
-            event: content_block_delta
-            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" Overview"}              }
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" Assistant Capabilities Overview"}       }
 
             event: content_block_stop
-            data: {"type":"content_block_stop","index":0       }
+            data: {"type":"content_block_stop","index":0}
 
             event: message_delta
-            data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":143,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":8}   }
+            data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":143,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":8}           }
 
             event: message_stop
-            data: {"type":"message_stop"          }
+            data: {"type":"message_stop"               }
 
         headers: {}
         status: 200 OK
         code: 200
-        duration: 2.575918292s
+        duration: 12.3666245s

--- a/e2e/testdata/cassettes/TestDebug_Title/Anthropic_Sonnet45.yaml
+++ b/e2e/testdata/cassettes/TestDebug_Title/Anthropic_Sonnet45.yaml
@@ -8,7 +8,7 @@ interactions:
         proto_minor: 1
         content_length: 0
         host: api.anthropic.com
-        body: '{"max_tokens":20,"messages":[{"content":[{"text":"Based on the following recent user messages from a conversation with an AI assistant, generate a short, descriptive title (maximum 50 characters) that captures the main topic or purpose of the conversation. Return ONLY the title text on a single line, nothing else. Do not include any newlines, explanations, or formatting.\n\nRecent user messages:\n1. What can you do?\n\n\n","cache_control":{"type":"ephemeral"},"type":"text"}],"role":"user"}],"model":"claude-sonnet-4-5","system":[{"text":"You are a helpful AI assistant that generates concise, descriptive titles for conversations. You will be given up to 2 recent user messages and asked to create a single-line title that captures the main topic. Never use newlines or line breaks in your response.","type":"text"}],"tools":[],"stream":true}'
+        body: '{"max_tokens":256,"messages":[{"content":[{"text":"Based on the following recent user messages from a conversation with an AI assistant, generate a short, descriptive title (maximum 50 characters) that captures the main topic or purpose of the conversation. Return ONLY the title text on a single line, nothing else. Do not include any newlines, explanations, or formatting.\n\nRecent user messages:\n1. What can you do?\n\n\n","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-5","system":[{"text":"You are a helpful AI assistant that generates concise, descriptive titles for conversations. You will be given up to 2 recent user messages and asked to create a single-line title that captures the main topic. Never use newlines or line breaks in your response.","type":"text"}],"tools":[],"stream":true}'
         url: https://api.anthropic.com/v1/messages
         method: POST
       response:
@@ -19,30 +19,30 @@ interactions:
         uncompressed: true
         body: |+
             event: message_start
-            data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01KxQUE5yzzqRRca9zb4iRW6","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":142,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"not_available"}}           }
+            data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_011Cd5zLZSzc2dkHamD56pby","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":142,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"not_available"}}          }
 
             event: content_block_start
-            data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}      }
+            data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}     }
 
             event: ping
             data: {"type": "ping"}
 
             event: content_block_delta
-            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"What"}     }
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"What"}          }
 
             event: content_block_delta
-            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" can you do?"}            }
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" can you do?"}}
 
             event: content_block_stop
-            data: {"type":"content_block_stop","index":0       }
+            data: {"type":"content_block_stop","index":0               }
 
             event: message_delta
-            data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":142,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":8}        }
+            data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":142,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":8}    }
 
             event: message_stop
-            data: {"type":"message_stop"           }
+            data: {"type":"message_stop"             }
 
         headers: {}
         status: 200 OK
         code: 200
-        duration: 1.153044208s
+        duration: 1.772543459s

--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -96,7 +96,7 @@ type Message struct {
 	// Only set for assistant messages.
 	FinishReason FinishReason `json:"finish_reason,omitempty"`
 
-	// CacheControl indicates whether this message is a cached message (only used by anthropic)
+	// CacheControl marks this message as a prompt-cache checkpoint candidate.
 	CacheControl bool `json:"cache_control,omitempty"`
 }
 

--- a/pkg/model/provider/anthropic/beta_client.go
+++ b/pkg/model/provider/anthropic/beta_client.go
@@ -37,6 +37,7 @@ func (c *Client) createBetaStream(
 	}
 
 	requestTools = c.toolsWithSupportedDeferral(requestTools)
+	messages = limitCacheControlMarkers(messages, containsDeferredTool(requestTools))
 	allTools, err := convertBetaTools(requestTools)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to convert tools for Anthropic Beta request", "error", err)

--- a/pkg/model/provider/anthropic/beta_converter.go
+++ b/pkg/model/provider/anthropic/beta_converter.go
@@ -47,6 +47,9 @@ func (c *Client) convertBetaMessagesWithDeferred(ctx context.Context, messages [
 						Role:    anthropic.BetaMessageParamRoleUser,
 						Content: contentBlocks,
 					})
+					if msg.CacheControl {
+						applyBetaMessageCacheControl(&betaMessages[len(betaMessages)-1])
+					}
 				}
 			} else {
 				betaMessages = append(betaMessages, anthropic.BetaMessageParam{
@@ -55,6 +58,9 @@ func (c *Client) convertBetaMessagesWithDeferred(ctx context.Context, messages [
 						{OfText: &anthropic.BetaTextBlockParam{Text: msg.Content}},
 					},
 				})
+				if msg.CacheControl {
+					applyBetaMessageCacheControl(&betaMessages[len(betaMessages)-1])
+				}
 			}
 			continue
 		}
@@ -101,6 +107,9 @@ func (c *Client) convertBetaMessagesWithDeferred(ctx context.Context, messages [
 					Role:    anthropic.BetaMessageParamRoleAssistant,
 					Content: contentBlocks,
 				})
+				if msg.CacheControl {
+					applyBetaMessageCacheControl(&betaMessages[len(betaMessages)-1])
+				}
 			}
 			continue
 		}
@@ -113,10 +122,12 @@ func (c *Client) convertBetaMessagesWithDeferred(ctx context.Context, messages [
 				return nil, err
 			}
 			toolResultBlocks := []anthropic.BetaContentBlockParamUnion{firstBlock}
+			cacheControl := msg.CacheControl
 
 			// Look ahead for consecutive tool messages and merge them
 			j := i + 1
 			for j < len(messages) && messages[j].Role == chat.MessageRoleTool {
+				cacheControl = cacheControl || messages[j].CacheControl
 				block, err := c.convertBetaToolResultBlockWithDeferred(ctx, &messages[j], deferredByCallID[messages[j].ToolCallID])
 				if err != nil {
 					return nil, err
@@ -130,15 +141,15 @@ func (c *Client) convertBetaMessagesWithDeferred(ctx context.Context, messages [
 				Role:    anthropic.BetaMessageParamRoleUser,
 				Content: toolResultBlocks,
 			})
+			if cacheControl {
+				applyBetaMessageCacheControl(&betaMessages[len(betaMessages)-1])
+			}
 
 			// Skip the messages we've already processed
 			i = j - 1
 			continue
 		}
 	}
-
-	// Add ephemeral cache to last 2 messages' last content block
-	applyBetaMessageCacheControl(betaMessages)
 
 	return betaMessages, nil
 }
@@ -379,29 +390,23 @@ func convertBetaTools(t []tools.Tool) ([]anthropic.BetaToolUnionParam, error) {
 	return betaTools, nil
 }
 
-// applyBetaMessageCacheControl adds ephemeral cache control to the last content block
-// of the last 2 messages for prompt caching.
-func applyBetaMessageCacheControl(messages []anthropic.BetaMessageParam) {
-	for i := len(messages) - 1; i >= 0 && i >= len(messages)-2; i-- {
-		msg := &messages[i]
-		if len(msg.Content) == 0 {
-			continue
-		}
-		lastIdx := len(msg.Content) - 1
-		block := &msg.Content[lastIdx]
-		cacheCtrl := anthropic.NewBetaCacheControlEphemeralParam()
-		switch {
-		case block.OfText != nil:
-			block.OfText.CacheControl = cacheCtrl
-		case block.OfToolUse != nil:
-			block.OfToolUse.CacheControl = cacheCtrl
-		case block.OfToolResult != nil:
-			block.OfToolResult.CacheControl = cacheCtrl
-		case block.OfImage != nil:
-			block.OfImage.CacheControl = cacheCtrl
-		case block.OfDocument != nil:
-			block.OfDocument.CacheControl = cacheCtrl
-		}
+func applyBetaMessageCacheControl(message *anthropic.BetaMessageParam) {
+	if len(message.Content) == 0 {
+		return
+	}
+	block := &message.Content[len(message.Content)-1]
+	cacheCtrl := anthropic.NewBetaCacheControlEphemeralParam()
+	switch {
+	case block.OfText != nil:
+		block.OfText.CacheControl = cacheCtrl
+	case block.OfToolUse != nil:
+		block.OfToolUse.CacheControl = cacheCtrl
+	case block.OfToolResult != nil:
+		block.OfToolResult.CacheControl = cacheCtrl
+	case block.OfImage != nil:
+		block.OfImage.CacheControl = cacheCtrl
+	case block.OfDocument != nil:
+		block.OfDocument.CacheControl = cacheCtrl
 	}
 }
 

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -203,6 +203,7 @@ func (c *Client) CreateChatCompletionStream(
 	}
 
 	requestTools = c.toolsWithSupportedDeferral(requestTools)
+	messages = limitCacheControlMarkers(messages, containsDeferredTool(requestTools))
 	allTools, err := convertTools(requestTools)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to convert tools for Anthropic request", "error", err)
@@ -335,9 +336,15 @@ func (c *Client) convertMessagesWithDeferred(ctx context.Context, messages []cha
 				}
 				if len(contentBlocks) > 0 {
 					anthropicMessages = append(anthropicMessages, anthropic.NewUserMessage(contentBlocks...))
+					if msg.CacheControl {
+						applyMessageCacheControl(&anthropicMessages[len(anthropicMessages)-1])
+					}
 				}
 			} else {
 				anthropicMessages = append(anthropicMessages, anthropic.NewUserMessage(anthropic.NewTextBlock(msg.Content)))
+				if msg.CacheControl {
+					applyMessageCacheControl(&anthropicMessages[len(anthropicMessages)-1])
+				}
 			}
 			continue
 		}
@@ -380,6 +387,9 @@ func (c *Client) convertMessagesWithDeferred(ctx context.Context, messages []cha
 					}
 				}
 				anthropicMessages = append(anthropicMessages, anthropic.NewAssistantMessage(toolUseBlocks...))
+				if msg.CacheControl {
+					applyMessageCacheControl(&anthropicMessages[len(anthropicMessages)-1])
+				}
 				// Mark that we expect the very next message to be the grouped tool_result blocks.
 				pendingAssistantToolUse = true
 			} else {
@@ -388,6 +398,9 @@ func (c *Client) convertMessagesWithDeferred(ctx context.Context, messages []cha
 				}
 				if len(contentBlocks) > 0 {
 					anthropicMessages = append(anthropicMessages, anthropic.NewAssistantMessage(contentBlocks...))
+					if msg.CacheControl {
+						applyMessageCacheControl(&anthropicMessages[len(anthropicMessages)-1])
+					}
 				}
 				// No tool_use in this assistant message
 				pendingAssistantToolUse = false
@@ -400,8 +413,10 @@ func (c *Client) convertMessagesWithDeferred(ctx context.Context, messages []cha
 			// This is to satisfy Anthropic's requirement that tool_use blocks are immediately followed
 			// by a single user message containing all corresponding tool_result blocks.
 			var blocks []anthropic.ContentBlockParamUnion
+			cacheControl := false
 			j := i
 			for j < len(messages) && messages[j].Role == chat.MessageRoleTool {
+				cacheControl = cacheControl || messages[j].CacheControl
 				if names := deferredByCallID[messages[j].ToolCallID]; len(names) > 0 {
 					content := make([]anthropic.ToolResultBlockParamContentUnion, 0, len(names))
 					for _, name := range names {
@@ -430,6 +445,9 @@ func (c *Client) convertMessagesWithDeferred(ctx context.Context, messages []cha
 				// sequencing errors.
 				if pendingAssistantToolUse {
 					anthropicMessages = append(anthropicMessages, anthropic.NewUserMessage(blocks...))
+					if cacheControl {
+						applyMessageCacheControl(&anthropicMessages[len(anthropicMessages)-1])
+					}
 				}
 				// Whether we used them or not, we've now handled the expected tool_result slot.
 				pendingAssistantToolUse = false
@@ -439,10 +457,41 @@ func (c *Client) convertMessagesWithDeferred(ctx context.Context, messages []cha
 		}
 	}
 
-	// Add ephemeral cache to last 2 messages' last content block
-	applyMessageCacheControl(anthropicMessages)
-
 	return anthropicMessages, nil
+}
+
+const maxCacheControlMarkers = 4
+
+func limitCacheControlMarkers(messages []chat.Message, reserveForDeferredTools bool) []chat.Message {
+	available := maxCacheControlMarkers
+	if reserveForDeferredTools {
+		available--
+	}
+
+	var candidates []int
+	for i := range messages {
+		if messages[i].CacheControl {
+			candidates = append(candidates, i)
+		}
+	}
+	if len(candidates) <= available {
+		return messages
+	}
+
+	limited := append([]chat.Message(nil), messages...)
+	for _, i := range candidates {
+		limited[i].CacheControl = false
+	}
+	if available == 0 {
+		return limited
+	}
+
+	// Preserve the stable prefix checkpoint and spend remaining slots on recent context.
+	limited[candidates[0]].CacheControl = true
+	for _, i := range candidates[len(candidates)-(available-1):] {
+		limited[i].CacheControl = true
+	}
+	return limited
 }
 
 func deferredToolNamesByCallID(requestTools []tools.Tool) map[string][]string {
@@ -623,29 +672,23 @@ func (c *Client) convertUserMultiContent(ctx context.Context, parts []chat.Messa
 	return contentBlocks, nil
 }
 
-// applyMessageCacheControl adds ephemeral cache control to the last content block
-// of the last 2 messages for prompt caching.
-func applyMessageCacheControl(messages []anthropic.MessageParam) {
-	for i := len(messages) - 1; i >= 0 && i >= len(messages)-2; i-- {
-		msg := &messages[i]
-		if len(msg.Content) == 0 {
-			continue
-		}
-		lastIdx := len(msg.Content) - 1
-		block := &msg.Content[lastIdx]
-		cacheCtrl := anthropic.NewCacheControlEphemeralParam()
-		switch {
-		case block.OfText != nil:
-			block.OfText.CacheControl = cacheCtrl
-		case block.OfToolUse != nil:
-			block.OfToolUse.CacheControl = cacheCtrl
-		case block.OfToolResult != nil:
-			block.OfToolResult.CacheControl = cacheCtrl
-		case block.OfImage != nil:
-			block.OfImage.CacheControl = cacheCtrl
-		case block.OfDocument != nil:
-			block.OfDocument.CacheControl = cacheCtrl
-		}
+func applyMessageCacheControl(message *anthropic.MessageParam) {
+	if len(message.Content) == 0 {
+		return
+	}
+	block := &message.Content[len(message.Content)-1]
+	cacheCtrl := anthropic.NewCacheControlEphemeralParam()
+	switch {
+	case block.OfText != nil:
+		block.OfText.CacheControl = cacheCtrl
+	case block.OfToolUse != nil:
+		block.OfToolUse.CacheControl = cacheCtrl
+	case block.OfToolResult != nil:
+		block.OfToolResult.CacheControl = cacheCtrl
+	case block.OfImage != nil:
+		block.OfImage.CacheControl = cacheCtrl
+	case block.OfDocument != nil:
+		block.OfDocument.CacheControl = cacheCtrl
 	}
 }
 

--- a/pkg/model/provider/anthropic/client_test.go
+++ b/pkg/model/provider/anthropic/client_test.go
@@ -509,6 +509,59 @@ func TestExtractSystemBlocks_MultiContent(t *testing.T) {
 	assert.Equal(t, "Part 2", blocks[1].Text)
 }
 
+func TestConvertMessagesUsesSessionCacheControl(t *testing.T) {
+	t.Parallel()
+
+	messages := []chat.Message{
+		{Role: chat.MessageRoleUser, Content: "one"},
+		{Role: chat.MessageRoleAssistant, Content: "two", CacheControl: true},
+		{Role: chat.MessageRoleUser, Content: "three"},
+	}
+
+	standard, err := testClient().convertMessages(t.Context(), messages)
+	require.NoError(t, err)
+	require.Len(t, standard, 3)
+	assert.Empty(t, string(standard[0].Content[0].OfText.CacheControl.Type))
+	assert.Equal(t, "ephemeral", string(standard[1].Content[0].OfText.CacheControl.Type))
+	assert.Empty(t, string(standard[2].Content[0].OfText.CacheControl.Type))
+
+	beta, err := testClient().convertBetaMessages(t.Context(), messages)
+	require.NoError(t, err)
+	require.Len(t, beta, 3)
+	assert.Empty(t, string(beta[0].Content[0].OfText.CacheControl.Type))
+	assert.Equal(t, "ephemeral", string(beta[1].Content[0].OfText.CacheControl.Type))
+	assert.Empty(t, string(beta[2].Content[0].OfText.CacheControl.Type))
+}
+
+func TestLimitCacheControlMarkers(t *testing.T) {
+	t.Parallel()
+
+	messages := make([]chat.Message, 6)
+	for i := range messages {
+		messages[i].CacheControl = true
+	}
+
+	limited := limitCacheControlMarkers(messages, false)
+	assert.True(t, limited[0].CacheControl)
+	assert.False(t, limited[1].CacheControl)
+	assert.False(t, limited[2].CacheControl)
+	assert.True(t, limited[3].CacheControl)
+	assert.True(t, limited[4].CacheControl)
+	assert.True(t, limited[5].CacheControl)
+
+	limited = limitCacheControlMarkers(messages, true)
+	assert.True(t, limited[0].CacheControl)
+	assert.False(t, limited[1].CacheControl)
+	assert.False(t, limited[2].CacheControl)
+	assert.False(t, limited[3].CacheControl)
+	assert.True(t, limited[4].CacheControl)
+	assert.True(t, limited[5].CacheControl)
+
+	for i := range messages {
+		assert.True(t, messages[i].CacheControl, "input must not be mutated")
+	}
+}
+
 func TestExtractSystemBlocksCacheControl(t *testing.T) {
 	t.Parallel()
 	msgs := []chat.Message{

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1522,6 +1522,21 @@ func markLastMessageAsCacheControl(messages []chat.Message) {
 	}
 }
 
+func markRecentConversationCacheControl(messages []chat.Message, count int) {
+	for i := range messages {
+		if messages[i].Role != chat.MessageRoleSystem {
+			messages[i].CacheControl = false
+		}
+	}
+	for i := len(messages) - 1; i >= 0 && count > 0; i-- {
+		if messages[i].Role == chat.MessageRoleSystem {
+			continue
+		}
+		messages[i].CacheControl = true
+		count--
+	}
+}
+
 // buildInvariantSystemMessages builds system messages that are identical
 // for all users of a given agent configuration. These messages can be
 // cached efficiently as they don't change between sessions, users, or projects.
@@ -1876,6 +1891,8 @@ func (s *Session) getMessages(a *agent.Agent, includeInstructionContext bool, ex
 			capToolResultContent(&messages[i], s.MaxToolResultTokens)
 		}
 	}
+
+	markRecentConversationCacheControl(messages, 2)
 
 	systemCount := 0
 	conversationCount := 0

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -240,6 +240,25 @@ func TestGetMessages_CacheControl(t *testing.T) {
 	assert.True(t, messages[1].CacheControl)
 }
 
+func TestGetMessages_MarksRecentConversationForCaching(t *testing.T) {
+	t.Parallel()
+
+	testAgent := agent.New("root", "instructions")
+	s := New()
+	for _, content := range []string{"one", "two", "three"} {
+		s.Messages = append(s.Messages, Item{Message: &Message{Message: chat.Message{
+			Role:    chat.MessageRoleUser,
+			Content: content,
+		}}})
+	}
+
+	messages := s.GetMessages(testAgent)
+	require.Len(t, messages, 4)
+	assert.False(t, messages[1].CacheControl)
+	assert.True(t, messages[2].CacheControl)
+	assert.True(t, messages[3].CacheControl)
+}
+
 func TestGetMessages_CacheControlWithSummary(t *testing.T) {
 	t.Parallel()
 
@@ -251,7 +270,7 @@ func TestGetMessages_CacheControlWithSummary(t *testing.T) {
 	//     extras (AddPromptFiles, AddEnvironmentInfo) participate in
 	//     prompt caching. This matches the prior
 	//     buildContextSpecificSystemMessages caching behavior.
-	//   - Summary and conversation messages are not cache-controlled.
+	//   - The two most recent conversation messages are cache-control candidates.
 	testAgent := agent.New("root", "instructions",
 		agent.WithToolSets(todoToolSet(t)),
 	)


### PR DESCRIPTION
 Fix Anthropic requests exceeding the provider’s limit of four cache-control breakpoints.

 Cache-control checkpoint selection now originates from the session, while the Anthropic provider translates those candidates into API markers and enforces Anthropic’s limit.

 What changed

 - Mark the two most recent conversation messages as cache-control candidates when assembling session messages.
 - Remove the Anthropic provider’s unconditional caching of the last two converted messages.
 - Apply Anthropic cache markers only when the source chat.Message has CacheControl enabled.
 - Propagate cache control correctly when consecutive tool-result messages are merged.
 - Limit each Anthropic request to four cache-control markers.
 - Reserve one marker slot when deferred tools require a cache breakpoint.
 - Preserve the stable prefix checkpoint and prioritize recent context when there are too many candidates.
 - Apply the same behavior to both standard and beta Anthropic APIs.
 - Refresh affected Anthropic title-generation cassettes.