### PR TITLE
refactor: consolidate and harden Anthropic prompt-cache checkpoint handling

### DIFF
--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -101,11 +101,12 @@ type Message struct {
 	// excess marks against the API's breakpoint limit).
 	//
 	// Contract: this is request-assembly state, not conversation state.
-	// The session sets it on assembled prompt copies (never on stored
-	// transcript items, and session.CompactionInput strips it
-	// defensively). It stays JSON-serialized because the assembled
-	// messages round-trip through before_llm_call hooks as JSON and the
-	// marks must survive hook rewrites.
+	// The session sets it on assembled prompt copies; transcripts never
+	// carry it (session.AddMessage strips it on ingestion and
+	// session.CompactionInput strips it defensively for legacy persisted
+	// rows). It stays JSON-serialized because the assembled messages
+	// round-trip through before_llm_call hooks as JSON and the marks
+	// must survive hook rewrites.
 	CacheControl bool `json:"cache_control,omitempty"`
 }
 

--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -96,7 +96,16 @@ type Message struct {
 	// Only set for assistant messages.
 	FinishReason FinishReason `json:"finish_reason,omitempty"`
 
-	// CacheControl indicates whether this message is a cached message (only used by anthropic)
+	// CacheControl marks this message as a prompt-cache checkpoint
+	// boundary (currently honored by the Anthropic provider, which caps
+	// excess marks against the API's breakpoint limit).
+	//
+	// Contract: this is request-assembly state, not conversation state.
+	// The session sets it on assembled prompt copies (never on stored
+	// transcript items, and session.CompactionInput strips it
+	// defensively). It stays JSON-serialized because the assembled
+	// messages round-trip through before_llm_call hooks as JSON and the
+	// marks must survive hook rewrites.
 	CacheControl bool `json:"cache_control,omitempty"`
 }
 

--- a/pkg/model/provider/anthropic/beta_converter.go
+++ b/pkg/model/provider/anthropic/beta_converter.go
@@ -389,24 +389,13 @@ func convertBetaTools(t []tools.Tool) ([]anthropic.BetaToolUnionParam, error) {
 // of the last `breakpoints` messages for prompt caching.
 func applyBetaMessageCacheControl(messages []anthropic.BetaMessageParam, breakpoints int) {
 	for i := len(messages) - 1; i >= 0 && i >= len(messages)-breakpoints; i-- {
-		msg := &messages[i]
-		if len(msg.Content) == 0 {
+		content := messages[i].Content
+		if len(content) == 0 {
 			continue
 		}
-		lastIdx := len(msg.Content) - 1
-		block := &msg.Content[lastIdx]
-		cacheCtrl := anthropic.NewBetaCacheControlEphemeralParam()
-		switch {
-		case block.OfText != nil:
-			block.OfText.CacheControl = cacheCtrl
-		case block.OfToolUse != nil:
-			block.OfToolUse.CacheControl = cacheCtrl
-		case block.OfToolResult != nil:
-			block.OfToolResult.CacheControl = cacheCtrl
-		case block.OfImage != nil:
-			block.OfImage.CacheControl = cacheCtrl
-		case block.OfDocument != nil:
-			block.OfDocument.CacheControl = cacheCtrl
+		// nil for block kinds without cache control (e.g. thinking blocks).
+		if cc := content[len(content)-1].GetCacheControl(); cc != nil {
+			*cc = anthropic.NewBetaCacheControlEphemeralParam()
 		}
 	}
 }

--- a/pkg/model/provider/anthropic/beta_converter.go
+++ b/pkg/model/provider/anthropic/beta_converter.go
@@ -137,14 +137,7 @@ func (c *Client) convertBetaMessagesWithDeferred(ctx context.Context, messages [
 		}
 	}
 
-	// Anthropic allows at most 4 cache_control breakpoints per request.
-	// Deferred tools consume one on the tool list, so keep a single message
-	// breakpoint in that case.
-	breakpoints := 2
-	if containsDeferredTool(requestTools) {
-		breakpoints = 1
-	}
-	applyBetaMessageCacheControl(betaMessages, breakpoints)
+	applyBetaMessageCacheControl(betaMessages, messageCacheBreakpoints(requestTools))
 
 	return betaMessages, nil
 }

--- a/pkg/model/provider/anthropic/beta_converter.go
+++ b/pkg/model/provider/anthropic/beta_converter.go
@@ -322,26 +322,6 @@ func (c *Client) convertBetaUserMultiContent(ctx context.Context, parts []chat.M
 	return contentBlocks, nil
 }
 
-// extractBetaSystemBlocks extracts system messages for Beta API format
-func extractBetaSystemBlocks(messages []chat.Message) []anthropic.BetaTextBlockParam {
-	regularBlocks := extractSystemBlocks(messages)
-
-	betaBlocks := make([]anthropic.BetaTextBlockParam, len(regularBlocks))
-	for i, block := range regularBlocks {
-		betaBlocks[i] = anthropic.BetaTextBlockParam{Text: block.Text}
-
-		// Copy over cache control from regular blocks (already set on first 2)
-		if block.CacheControl.Type != "" {
-			betaBlocks[i].CacheControl = anthropic.BetaCacheControlEphemeralParam{
-				Type: block.CacheControl.Type,
-				TTL:  anthropic.BetaCacheControlEphemeralTTL(block.CacheControl.TTL),
-			}
-		}
-	}
-
-	return betaBlocks
-}
-
 // convertBetaTools converts tools to Beta API format
 func convertBetaTools(t []tools.Tool) ([]anthropic.BetaToolUnionParam, error) {
 	hasDeferredTools := containsDeferredTool(t)

--- a/pkg/model/provider/anthropic/beta_converter.go
+++ b/pkg/model/provider/anthropic/beta_converter.go
@@ -378,21 +378,6 @@ func convertBetaTools(t []tools.Tool) ([]anthropic.BetaToolUnionParam, error) {
 	return betaTools, nil
 }
 
-// applyBetaMessageCacheControl adds ephemeral cache control to the last content block
-// of the last `breakpoints` messages for prompt caching.
-func applyBetaMessageCacheControl(messages []anthropic.BetaMessageParam, breakpoints int) {
-	for i := len(messages) - 1; i >= 0 && i >= len(messages)-breakpoints; i-- {
-		content := messages[i].Content
-		if len(content) == 0 {
-			continue
-		}
-		// nil for block kinds without cache control (e.g. thinking blocks).
-		if cc := content[len(content)-1].GetCacheControl(); cc != nil {
-			*cc = anthropic.NewBetaCacheControlEphemeralParam()
-		}
-	}
-}
-
 // stdBlocksToBeta converts standard Anthropic SDK content blocks to their Beta
 // API equivalents. The beta path (convertBetaUserMultiContent) requires
 // BetaContentBlockParamUnion, but convertDocument produces the standard type.

--- a/pkg/model/provider/anthropic/cache_control.go
+++ b/pkg/model/provider/anthropic/cache_control.go
@@ -6,15 +6,39 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
+// Anthropic allows at most 4 cache_control breakpoints per request; a
+// request exceeding the limit is rejected outright. The budget is
+// allocated in one place — this file — as follows:
+//
+//	tool list       0 or 1 (only when deferred tools are in play)
+//	system blocks   up to maxSystemCacheBreakpoints, honoring upstream
+//	                CacheControl marks (excess marks are dropped)
+//	message tail    the remainder (messageCacheBreakpoints)
+const maxSystemCacheBreakpoints = 2
+
 // messageCacheBreakpoints returns how many message-level cache_control
-// breakpoints a request may use. Anthropic allows at most 4 per request;
-// deferred tools consume one on the tool list, leaving one fewer for
-// messages.
+// breakpoints a request may use: what remains of the budget after the
+// tool list and system blocks take their share.
 func messageCacheBreakpoints(requestTools []tools.Tool) int {
 	if containsDeferredTool(requestTools) {
 		return 1
 	}
 	return 2
+}
+
+// markSystemBlockCacheControl marks the block as a cache breakpoint if the
+// system-block budget allows it, returning the updated count of marked
+// blocks. Re-marking an already-marked block is a no-op so that duplicate
+// upstream marks don't burn budget.
+func markSystemBlockCacheControl(block *anthropic.TextBlockParam, marked int) int {
+	if block.CacheControl.Type != "" {
+		return marked
+	}
+	if marked >= maxSystemCacheBreakpoints {
+		return marked
+	}
+	block.CacheControl = anthropic.NewCacheControlEphemeralParam()
+	return marked + 1
 }
 
 // applyMessageCacheControl adds ephemeral cache control to the last content block

--- a/pkg/model/provider/anthropic/cache_control.go
+++ b/pkg/model/provider/anthropic/cache_control.go
@@ -1,0 +1,48 @@
+package anthropic
+
+import (
+	"github.com/anthropics/anthropic-sdk-go"
+
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// messageCacheBreakpoints returns how many message-level cache_control
+// breakpoints a request may use. Anthropic allows at most 4 per request;
+// deferred tools consume one on the tool list, leaving one fewer for
+// messages.
+func messageCacheBreakpoints(requestTools []tools.Tool) int {
+	if containsDeferredTool(requestTools) {
+		return 1
+	}
+	return 2
+}
+
+// applyMessageCacheControl adds ephemeral cache control to the last content block
+// of the last `breakpoints` messages for prompt caching.
+func applyMessageCacheControl(messages []anthropic.MessageParam, breakpoints int) {
+	for i := len(messages) - 1; i >= 0 && i >= len(messages)-breakpoints; i-- {
+		content := messages[i].Content
+		if len(content) == 0 {
+			continue
+		}
+		// nil for block kinds without cache control (e.g. thinking blocks).
+		if cc := content[len(content)-1].GetCacheControl(); cc != nil {
+			*cc = anthropic.NewCacheControlEphemeralParam()
+		}
+	}
+}
+
+// applyBetaMessageCacheControl adds ephemeral cache control to the last content block
+// of the last `breakpoints` messages for prompt caching.
+func applyBetaMessageCacheControl(messages []anthropic.BetaMessageParam, breakpoints int) {
+	for i := len(messages) - 1; i >= 0 && i >= len(messages)-breakpoints; i-- {
+		content := messages[i].Content
+		if len(content) == 0 {
+			continue
+		}
+		// nil for block kinds without cache control (e.g. thinking blocks).
+		if cc := content[len(content)-1].GetCacheControl(); cc != nil {
+			*cc = anthropic.NewBetaCacheControlEphemeralParam()
+		}
+	}
+}

--- a/pkg/model/provider/anthropic/cache_control.go
+++ b/pkg/model/provider/anthropic/cache_control.go
@@ -1,8 +1,11 @@
 package anthropic
 
 import (
+	"strings"
+
 	"github.com/anthropics/anthropic-sdk-go"
 
+	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
@@ -39,6 +42,61 @@ func markSystemBlockCacheControl(block *anthropic.TextBlockParam, marked int) in
 	}
 	block.CacheControl = anthropic.NewCacheControlEphemeralParam()
 	return marked + 1
+}
+
+// extractSystemBlocks converts any system-role messages into Anthropic system text blocks
+// to be set on the top-level MessageNewParams.System field.
+func extractSystemBlocks(messages []chat.Message) []anthropic.TextBlockParam {
+	var systemBlocks []anthropic.TextBlockParam
+	marked := 0
+	for i := range messages {
+		msg := &messages[i]
+		if msg.Role != chat.MessageRoleSystem {
+			continue
+		}
+
+		if len(msg.MultiContent) > 0 {
+			for _, part := range msg.MultiContent {
+				if part.Type == chat.MessagePartTypeText {
+					if txt := strings.TrimSpace(part.Text); txt != "" {
+						systemBlocks = append(systemBlocks, anthropic.TextBlockParam{Text: txt})
+					}
+				}
+			}
+		} else if txt := strings.TrimSpace(msg.Content); txt != "" {
+			// Trim system-message content: YAML literal blocks (instruction: |) always
+			// append a trailing newline, and we don't want that in API payloads.
+			systemBlocks = append(systemBlocks, anthropic.TextBlockParam{
+				Text: txt,
+			})
+		}
+
+		if msg.CacheControl && len(systemBlocks) > 0 {
+			marked = markSystemBlockCacheControl(&systemBlocks[len(systemBlocks)-1], marked)
+		}
+	}
+
+	return systemBlocks
+}
+
+// extractBetaSystemBlocks extracts system messages for Beta API format
+func extractBetaSystemBlocks(messages []chat.Message) []anthropic.BetaTextBlockParam {
+	regularBlocks := extractSystemBlocks(messages)
+
+	betaBlocks := make([]anthropic.BetaTextBlockParam, len(regularBlocks))
+	for i, block := range regularBlocks {
+		betaBlocks[i] = anthropic.BetaTextBlockParam{Text: block.Text}
+
+		// Copy over cache control from regular blocks (already set on first 2)
+		if block.CacheControl.Type != "" {
+			betaBlocks[i].CacheControl = anthropic.BetaCacheControlEphemeralParam{
+				Type: block.CacheControl.Type,
+				TTL:  anthropic.BetaCacheControlEphemeralTTL(block.CacheControl.TTL),
+			}
+		}
+	}
+
+	return betaBlocks
 }
 
 // applyMessageCacheControl adds ephemeral cache control to the last content block

--- a/pkg/model/provider/anthropic/cache_control.go
+++ b/pkg/model/provider/anthropic/cache_control.go
@@ -1,6 +1,7 @@
 package anthropic
 
 import (
+	"log/slog"
 	"strings"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -32,12 +33,15 @@ func messageCacheBreakpoints(requestTools []tools.Tool) int {
 // markSystemBlockCacheControl marks the block as a cache breakpoint if the
 // system-block budget allows it, returning the updated count of marked
 // blocks. Re-marking an already-marked block is a no-op so that duplicate
-// upstream marks don't burn budget.
+// upstream marks don't burn budget; over-budget marks are dropped (and
+// logged) so a request can never exceed Anthropic's breakpoint limit.
 func markSystemBlockCacheControl(block *anthropic.TextBlockParam, marked int) int {
 	if block.CacheControl.Type != "" {
 		return marked
 	}
 	if marked >= maxSystemCacheBreakpoints {
+		slog.Debug("Dropping over-budget system cache breakpoint mark",
+			"max", maxSystemCacheBreakpoints)
 		return marked
 	}
 	block.CacheControl = anthropic.NewCacheControlEphemeralParam()

--- a/pkg/model/provider/anthropic/cache_control_test.go
+++ b/pkg/model/provider/anthropic/cache_control_test.go
@@ -1,0 +1,62 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/stretchr/testify/assert"
+)
+
+// applyMessageCacheControl and applyBetaMessageCacheControl rely on the
+// SDK's GetCacheControl union accessors to decide which block kinds can
+// carry a breakpoint. Pin that contract for every block kind our
+// converters produce, so an SDK bump that changes accessor coverage
+// (e.g. adding cache control to thinking blocks) fails here instead of
+// silently changing which requests get cached.
+func TestSDKCacheControlAccessorCoverage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("standard", func(t *testing.T) {
+		t.Parallel()
+		cacheable := map[string]anthropic.ContentBlockParamUnion{
+			"text":        anthropic.NewTextBlock("x"),
+			"tool_use":    {OfToolUse: &anthropic.ToolUseBlockParam{ID: "1", Name: "t"}},
+			"tool_result": anthropic.NewToolResultBlock("1", "ok", false),
+			"image":       anthropic.NewImageBlock(anthropic.Base64ImageSourceParam{Data: "d"}),
+			"document":    {OfDocument: &anthropic.DocumentBlockParam{}},
+		}
+		for name, block := range cacheable {
+			assert.NotNil(t, block.GetCacheControl(), "%s blocks must accept cache control", name)
+		}
+
+		uncacheable := map[string]anthropic.ContentBlockParamUnion{
+			"thinking":          anthropic.NewThinkingBlock("sig", "why"),
+			"redacted_thinking": anthropic.NewRedactedThinkingBlock("sig"),
+		}
+		for name, block := range uncacheable {
+			assert.Nil(t, block.GetCacheControl(), "%s blocks must not accept cache control", name)
+		}
+	})
+
+	t.Run("beta", func(t *testing.T) {
+		t.Parallel()
+		cacheable := map[string]anthropic.BetaContentBlockParamUnion{
+			"text":        {OfText: &anthropic.BetaTextBlockParam{Text: "x"}},
+			"tool_use":    {OfToolUse: &anthropic.BetaToolUseBlockParam{ID: "1", Name: "t"}},
+			"tool_result": {OfToolResult: &anthropic.BetaToolResultBlockParam{ToolUseID: "1"}},
+			"image":       {OfImage: &anthropic.BetaImageBlockParam{}},
+			"document":    {OfDocument: &anthropic.BetaRequestDocumentBlockParam{}},
+		}
+		for name, block := range cacheable {
+			assert.NotNil(t, block.GetCacheControl(), "beta %s blocks must accept cache control", name)
+		}
+
+		uncacheable := map[string]anthropic.BetaContentBlockParamUnion{
+			"thinking":          anthropic.NewBetaThinkingBlock("sig", "why"),
+			"redacted_thinking": anthropic.NewBetaRedactedThinkingBlock("sig"),
+		}
+		for name, block := range uncacheable {
+			assert.Nil(t, block.GetCacheControl(), "beta %s blocks must not accept cache control", name)
+		}
+	})
+}

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -633,24 +633,13 @@ func (c *Client) convertUserMultiContent(ctx context.Context, parts []chat.Messa
 // of the last `breakpoints` messages for prompt caching.
 func applyMessageCacheControl(messages []anthropic.MessageParam, breakpoints int) {
 	for i := len(messages) - 1; i >= 0 && i >= len(messages)-breakpoints; i-- {
-		msg := &messages[i]
-		if len(msg.Content) == 0 {
+		content := messages[i].Content
+		if len(content) == 0 {
 			continue
 		}
-		lastIdx := len(msg.Content) - 1
-		block := &msg.Content[lastIdx]
-		cacheCtrl := anthropic.NewCacheControlEphemeralParam()
-		switch {
-		case block.OfText != nil:
-			block.OfText.CacheControl = cacheCtrl
-		case block.OfToolUse != nil:
-			block.OfToolUse.CacheControl = cacheCtrl
-		case block.OfToolResult != nil:
-			block.OfToolResult.CacheControl = cacheCtrl
-		case block.OfImage != nil:
-			block.OfImage.CacheControl = cacheCtrl
-		case block.OfDocument != nil:
-			block.OfDocument.CacheControl = cacheCtrl
+		// nil for block kinds without cache control (e.g. thinking blocks).
+		if cc := content[len(content)-1].GetCacheControl(); cc != nil {
+			*cc = anthropic.NewCacheControlEphemeralParam()
 		}
 	}
 }

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -439,16 +439,20 @@ func (c *Client) convertMessagesWithDeferred(ctx context.Context, messages []cha
 		}
 	}
 
-	// Anthropic allows at most 4 cache_control breakpoints per request.
-	// Deferred tools consume one on the tool list, so keep a single message
-	// breakpoint in that case.
-	breakpoints := 2
-	if containsDeferredTool(requestTools) {
-		breakpoints = 1
-	}
-	applyMessageCacheControl(anthropicMessages, breakpoints)
+	applyMessageCacheControl(anthropicMessages, messageCacheBreakpoints(requestTools))
 
 	return anthropicMessages, nil
+}
+
+// messageCacheBreakpoints returns how many message-level cache_control
+// breakpoints a request may use. Anthropic allows at most 4 per request;
+// deferred tools consume one on the tool list, leaving one fewer for
+// messages.
+func messageCacheBreakpoints(requestTools []tools.Tool) int {
+	if containsDeferredTool(requestTools) {
+		return 1
+	}
+	return 2
 }
 
 func deferredToolNamesByCallID(requestTools []tools.Tool) map[string][]string {

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -626,6 +626,7 @@ func (c *Client) convertUserMultiContent(ctx context.Context, parts []chat.Messa
 // to be set on the top-level MessageNewParams.System field.
 func extractSystemBlocks(messages []chat.Message) []anthropic.TextBlockParam {
 	var systemBlocks []anthropic.TextBlockParam
+	marked := 0
 	for i := range messages {
 		msg := &messages[i]
 		if msg.Role != chat.MessageRoleSystem {
@@ -649,7 +650,7 @@ func extractSystemBlocks(messages []chat.Message) []anthropic.TextBlockParam {
 		}
 
 		if msg.CacheControl && len(systemBlocks) > 0 {
-			systemBlocks[len(systemBlocks)-1].CacheControl = anthropic.NewCacheControlEphemeralParam()
+			marked = markSystemBlockCacheControl(&systemBlocks[len(systemBlocks)-1], marked)
 		}
 	}
 

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -444,17 +444,6 @@ func (c *Client) convertMessagesWithDeferred(ctx context.Context, messages []cha
 	return anthropicMessages, nil
 }
 
-// messageCacheBreakpoints returns how many message-level cache_control
-// breakpoints a request may use. Anthropic allows at most 4 per request;
-// deferred tools consume one on the tool list, leaving one fewer for
-// messages.
-func messageCacheBreakpoints(requestTools []tools.Tool) int {
-	if containsDeferredTool(requestTools) {
-		return 1
-	}
-	return 2
-}
-
 func deferredToolNamesByCallID(requestTools []tools.Tool) map[string][]string {
 	result := make(map[string][]string)
 	for _, tool := range requestTools {
@@ -631,21 +620,6 @@ func (c *Client) convertUserMultiContent(ctx context.Context, parts []chat.Messa
 	}
 
 	return contentBlocks, nil
-}
-
-// applyMessageCacheControl adds ephemeral cache control to the last content block
-// of the last `breakpoints` messages for prompt caching.
-func applyMessageCacheControl(messages []anthropic.MessageParam, breakpoints int) {
-	for i := len(messages) - 1; i >= 0 && i >= len(messages)-breakpoints; i-- {
-		content := messages[i].Content
-		if len(content) == 0 {
-			continue
-		}
-		// nil for block kinds without cache control (e.g. thinking blocks).
-		if cc := content[len(content)-1].GetCacheControl(); cc != nil {
-			*cc = anthropic.NewCacheControlEphemeralParam()
-		}
-	}
 }
 
 // extractSystemBlocks converts any system-role messages into Anthropic system text blocks

--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -622,41 +622,6 @@ func (c *Client) convertUserMultiContent(ctx context.Context, parts []chat.Messa
 	return contentBlocks, nil
 }
 
-// extractSystemBlocks converts any system-role messages into Anthropic system text blocks
-// to be set on the top-level MessageNewParams.System field.
-func extractSystemBlocks(messages []chat.Message) []anthropic.TextBlockParam {
-	var systemBlocks []anthropic.TextBlockParam
-	marked := 0
-	for i := range messages {
-		msg := &messages[i]
-		if msg.Role != chat.MessageRoleSystem {
-			continue
-		}
-
-		if len(msg.MultiContent) > 0 {
-			for _, part := range msg.MultiContent {
-				if part.Type == chat.MessagePartTypeText {
-					if txt := strings.TrimSpace(part.Text); txt != "" {
-						systemBlocks = append(systemBlocks, anthropic.TextBlockParam{Text: txt})
-					}
-				}
-			}
-		} else if txt := strings.TrimSpace(msg.Content); txt != "" {
-			// Trim system-message content: YAML literal blocks (instruction: |) always
-			// append a trailing newline, and we don't want that in API payloads.
-			systemBlocks = append(systemBlocks, anthropic.TextBlockParam{
-				Text: txt,
-			})
-		}
-
-		if msg.CacheControl && len(systemBlocks) > 0 {
-			marked = markSystemBlockCacheControl(&systemBlocks[len(systemBlocks)-1], marked)
-		}
-	}
-
-	return systemBlocks
-}
-
 func (c *Client) supportsDeferredTools() bool {
 	if enabled, ok := providerutil.GetProviderOptBool(c.ModelConfig.ProviderOpts, "supports_deferred_tools"); ok {
 		return enabled

--- a/pkg/model/provider/anthropic/client_test.go
+++ b/pkg/model/provider/anthropic/client_test.go
@@ -552,6 +552,26 @@ func TestExtractSystemBlocksCacheControl(t *testing.T) {
 	assert.Empty(t, string(blocks[3].CacheControl.TTL))
 }
 
+func TestExtractSystemBlocks_CapsCacheBreakpoints(t *testing.T) {
+	t.Parallel()
+
+	// More upstream marks than the system-block budget: only the first
+	// maxSystemCacheBreakpoints are honored so the request can never
+	// exceed Anthropic's 4-breakpoint limit.
+	msgs := []chat.Message{
+		{Role: chat.MessageRoleSystem, Content: "invariant", CacheControl: true},
+		{Role: chat.MessageRoleSystem, Content: "instruction context", CacheControl: true},
+		{Role: chat.MessageRoleSystem, Content: "extras", CacheControl: true},
+	}
+
+	blocks := extractSystemBlocks(msgs)
+
+	require.Len(t, blocks, 3)
+	assert.Equal(t, "ephemeral", string(blocks[0].CacheControl.Type))
+	assert.Equal(t, "ephemeral", string(blocks[1].CacheControl.Type))
+	assert.Empty(t, string(blocks[2].CacheControl.Type))
+}
+
 func TestExtractSystemBlocks_EmptyContentWithCacheControl(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/model/provider/anthropic/tool_deferrals_test.go
+++ b/pkg/model/provider/anthropic/tool_deferrals_test.go
@@ -106,11 +106,14 @@ func TestDeferredToolsKeepSingleMessageCacheBreakpoint(t *testing.T) {
 }
 
 // Anthropic rejects requests with more than 4 cache_control blocks. Build the
-// worst-case request (2 system breakpoints from the session, deferred tools,
-// long conversation) and count breakpoints across system + tools + messages.
+// worst-case request (MORE system marks than the budget allows, deferred
+// tools, long conversation) and count breakpoints across system + tools +
+// messages. Without the provider-side cap, three session marks plus the
+// message-tail breakpoints would exceed the limit.
 func TestRequestStaysWithinCacheBreakpointLimit(t *testing.T) {
 	messages := []chat.Message{
 		{Role: chat.MessageRoleSystem, Content: "invariant instructions", CacheControl: true},
+		{Role: chat.MessageRoleSystem, Content: "instruction context", CacheControl: true},
 		{Role: chat.MessageRoleSystem, Content: "dynamic context", CacheControl: true},
 		{Role: chat.MessageRoleUser, Content: "first"},
 		{Role: chat.MessageRoleAssistant, Content: "second"},

--- a/pkg/runtime/compactor/compactor.go
+++ b/pkg/runtime/compactor/compactor.go
@@ -251,40 +251,8 @@ func RunLLM(ctx context.Context, args LLMArgs) (result *Result, err error) {
 // a hook supplies its own summary so the kept-tail policy stays
 // consistent across the two strategies.
 func ComputeFirstKeptEntry(sess *session.Session, contextLimit int64) int {
-	messages, sessIndices, itemCount := gatherCompactionInput(sess)
+	messages, sessIndices, itemCount := sess.CompactionInput()
 	return firstKeptSessionIndex(sessIndices, itemCount, compaction.SplitIndexForKeep(messages, keepTokenBudget(contextLimit)))
-}
-
-// gatherCompactionInput is a thin wrapper around
-// [session.Session.CompactionInput] that clears compaction-specific
-// fields on the returned chat messages.
-//
-// Cost is per-message bookkeeping already accumulated into
-// sess.TotalCost(); leaving it set would double-count when the
-// summarization session reports its own TotalCost back through
-// [Result.Cost]. CacheControl pins a provider cache checkpoint
-// (Anthropic prompt caching, etc.); pinning it inside the
-// summarization sub-call would associate the cache point with the
-// throwaway compaction conversation rather than the parent session.
-//
-// The reconstruction work — surfacing a synthetic "Session Summary"
-// message when a prior summary exists, picking the right start index
-// past the prior summary, and tracking origin indices in sess.Messages
-// — lives on Session itself so it can run under sess.mu.RLock and stay
-// race-safe against concurrent AddMessage / ApplyCompaction calls.
-//
-// The returned itemCount is the SAME snapshot's total item count
-// (session.Session.CompactionInput's third return value); callers must use
-// it — not a fresh sess.ItemCount() call — for any out-of-range sentinel
-// derived from messages/sessIndices, or the boundary can describe a later
-// session length than the snapshot it is supposed to describe (#3590).
-func gatherCompactionInput(sess *session.Session) (messages []chat.Message, sessIndices []int, itemCount int) {
-	messages, sessIndices, itemCount = sess.CompactionInput()
-	for i := range messages {
-		messages[i].Cost = 0
-		messages[i].CacheControl = false
-	}
-	return messages, sessIndices, itemCount
 }
 
 // extractMessages returns the messages to send to the compaction
@@ -295,15 +263,15 @@ func gatherCompactionInput(sess *session.Session) (messages []chat.Message, sess
 //
 // The returned messages always begin with the canonical compaction
 // system prompt and end with the user prompt (optionally extended by
-// additionalPrompt). Cost / cache-control flags on the conversation
-// are cleared so the summarization request doesn't accidentally pin
-// a cache checkpoint or accrue duplicate cost.
+// additionalPrompt). [session.Session.CompactionInput] clears cost and
+// cache-control flags on the conversation so the summarization request
+// doesn't accidentally pin a cache checkpoint or accrue duplicate cost.
 //
 // If the conversation tail itself doesn't fit in
 // (contextLimit − summary budget − prompt-overhead), older messages
 // are dropped from the front of the to-compact list to make room.
 func extractMessages(sess *session.Session, _ *agent.Agent, contextLimit int64, additionalPrompt string) ([]chat.Message, int) {
-	messages, sessIndices, itemCount := gatherCompactionInput(sess)
+	messages, sessIndices, itemCount := sess.CompactionInput()
 
 	splitIdx := compaction.SplitIndexForKeep(messages, keepTokenBudget(contextLimit))
 	firstKeptEntry := firstKeptSessionIndex(sessIndices, itemCount, splitIdx)
@@ -341,7 +309,7 @@ func extractMessages(sess *session.Session, _ *agent.Agent, contextLimit int64, 
 }
 
 // firstKeptSessionIndex translates a split index produced against the
-// chat-message list returned by [gatherCompactionInput] back to an
+// chat-message list returned by [session.Session.CompactionInput] back to an
 // index in sess.Messages, suitable for the new summary's
 // FirstKeptEntry. Out-of-range splits map to itemCount, matching the
 // "compact everything; keep nothing of the tail" sentinel that
@@ -349,7 +317,7 @@ func extractMessages(sess *session.Session, _ *agent.Agent, contextLimit int64, 
 // conversation loop.
 //
 // itemCount MUST come from the same [session.Session.CompactionInput]
-// snapshot as sessIndices (i.e. via gatherCompactionInput), not a fresh
+// snapshot as sessIndices (i.e. via CompactionInput), not a fresh
 // sess.ItemCount() call: the live session can already hold an append
 // that landed after the snapshot was taken, which would describe a
 // boundary the snapshot never had (#3590).

--- a/pkg/runtime/compactor/compactor_test.go
+++ b/pkg/runtime/compactor/compactor_test.go
@@ -285,7 +285,7 @@ func TestGatherCompactionInput_NoPriorSummary(t *testing.T) {
 		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "u2"}}),
 	}))
 
-	messages, sessIndices, itemCount := gatherCompactionInput(sess)
+	messages, sessIndices, itemCount := sess.CompactionInput()
 	require.Len(t, messages, 3)
 	assert.Equal(t, []int{1, 2, 4}, sessIndices)
 
@@ -333,7 +333,7 @@ func TestGatherCompactionInput_WithPriorSummary(t *testing.T) {
 	}
 	sess := session.New(session.WithMessages(items))
 
-	messages, sessIndices, itemCount := gatherCompactionInput(sess)
+	messages, sessIndices, itemCount := sess.CompactionInput()
 
 	// Expected filtered list:
 	//   [0]: synthetic Session Summary user message (origin: prior summary at idx 10)
@@ -395,14 +395,14 @@ func TestFirstKeptSessionIndex_SplitZeroOnEmptyInputUsesSafeSentinel(t *testing.
 
 // TestGatherCompactionInputConcurrent extends session's own
 // TestCompactionInputConcurrent (pkg/session/session_race_test.go) to the
-// compactor's own boundary computation: gatherCompactionInput plus
+// compactor's own boundary computation: session.CompactionInput plus
 // firstKeptSessionIndex must stay race-free when called concurrently with
 // AddMessage on the same live session. firstKeptSessionIndex itself no
 // longer touches the session (it now takes the snapshot's own itemCount
 // instead of calling sess.ItemCount() — see
 // TestGatherCompactionInput_OutOfRangeSentinelMatchesSnapshotCount below for
 // why), so the only thing left to prove race-free here is
-// gatherCompactionInput's snapshot read itself.
+// CompactionInput's snapshot read itself.
 func TestGatherCompactionInputConcurrent(t *testing.T) {
 	t.Parallel()
 
@@ -413,7 +413,7 @@ func TestGatherCompactionInputConcurrent(t *testing.T) {
 			sess.AddMessage(session.UserMessage("u"))
 		})
 		wg.Go(func() {
-			_, sessIndices, itemCount := gatherCompactionInput(sess)
+			_, sessIndices, itemCount := sess.CompactionInput()
 			_ = firstKeptSessionIndex(sessIndices, itemCount, 0)
 		})
 	}
@@ -422,7 +422,7 @@ func TestGatherCompactionInputConcurrent(t *testing.T) {
 
 // TestGatherCompactionInput_OutOfRangeSentinelMatchesSnapshotCount pins the
 // other #3590 blocker: the out-of-range sentinel returned by
-// firstKeptSessionIndex must describe the SAME snapshot gatherCompactionInput
+// firstKeptSessionIndex must describe the SAME snapshot CompactionInput
 // produced sessIndices from, not whatever sess.ItemCount() returns when read
 // later. A reviewer probe demonstrated the bug directly: the sentinel
 // described a session length one longer (200001) than the snapshot it was
@@ -438,7 +438,7 @@ func TestGatherCompactionInput_OutOfRangeSentinelMatchesSnapshotCount(t *testing
 		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleAssistant, Content: "a1"}}),
 	}))
 
-	_, sessIndices, itemCount := gatherCompactionInput(sess)
+	_, sessIndices, itemCount := sess.CompactionInput()
 	snapshotCount := len(sess.Messages)
 	require.Equal(t, snapshotCount, itemCount)
 
@@ -475,7 +475,7 @@ func TestGatherCompactionInput_PriorSummaryWithoutFirstKeptEntry(t *testing.T) {
 	}
 	sess := session.New(session.WithMessages(items))
 
-	messages, sessIndices, _ := gatherCompactionInput(sess)
+	messages, sessIndices, _ := sess.CompactionInput()
 
 	// Filtered list: synthetic-summary, items[3], items[4].
 	// items[0..1] are excluded because they were compacted into the

--- a/pkg/runtime/compactor/scenarios_test.go
+++ b/pkg/runtime/compactor/scenarios_test.go
@@ -38,7 +38,7 @@ func TestScenario_SecondRoundCompaction_PartitionIsExact(t *testing.T) {
 	}
 	sess := session.New(session.WithMessages(items))
 
-	messages, sessIndices, _ := gatherCompactionInput(sess)
+	messages, sessIndices, _ := sess.CompactionInput()
 	// synthetic summary(->4), m2(->2), m3(->3), m5..m8(->5..8)
 	require.Equal(t, []int{4, 2, 3, 5, 6, 7, 8}, sessIndices)
 	require.Contains(t, messages[0].Content, "Session Summary: old summary")
@@ -54,7 +54,7 @@ func TestScenario_SecondRoundCompaction_PartitionIsExact(t *testing.T) {
 
 	// Reconstruct what the next prompt will contain via a third
 	// CompactionInput round (mirrors buildSessionSummaryMessages).
-	after, afterIdx, _ := gatherCompactionInput(sess)
+	after, afterIdx, _ := sess.CompactionInput()
 	require.Contains(t, after[0].Content, "Session Summary: new summary")
 
 	// Every original message must be either folded (index < firstKept in
@@ -112,7 +112,7 @@ func TestScenario_MessagesAppendedDuringCompactionAreKept(t *testing.T) {
 	sess.AddMessage(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "raced steer"}})
 	sess.ApplyCompaction(10, 0, session.Item{Summary: "sum", FirstKeptEntry: firstKept})
 
-	msgs, _, _ := gatherCompactionInput(sess)
+	msgs, _, _ := sess.CompactionInput()
 	require.Len(t, msgs, 2, "summary + raced message")
 	assert.Contains(t, msgs[0].Content, "Session Summary: sum")
 	assert.Equal(t, "raced steer", msgs[1].Content, "the raced message must be preserved verbatim")

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -667,6 +667,11 @@ func (s *Session) AddMessage(msg *Message) int {
 	defer s.mu.Unlock()
 	if msg != nil {
 		capToolResultContent(&msg.Message, s.MaxToolResultTokens)
+		// Transcripts never carry cache checkpoint marks: CacheControl is
+		// request-assembly state (see chat.Message.CacheControl); a mark
+		// slipping in here (e.g. echoed back by an API client) would
+		// resurface on every future prompt assembly.
+		msg.Message.CacheControl = false
 	}
 	s.Messages = append(s.Messages, NewMessageItem(msg))
 	return len(s.Messages) - 1
@@ -1749,12 +1754,12 @@ func (s *Session) CompactionInput() ([]chat.Message, []int, int) {
 		if msg.Role == chat.MessageRoleSystem {
 			continue
 		}
-		// Clear per-request bookkeeping on the copy: Cost is already
-		// accumulated into TotalCost and would double-count through the
-		// summarization session's Result.Cost; CacheControl marks would
-		// pin a provider cache checkpoint on the throwaway summarization
-		// request instead of the parent session (marks can enter stored
-		// items via legacy persisted rows or API-supplied messages).
+		// Clear per-request bookkeeping on the copy: callers feed these
+		// messages into a new LLM request, so per-message Cost (already
+		// folded into the session totals) would double-count, and
+		// CacheControl marks (request-assembly state that legacy persisted
+		// rows may still carry) would pin a provider cache checkpoint on
+		// the wrong request.
 		msg.Cost = 0
 		msg.CacheControl = false
 		messages = append(messages, msg)

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1749,6 +1749,14 @@ func (s *Session) CompactionInput() ([]chat.Message, []int, int) {
 		if msg.Role == chat.MessageRoleSystem {
 			continue
 		}
+		// Clear per-request bookkeeping on the copy: Cost is already
+		// accumulated into TotalCost and would double-count through the
+		// summarization session's Result.Cost; CacheControl marks would
+		// pin a provider cache checkpoint on the throwaway summarization
+		// request instead of the parent session (marks can enter stored
+		// items via legacy persisted rows or API-supplied messages).
+		msg.Cost = 0
+		msg.CacheControl = false
 		messages = append(messages, msg)
 		sessIndices = append(sessIndices, i)
 	}

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -224,6 +224,22 @@ func TestGetMessages_Instructions(t *testing.T) {
 	assert.True(t, messages[0].CacheControl)
 }
 
+func TestAddMessage_StripsCacheControl(t *testing.T) {
+	t.Parallel()
+
+	// CacheControl is request-assembly state; transcripts must never
+	// carry it (e.g. a mark echoed back by an API client), or it would
+	// resurface on every future prompt assembly.
+	s := New()
+	s.AddMessage(&Message{Message: chat.Message{
+		Role:         chat.MessageRoleUser,
+		Content:      "hello",
+		CacheControl: true,
+	}})
+
+	assert.False(t, s.Messages[0].Message.Message.CacheControl)
+}
+
 func TestGetMessages_CacheControl(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`chat.Message.CacheControl` (Anthropic prompt-cache checkpoints) was handled in seven places with implicit cross-layer contracts, which had already produced two production bugs: markers surviving compaction and exceeding Anthropic's 4-breakpoint limit, and a panic in `extractSystemBlocks` on empty flagged messages. This PR consolidates the handling to three logical owners and makes the known failure modes structurally impossible.

On the deduplication side, the two hand-rolled 5-case cache-control switches are replaced with the SDK's `GetCacheControl` union accessor (verified to cover every block kind the converters produce, on both standard and Beta unions — this test already caught a regression when `anthropic-sdk-go` v1.57→v1.58 landed on main mid-branch). The shared message-breakpoint budget helper is extracted, and the entire mechanism — budget ledger, system-block marking, message-tail breakpoints, system-block extraction — is consolidated into `pkg/model/provider/anthropic/cache_control.go`.

On the robustness side, system cache breakpoints are now capped so a request can never exceed Anthropic's 4-breakpoint limit regardless of upstream marks; excess marks are dropped and debug-logged, and the worst case is pinned by test. `session.CompactionInput` clears `Cost`/`CacheControl` on its own copies, removing the compactor's mirrored clearing loops. `session.AddMessage` strips `CacheControl` at ingestion, enforcing the documented contract that transcripts never carry marks — guarding against API clients that echo marks back. `chat.Message.CacheControl` now documents its full contract, including why the field must stay JSON-serialized (marks must survive `before_llm_call` hook rewrite round-trips; out-of-band boundary indices would be silently misplaced by hook message inserts/deletes).

Behavior changes only affect inputs that previously caused API rejections or panics. All other paths are byte-identical, confirmed by e2e cassette replay.