### PR TITLE
fix(mcp): give allow-private-ips OAuth clients a private connection pool

### DIFF
--- a/pkg/tools/mcp/main_test.go
+++ b/pkg/tools/mcp/main_test.go
@@ -3,15 +3,15 @@ package mcp
 import (
 	"os"
 	"testing"
-	"time"
-
-	"github.com/docker/docker-agent/pkg/httpclient"
 )
 
 // TestMain swaps the OAuth helpers' SSRF-safe HTTP client for the
 // loopback-allowing variant so tests can hit httptest.NewServer (which
-// binds to 127.0.0.1). Production code keeps the safe client.
+// binds to 127.0.0.1). Production code keeps the safe client. The variant
+// carries its own connection pool, so parallel tests closing httptest
+// servers (which prunes http.DefaultTransport's pool) can't break its
+// in-flight requests.
 func TestMain(m *testing.M) {
-	oauthHTTPClient = httpclient.NewSafeClient(30*time.Second, true)
+	oauthHTTPClient = oauthHTTPClientForAllowPrivateIPs(true)
 	os.Exit(m.Run())
 }

--- a/pkg/tools/mcp/oauth_helpers.go
+++ b/pkg/tools/mcp/oauth_helpers.go
@@ -37,7 +37,14 @@ var oauthHTTPClient = httpclient.NewSafeClient(30*time.Second, false)
 
 func oauthHTTPClientForAllowPrivateIPs(allowPrivateIPs bool) *http.Client {
 	if allowPrivateIPs {
-		return &http.Client{Timeout: 30 * time.Second}
+		// Clone keeps the default proxy/HTTP2/timeout behavior but gives the
+		// client its own connection pool: a nil Transport would share
+		// http.DefaultTransport's pool, which third parties may prune via
+		// CloseIdleConnections (httptest.Server.Close does).
+		return &http.Client{
+			Timeout:   30 * time.Second,
+			Transport: http.DefaultTransport.(*http.Transport).Clone(),
+		}
 	}
 	return oauthHTTPClient
 }

--- a/pkg/tools/mcp/oauth_server_test.go
+++ b/pkg/tools/mcp/oauth_server_test.go
@@ -99,7 +99,7 @@ func TestCallbackServer_DuplicateCallbacksDoNotBlock(t *testing.T) {
 	cs.SetExpectedState("expected-state")
 	callbackURL := cs.GetRedirectURI() + "?code=authcode&state=expected-state"
 
-	client := &http.Client{Timeout: 2 * time.Second}
+	client := &http.Client{Timeout: 2 * time.Second, Transport: newTestTransport(t)}
 
 	// Fire several callbacks back-to-back. Each one must complete (so the
 	// handler goroutine isn't stuck) regardless of whether anyone is

--- a/pkg/tools/mcp/oauth_test.go
+++ b/pkg/tools/mcp/oauth_test.go
@@ -28,7 +28,7 @@ import (
 // test's in-flight request ("transport connection broken").
 func newTestTransport(t *testing.T) *http.Transport {
 	t.Helper()
-	tr := &http.Transport{}
+	tr := http.DefaultTransport.(*http.Transport).Clone()
 	t.Cleanup(tr.CloseIdleConnections)
 	return tr
 }


### PR DESCRIPTION
Follow-up to f7b5c105f (#3704), which fixed a flaky-test root cause — `oauthTransport` sharing `http.DefaultTransport` as its base `RoundTripper` — but left two paths untouched. Both surfaced in CI on #3696 as `net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called` in `TestUnmanagedOAuthFlow_LegacyMode_NoAuthorizeURLInElicitation`. The culprit is `httptest.Server.Close`, called by every finishing parallel test, which drains the *shared* `http.DefaultTransport` idle-connection pool. When another test's OAuth client holds a connection from that same pool — between the server's 401 and the authorized retry — the connection is killed mid-flight.

`oauthHTTPClientForAllowPrivateIPs(true)` returned a client with a nil `Transport`, so it fell back to `http.DefaultTransport`. The fix clones the default transport instead, giving each remote-client its own private pool while preserving the same proxy, HTTP/2, and timeout settings. The clone is constructed once per remote-client, so connection reuse within a single client is still effective. On the test side, `newTestTransport` similarly clones the default transport rather than returning a bare `&http.Transport{}`, `TestMain` reuses the production helper so its swapped-in client is also isolated, and the callback-server test client gets a per-test transport.

No behavior change in production beyond connection-pool isolation; the fix only affects which pool a client draws from.