### PR TITLE
Implements the path-aware, two-tier documentation accessibility CI gate

### DIFF
--- a/.github/workflows/docs-a11y.yml
+++ b/.github/workflows/docs-a11y.yml
@@ -1,21 +1,38 @@
-# Scans the built docs site for WCAG 2 AA accessibility violations
-# with pa11y-ci, using the same "hugo server" flow contributors run
-# locally (see docs/Dockerfile). Lands as the last step of the
-# docs-a11y-audit remediation (docs-a11y-audit plan, PR 9): the fixes
-# in PRs 1-8 land first so this job starts from a green baseline.
+# Scans the built docs site for WCAG 2 AA accessibility violations with
+# pa11y-ci, using the same "hugo server" flow contributors run locally
+# (see docs/Dockerfile). Originally landed as the last step of the
+# docs-a11y-audit remediation (PR 9); the docs-a11y-smart-gate plan later
+# evolved it from a fixed URL list into a path-aware, two-tier scan:
 #
-# docs/.pa11yci.json lists each scanned page twice, once with
-# ?theme=light and once with ?theme=dark: the headless browser's
-# default color-scheme is otherwise indeterminate (observed as
-# "light" locally), so without the query param the gate would only
-# ever exercise one theme. js/app.js's initTheme() honors ?theme=
-# ahead of localStorage/prefers-color-scheme for exactly this reason.
+#   Tier 1 (always): a small static list of layout-archetype pages in
+#   docs/.pa11yci.json, each scanned in both themes — guards against
+#   systemic regressions (shared CSS/JS/templates/SVG) on every run.
 #
-# pa11y only treats HTML_CodeSniffer "error"-level results as
-# failures (warnings/notices are informational and excluded by
-# default), so this gates on real violations rather than every
-# possible nit — see docs/.pa11yci.json for the scanned URLs and
-# docs/STYLE.md for how to reproduce a failure locally.
+#   Tier 2 (pull_request only): the content pages the PR actually
+#   modifies, mapped from changed Markdown to rendered URLs by
+#   scripts/docs-a11y-urls.sh (deterministically capped, both themes) —
+#   guards against authored-content issues on exactly what changed. A
+#   generated config (static + changed) is used when there's anything to
+#   add; push-to-main and content-free PRs fall back to the static-only
+#   config, since there's no PR diff to compute Tier 2 from.
+#
+# Each URL is listed once with ?theme=light and once with ?theme=dark:
+# the headless browser's default color-scheme is otherwise indeterminate
+# (observed as "light" locally), so without the query param the gate
+# would only ever exercise one theme. js/app.js's initTheme() honors
+# ?theme= ahead of localStorage/prefers-color-scheme for exactly this
+# reason.
+#
+# The changed-file diff is git-native (`git diff HEAD^1 HEAD` against the
+# pull_request test-merge commit, fetch-depth: 2) rather than a
+# changed-files action, keeping the SHA-pinned, minimal-supply-chain
+# convention (see scripts/docs-a11y-urls.sh's header for the mapping
+# rules and env vars, and docs/STYLE.md for how to reproduce a scan
+# locally).
+#
+# pa11y only treats HTML_CodeSniffer "error"-level results as failures
+# (warnings/notices are informational and excluded by default), so this
+# gates on real violations rather than every possible nit.
 name: docs-a11y
 
 permissions:
@@ -31,10 +48,12 @@ on:
     paths:
       - ".github/workflows/docs-a11y.yml"
       - "docs/**"
+      - "scripts/docs-a11y-urls.sh"
   pull_request:
     paths:
       - ".github/workflows/docs-a11y.yml"
       - "docs/**"
+      - "scripts/docs-a11y-urls.sh"
 
 env:
   HUGO_VERSION: 0.163.0
@@ -45,6 +64,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Need the merge commit's parent too, so `git diff HEAD^1 HEAD`
+          # (below) can compute the PR's changed files without a
+          # changed-files action or extra token scope.
+          fetch-depth: 2
 
       # pa11y-ci@3.1.0 bundles an old Puppeteer whose postinstall Chromium
       # download doesn't happen under `npx --yes` ("Could not find expected
@@ -70,11 +94,47 @@ jobs:
       - name: Wait for server
         run: npx --yes wait-on@7.2.0 http://127.0.0.1:1313/docker-agent/ --timeout 60000
 
+      # Tier 2: map this PR's changed content Markdown to rendered URLs.
+      # `actions/checkout` puts the pull_request test-merge commit at
+      # HEAD, whose first parent (HEAD^1) is the base branch tip, so this
+      # diff is exactly the PR's changed files — token-free and identical
+      # for fork PRs. Skipped on push (no PR diff to compute from).
+      - name: Compute changed-page URLs
+        id: changed-urls
+        if: github.event_name == 'pull_request'
+        env:
+          A11Y_BASE_URL: http://127.0.0.1:1313
+        run: |
+          git diff --name-only --diff-filter=d HEAD^1 HEAD \
+            | ./scripts/docs-a11y-urls.sh > /tmp/changed-urls.txt
+          count=$(wc -l < /tmp/changed-urls.txt | tr -d ' ')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Tier 2: $count changed-page URL(s):"
+          cat /tmp/changed-urls.txt
+
+      # Merge Tier 2's URLs into the static (Tier 1) config from
+      # docs/.pa11yci.json. Only runs when there's something to add;
+      # otherwise the run step below falls back to the static-only config.
+      - name: Assemble pa11y config
+        if: github.event_name == 'pull_request' && steps.changed-urls.outputs.count != '0'
+        run: |
+          jq -Rn '[inputs]' /tmp/changed-urls.txt > /tmp/changed-urls.json
+          jq --slurpfile extra /tmp/changed-urls.json '.urls += $extra[0]' \
+            docs/.pa11yci.json > /tmp/pa11yci.generated.json
+          echo "Merged pa11y-ci config (static + changed pages):"
+          jq -r '.urls[]' /tmp/pa11yci.generated.json
+
       - name: Run pa11y-ci
         working-directory: docs
         env:
           PUPPETEER_EXECUTABLE_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
-        run: npx --yes pa11y-ci@3.1.0 --config .pa11yci.json
+        run: |
+          config=.pa11yci.json
+          if [ -f /tmp/pa11yci.generated.json ]; then
+            config=/tmp/pa11yci.generated.json
+          fi
+          echo "Using pa11y-ci config: $config"
+          npx --yes pa11y-ci@3.1.0 --config "$config"
 
       - name: Show Hugo server log on failure
         if: failure()

--- a/docs/.pa11yci.json
+++ b/docs/.pa11yci.json
@@ -12,9 +12,13 @@
     "http://127.0.0.1:1313/docker-agent/configuration/sandbox/?theme=light",
     "http://127.0.0.1:1313/docker-agent/getting-started/quickstart/?theme=light",
     "http://127.0.0.1:1313/docker-agent/404.html?theme=light",
+    "http://127.0.0.1:1313/docker-agent/features/tui/?theme=light",
+    "http://127.0.0.1:1313/docker-agent/concepts/multi-agent/?theme=light",
     "http://127.0.0.1:1313/docker-agent/?theme=dark",
     "http://127.0.0.1:1313/docker-agent/configuration/sandbox/?theme=dark",
     "http://127.0.0.1:1313/docker-agent/getting-started/quickstart/?theme=dark",
-    "http://127.0.0.1:1313/docker-agent/404.html?theme=dark"
+    "http://127.0.0.1:1313/docker-agent/404.html?theme=dark",
+    "http://127.0.0.1:1313/docker-agent/features/tui/?theme=dark",
+    "http://127.0.0.1:1313/docker-agent/concepts/multi-agent/?theme=dark"
   ]
 }

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -341,23 +341,68 @@ that touches `js/app.js`, `layouts/`, or the demo media:
 ### Running the accessibility scan locally
 
 CI (`docs-a11y` workflow) runs [pa11y-ci](https://github.com/pa11y/pa11y-ci)
-against the URLs in `docs/.pa11yci.json` at the `WCAG2AA` standard.
-Each page is listed twice, once with `?theme=light` and once with
-`?theme=dark` — `js/app.js`'s `initTheme()` honors that query param
-ahead of `localStorage`/`prefers-color-scheme`, so the gate
-deterministically exercises both themes regardless of the scanning
-browser's default color scheme (observed to default to light
-headless, which is exactly why earlier local runs only ever caught
-light-mode regressions). To reproduce locally:
+at the `WCAG2AA` standard against a two-tier URL list:
+
+- **Tier 1 (always)** — a small static set of layout-archetype pages
+  in `docs/.pa11yci.json`: home (`/`), `configuration/sandbox/`
+  (wide tables + callouts), `getting-started/quickstart/` (tutorial
+  prose), `404.html` (standalone layout), `features/tui/` (the
+  densest page — images, inline HTML, many callouts/tables), and
+  `concepts/multi-agent/` (deep heading structure, tables). Each is
+  listed twice, once with `?theme=light` and once with `?theme=dark`
+  — 12 URLs in total. This tier guards against systemic regressions
+  (shared CSS/JS/templates/SVG) and runs on every push and PR.
+- **Tier 2 (pull requests only)** — the content pages the PR actually
+  modifies. `scripts/docs-a11y-urls.sh` maps changed Markdown to
+  rendered URLs (dropping `_index.md`/`STYLE.md`/non-content files,
+  de-duping against the Tier 1 list, live-probing to catch renames,
+  and emitting both themes), deterministically capped at
+  `${A11Y_MAX_PAGES:-10}` changed pages (lexicographic sort, so a
+  PR touching more than that always scans the same subset and logs
+  the rest as skipped). The CI workflow jq-merges these URLs into a
+  generated config on top of `docs/.pa11yci.json`; a push to `main`
+  or a PR that touches no content Markdown stays static-only (Tier 1).
+
+`js/app.js`'s `initTheme()` honors the `?theme=` query param ahead of
+`localStorage`/`prefers-color-scheme`, so the gate deterministically
+exercises both themes regardless of the scanning browser's default
+color scheme (observed to default to light headless, which is exactly
+why earlier local runs only ever caught light-mode regressions).
+
+To reproduce the full two-tier scan locally:
 
 ```bash
 # Serve the site the same way the Dockerfile does
 docker build -t docs docs/
 docker run --rm -p 1313:1313 -v $(pwd)/docs:/src docs
 
-# In another terminal, once it's serving at http://localhost:1313/docker-agent/
+# In another terminal, once it's serving at http://localhost:1313/docker-agent/:
+
+# Tier 1 only (the static archetype list):
 cd docs && npx --yes pa11y-ci@3.1.0 --config .pa11yci.json
+
+# Tier 1 + Tier 2 (mirrors what a PR's CI run scans), from the repo root:
+git diff --name-only main...HEAD | A11Y_BASE_URL=http://localhost:1313 ./scripts/docs-a11y-urls.sh > /tmp/changed-urls.txt
+jq -Rn '[inputs]' /tmp/changed-urls.txt > /tmp/changed-urls.json
+jq --slurpfile extra /tmp/changed-urls.json '.urls += $extra[0]' docs/.pa11yci.json > /tmp/pa11yci.generated.json
+npx --yes pa11y-ci@3.1.0 --config /tmp/pa11yci.generated.json
 ```
+
+`scripts/docs-a11y-urls.sh --self-test` exercises the mapping rules
+against fixtures (no server needed) and is safe to run any time.
+
+**Adding or retiring a Tier 1 archetype:** edit the `urls` array in
+`docs/.pa11yci.json` (both the light and dark entries — never add
+or remove just one theme). Before adding a page, run the full local
+scan above with it included and confirm 0 errors in both themes
+first (the "green-baseline" rule) — a latent shared-CSS bug that
+happens to be invisible on the current six pages must be fixed
+*before* the new archetype joins the always-on gate, or every future
+PR starts failing on a pre-existing issue unrelated to its own change.
+
+**Tuning the Tier-2 cap:** `A11Y_MAX_PAGES` (default 10) is the only
+knob; raise it in the workflow's `Compute changed-page URLs` step if
+PRs regularly touch more content pages than that.
 
 `pa11y-ci` only fails the build on HTML_CodeSniffer `error`-level
 results (warnings/notices are informational and don't fail CI), so a

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -183,6 +183,22 @@ tokens, templates, or JS, keep these conventions:
   terms): blue-300 in dark (blue-400 only reads 4.08:1 on the dark
   card), blue-500 in light (already 5.0:1 there). Use it instead of
   the bare `--accent` for any *new* text-on-card component.
+- **Links inside a callout need their own color, not the prose-link
+  one.** Callout panels (warning/info/tip) sit on their own
+  variant-colored background, not the page background, so
+  `--accent-hover` (the dark prose-link color) can fail there even
+  where it's fine everywhere else — it read only 3.95:1 on the dark
+  warning callout (`#643700`). `.content .callout a:not(.btn)` scopes
+  `--blue-200` to callout links in dark (6.46:1 warning / 11.50:1 info /
+  8.51:1 tip); light already passed with `--accent` (4.60–4.83:1) and
+  is restored explicitly rather than left to inherit the dark value.
+  Because that selector's specificity ties with `.content
+  a:not(.btn):hover`'s, the hover state needed its own explicit
+  `.content .callout a:not(.btn):hover` rule too — an unconditional,
+  equal-specificity selector coming later in the stylesheet otherwise
+  wins over a `:hover` one regardless of hover state, flattening the
+  hover color. Same lesson as the specificity bullets above: always
+  check what a new equal-or-higher-specificity rule shadows nearby.
 - **SVGs embedded via `<img>` can't inherit `currentColor` or CSS
   custom properties from the page**, so a single hardcoded palette has
   to clear AA against *both* a near-black dark card (`#1E2129`) and a
@@ -234,6 +250,7 @@ tokens, templates, or JS, keep these conventions:
 | `.pain-x` badge (white text) | `--error-strong` `#DC2626`, 4.83:1 | same |
 | `#search-input` (search trigger button) text | `--text-muted` (gray-600), 5.88:1 on `--bg-hover` white | gray-300, 6.07:1 on `--bg-hover` gray-800 (was `--text-muted` gray-400, 4.42:1 — fail) |
 | `.preview-banner a` | `--accent-on-card` (unchanged, blue-500 5.0:1) | `--accent-on-card` blue-300, 5.89:1 (was `--accent` blue-400, 4.08:1 — fail) |
+| `.content .callout a:not(.btn)` (links inside a callout) | `--accent`, 4.60–4.83:1 (unchanged) | `--blue-200`, 6.46:1 warning / 11.50:1 info / 8.51:1 tip (was `--accent-hover` blue-400, 3.95:1 on warning — fail) |
 | `.btn-primary`/`.btn-secondary` as `.content a` links (Quick Start, Back to Docs) | unchanged (blue-500-on-white 5.00:1 / white-on-translucent) | own `color` restored via `.content a:not(.btn)`, was 2.55:1 (`--accent-hover` leaking onto a white button bg) |
 | `how-it-works.svg` diagram text | gray-600 body 5.88:1 / blue-500 accent 5.00:1 (light-only file, on white) | gray-400 body 5.59:1 / blue-300 accent 5.89:1 (dark-only file, on `#1E2129`) |
 

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -978,6 +978,21 @@ details.sidebar-section[open] > summary.sidebar-heading::after {
 }
 [data-theme="light"] .callout-warning p { color: #92400E; }
 
+/* Links inside a callout sit on a variant-colored panel (warning/info/tip),
+ * not the page background, so the shared .content a:not(.btn) color can
+ * fail there even where it's fine elsewhere: --accent-hover (dark) reads
+ * only 3.95:1 on the dark warning background (#643700). --blue-200 clears
+ * AA on all three dark callout backgrounds (6.46:1 warning / 11.50:1 info /
+ * 8.51:1 tip); light already passes with --accent (4.60-4.83:1) so it's
+ * restored explicitly rather than left to inherit a dark-only value. Both
+ * rules match .content a:not(.btn)'s own specificity (0,2,1) plus one, so
+ * they win regardless of source order; an explicit :hover variant is
+ * needed too or these same-specificity rules would flatten the shared
+ * hover color (--link-hover, already AA on every callout background). */
+.content .callout a:not(.btn) { color: var(--blue-200); }
+.content .callout a:not(.btn):hover { color: var(--link-hover); }
+[data-theme="light"] .content .callout a:not(.btn) { color: var(--accent); }
+
 /* ===== Cards Grid ===== */
 .cards {
   display: grid;

--- a/scripts/docs-a11y-urls.sh
+++ b/scripts/docs-a11y-urls.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# scripts/docs-a11y-urls.sh — map changed docs Markdown files to rendered
+# URLs for Tier 2 of the docs-a11y gate (see docs-a11y-smart-gate plan and
+# .github/workflows/docs-a11y.yml). Reads changed repo-root-relative paths
+# on stdin (one per line, e.g. from `git diff --name-only`), applies the
+# mapping rules below, de-dupes against the static archetype list already
+# in docs/.pa11yci.json, optionally live-probes the mapped pages, caps the
+# result, and prints fully-qualified both-theme URLs on stdout (one per
+# line) — ready to be jq-merged into a generated pa11y-ci config.
+#
+# Mapping rules (this site's Hugo config: disableKinds includes "section",
+# so _index.md renders nothing; content lives at content/<section>/<page>/
+# index.md leaf bundles — see docs/hugo.yaml):
+#
+#   docs/index.md                          -> /
+#   docs/404.md                            -> /404.html
+#   docs/<section>/<page>/index.md         -> /<section>/<page>/
+#     for <section> in the mounted set below
+#   docs/**/_index.md                      -> dropped (section kind disabled)
+#   docs/STYLE.md                          -> dropped (not mounted)
+#   any other docs/**/*.md                 -> dropped, with an ::notice
+#                                              (an unexpected new location)
+#   anything not under docs/ or not *.md   -> ignored silently (systemic
+#                                              files are the archetypes'
+#                                              job to catch, not Tier 2's)
+#
+# Env vars:
+#   A11Y_MAX_PAGES   deterministic cap on mapped pages (default 10)
+#   A11Y_BASE_URL    Hugo server base (default http://127.0.0.1:1313)
+#   A11Y_PA11YCI     path to the static config used for de-dup
+#                    (default <repo-root>/docs/.pa11yci.json)
+#
+# Usage:
+#   git diff --name-only --diff-filter=d HEAD^1 HEAD | ./scripts/docs-a11y-urls.sh
+#   ./scripts/docs-a11y-urls.sh --self-test
+
+set -euo pipefail
+
+# Allow running from any directory, like scripts/workflow-lint.sh.
+if [ -d ".github/workflows" ]; then
+  REPO_ROOT="$(pwd)"
+else
+  REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+fi
+
+PA11YCI="${A11Y_PA11YCI:-$REPO_ROOT/docs/.pa11yci.json}"
+BASE_PATH="/docker-agent"
+
+# Sections actually mounted as content in docs/hugo.yaml.
+MOUNTED_SECTIONS="getting-started concepts configuration tools providers features guides community"
+
+# base_url / max_pages — read fresh on every call (rather than snapshotted
+# once at parse time) so tests can override them per-invocation via env
+# var prefixes on a function call, same as they would on a subprocess.
+base_url() { printf '%s' "${A11Y_BASE_URL:-http://127.0.0.1:1313}"; }
+max_pages() { printf '%s' "${A11Y_MAX_PAGES:-10}"; }
+
+notice() {
+  printf '::notice::%s\n' "$1" >&2
+}
+
+is_mounted_section() {
+  local section="$1"
+  for s in $MOUNTED_SECTIONS; do
+    [ "$s" = "$section" ] && return 0
+  done
+  return 1
+}
+
+# map_path <repo-relative-path> — prints the rendered path (e.g.
+# "/configuration/sandbox/") on stdout if the input maps to a rendered
+# page, or nothing (with a logged ::notice for the unexpected-location
+# case) if it doesn't.
+map_path() {
+  local path="$1"
+
+  case "$path" in
+    *.md) ;;
+    *) return 0 ;;  # not Markdown: ignored silently
+  esac
+
+  case "$path" in
+    docs/index.md)
+      printf '/\n'
+      return 0
+      ;;
+    docs/404.md)
+      printf '/404.html\n'
+      return 0
+      ;;
+    docs/STYLE.md)
+      return 0  # known, never mounted — dropped silently
+      ;;
+  esac
+
+  # docs/**/_index.md never renders (disableKinds: section).
+  case "$path" in
+    */_index.md)
+      return 0
+      ;;
+  esac
+
+  # docs/<section>/<page>/index.md -> /<section>/<page>/
+  if [[ "$path" =~ ^docs/([^/]+)/([^/]+)/index\.md$ ]]; then
+    local section="${BASH_REMATCH[1]}" page="${BASH_REMATCH[2]}"
+    if is_mounted_section "$section"; then
+      printf '/%s/%s/\n' "$section" "$page"
+      return 0
+    fi
+  fi
+
+  notice "docs-a11y-urls: unmapped markdown file, dropped: $path"
+  return 0
+}
+
+# static_paths — the archetype paths already scanned every run, so Tier 2
+# never re-lists them (compares on path, ignoring the ?theme= query and
+# the /docker-agent baseURL prefix).
+static_paths() {
+  [ -f "$PA11YCI" ] || return 0
+  jq -r '.urls[]' "$PA11YCI" \
+    | sed -E "s#^https?://[^/]+$BASE_PATH##; s/\?theme=(light|dark)$//" \
+    | LC_ALL=C sort -u
+}
+
+# probe <path> — returns 0 (keep) if the base URL is unreachable (nothing
+# to verify against, e.g. during --self-test) or the page responds 200;
+# returns 1 (drop, with a notice) only when the server IS reachable and
+# this specific page 404s (renames/deletions the diff filter missed).
+probe() {
+  local path="$1" base
+  base="$(base_url)"
+  if [ -z "${_A11Y_SERVER_REACHABLE:-}" ]; then
+    if curl -s -o /dev/null --max-time 2 "$base$BASE_PATH/" 2>/dev/null; then
+      _A11Y_SERVER_REACHABLE=1
+    else
+      _A11Y_SERVER_REACHABLE=0
+      notice "docs-a11y-urls: $base unreachable, skipping the live-probe safety net"
+    fi
+  fi
+  [ "$_A11Y_SERVER_REACHABLE" = 0 ] && return 0
+
+  local code
+  code="$(curl -s -o /dev/null --max-time 5 -w '%{http_code}' "$base$BASE_PATH$path" 2>/dev/null || echo 000)"
+  if [ "$code" != "200" ]; then
+    notice "docs-a11y-urls: $path responded $code, dropping (renamed or deleted?)"
+    return 1
+  fi
+  return 0
+}
+
+# run_mapping — reads changed paths on stdin, prints final both-theme URLs.
+run_mapping() {
+  local base cap
+  base="$(base_url)"
+  cap="$(max_pages)"
+  unset _A11Y_SERVER_REACHABLE
+
+  local mapped=()
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    while IFS= read -r p; do
+      [ -n "$p" ] && mapped+=("$p")
+    done < <(map_path "$line")
+  done
+
+  # De-dupe against the static archetype list.
+  local statics
+  statics="$(static_paths)"
+  local deduped=()
+  for p in "${mapped[@]:-}"; do
+    [ -z "$p" ] && continue
+    if ! grep -qxF "$p" <<<"$statics" 2>/dev/null; then
+      deduped+=("$p")
+    fi
+  done
+
+  # Uniq + probe.
+  local uniq_sorted
+  uniq_sorted="$(printf '%s\n' "${deduped[@]:-}" | grep -v '^$' | LC_ALL=C sort -u || true)"
+
+  local probed=()
+  while IFS= read -r p; do
+    [ -z "$p" ] && continue
+    if probe "$p"; then
+      probed+=("$p")
+    fi
+  done <<<"$uniq_sorted"
+
+  # Deterministic cap: lexicographic, first N win; log the remainder.
+  local total=${#probed[@]}
+  local capped=("${probed[@]:0:$cap}")
+  if [ "$total" -gt "$cap" ]; then
+    local skipped=("${probed[@]:$cap}")
+    notice "docs-a11y-urls: $total changed pages mapped, capped at $cap; skipped: ${skipped[*]}"
+  fi
+
+  for p in "${capped[@]:-}"; do
+    [ -z "$p" ] && continue
+    printf '%s%s%s?theme=light\n' "$base" "$BASE_PATH" "$p"
+    printf '%s%s%s?theme=dark\n' "$base" "$BASE_PATH" "$p"
+  done
+}
+
+self_test() {
+  local failures=0
+
+  check() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+      printf 'ok - %s\n' "$desc"
+    else
+      printf 'not ok - %s\n  expected: %q\n  actual:   %q\n' "$desc" "$expected" "$actual" >&2
+      failures=$((failures + 1))
+    fi
+  }
+
+  # Individual mapping rules.
+  check "docs/index.md maps to /" "/" "$(map_path docs/index.md)"
+  check "docs/404.md maps to /404.html" "/404.html" "$(map_path docs/404.md)"
+  check "leaf index.md maps to /<section>/<page>/" "/guides/go-sdk/" \
+    "$(map_path docs/guides/go-sdk/index.md)"
+  check "static-list page still maps (de-dup happens later)" "/configuration/sandbox/" \
+    "$(map_path docs/configuration/sandbox/index.md)"
+  check "_index.md is dropped" "" "$(map_path docs/concepts/_index.md 2>/dev/null)"
+  check "docs/STYLE.md is dropped" "" "$(map_path docs/STYLE.md 2>/dev/null)"
+  check "unmounted section is dropped (logs a notice)" "" \
+    "$(map_path docs/unknown-section/page/index.md 2>/dev/null)"
+  check "a CSS file is ignored" "" "$(map_path docs/css/style.css 2>/dev/null)"
+  check "an image is ignored" "" "$(map_path docs/demo.gif 2>/dev/null)"
+
+  # De-dup against the static archetype list, unreachable server (probe no-ops).
+  local out
+  out="$(A11Y_BASE_URL="http://127.0.0.1:1" run_mapping <<'EOF'
+docs/configuration/sandbox/index.md
+docs/guides/go-sdk/index.md
+EOF
+)"
+  check "static-list page is de-duped away, non-static page survives" \
+    "http://127.0.0.1:1/docker-agent/guides/go-sdk/?theme=light
+http://127.0.0.1:1/docker-agent/guides/go-sdk/?theme=dark" "$out"
+
+  # Every emitted URL carries theme= and comes in light+dark pairs.
+  local non_theme_lines
+  non_theme_lines="$(printf '%s\n' "$out" | grep -vc 'theme=' || true)"
+  check "every emitted URL carries theme=" "0" "$non_theme_lines"
+
+  # Cap at N, lexicographic winners, notice for the remainder.
+  local many
+  many="$(for i in $(seq -w 1 12); do printf 'docs/guides/page%s/index.md\n' "$i"; done)"
+  local capped_out notice_out
+  capped_out="$(printf '%s\n' "$many" | A11Y_BASE_URL="http://127.0.0.1:1" A11Y_MAX_PAGES=10 run_mapping 2>/tmp/docs-a11y-urls-selftest-notices)"
+  notice_out="$(cat /tmp/docs-a11y-urls-selftest-notices)"
+  rm -f /tmp/docs-a11y-urls-selftest-notices
+  check "12 pages capped at 10 -> 20 URLs" "20" "$(printf '%s\n' "$capped_out" | grep -c 'theme=')"
+  check "lexicographic winner: page01 kept (both themes)" "2" \
+    "$(printf '%s\n' "$capped_out" | grep -c '/guides/page01/')"
+  check "lexicographic loser: page11 skipped" "0" \
+    "$(printf '%s\n' "$capped_out" | grep -c '/guides/page11/')"
+  check "cap emits a notice naming the skipped remainder" "1" \
+    "$(printf '%s\n' "$notice_out" | grep -c 'capped at 10')"
+
+  if [ "$failures" -gt 0 ]; then
+    printf '\ndocs-a11y-urls --self-test: %d failure(s)\n' "$failures" >&2
+    return 1
+  fi
+  printf '\ndocs-a11y-urls --self-test: all checks passed\n' >&2
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+  self_test
+else
+  run_mapping
+fi


### PR DESCRIPTION
described in the shared plan `docs-a11y-smart-gate` (prior context:
`docs-a11y-audit`, shipped as PR #3687).

## What changed

**PR 1 — dark-mode callout-link contrast fix (`docs/css/style.css`)**
Links inside a callout (warning/info/tip) sat on a variant-colored panel,
not the page background, so the shared prose-link color
(`--accent-hover`) failed there even though it passes everywhere else:
3.95:1 on the dark warning callout background (`#643700`), below the
4.5:1 AA threshold. This was a pre-existing bug, first surfaced while
pre-verifying `features/tui/` as a new archetype (see below) — that page
has a link inside a `[!WARNING]` callout at line 503.

Scoped `.content .callout a:not(.btn) { color: var(--blue-200); }` (plus
a light-mode override restoring `--accent`, and an explicit `:hover`
rule so the shared `--link-hover` token isn't shadowed by the new
equal-specificity selector). Verified contrast ratios:

| Background | `--blue-200` (dark) | `--accent` (light, unchanged) |
|---|---|---|
| warning `#643700` | 6.46:1 | 4.83:1 |
| info `#00153C` | 11.50:1 | 4.60:1 |
| tip `#11371A` | 8.51:1 | 4.75:1 |

The fix is intentionally scoped to callout links only — nothing broader
was touched.

**PR 2 — `scripts/docs-a11y-urls.sh` (new)**
Maps changed docs Markdown files to rendered URLs for Tier 2 of the
gate: `docs/index.md` → `/`, `docs/404.md` → `/404.html`,
`docs/<section>/<page>/index.md` → `/<section>/<page>/` for the 8
mounted sections, `_index.md`/`STYLE.md`/non-Markdown files dropped
(silently or via `::notice` for unexpected locations), de-dupes against
the static archetype list already in `docs/.pa11yci.json`, live-probes
survivors to catch renames, caps at `${A11Y_MAX_PAGES:-10}` pages
(lexicographic, deterministic), and emits both `?theme=light` and
`?theme=dark` for each surviving page. Ships with `--self-test`
(fixture-driven, no server required) and a header comment documenting
the mapping rules and env vars.

**PR 3 — expand the static archetype list 8 → 12 URLs
(`docs/.pa11yci.json`)**
Kept the existing 4 pages (home, `configuration/sandbox/`,
`getting-started/quickstart/`, `404.html`) and added 2 more layout
archetypes: `features/tui/` (the densest page — images, inline HTML,
many callouts/tables) and `concepts/multi-agent/` (deep heading
structure). Each listed in both themes, so this tier is now 12 URLs.
Depends on PR 1 (the callout-link fix), since `features/tui/?theme=dark`
would otherwise fail immediately on the pre-existing bug.

**PR 4 — wire Tier 2 into `.github/workflows/docs-a11y.yml`**
- `actions/checkout` gets `fetch-depth: 2` so `git diff HEAD^1 HEAD`
  (against the `pull_request` test-merge commit) yields exactly the
  PR's changed files — token-free, fork-safe, no changed-files action.
- A `Compute changed-page URLs` step (PR-only) runs the new helper
  script against that diff.
- An `Assemble pa11y config` step jq-merges the changed-page URLs into
  a generated config on top of the checked-in `docs/.pa11yci.json`
  (which stays the single source of truth for the static list and
  defaults, so the local contributor flow is unchanged).
- The `Run pa11y-ci` step uses the generated config when one exists,
  else falls back to the static-only config — so push-to-main and
  content-free PRs stay static-only (12 URLs), matching the plan (no
  PR diff to compute Tier 2 from on push).
- Workflow header comment rewritten to describe the two-tier model;
  `scripts/docs-a11y-urls.sh` added to both `paths:` trigger lists.

`docs/STYLE.md` updated in the same PRs that introduce each piece: the
callout-link contrast rule + table row (PR 1), and the two-tier
model/cap/archetype-maintenance guidance under "Running the
accessibility scan locally" (PR 4).

## Deviations from the plan

None. All mechanisms (checked-in static config + generated merge file,
git-native diff, deterministic lexicographic cap at N=10, static+changed
for mixed PRs, 6-page/12-URL archetype list, callout-scoped contrast
fix) match the plan's recommendations as confirmed by the user. No
scope expansion beyond the callout-link fix.

## Validation

- `./scripts/docs-a11y-urls.sh --self-test` — all checks pass (mapping
  rules, de-dup, both-theme emission, cap + lexicographic tie-break +
  notice).
- `shellcheck scripts/docs-a11y-urls.sh` — clean.
- `actionlint .github/workflows/docs-a11y.yml` and
  `./scripts/workflow-lint.sh` — clean.
- `python3 -c "import json; json.load(open('docs/.pa11yci.json'))"` —
  valid JSON.
- `npx markdownlint-cli2 STYLE.md` — 0 errors.
- Local `hugo server` (Hugo v0.164.0) + `pa11y-ci@3.1.0` (system Chrome
  via `PUPPETEER_EXECUTABLE_PATH`, Docker was unavailable in this
  sandbox) against the full 12-URL static set, both themes: **12/12
  passed, 0 errors** — including `features/tui/?theme=dark`, confirming
  the PR 1 fix.
- End-to-end simulation of the exact CI mechanism (helper script → jq
  merge → generated config → pa11y-ci) against a real changed-page
  example: 14/14 passed (12 static + 2 changed-page URLs, with a
  static-list page correctly de-duped away and a nonexistent/renamed
  page correctly dropped by the live-probe safety net).
- No dark-mode regression: only the callout-link token changed, and it
  doesn't touch anything on the `docs-a11y-audit` "verified passing —
  do not touch" list.

Final green CI is to be confirmed on GitHub once this PR is open — not
verifiable from the local sandbox for the GitHub Actions runner itself
(the local run stands in for the mechanism, using system Chrome instead
of `browser-actions/setup-chrome`).

## Note: unrelated pre-existing uncommitted changes in the sandbox

The working tree also had uncommitted changes to `docs/hugo.yaml`,
`docs/layouts/_partials/footer.html`, and a new
`docs/layouts/home.llms.txt` (an in-progress `llms.txt` output-format
feature) that predate this task and are unrelated to the a11y gate.
They were deliberately left uncommitted/untouched — not included in any
commit here — so this PR stays scoped to the accessibility gate only.

Refs: plan `docs-a11y-smart-gate`, plan `docs-a11y-audit`, PR #3687.