### PR TITLE
feat(tui): extend session browser search to match session IDs

### DIFF
--- a/pkg/tui/dialog/session_browser.go
+++ b/pkg/tui/dialog/session_browser.go
@@ -317,6 +317,8 @@ func (d *sessionBrowserDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 
 func (d *sessionBrowserDialog) filterSessions() {
 	query := strings.ToLower(strings.TrimSpace(d.textInput.Value()))
+	// IDs are matched with dashes stripped so partial UUIDs paste-match.
+	idQuery := strings.ReplaceAll(query, "-", "")
 
 	var workspace, elsewhere []session.Summary
 	for _, sess := range d.sessions {
@@ -348,7 +350,7 @@ func (d *sessionBrowserDialog) filterSessions() {
 			if title == "" {
 				title = "Untitled"
 			}
-			if !strings.Contains(strings.ToLower(title), query) {
+			if !strings.Contains(strings.ToLower(title), query) && !matchesSessionID(sess.ID, idQuery) {
 				continue
 			}
 		}
@@ -373,6 +375,16 @@ func (d *sessionBrowserDialog) filterSessions() {
 	// scrollbar clamp correctly even before View() runs.
 	d.scrollview.SetContent(nil, len(d.rows))
 	d.scrollview.SetScrollOffset(0)
+}
+
+// matchesSessionID reports whether the session ID contains the query,
+// case-insensitively and ignoring "-" characters on both sides.
+func matchesSessionID(id, idQuery string) bool {
+	if idQuery == "" {
+		return false
+	}
+	id = strings.ReplaceAll(strings.ToLower(id), "-", "")
+	return strings.Contains(id, idQuery)
 }
 
 // rebuildRows lays out the filtered sessions as visual rows. Section headers

--- a/pkg/tui/dialog/session_browser_test.go
+++ b/pkg/tui/dialog/session_browser_test.go
@@ -462,6 +462,37 @@ func TestSessionBrowserWorkspaceFilterCombinesWithStarAndSearch(t *testing.T) {
 	require.NotEmpty(t, d.View())
 }
 
+func TestSessionBrowserSearchByID(t *testing.T) {
+	t.Parallel()
+	sessions := []session.Summary{
+		{ID: "abc-123-def", Title: "First session", CreatedAt: time.Now()},
+		{ID: "xyz-789", Title: "Second session", CreatedAt: time.Now()},
+	}
+
+	dialog := NewSessionBrowserDialog(sessions, "")
+	d := dialog.(*sessionBrowserDialog)
+	d.Init()
+	d.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
+
+	tests := []struct {
+		query string
+		want  []string
+	}{
+		{"abc-123-def", []string{"abc-123-def"}},        // full ID
+		{"abc123def", []string{"abc-123-def"}},          // ID without dashes
+		{"c-123-d", []string{"abc-123-def"}},            // partial ID with dashes
+		{"c123d", []string{"abc-123-def"}},              // partial ID without dashes
+		{"ABC123", []string{"abc-123-def"}},             // case-insensitive
+		{"session", []string{"abc-123-def", "xyz-789"}}, // title match still works
+		{"nope", []string{}},
+	}
+	for _, tc := range tests {
+		d.textInput.SetValue(tc.query)
+		d.filterSessions()
+		require.Equal(t, tc.want, filteredIDs(d), "query %q", tc.query)
+	}
+}
+
 func TestSessionBrowserWorkspacePathNormalization(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The `/sessions` browser search filter previously matched only session titles. Users who copy a session ID (e.g. from `ctrl+y` or a log) and paste it into the search box got no results, which made it hard to jump back to a known session.

This change extends `filterSessions` so that a query also matches against the session ID, case-insensitively and with `-` characters stripped on both sides. That means full UUIDs, dash-less variants, and partial fragments — however the user pastes or types them — all resolve to the right session. Title matching is completely unchanged.

A new test `TestSessionBrowserSearchByID` covers full-ID, dash-less, partial-with-dashes, partial-without-dashes, case-insensitive, title-fallback, and no-match cases.