### PR TITLE
fix(anthropic): keep cache breakpoints within Anthropic's limit of 4 with deferred tools

### DIFF
--- a/pkg/model/provider/anthropic/beta_converter.go
+++ b/pkg/model/provider/anthropic/beta_converter.go
@@ -137,8 +137,14 @@ func (c *Client) convertBetaMessagesWithDeferred(ctx context.Context, messages [
 		}
 	}
 
-	// Add ephemeral cache to last 2 messages' last content block
-	applyBetaMessageCacheControl(betaMessages)
+	// Anthropic allows at most 4 cache_control breakpoints per request.
+	// Deferred tools consume one on the tool list, so keep a single message
+	// breakpoint in that case.
+	breakpoints := 2
+	if containsDeferredTool(requestTools) {
+		breakpoints = 1
+	}
+	applyBetaMessageCacheControl(betaMessages, breakpoints)
 
 	return betaMessages, nil
 }
@@ -380,9 +386,9 @@ func convertBetaTools(t []tools.Tool) ([]anthropic.BetaToolUnionParam, error) {
 }
 
 // applyBetaMessageCacheControl adds ephemeral cache control to the last content block
-// of the last 2 messages for prompt caching.
-func applyBetaMessageCacheControl(messages []anthropic.BetaMessageParam) {
-	for i := len(messages) - 1; i >= 0 && i >= len(messages)-2; i-- {
+// of the last `breakpoints` messages for prompt caching.
+func applyBetaMessageCacheControl(messages []anthropic.BetaMessageParam, breakpoints int) {
+	for i := len(messages) - 1; i >= 0 && i >= len(messages)-breakpoints; i-- {
 		msg := &messages[i]
 		if len(msg.Content) == 0 {
 			continue

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -439,8 +439,14 @@ func (c *Client) convertMessagesWithDeferred(ctx context.Context, messages []cha
 		}
 	}
 
-	// Add ephemeral cache to last 2 messages' last content block
-	applyMessageCacheControl(anthropicMessages)
+	// Anthropic allows at most 4 cache_control breakpoints per request.
+	// Deferred tools consume one on the tool list, so keep a single message
+	// breakpoint in that case.
+	breakpoints := 2
+	if containsDeferredTool(requestTools) {
+		breakpoints = 1
+	}
+	applyMessageCacheControl(anthropicMessages, breakpoints)
 
 	return anthropicMessages, nil
 }
@@ -624,9 +630,9 @@ func (c *Client) convertUserMultiContent(ctx context.Context, parts []chat.Messa
 }
 
 // applyMessageCacheControl adds ephemeral cache control to the last content block
-// of the last 2 messages for prompt caching.
-func applyMessageCacheControl(messages []anthropic.MessageParam) {
-	for i := len(messages) - 1; i >= 0 && i >= len(messages)-2; i-- {
+// of the last `breakpoints` messages for prompt caching.
+func applyMessageCacheControl(messages []anthropic.MessageParam, breakpoints int) {
+	for i := len(messages) - 1; i >= 0 && i >= len(messages)-breakpoints; i-- {
 		msg := &messages[i]
 		if len(msg.Content) == 0 {
 			continue

--- a/pkg/model/provider/anthropic/tool_deferrals_test.go
+++ b/pkg/model/provider/anthropic/tool_deferrals_test.go
@@ -104,3 +104,46 @@ func TestDeferredToolsKeepSingleMessageCacheBreakpoint(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, countBreakpoints(beta))
 }
+
+// Anthropic rejects requests with more than 4 cache_control blocks. Build the
+// worst-case request (2 system breakpoints from the session, deferred tools,
+// long conversation) and count breakpoints across system + tools + messages.
+func TestRequestStaysWithinCacheBreakpointLimit(t *testing.T) {
+	messages := []chat.Message{
+		{Role: chat.MessageRoleSystem, Content: "invariant instructions", CacheControl: true},
+		{Role: chat.MessageRoleSystem, Content: "dynamic context", CacheControl: true},
+		{Role: chat.MessageRoleUser, Content: "first"},
+		{Role: chat.MessageRoleAssistant, Content: "second"},
+		{Role: chat.MessageRoleUser, Content: "third"},
+	}
+
+	countBreakpoints := func(parts ...any) int {
+		total := 0
+		for _, part := range parts {
+			data, err := json.Marshal(part)
+			require.NoError(t, err)
+			total += strings.Count(string(data), `"cache_control"`)
+		}
+		return total
+	}
+
+	for _, requestTools := range [][]tools.Tool{
+		nil,
+		{
+			{Name: "read", Parameters: map[string]any{"type": "object"}},
+			{Name: "search", Parameters: map[string]any{"type": "object"}, Deferred: true},
+		},
+	} {
+		convertedTools, err := convertTools(requestTools)
+		require.NoError(t, err)
+		converted, err := testClient().convertMessagesWithDeferred(t.Context(), messages, requestTools)
+		require.NoError(t, err)
+		assert.LessOrEqual(t, countBreakpoints(extractSystemBlocks(messages), convertedTools, converted), 4)
+
+		betaTools, err := convertBetaTools(requestTools)
+		require.NoError(t, err)
+		betaConverted, err := testClient().convertBetaMessagesWithDeferred(t.Context(), messages, requestTools)
+		require.NoError(t, err)
+		assert.LessOrEqual(t, countBreakpoints(extractBetaSystemBlocks(messages), betaTools, betaConverted), 4)
+	}
+}

--- a/pkg/model/provider/anthropic/tool_deferrals_test.go
+++ b/pkg/model/provider/anthropic/tool_deferrals_test.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,4 +70,37 @@ func TestDeferredToolsAreReferencedAtTheirLoadPoint(t *testing.T) {
 	betaJSON, err := json.Marshal(beta)
 	require.NoError(t, err)
 	assert.Contains(t, string(betaJSON), `"tool_name":"search","type":"tool_reference"`)
+}
+
+func TestDeferredToolsKeepSingleMessageCacheBreakpoint(t *testing.T) {
+	messages := []chat.Message{
+		{Role: chat.MessageRoleUser, Content: "first"},
+		{Role: chat.MessageRoleAssistant, Content: "second"},
+		{Role: chat.MessageRoleUser, Content: "third"},
+	}
+	deferredTools := []tools.Tool{{Name: "search", Parameters: map[string]any{"type": "object"}, Deferred: true}}
+
+	countBreakpoints := func(v any) int {
+		data, err := json.Marshal(v)
+		require.NoError(t, err)
+		return strings.Count(string(data), `"cache_control"`)
+	}
+
+	standard, err := testClient().convertMessagesWithDeferred(t.Context(), messages, deferredTools)
+	require.NoError(t, err)
+	assert.Equal(t, 1, countBreakpoints(standard))
+
+	beta, err := testClient().convertBetaMessagesWithDeferred(t.Context(), messages, deferredTools)
+	require.NoError(t, err)
+	assert.Equal(t, 1, countBreakpoints(beta))
+
+	// Without deferred tools the tool list carries no breakpoint, so two
+	// message breakpoints remain in use.
+	standard, err = testClient().convertMessagesWithDeferred(t.Context(), messages, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, countBreakpoints(standard))
+
+	beta, err = testClient().convertBetaMessagesWithDeferred(t.Context(), messages, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, countBreakpoints(beta))
 }


### PR DESCRIPTION
Commit 83956fcb6 added a `cache_control` breakpoint on the tool list when deferred tools are present. Combined with the existing breakpoints applied to system blocks (up to 2) and the last conversation messages (up to 2), requests could exceed Anthropic's hard limit of 4 `cache_control` blocks and return API errors at runtime.

`applyMessageCacheControl` and `applyBetaMessageCacheControl` now accept a breakpoint budget. When deferred tools are in the request, only the last message receives a breakpoint instead of the last two, keeping the total at or below 4. The non-deferred path is unchanged: 2 system + 2 messages = 4. With deferred tools the worst case is 2 system + 1 tools + 1 message = 4. Cache efficiency is preserved because Anthropic's caching layer automatically looks back roughly 20 blocks for prior hits, so a single message breakpoint still gets cache hits on subsequent turns.

New tests assert that a worst-case request — two system breakpoints, deferred tools, and a multi-turn conversation — stays within the 4-block limit for both the standard and beta converters, and that the message breakpoint count drops from two to one when deferred tools are present.