### PR TITLE
fix(docs): render --link-hover on light-mode callout-link hover

### DIFF
--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -197,8 +197,14 @@ tokens, templates, or JS, keep these conventions:
   `.content .callout a:not(.btn):hover` rule too — an unconditional,
   equal-specificity selector coming later in the stylesheet otherwise
   wins over a `:hover` one regardless of hover state, flattening the
-  hover color. Same lesson as the specificity bullets above: always
-  check what a new equal-or-higher-specificity rule shadows nearby.
+  hover color. **The same shadowing hit the light override too**: the
+  `[data-theme="light"]` default sits after the shared `:hover` rule,
+  so light hover silently fell back to `--accent` instead of
+  `--link-hover` (still AA — 4.60–4.83:1 — but not the intended token).
+  Fixed with a `[data-theme="light"] ... :hover` rule of its own, right
+  after the light default. Same lesson as the specificity bullets
+  above: always check what a new equal-or-higher-specificity rule
+  shadows nearby — including rules added later for the *other* theme.
 - **SVGs embedded via `<img>` can't inherit `currentColor` or CSS
   custom properties from the page**, so a single hardcoded palette has
   to clear AA against *both* a near-black dark card (`#1E2129`) and a
@@ -251,6 +257,7 @@ tokens, templates, or JS, keep these conventions:
 | `#search-input` (search trigger button) text | `--text-muted` (gray-600), 5.88:1 on `--bg-hover` white | gray-300, 6.07:1 on `--bg-hover` gray-800 (was `--text-muted` gray-400, 4.42:1 — fail) |
 | `.preview-banner a` | `--accent-on-card` (unchanged, blue-500 5.0:1) | `--accent-on-card` blue-300, 5.89:1 (was `--accent` blue-400, 4.08:1 — fail) |
 | `.content .callout a:not(.btn)` (links inside a callout) | `--accent`, 4.60–4.83:1 (unchanged) | `--blue-200`, 6.46:1 warning / 11.50:1 info / 8.51:1 tip (was `--accent-hover` blue-400, 3.95:1 on warning — fail) |
+| `.content .callout a:not(.btn):hover` | `--link-hover` blue-600, 6.21–6.52:1 (was silently `--accent`, same as default — not a fail, but not the intended token) | `--link-hover` blue-200 (unchanged, same token/ratios as the shared prose-link hover above) |
 | `.btn-primary`/`.btn-secondary` as `.content a` links (Quick Start, Back to Docs) | unchanged (blue-500-on-white 5.00:1 / white-on-translucent) | own `color` restored via `.content a:not(.btn)`, was 2.55:1 (`--accent-hover` leaking onto a white button bg) |
 | `how-it-works.svg` diagram text | gray-600 body 5.88:1 / blue-500 accent 5.00:1 (light-only file, on white) | gray-400 body 5.59:1 / blue-300 accent 5.89:1 (dark-only file, on `#1E2129`) |
 

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -986,12 +986,15 @@ details.sidebar-section[open] > summary.sidebar-heading::after {
  * 8.51:1 tip); light already passes with --accent (4.60-4.83:1) so it's
  * restored explicitly rather than left to inherit a dark-only value. Both
  * rules match .content a:not(.btn)'s own specificity (0,2,1) plus one, so
- * they win regardless of source order; an explicit :hover variant is
- * needed too or these same-specificity rules would flatten the shared
- * hover color (--link-hover, already AA on every callout background). */
+ * they win regardless of source order — including each other: the light
+ * override comes after the shared :hover rule, so it also needs its own
+ * :hover variant, or hover in light silently flattens back to --accent
+ * instead of --link-hover (still AA either way, but not the intended
+ * token — see docs/STYLE.md). */
 .content .callout a:not(.btn) { color: var(--blue-200); }
 .content .callout a:not(.btn):hover { color: var(--link-hover); }
 [data-theme="light"] .content .callout a:not(.btn) { color: var(--accent); }
+[data-theme="light"] .content .callout a:not(.btn):hover { color: var(--link-hover); }
 
 /* ===== Cards Grid ===== */
 .cards {


### PR DESCRIPTION
## What changed

Small follow-up to PR #3691's review: a non-blocking, should-fix
cosmetic CSS issue in `docs/css/style.css`.

In light mode, hovering a callout link (inside a warning/info/tip
admonition) never switched to `--link-hover` (`#1A4DD9`) as
`docs/STYLE.md` documents — it silently stayed `--accent` (`#2560FF`).

The light-mode default override
(`[data-theme="light"] .content .callout a:not(.btn)`) has the exact
same specificity as the shared `.content .callout a:not(.btn):hover`
rule, but sits after it in source order, so it won on `:hover` too.
This mirrors the dark-mode shadowing bug already fixed in PR #3691 —
that fix added an explicit dark-scoped `:hover` rule, but the same
gap existed for light and was missed.

Not an accessibility failure: `--accent` on hover still cleared AA on
all three callout backgrounds (4.60–4.83:1). Purely a
behavior/documentation mismatch.

**Fix**: add `[data-theme="light"] .content .callout a:not(.btn):hover
{ color: var(--link-hover); }` right after the light default, same
pattern as the existing dark-mode rule. Scoped to callout links only —
non-callout prose links, `.btn` links, and dark-mode behavior are
untouched.

`docs/STYLE.md` updated (the callout-link bullet + contrast table) so
the doc matches the fixed cascade.

## Verification

- Computed styles via Puppeteer/system Chrome against a local Hugo
  build (`features/tui/`, which exercises all three callout variants):
  - Light: default `rgb(37,96,255)` (`--accent`) →
    hover `rgb(26,77,217)` (`--link-hover`, `#1A4DD9`) ✅
  - Dark: default/hover both `rgb(191,206,255)` (`--blue-200`, dark's
    `--link-hover` value) — unchanged from before this fix ✅
  - Non-callout prose link and `.hero-buttons .btn`: hover behavior
    unchanged in both themes ✅
- New light-mode hover contrast ratios (blue-600 `#1A4DD9` is darker
  than blue-500, so contrast only improves): 6.52:1 warning, 6.21:1
  info, 6.42:1 tip — all comfortably above AA's 4.5:1.
- Local Hugo (v0.164.0) + `pa11y-ci@4.1.1` (system Chrome via
  `PUPPETEER_EXECUTABLE_PATH`; Docker was unresponsive in this
  sandbox) against the full static 12-URL set (both themes):
  **12/12 passed, 0 errors**.
- `npx markdownlint-cli2 STYLE.md` — 0 errors.

actionlint wasn't run — no workflow files were touched.

Refs: PR #3691 (review follow-up).