### PR TITLE
feat(tui): show usage details per agent

### DIFF
--- a/pkg/tui/components/sidebar/agent_click_test.go
+++ b/pkg/tui/components/sidebar/agent_click_test.go
@@ -80,6 +80,7 @@ func TestSidebar_AgentClickZones_EveryRenderedLineMapped(t *testing.T) {
 	}
 	m.width = 40
 	m.height = 50
+	m.SetAgentInfoMode(AgentInfoDetailed)
 
 	_ = sb.View()
 

--- a/pkg/tui/components/sidebar/agent_click_test.go
+++ b/pkg/tui/components/sidebar/agent_click_test.go
@@ -92,10 +92,10 @@ func TestSidebar_AgentClickZones_EveryRenderedLineMapped(t *testing.T) {
 	}
 	assert.Positive(t, counts["agent1"], "agent1 should own rendered lines")
 	assert.Positive(t, counts["agent2"], "agent2 should own rendered lines")
-	// agent2 is a non-current roster agent: its entry spans two lines (name+badge
-	// then the indented model), and BOTH must map to it so a click on either
-	// switches to the agent.
-	assert.Equal(t, 2, counts["agent2"], "a roster agent owns both of its two entry lines")
+	// agent2 is a non-current roster agent: its mini-card spans the name line,
+	// the model line and two metric lines at this width, and ALL of them must
+	// map to it so a click on any card line switches to the agent.
+	assert.Equal(t, 4, counts["agent2"], "a roster agent owns every line of its card")
 
 	// The number of click zones equals the number of owned (non-blank) lines:
 	// every owned line is clickable.

--- a/pkg/tui/components/sidebar/agent_context_test.go
+++ b/pkg/tui/components/sidebar/agent_context_test.go
@@ -25,9 +25,9 @@ func recordAgentUsage(m *model, sessionID, agentName string, contextLen, context
 	})
 }
 
-// TestAgentRosterShowsPerAgentContextPercent verifies line 2 of each roster
-// entry carries the agent's own context percentage, right-aligned, once that
-// agent has emitted usage — and stays bare for agents that have not run.
+// TestAgentRosterShowsPerAgentContextPercent verifies each card's metric line
+// carries the agent's own labeled context percentage once that agent has
+// emitted usage — and an explicit "—" for agents that have not run.
 func TestAgentRosterShowsPerAgentContextPercent(t *testing.T) {
 	t.Parallel()
 
@@ -40,17 +40,17 @@ func TestAgentRosterShowsPerAgentContextPercent(t *testing.T) {
 	recordAgentUsage(m, "session-root", "root", 30_000, 100_000)
 	recordAgentUsage(m, "session-child", "developer", 42_000, 100_000)
 
+	assert.Contains(t, agentMetrics(m, "root"), "Context 30%",
+		"root's card shows its own labeled context percent")
 	_, rootLine2 := agentLines(m, "root")
-	assert.True(t, strings.HasSuffix(strings.TrimRight(rootLine2, " "), "30%"),
-		"root's line 2 ends with its context percent, got %q", rootLine2)
 	assert.Contains(t, rootLine2, "anthropic/opus", "model text stays on line 2")
 
-	_, devLine2 := agentLines(m, "developer")
-	assert.True(t, strings.HasSuffix(strings.TrimRight(devLine2, " "), "42%"),
-		"developer's line 2 ends with its context percent, got %q", devLine2)
+	assert.Contains(t, agentMetrics(m, "developer"), "Context 42%",
+		"developer's card shows its own labeled context percent")
 
-	_, idleLine2 := agentLines(m, "idle")
-	assert.NotContains(t, idleLine2, "%", "agents that never ran show no percent")
+	idleMetrics := agentMetrics(m, "idle")
+	assert.Contains(t, idleMetrics, "Context —", "agents that never ran show an explicit —")
+	assert.NotContains(t, idleMetrics, "%", "agents that never ran show no percent")
 }
 
 // TestAgentContextPercent_LatestSnapshotWins verifies a fresh delegation to the
@@ -71,7 +71,7 @@ func TestAgentContextPercent_LatestSnapshotWins(t *testing.T) {
 
 // TestAgentContextPercent_UnknownLimit verifies no percent is shown when the
 // context limit is unknown (e.g. harness-backed agents) or nothing was
-// recorded for the agent.
+// recorded for the agent — the card shows an explicit "—" instead.
 func TestAgentContextPercent_UnknownLimit(t *testing.T) {
 	t.Parallel()
 
@@ -84,8 +84,9 @@ func TestAgentContextPercent_UnknownLimit(t *testing.T) {
 	recordAgentUsage(m, "session-1", "root", 30_000, 0)
 	assert.Empty(t, m.agentContextPercent("root"), "no percent without a context limit")
 
-	_, line2 := agentLines(m, "root")
-	assert.NotContains(t, line2, "%")
+	metrics := agentMetrics(m, "root")
+	assert.Contains(t, metrics, "Context —", "unknown context reads —, not a blank")
+	assert.NotContains(t, metrics, "%")
 }
 
 // TestAgentContextPercent_BackgroundAgentUsage verifies a usage event from a
@@ -106,29 +107,33 @@ func TestAgentContextPercent_BackgroundAgentUsage(t *testing.T) {
 	recordAgentUsage(m, "session-root", "root", 20_000, 100_000)
 	recordAgentUsage(m, "bg-session", "worker", 55_000, 100_000)
 
-	_, workerLine2 := agentLines(m, "worker")
-	assert.True(t, strings.HasSuffix(strings.TrimRight(workerLine2, " "), "55%"),
-		"background worker's line 2 ends with its context percent, got %q", workerLine2)
+	assert.Contains(t, agentMetrics(m, "worker"), "Context 55%",
+		"background worker's card shows its own context percent")
 
 	assert.Equal(t, "20%", m.contextPercent(),
 		"the main context gauge keeps tracking the active session, not the background one")
 }
 
-// TestAgentRosterLine2ReservesRoomForPercent verifies the model text yields
-// space to the percent instead of colliding with it at narrow widths.
-func TestAgentRosterLine2ReservesRoomForPercent(t *testing.T) {
+// TestAgentCardMetricLinesFitNarrowWidth verifies the labeled metrics wrap
+// into lines that never exceed the content width at the minimum sidebar
+// width, instead of colliding with or truncating one another.
+func TestAgentCardMetricLinesFitNarrowWidth(t *testing.T) {
 	t.Parallel()
 
-	m := newAgentPanelSidebar(t, 28,
-		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "claude-sonnet-4-6"},
+	m := newAgentPanelSidebar(t, MinWidth,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "claude-sonnet-4-6", Thinking: "high"},
 	)
 	recordAgentUsage(m, "session-1", "root", 100_000, 100_000)
 
-	_, line2 := agentLines(m, "root")
-	require.NotEmpty(t, line2)
-	trimmed := strings.TrimRight(line2, " ")
-	assert.True(t, strings.HasSuffix(trimmed, " 100%"),
-		"percent stays separated from the truncated model, got %q", line2)
-	assert.Contains(t, line2, "…", "overflowing model is still left-truncated")
-	assert.Contains(t, line2, "-4-6", "informative model tail survives")
+	contentWidth := m.contentWidth(false)
+	card := agentCard(m, "root")
+	require.NotEmpty(t, card)
+	for _, line := range card {
+		assert.LessOrEqualf(t, len([]rune(line)), contentWidth,
+			"card line must fit the content width: %q", line)
+	}
+
+	metrics := strings.Join(card[2:], "\n")
+	assert.Contains(t, metrics, gaugePattern(4), "the full six-cell gauge survives the minimum width")
+	assert.Contains(t, metrics, "Ctx 100%", "the compact context label keeps its percent")
 }

--- a/pkg/tui/components/sidebar/agent_cost_test.go
+++ b/pkg/tui/components/sidebar/agent_cost_test.go
@@ -1,0 +1,360 @@
+package sidebar
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+// recordAgentUsageWithCost feeds a TokenUsageEvent carrying a cumulative cost
+// snapshot through the sidebar's normal entry point.
+func recordAgentUsageWithCost(m *model, sessionID, agentName string, contextLen, contextLimit int64, cost float64) {
+	m.SetTokenUsage(&runtime.TokenUsageEvent{
+		SessionID:    sessionID,
+		AgentContext: runtime.AgentContext{AgentName: agentName},
+		Usage: &runtime.Usage{
+			InputTokens:   contextLen / 2,
+			OutputTokens:  contextLen - contextLen/2,
+			ContextLength: contextLen,
+			ContextLimit:  contextLimit,
+			Cost:          cost,
+		},
+	})
+}
+
+// restoredItem returns a persisted assistant-message item: agent name,
+// per-message cost, and its usage record (present even at zero cost, as the
+// runtime persists one for every assistant response).
+func restoredItem(agentName string, cost float64) session.Item {
+	return session.Item{Message: &session.Message{
+		AgentName: agentName,
+		Message: chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: "done",
+			Cost:    cost,
+			Usage:   &chat.Usage{InputTokens: 1000, OutputTokens: 200},
+		},
+	}}
+}
+
+// TestAgentCardShowsPerAgentCost verifies each card carries the agent's own
+// labeled cumulative cost: repeated cumulative snapshots of one session
+// replace rather than add, distinct sessions (sub-sessions, background tasks)
+// add, an agent that ran at zero cost reads $0.00, and an agent that never
+// ran reads an explicit —.
+func TestAgentCardShowsPerAgentCost(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus", Thinking: "high"},
+		runtime.AgentDetails{Name: "worker", Provider: "openai", Model: "gpt-5.4"},
+		runtime.AgentDetails{Name: "idle", Provider: "openai", Model: "gpt-4o"},
+	)
+
+	// Two cumulative snapshots of the same session, then a second session.
+	recordAgentUsageWithCost(m, "session-1", "root", 10_000, 100_000, 0.10)
+	recordAgentUsageWithCost(m, "session-1", "root", 30_000, 100_000, 0.30)
+	recordAgentUsageWithCost(m, "session-2", "root", 5_000, 100_000, 0.05)
+
+	// A background worker that ran for free.
+	recordAgentUsageWithCost(m, "bg-session", "worker", 8_000, 100_000, 0)
+
+	rootMetrics := agentMetrics(m, "root")
+	assert.Contains(t, rootMetrics, "Cost $0.35",
+		"same-session snapshots replace, distinct sessions add: got %q", rootMetrics)
+
+	assert.Contains(t, agentMetrics(m, "worker"), "Cost $0.00",
+		"an agent that ran at zero cost reads $0.00, not —")
+
+	idleMetrics := agentMetrics(m, "idle")
+	assert.Contains(t, idleMetrics, "Cost —", "an agent that never ran reads —")
+	assert.NotContains(t, idleMetrics, "$", "an agent that never ran shows no dollar amount")
+}
+
+// TestAgentCardCostPrecision verifies the card uses the shared precise cost
+// formatting: four decimals for non-zero amounts below one cent, two decimals
+// at or above.
+func TestAgentCardCostPrecision(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus"},
+		runtime.AgentDetails{Name: "cheap", Provider: "openai", Model: "gpt-5.4-mini"},
+	)
+
+	recordAgentUsageWithCost(m, "session-root", "root", 30_000, 100_000, 0.1284)
+	recordAgentUsageWithCost(m, "session-cheap", "cheap", 2_000, 100_000, 0.0042)
+
+	assert.Contains(t, agentMetrics(m, "root"), "Cost $0.13")
+	assert.Contains(t, agentMetrics(m, "cheap"), "Cost $0.0042")
+}
+
+// TestAgentCardCostRestoredFromSession verifies costs reconstructed from a
+// restored session tree appear on the cards immediately: every agent that
+// left per-message records — including in nested sub-sessions — shows its
+// exact historical spend, a zero-cost run stays distinct from never-ran,
+// unattributed compaction spend appears on no card but stays in the
+// aggregate total, and per-agent context remains unknown rather than
+// fabricated.
+func TestAgentCardCostRestoredFromSession(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus"},
+		runtime.AgentDetails{Name: "developer", Provider: "openai", Model: "gpt-5.4"},
+		runtime.AgentDetails{Name: "writer", Provider: "google", Model: "gemini-flash"},
+		runtime.AgentDetails{Name: "local", Provider: "dmr", Model: "llama3.2"},
+		runtime.AgentDetails{Name: "idle", Provider: "openai", Model: "gpt-4o"},
+	)
+
+	// root ($0.10), a zero-cost local run and a compaction summary ($0.01) in
+	// the root session; developer ($0.05) in a sub-session holding a nested
+	// sub-sub-session for writer ($0.02).
+	sess := session.New()
+	sess.Messages = append(sess.Messages,
+		restoredItem("root", 0.10),
+		restoredItem("local", 0),
+		session.Item{Summary: "compacted", Cost: 0.01},
+	)
+	subSub := session.New()
+	subSub.Messages = append(subSub.Messages, restoredItem("writer", 0.02))
+	sub := session.New(session.WithParentID(sess.ID))
+	sub.Messages = append(sub.Messages, restoredItem("developer", 0.05), session.Item{SubSession: subSub})
+	sess.Messages = append(sess.Messages, session.Item{SubSession: sub})
+
+	m.LoadFromSession(sess)
+
+	assert.Contains(t, agentMetrics(m, "root"), "Cost $0.10")
+	assert.Contains(t, agentMetrics(m, "developer"), "Cost $0.05", "sub-session spend shows on its agent")
+	assert.Contains(t, agentMetrics(m, "writer"), "Cost $0.02", "nested sub-sub-session spend shows too")
+	assert.Contains(t, agentMetrics(m, "local"), "Cost $0.00", "a restored zero-cost run reads $0.00")
+	idle := agentMetrics(m, "idle")
+	assert.Contains(t, idle, "Cost —", "an agent absent from the restored tree reads —")
+	assert.NotContains(t, idle, "$")
+
+	for _, name := range []string{"root", "developer", "writer", "local", "idle"} {
+		assert.Containsf(t, agentMetrics(m, name), "Context —",
+			"restored context is unknown for %q, never fabricated", name)
+	}
+
+	assert.InDelta(t, 0.18, m.computeUsageStats().totalCost, 1e-9,
+		"the aggregate keeps the unattributed compaction spend no card shows")
+}
+
+// TestAgentCardCostRestoredThenLive verifies restored totals and live
+// cumulative snapshots coexist without double counting: the resumed root
+// session's snapshots cover the whole restored tree, so its agent gains only
+// the new spend, while a fresh live sub-session adds in full.
+func TestAgentCardCostRestoredThenLive(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus"},
+		runtime.AgentDetails{Name: "developer", Provider: "openai", Model: "gpt-5.4"},
+	)
+
+	// Restored: root $0.10 + developer sub-session $0.05 + compaction $0.01.
+	sess := session.New()
+	sess.Messages = append(sess.Messages,
+		restoredItem("root", 0.10),
+		session.Item{Summary: "compacted", Cost: 0.01},
+	)
+	sub := session.New(session.WithParentID(sess.ID))
+	sub.Messages = append(sub.Messages, restoredItem("developer", 0.05))
+	sess.Messages = append(sess.Messages, session.Item{SubSession: sub})
+	m.LoadFromSession(sess)
+
+	// The root session resumes and spends $0.02 more: its live snapshot is
+	// cumulative over the restored tree ($0.16) plus the new spend.
+	recordAgentUsageWithCost(m, sess.ID, "root", 40_000, 100_000, 0.18)
+	assert.Contains(t, agentMetrics(m, "root"), "Cost $0.12",
+		"restored total plus only the spend beyond the restored baseline")
+	assert.Contains(t, agentMetrics(m, "developer"), "Cost $0.05",
+		"restored sub-session spend keeps its agent")
+	assert.InDelta(t, 0.18, m.computeUsageStats().totalCost, 1e-9)
+
+	// A fresh delegation runs in a new sub-session: new spend in full.
+	recordAgentUsageWithCost(m, "live-sub", "developer", 8_000, 200_000, 0.03)
+	assert.Contains(t, agentMetrics(m, "developer"), "Cost $0.08")
+	assert.InDelta(t, 0.21, m.computeUsageStats().totalCost, 1e-9)
+}
+
+// TestAgentCardCostRepeatedRestoreAndSwitch verifies the replace semantics of
+// LoadFromSession: a repeated load of the same session doubles nothing, and
+// loading a different session drops every trace of the previous one — cards
+// and aggregate alike.
+func TestAgentCardCostRepeatedRestoreAndSwitch(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus"},
+		runtime.AgentDetails{Name: "developer", Provider: "openai", Model: "gpt-5.4"},
+	)
+
+	first := session.New()
+	first.Messages = append(first.Messages, restoredItem("root", 0.10))
+	sub := session.New(session.WithParentID(first.ID))
+	sub.Messages = append(sub.Messages, restoredItem("developer", 0.05))
+	first.Messages = append(first.Messages, session.Item{SubSession: sub})
+
+	m.LoadFromSession(first)
+	m.LoadFromSession(first)
+	assert.Contains(t, agentMetrics(m, "root"), "Cost $0.10", "no doubling on repeated load")
+	assert.Contains(t, agentMetrics(m, "developer"), "Cost $0.05")
+	assert.InDelta(t, 0.15, m.computeUsageStats().totalCost, 1e-9, "aggregate not doubled either")
+
+	// Switching to another session leaves nothing of the first behind.
+	second := session.New()
+	second.Messages = append(second.Messages, restoredItem("root", 0.04))
+	m.LoadFromSession(second)
+	assert.Contains(t, agentMetrics(m, "root"), "Cost $0.04")
+	developer := agentMetrics(m, "developer")
+	assert.Contains(t, developer, "Cost —", "the previous session's spend is gone")
+	assert.NotContains(t, developer, "$")
+	assert.InDelta(t, 0.04, m.computeUsageStats().totalCost, 1e-9)
+}
+
+// TestAgentCardSingleMetricsLineAtWideWidth verifies all three labeled
+// metrics share one line when the sidebar is wide enough to hold them — the
+// design's ideal three-line card.
+func TestAgentCardSingleMetricsLineAtWideWidth(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 56,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "claude-opus-4-8", Thinking: "high"},
+	)
+	recordAgentUsageWithCost(m, "session-root", "root", 30_000, 100_000, 0.1284)
+
+	card := agentCard(m, "root")
+	require.Len(t, card, 3, "name, model and one combined metrics line")
+	assert.Equal(t, "Effort "+gaugePattern(4)+" high · Context 30% · Cost $0.13",
+		strings.TrimSpace(card[2]))
+}
+
+// previewSidebar builds the deterministic three-agent roster used by the
+// exact-output preview tests: the current agent with usage, a zero-effort
+// agent with sub-cent usage, and an agent that never ran.
+func previewSidebar(t *testing.T, width int) *model {
+	t.Helper()
+	m := newAgentPanelSidebar(t, width,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "claude-opus-4-8", Thinking: "high"},
+		runtime.AgentDetails{Name: "scout", Provider: "openai", Model: "gpt-5.4-mini", Thinking: "off"},
+		runtime.AgentDetails{Name: "writer", Provider: "google", Model: "gemini-flash"},
+	)
+	recordAgentUsageWithCost(m, "session-root", "root", 30_000, 100_000, 0.1284)
+	recordAgentUsageWithCost(m, "session-scout", "scout", 12_000, 200_000, 0.0042)
+	return m
+}
+
+// previewLines renders the Agents panel and strips the trailing-space padding
+// the tab body adds to every line, leaving the visible content for exact
+// comparison.
+func previewLines(m *model) []string {
+	lines := renderAgentPanel(m)
+	out := make([]string, len(lines))
+	for i, l := range lines {
+		out[i] = strings.TrimRight(l, " ")
+	}
+	return out
+}
+
+// TestAgentCardPreview_DefaultWidth pins the exact ANSI-stripped Agents panel
+// at the default sidebar width (40 → 39 content columns). It doubles as the
+// visual reference for the mini-card design.
+func TestAgentCardPreview_DefaultWidth(t *testing.T) {
+	t.Parallel()
+
+	m := previewSidebar(t, DefaultWidth)
+	got := previewLines(m)
+
+	want := []string{
+		"Agents ────────────────────────────────",
+		"",
+		"▶ root                               ^1",
+		"  anthropic/claude-opus-4-8",
+		"  Effort ▰▰▰▰▱▱ high",
+		"  Context 30% · Cost $0.13",
+		"",
+		"  scout                              ^2",
+		"  openai/gpt-5.4-mini",
+		"  Effort ▱▱▱▱▱▱ off",
+		"  Context 6% · Cost $0.0042",
+		"",
+		"  writer                             ^3",
+		"  google/gemini-flash",
+		"  Context — · Cost —",
+	}
+	require.Equal(t, want, got, "default-width preview changed:\n%s", strings.Join(got, "\n"))
+}
+
+// TestAgentCardPreview_MinWidth pins the exact ANSI-stripped Agents panel at
+// the minimum sidebar width (20 → 19 content columns): the full six-cell
+// effort gauge survives on its dedicated line (dropping only the value word
+// when it does not fit) and the context label compacts to "Ctx".
+func TestAgentCardPreview_MinWidth(t *testing.T) {
+	t.Parallel()
+
+	m := previewSidebar(t, MinWidth)
+	got := previewLines(m)
+
+	want := []string{
+		"Agents ────────────",
+		"",
+		"▶ root           ^1",
+		"  …/claude-opus-4-8",
+		"  Effort ▰▰▰▰▱▱",
+		"  Ctx 30%",
+		"  Cost $0.13",
+		"",
+		"  scout          ^2",
+		"  …nai/gpt-5.4-mini",
+		"  Effort ▱▱▱▱▱▱ off",
+		"  Ctx 6%",
+		"  Cost $0.0042",
+		"",
+		"  writer         ^3",
+		"  …gle/gemini-flash",
+		"  Ctx — · Cost —",
+	}
+	require.Equal(t, want, got, "min-width preview changed:\n%s", strings.Join(got, "\n"))
+}
+
+// TestAgentCardPreviewLineInvariants guards the layout invariants behind the
+// pinned previews at both reference widths: every rendered line fits the
+// content width and each card carries exactly one provider/model line.
+func TestAgentCardPreviewLineInvariants(t *testing.T) {
+	t.Parallel()
+
+	// Informative model-name tails: they survive the left-truncation of the
+	// model line at narrow widths and appear on no other card line.
+	modelTails := map[string]string{
+		"root":   "claude-opus-4-8",
+		"scout":  "gpt-5.4-mini",
+		"writer": "gemini-flash",
+	}
+	for _, width := range []int{DefaultWidth, MinWidth} {
+		m := previewSidebar(t, width)
+		contentWidth := m.contentWidth(false)
+		for _, line := range previewLines(m) {
+			assert.LessOrEqualf(t, lipgloss.Width(line), contentWidth,
+				"width %d: line %q must fit the content width", width, line)
+		}
+		for name, tail := range modelTails {
+			modelLines := 0
+			for _, line := range agentCard(m, name) {
+				if strings.Contains(line, tail) {
+					modelLines++
+				}
+			}
+			assert.Equalf(t, 1, modelLines,
+				"width %d: card %q must contain exactly one model line", width, name)
+		}
+	}
+}

--- a/pkg/tui/components/sidebar/agent_info_mode_test.go
+++ b/pkg/tui/components/sidebar/agent_info_mode_test.go
@@ -1,0 +1,331 @@
+package sidebar
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tui/service"
+	"github.com/docker/docker-agent/pkg/tui/styles"
+)
+
+// newCompactPanelSidebar builds a sidebar like newAgentPanelSidebar but keeps
+// the default (zero-value) agent info mode: the compact two-line roster.
+func newCompactPanelSidebar(t *testing.T, width int, agents ...runtime.AgentDetails) *model {
+	t.Helper()
+	sess := session.New()
+	ss := service.NewSessionState(sess)
+	ss.SetCurrentAgentName("root")
+	m := New(t.Context(), ss).(*model)
+	m.sessionHasContent = true
+	m.titleGenerated = true
+	m.sessionTitle = "Test"
+	m.currentAgent = "root"
+	m.availableAgents = agents
+	m.width = width
+	m.height = 200
+	t.Cleanup(m.transferAnimation.Stop)
+	return m
+}
+
+// infoModeFixtureRoster is the fixed roster used by the exact-output tests:
+// an effort level, a disabled thinking config, a token budget, and a model
+// with no thinking configuration.
+func infoModeFixtureRoster() []runtime.AgentDetails {
+	return []runtime.AgentDetails{
+		{Name: "root", Provider: "anthropic", Model: "claude-opus-4-8", Thinking: "high"},
+		{Name: "helper", Provider: "openai", Model: "gpt-5.4-mini", Thinking: "off"},
+		{Name: "budget", Provider: "openai", Model: "gpt-4o", Thinking: "8192"},
+		{Name: "plain", Provider: "google", Model: "gemini-flash"},
+	}
+}
+
+// recordInfoModeFixtureUsage feeds usage for root (30%) and helper (91%) with
+// attributed costs; budget and plain never run.
+func recordInfoModeFixtureUsage(m *model) {
+	recordAgentUsageWithCost(m, "s-root", "root", 30_000, 100_000, 0.13)
+	recordAgentUsageWithCost(m, "s-helper", "helper", 91_000, 100_000, 0.02)
+}
+
+// trimmedAgentBody returns the ANSI-stripped panel body lines with trailing
+// padding removed, for exact-output comparisons.
+func trimmedAgentBody(m *model) []string {
+	body := agentBody(m)
+	trimmed := make([]string, len(body))
+	for i, line := range body {
+		trimmed[i] = strings.TrimRight(line, " ")
+	}
+	return trimmed
+}
+
+// TestAgentInfoModeExactOutputs pins the exact roster rendering of both info
+// modes at the default (40) and minimum (20) sidebar widths. The compact
+// lines reproduce the pre-card roster: two lines per agent, the thinking
+// badge right-aligned on line 1 (single-cell glyph near MinWidth), the bare
+// context percent right-aligned on line 2, and no cost display.
+func TestAgentInfoModeExactOutputs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		mode  AgentInfoMode
+		width int
+		want  []string
+	}{
+		{
+			name: "compact width 40", mode: AgentInfoCompact, width: 40,
+			want: []string{
+				"▶ root                        ▰▰▰▰▱▱ ^1",
+				"  anthropic/claude-opus-4-8         30%",
+				"",
+				"  helper                      ▱▱▱▱▱▱ ^2",
+				"  openai/gpt-5.4-mini               91%",
+				"",
+				"  budget                      ◉ 8.2K ^3",
+				"  openai/gpt-4o",
+				"",
+				"  plain                              ^4",
+				"  google/gemini-flash",
+			},
+		},
+		{
+			name: "compact width 20", mode: AgentInfoCompact, width: 20,
+			want: []string{
+				"▶ root         ▰ ^1",
+				"  …ude-opus-4-8 30%",
+				"",
+				"  helper       ▱ ^2",
+				"  …gpt-5.4-mini 91%",
+				"",
+				"  budget       ◉ ^3",
+				"  openai/gpt-4o",
+				"",
+				"  plain          ^4",
+				"  …gle/gemini-flash",
+			},
+		},
+		{
+			name: "detailed width 40", mode: AgentInfoDetailed, width: 40,
+			want: []string{
+				"▶ root                               ^1",
+				"  anthropic/claude-opus-4-8",
+				"  Effort ▰▰▰▰▱▱ high",
+				"  Context 30% · Cost $0.13",
+				"",
+				"  helper                             ^2",
+				"  openai/gpt-5.4-mini",
+				"  Effort ▱▱▱▱▱▱ off",
+				"  Context 91% · Cost $0.02",
+				"",
+				"  budget                             ^3",
+				"  openai/gpt-4o",
+				"  Effort ◉ 8.2K · Context — · Cost —",
+				"",
+				"  plain                              ^4",
+				"  google/gemini-flash",
+				"  Context — · Cost —",
+			},
+		},
+		{
+			name: "detailed width 20", mode: AgentInfoDetailed, width: 20,
+			want: []string{
+				"▶ root           ^1",
+				"  …/claude-opus-4-8",
+				"  Effort ▰▰▰▰▱▱",
+				"  Ctx 30%",
+				"  Cost $0.13",
+				"",
+				"  helper         ^2",
+				"  …nai/gpt-5.4-mini",
+				"  Effort ▱▱▱▱▱▱ off",
+				"  Ctx 91%",
+				"  Cost $0.02",
+				"",
+				"  budget         ^3",
+				"  openai/gpt-4o",
+				"  Effort ◉ 8.2K",
+				"  Ctx — · Cost —",
+				"",
+				"  plain          ^4",
+				"  …gle/gemini-flash",
+				"  Ctx — · Cost —",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := newCompactPanelSidebar(t, tt.width, infoModeFixtureRoster()...)
+			m.SetAgentInfoMode(tt.mode)
+			recordInfoModeFixtureUsage(m)
+
+			assert.Equal(t, tt.want, trimmedAgentBody(m))
+		})
+	}
+}
+
+// TestCompactRosterIsDefault verifies the zero-value sidebar renders the
+// compact roster: two owned lines per agent and none of the detailed card's
+// labeled metrics.
+func TestCompactRosterIsDefault(t *testing.T) {
+	t.Parallel()
+
+	m := newCompactPanelSidebar(t, 40, infoModeFixtureRoster()...)
+	recordInfoModeFixtureUsage(m)
+
+	body := strings.Join(agentBody(m), "\n")
+	assert.NotContains(t, body, "Effort", "compact roster carries no labeled effort metric")
+	assert.NotContains(t, body, "Cost", "compact roster carries no cost display")
+	assert.NotContains(t, body, "Context", "compact roster shows the bare percent, not a label")
+	assert.Contains(t, body, "30%", "context percent still shows on the model line")
+
+	counts := map[string]int{}
+	for _, owner := range m.agentLineOwners {
+		if owner != "" {
+			counts[owner]++
+		}
+	}
+	for _, name := range []string{"root", "helper", "budget", "plain"} {
+		assert.Equalf(t, 2, counts[name], "compact agent %q owns exactly its two lines", name)
+	}
+}
+
+// TestCompactThinkingBadgeVocabularyOnLine verifies the compact roster's
+// thinking badge vocabulary renders on the agent's name line: effort levels
+// become the gauge, token budgets keep the token glyph, adaptive becomes
+// "auto", and off becomes an empty gauge.
+func TestCompactThinkingBadgeVocabularyOnLine(t *testing.T) {
+	t.Parallel()
+
+	m := newCompactPanelSidebar(t, 40,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus", Thinking: "high"},
+		runtime.AgentDetails{Name: "alpha", Provider: "openai", Model: "gpt-5.4-mini", Thinking: "off"},
+		runtime.AgentDetails{Name: "beta", Provider: "openai", Model: "gpt-5.4", Thinking: "high"},
+		runtime.AgentDetails{Name: "gamma", Provider: "openai", Model: "gpt-4o", Thinking: "8192"},
+		runtime.AgentDetails{Name: "delta", Provider: "google", Model: "gemini", Thinking: "adaptive"},
+	)
+
+	want := map[string]string{
+		"alpha": gaugePattern(0),
+		"beta":  gaugePattern(4),
+		"gamma": styles.TokenGlyph + " 8.2K",
+		"delta": "auto",
+	}
+	for name, badge := range want {
+		line1, _ := agentLines(m, name)
+		require.NotEmptyf(t, line1, "row for %q should render", name)
+		assert.Containsf(t, line1, badge, "row %q should show badge %q", name, badge)
+	}
+}
+
+// TestCompactNameTruncatesNearMinWidth verifies that at a narrow width the
+// compact roster collapses the gauge to a single cell while the model still
+// occupies line 2.
+func TestCompactNameTruncatesNearMinWidth(t *testing.T) {
+	t.Parallel()
+
+	m := newCompactPanelSidebar(t, 21,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus", Thinking: "high"},
+		runtime.AgentDetails{Name: "agent2", Provider: "anthropic", Model: "claude-sonnet-4-6", Thinking: "high"},
+	)
+
+	line1, line2 := agentLines(m, "agent2")
+	require.NotEmpty(t, line1)
+	// glyph-only step keeps a single filled gauge cell, not the full six-cell gauge.
+	assert.NotContains(t, line1, gaugePattern(4), "narrow layout collapses the full gauge")
+	assert.Contains(t, line1, styles.GaugeFilled, "narrow layout keeps a single gauge cell")
+	assert.Contains(t, line2, "…", "narrow layout left-truncates the model on line 2")
+}
+
+// TestCompactClickZonesEveryLine verifies both compact lines of every agent
+// resolve to that agent through the full View/click pipeline.
+func TestCompactClickZonesEveryLine(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	ss := service.NewSessionState(sess)
+	ss.SetCurrentAgentName("root")
+	sb := New(t.Context(), ss)
+	m := sb.(*model)
+	m.sessionHasContent = true
+	m.titleGenerated = true
+	m.sessionTitle = "Test"
+	m.currentAgent = "root"
+	m.availableAgents = []runtime.AgentDetails{
+		{Name: "first", Provider: "openai", Model: "gpt-5.4-mini", Thinking: "off"},
+		{Name: "root", Provider: "anthropic", Model: "claude-opus-4-8", Thinking: "high"},
+	}
+	m.width = 40
+	m.height = 200
+
+	_ = sb.View()
+
+	clicks := map[string]int{}
+	for y := range len(m.cachedLines) {
+		if result, name := sb.HandleClickType(m.layoutCfg.PaddingLeft+2, y); result == ClickAgent {
+			clicks[name]++
+		}
+	}
+	assert.Equal(t, 2, clicks["root"], "both compact lines of the current agent are clickable")
+	assert.Equal(t, 2, clicks["first"], "both compact lines of the other agent are clickable")
+}
+
+// TestSetAgentInfoMode_LiveSwitch verifies switching modes invalidates the
+// render cache, that costs tracked while compact surface immediately in
+// detailed, and that click-zone ownership follows the active mode.
+func TestSetAgentInfoMode_LiveSwitch(t *testing.T) {
+	t.Parallel()
+
+	m := newCompactPanelSidebar(t, 40, infoModeFixtureRoster()...)
+	recordInfoModeFixtureUsage(m)
+
+	require.NotContains(t, strings.Join(agentBody(m), "\n"), "Cost",
+		"compact mode shows no cost")
+	compactOwned := 0
+	for _, owner := range m.agentLineOwners {
+		if owner == "root" {
+			compactOwned++
+		}
+	}
+	require.Equal(t, 2, compactOwned)
+
+	m.cacheDirty = false
+	m.SetAgentInfoMode(AgentInfoDetailed)
+	assert.True(t, m.cacheDirty, "switching the mode must invalidate the cache")
+
+	body := strings.Join(agentBody(m), "\n")
+	assert.Contains(t, body, "Cost $0.13",
+		"costs tracked while compact surface immediately after switching to detailed")
+	detailedOwned := 0
+	for _, owner := range m.agentLineOwners {
+		if owner == "root" {
+			detailedOwned++
+		}
+	}
+	assert.Equal(t, 4, detailedOwned, "click-zone ownership follows the detailed card lines")
+
+	m.SetAgentInfoMode(AgentInfoCompact)
+	assert.NotContains(t, strings.Join(agentBody(m), "\n"), "Cost",
+		"switching back restores the compact roster")
+}
+
+// TestSetAgentInfoMode_NoopWhenUnchanged verifies reapplying the current mode
+// does not invalidate the render cache.
+func TestSetAgentInfoMode_NoopWhenUnchanged(t *testing.T) {
+	t.Parallel()
+
+	s := newTestSidebar(t)
+	s.renderSections(40)
+	s.cacheDirty = false
+
+	s.SetAgentInfoMode(AgentInfoCompact)
+	assert.False(t, s.cacheDirty, "identical mode must not invalidate the cache")
+
+	s.SetAgentInfoMode(AgentInfoDetailed)
+	assert.True(t, s.cacheDirty)
+}

--- a/pkg/tui/components/sidebar/agent_panel_test.go
+++ b/pkg/tui/components/sidebar/agent_panel_test.go
@@ -16,9 +16,11 @@ import (
 
 // newAgentPanelSidebar builds a sidebar whose current agent is "root" and whose
 // roster is set, ready to render the Agents panel at the given outer width.
-// The transfer-box animation is always stopped on cleanup so tests that start
-// it (via SetAgentSwitching) cannot leak a registration on the global
-// animation coordinator into parallel tests.
+// The panel is pinned to the detailed card mode, which most panel tests
+// target; compact-roster tests build their own sidebar (see
+// agent_info_mode_test.go). The transfer-box animation is always stopped on
+// cleanup so tests that start it (via SetAgentSwitching) cannot leak a
+// registration on the global animation coordinator into parallel tests.
 func newAgentPanelSidebar(t *testing.T, width int, agents ...runtime.AgentDetails) *model {
 	t.Helper()
 	sess := session.New()
@@ -32,6 +34,7 @@ func newAgentPanelSidebar(t *testing.T, width int, agents ...runtime.AgentDetail
 	m.availableAgents = agents
 	m.width = width
 	m.height = 200
+	m.SetAgentInfoMode(AgentInfoDetailed)
 	t.Cleanup(m.transferAnimation.Stop)
 	return m
 }

--- a/pkg/tui/components/sidebar/agent_panel_test.go
+++ b/pkg/tui/components/sidebar/agent_panel_test.go
@@ -51,19 +51,40 @@ func agentBody(m *model) (body []string) {
 	return lines[tabHeaderLines : tabHeaderLines+len(m.agentLineOwners)]
 }
 
-// agentLines returns the two ANSI-stripped content lines owned by the named
-// agent: line1 (name + thinking + shortcut) and line2 (provider/model).
-func agentLines(m *model, name string) (line1, line2 string) {
+// agentCard returns all ANSI-stripped content lines owned by the named agent:
+// the name line, the model line, and its labeled metric line(s).
+func agentCard(m *model, name string) []string {
 	body := agentBody(m)
+	var lines []string
 	for j, owner := range m.agentLineOwners {
 		if owner == name {
-			if j+1 < len(body) {
-				return body[j], body[j+1]
-			}
-			return body[j], ""
+			lines = append(lines, body[j])
 		}
 	}
-	return "", ""
+	return lines
+}
+
+// agentLines returns the first two ANSI-stripped content lines owned by the
+// named agent: line1 (name + shortcut) and line2 (provider/model).
+func agentLines(m *model, name string) (line1, line2 string) {
+	card := agentCard(m, name)
+	switch len(card) {
+	case 0:
+		return "", ""
+	case 1:
+		return card[0], ""
+	}
+	return card[0], card[1]
+}
+
+// agentMetrics returns the joined ANSI-stripped metric line(s) of the named
+// agent's card (everything after the name and model lines).
+func agentMetrics(m *model, name string) string {
+	card := agentCard(m, name)
+	if len(card) <= 2 {
+		return ""
+	}
+	return strings.Join(card[2:], "\n")
 }
 
 func TestClassifyThinking(t *testing.T) {
@@ -88,9 +109,10 @@ func TestClassifyThinking(t *testing.T) {
 	}
 }
 
-// TestAgentEntryLayout verifies an agent renders as two lines: line 1 carries
-// the name, thinking badge and "^N" shortcut (no description), and line 2 the
-// provider/model.
+// TestAgentEntryLayout verifies an agent renders as a labeled mini-card:
+// line 1 carries the name and "^N" shortcut (no description), line 2 the
+// provider/model, and the metric lines the labeled effort gauge, context and
+// cost.
 func TestAgentEntryLayout(t *testing.T) {
 	t.Parallel()
 
@@ -102,17 +124,21 @@ func TestAgentEntryLayout(t *testing.T) {
 	require.NotEmpty(t, line1)
 	assert.Contains(t, line1, "root", "line 1 shows the agent name")
 	assert.Contains(t, line1, "^1", "line 1 shows the switch shortcut")
-	assert.Contains(t, line1, gaugePattern(4), "line 1 shows the thinking gauge")
 	assert.NotContains(t, line1, "Executive assistant", "description is not shown")
+	assert.Contains(t, line2, "anthropic/claude-opus-4-8", "line 2 shows the provider/model")
+
+	metrics := agentMetrics(m, "root")
+	assert.Contains(t, metrics, "Effort "+gaugePattern(4)+" high", "metrics carry the labeled full effort gauge with its value")
+	assert.Contains(t, metrics, "Context —", "metrics carry the labeled context (unknown before any run)")
+	assert.Contains(t, metrics, "Cost —", "metrics carry the labeled cost (unknown before any run)")
 
 	body := strings.Join(agentBody(m), "\n")
 	assert.NotContains(t, body, "Executive assistant", "description is not shown anywhere")
-	assert.Contains(t, line2, "anthropic/claude-opus-4-8", "line 2 shows the provider/model")
 }
 
 // TestCurrentAgentMarker verifies the current agent is marked with ▶ while the
-// other agents are not, and that each agent owns exactly its two content lines
-// (separators are unowned).
+// other agents are not, and that each agent owns exactly its card's content
+// lines (separators are unowned).
 func TestCurrentAgentMarker(t *testing.T) {
 	t.Parallel()
 
@@ -129,7 +155,7 @@ func TestCurrentAgentMarker(t *testing.T) {
 	assert.Contains(t, rootLine1, "▶", "current agent is marked with ▶")
 	assert.NotContains(t, firstLine1, "▶", "non-current agents have no marker")
 
-	// Each agent owns exactly its two content lines; separators are unowned.
+	// Each agent owns exactly its card's content lines; separators are unowned.
 	counts := map[string]int{}
 	blanks := 0
 	for _, owner := range m.agentLineOwners {
@@ -139,9 +165,10 @@ func TestCurrentAgentMarker(t *testing.T) {
 		}
 		counts[owner]++
 	}
-	assert.Equal(t, 2, counts["first"])
-	assert.Equal(t, 2, counts["root"])
-	assert.Equal(t, 2, counts["last"])
+	for _, name := range []string{"first", "root", "last"} {
+		assert.Equalf(t, len(agentCard(m, name)), counts[name], "agent %q owns exactly its card lines", name)
+		assert.GreaterOrEqualf(t, counts[name], 3, "agent %q renders at least name, model and one metric line", name)
+	}
 	assert.Positive(t, blanks, "entries are separated by blank, unowned lines")
 }
 
@@ -188,11 +215,11 @@ func TestShortcutColumnAlignment(t *testing.T) {
 	}
 }
 
-// TestThinkingBadgeVocabularyOnLine verifies the thinking badge vocabulary
-// renders on the agent's name line: effort levels become the gauge, token
-// budgets keep the token glyph, adaptive becomes "auto", and off becomes an
-// empty gauge.
-func TestThinkingBadgeVocabularyOnLine(t *testing.T) {
+// TestEffortVocabularyOnCard verifies the effort vocabulary renders on the
+// card's labeled metric line: effort levels keep the full six-cell gauge with
+// the level word, token budgets keep the token glyph with the budget,
+// adaptive reads "auto", and off shows an empty gauge with the word "off".
+func TestEffortVocabularyOnCard(t *testing.T) {
 	t.Parallel()
 
 	m := newAgentPanelSidebar(t, 40,
@@ -201,19 +228,23 @@ func TestThinkingBadgeVocabularyOnLine(t *testing.T) {
 		runtime.AgentDetails{Name: "beta", Provider: "openai", Model: "gpt-5.4", Thinking: "high"},
 		runtime.AgentDetails{Name: "gamma", Provider: "openai", Model: "gpt-4o", Thinking: "8192"},
 		runtime.AgentDetails{Name: "delta", Provider: "google", Model: "gemini", Thinking: "adaptive"},
+		runtime.AgentDetails{Name: "plain", Provider: "openai", Model: "gpt-4o"},
 	)
 
 	want := map[string]string{
-		"alpha": gaugePattern(0),
-		"beta":  gaugePattern(4),
-		"gamma": styles.TokenGlyph + " 8.2K",
-		"delta": "auto",
+		"alpha": "Effort " + gaugePattern(0) + " off",
+		"beta":  "Effort " + gaugePattern(4) + " high",
+		"gamma": "Effort " + styles.TokenGlyph + " 8.2K",
+		"delta": "Effort auto",
 	}
-	for name, badge := range want {
-		line1, _ := agentLines(m, name)
-		require.NotEmptyf(t, line1, "row for %q should render", name)
-		assert.Containsf(t, line1, badge, "row %q should show badge %q", name, badge)
+	for name, effortText := range want {
+		metrics := agentMetrics(m, name)
+		require.NotEmptyf(t, metrics, "card for %q should render metrics", name)
+		assert.Containsf(t, metrics, effortText, "card %q should show %q", name, effortText)
 	}
+
+	assert.NotContains(t, agentMetrics(m, "plain"), "Effort",
+		"a model with no thinking configuration has no effort metric")
 }
 
 // TestModelLineLeftTruncated verifies the provider/model on line 2 keeps its
@@ -255,9 +286,11 @@ func TestMoreThanNineAgentsNoShortcutBeyond9(t *testing.T) {
 	assert.NotContains(t, body, "^10", "agents beyond the 9th have no shortcut")
 }
 
-// TestNameTruncatesNearMinWidth verifies that at a narrow width the gauge
-// collapses to a single cell while the model still occupies line 2.
-func TestNameTruncatesNearMinWidth(t *testing.T) {
+// TestNarrowWidthKeepsFullGauge verifies that at a narrow width the effort
+// gauge keeps its full six cells on a dedicated metric line (dropping only
+// the value word when it does not fit), the context label compacts to "Ctx",
+// and the model still occupies line 2.
+func TestNarrowWidthKeepsFullGauge(t *testing.T) {
 	t.Parallel()
 
 	m := newAgentPanelSidebar(t, 21,
@@ -265,12 +298,17 @@ func TestNameTruncatesNearMinWidth(t *testing.T) {
 		runtime.AgentDetails{Name: "agent2", Provider: "anthropic", Model: "claude-sonnet-4-6", Thinking: "high"},
 	)
 
-	line1, line2 := agentLines(m, "agent2")
-	require.NotEmpty(t, line1)
-	// glyph-only step keeps a single filled gauge cell, not the full six-cell gauge.
-	assert.NotContains(t, line1, gaugePattern(4), "narrow layout collapses the full gauge")
-	assert.Contains(t, line1, styles.GaugeFilled, "narrow layout keeps a single gauge cell")
+	_, line2 := agentLines(m, "agent2")
+	metrics := agentMetrics(m, "agent2")
+	assert.Contains(t, metrics, gaugePattern(4), "narrow layout keeps the full six-cell gauge")
+	assert.Contains(t, metrics, "Ctx ", "narrow layout compacts the context label")
+	assert.NotContains(t, metrics, "Context", "narrow layout does not use the full context label")
 	assert.Contains(t, line2, "…", "narrow layout left-truncates the model on line 2")
+
+	contentWidth := m.contentWidth(false)
+	for _, line := range agentCard(m, "agent2") {
+		assert.LessOrEqual(t, len([]rune(line)), contentWidth, "no card line exceeds the content width: %q", line)
+	}
 }
 
 // TestClickZonesEveryLine verifies that clicking any rendered agent line (either
@@ -316,8 +354,9 @@ func TestClickZonesEveryLine(t *testing.T) {
 }
 
 // TestRosterSeparatesAgentsWithBlankLine verifies a blank separator line is
-// inserted between agent entries and that the separator carries an empty owner,
-// so each agent owns exactly its two content lines and click zones stay aligned.
+// inserted between agent cards and that the separator carries an empty owner,
+// so each agent owns exactly its card's content lines and click zones stay
+// aligned.
 func TestRosterSeparatesAgentsWithBlankLine(t *testing.T) {
 	t.Parallel()
 
@@ -338,9 +377,10 @@ func TestRosterSeparatesAgentsWithBlankLine(t *testing.T) {
 		}
 		counts[owner]++
 	}
-	assert.Equal(t, 2, counts["root"], "an agent owns exactly its two content lines, not the separator")
-	assert.Equal(t, 2, counts["alpha"])
-	assert.Equal(t, 2, counts["beta"])
+	for _, name := range []string{"root", "alpha", "beta"} {
+		assert.Equalf(t, len(agentCard(m, name)), counts[name],
+			"agent %q owns exactly its card lines, not the separator", name)
+	}
 	assert.Positive(t, blanks, "agents are separated by blank, unowned lines")
 
 	// The panel does not start with a separator, and a blank separator precedes

--- a/pkg/tui/components/sidebar/agent_transfer_test.go
+++ b/pkg/tui/components/sidebar/agent_transfer_test.go
@@ -89,13 +89,15 @@ func TestTransferPanelContentAndPlacement(t *testing.T) {
 	idx := transferRelationIndex(m)
 	require.GreaterOrEqual(t, idx, 0, "a transfer relation line should render")
 
-	// The roster stays uninterrupted: each agent keeps its two lines and the
+	// The roster stays uninterrupted: each agent keeps its card lines and the
 	// blank separators, then the breathing line and the three box lines follow.
 	assert.Equal(t, []string{
-		"root", "root", "", "Scout", "Scout", "", "Coder", "Coder",
+		"root", "root", "root", "root", "",
+		"Scout", "Scout", "Scout", "Scout", "",
+		"Coder", "Coder", "Coder", "Coder",
 		"", "", "", "",
 	}, m.agentLineOwners)
-	require.Len(t, body, 12)
+	require.Len(t, body, 18)
 	assert.Equal(t, len(body)-2, idx, "the relation line is the box's middle line")
 	assert.Empty(t, strings.TrimSpace(body[len(body)-4]), "a blank breathing line precedes the box")
 
@@ -137,7 +139,9 @@ func TestTransferPanelBelowRosterAnyOrder(t *testing.T) {
 	require.GreaterOrEqual(t, idx, 0)
 
 	assert.Equal(t, []string{
-		"Coder", "Coder", "", "middle", "middle", "", "Scout", "Scout",
+		"Coder", "Coder", "Coder", "Coder", "",
+		"middle", "middle", "middle", "middle", "",
+		"Scout", "Scout", "Scout", "Scout",
 		"", "", "", "",
 	}, m.agentLineOwners, "nothing is inserted inside the roster")
 	assert.Equal(t, len(body)-2, idx, "the box stays at the bottom of the panel body")

--- a/pkg/tui/components/sidebar/effort_gauge_test.go
+++ b/pkg/tui/components/sidebar/effort_gauge_test.go
@@ -20,51 +20,53 @@ func gaugePattern(filled int) string {
 		strings.Repeat(styles.GaugeEmpty, toolcommon.EffortGaugeCells-filled)
 }
 
-// TestThinkingBadgeLevelUsesGauge verifies the level case of thinkingBadge
-// renders the shared six-cell gauge (no ✻ glyph) while the glyph-only
-// degradation step returns a single ramp-colored filled cell.
-func TestThinkingBadgeLevelUsesGauge(t *testing.T) {
+// TestEffortSegmentLevelUsesGauge verifies the level case of effortSegment
+// renders the labeled six-cell gauge with the level word (no ✻ glyph), and
+// that the minimal degradation drops only the word, never the gauge.
+func TestEffortSegmentLevelUsesGauge(t *testing.T) {
 	t.Parallel()
 
-	badge, compact := thinkingBadge("high")
-	assert.Equal(t, gaugePattern(4), ansi.Strip(badge), "high renders a 4/6-cell gauge")
-	assert.NotContains(t, ansi.Strip(badge), styles.ThinkingGlyph, "gauge carries no ✻ glyph")
-	assert.Equal(t, styles.GaugeFilled, ansi.Strip(compact), "glyph-only step is a single filled cell")
+	seg := effortSegment("high")
+	assert.Equal(t, "Effort "+gaugePattern(4)+" high", ansi.Strip(seg.full),
+		"high renders the labeled 4/6-cell gauge with its value")
+	assert.NotContains(t, ansi.Strip(seg.full), styles.ThinkingGlyph, "gauge carries no ✻ glyph")
+	assert.Equal(t, "Effort "+gaugePattern(4), ansi.Strip(seg.minimal),
+		"the minimal form keeps the full six-cell gauge and drops only the word")
 }
 
-// TestThinkingBadgeUnknownLevelFallsBackToText verifies an unparseable level
-// label keeps a plain text badge (no glyph) so unknown/future labels still
-// render.
-func TestThinkingBadgeUnknownLevelFallsBackToText(t *testing.T) {
+// TestEffortSegmentUnknownLevelFallsBackToText verifies an unparseable level
+// label keeps a plain labeled text segment (no glyph) so unknown/future labels
+// still render.
+func TestEffortSegmentUnknownLevelFallsBackToText(t *testing.T) {
 	t.Parallel()
 
-	badge, compact := thinkingBadge("on")
-	assert.Equal(t, "on", ansi.Strip(badge), "unknown label keeps a plain text badge")
-	assert.NotContains(t, ansi.Strip(badge), styles.ThinkingGlyph, "no ✻ glyph")
-	assert.Equal(t, "on", ansi.Strip(compact))
+	seg := effortSegment("on")
+	assert.Equal(t, "Effort on", ansi.Strip(seg.full), "unknown label keeps a plain text value")
+	assert.NotContains(t, ansi.Strip(seg.full), styles.ThinkingGlyph, "no ✻ glyph")
+	assert.Equal(t, "Effort on", ansi.Strip(seg.minimal))
 }
 
-// TestThinkingBadgeVocabulary verifies the full no-✻ badge vocabulary: none
-// renders nothing, off is an empty gauge, adaptive is "auto", and a token budget
-// keeps its token glyph.
-func TestThinkingBadgeVocabulary(t *testing.T) {
+// TestEffortSegmentVocabulary verifies the full no-✻ segment vocabulary: none
+// renders nothing, off is an empty gauge with the word "off", adaptive is
+// "auto", and a token budget keeps its token glyph with the count.
+func TestEffortSegmentVocabulary(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
 		label   string
-		badge   string
-		compact string
+		full    string
+		minimal string
 	}{
 		{"", "", ""},
-		{"off", strings.Repeat(styles.GaugeEmpty, toolcommon.EffortGaugeCells), styles.GaugeEmpty},
-		{"adaptive", "auto", "auto"},
-		{"8192", styles.TokenGlyph + " 8.2K", styles.TokenGlyph},
+		{"off", "Effort " + gaugePattern(0) + " off", "Effort " + gaugePattern(0)},
+		{"adaptive", "Effort auto", "Effort auto"},
+		{"8192", "Effort " + styles.TokenGlyph + " 8.2K", "Effort " + styles.TokenGlyph},
 	}
 	for _, c := range cases {
-		badge, compact := thinkingBadge(c.label)
-		assert.Equalf(t, c.badge, ansi.Strip(badge), "badge for %q", c.label)
-		assert.Equalf(t, c.compact, ansi.Strip(compact), "compact for %q", c.label)
-		assert.NotContainsf(t, ansi.Strip(badge), styles.ThinkingGlyph, "badge for %q must carry no ✻", c.label)
+		seg := effortSegment(c.label)
+		assert.Equalf(t, c.full, ansi.Strip(seg.full), "full segment for %q", c.label)
+		assert.Equalf(t, c.minimal, ansi.Strip(seg.minimal), "minimal segment for %q", c.label)
+		assert.NotContainsf(t, ansi.Strip(seg.full), styles.ThinkingGlyph, "segment for %q must carry no ✻", c.label)
 	}
 }
 
@@ -86,10 +88,10 @@ func TestThinkingGaugeValueShowsGaugeAndWord(t *testing.T) {
 	assert.Empty(t, ansi.Strip(toolcommon.ThinkingGaugeValue("")))
 }
 
-// TestRowGaugeColumnAlignment verifies a roster of effort-level agents renders
-// fixed-width six-cell gauges on their name line, and that the gauges all end
-// at the same right-aligned column (just before the shared shortcut column).
-func TestRowGaugeColumnAlignment(t *testing.T) {
+// TestCardGaugeColumnAlignment verifies a roster of effort-level agents renders
+// fixed-width six-cell gauges on their labeled effort line, and that the gauges
+// all start at the same column (right after the shared "Effort " label).
+func TestCardGaugeColumnAlignment(t *testing.T) {
 	t.Parallel()
 
 	m := newAgentPanelSidebar(t, 40,
@@ -104,21 +106,19 @@ func TestRowGaugeColumnAlignment(t *testing.T) {
 		"beta":  gaugePattern(3),
 		"gamma": gaugePattern(6),
 	}
-	gaugeEnd := -1
+	gaugeStart := -1
 	for name, gauge := range wantGauge {
-		line1, _ := agentLines(m, name)
-		require.NotEmptyf(t, line1, "row for %q should render", name)
-		assert.Containsf(t, line1, gauge, "row %q should contain gauge %q", name, gauge)
+		metrics := agentMetrics(m, name)
+		require.NotEmptyf(t, metrics, "card for %q should render metrics", name)
+		assert.Containsf(t, metrics, "Effort "+gauge, "card %q should contain labeled gauge %q", name, gauge)
 
-		// The gauge column ends where the gauge substring ends; all rows must
-		// share that column so the badges line up.
-		idx := strings.Index(line1, gauge)
-		require.GreaterOrEqualf(t, idx, 0, "gauge %q must appear in row %q", gauge, line1)
-		end := len([]rune(line1[:idx])) + len([]rune(gauge))
-		if gaugeEnd == -1 {
-			gaugeEnd = end
+		idx := strings.Index(metrics, gauge)
+		require.GreaterOrEqualf(t, idx, 0, "gauge %q must appear in card %q", gauge, metrics)
+		start := len([]rune(metrics[:idx]))
+		if gaugeStart == -1 {
+			gaugeStart = start
 		} else {
-			assert.Equalf(t, gaugeEnd, end, "gauge for %q must end in the shared badge column", name)
+			assert.Equalf(t, gaugeStart, start, "gauge for %q must start in the shared column", name)
 		}
 	}
 }

--- a/pkg/tui/components/sidebar/layout.go
+++ b/pkg/tui/components/sidebar/layout.go
@@ -17,9 +17,14 @@ const (
 	// edge whether or not a given agent has one.
 	agentShortcutWidth = 2
 
+	// rowGlyphOnlyMinWidth is the content-column breakpoint (near MinWidth) below
+	// which a compact agent line's thinking gauge collapses to a single cell so
+	// the name column keeps usable room.
+	rowGlyphOnlyMinWidth = 22
+
 	// cardNarrowMinWidth is the content-column breakpoint (near MinWidth) below
-	// which an agent card compacts its metric labels (Context → Ctx). The
-	// effort gauge keeps its full six cells at every width; only its value
+	// which a detailed agent card compacts its metric labels (Context → Ctx).
+	// The effort gauge keeps its full six cells at every width; only its value
 	// word may be dropped when the line cannot hold it.
 	cardNarrowMinWidth = 22
 

--- a/pkg/tui/components/sidebar/layout.go
+++ b/pkg/tui/components/sidebar/layout.go
@@ -17,10 +17,11 @@ const (
 	// edge whether or not a given agent has one.
 	agentShortcutWidth = 2
 
-	// rowGlyphOnlyMinWidth is the content-column breakpoint (near MinWidth) below
-	// which an agent line's thinking gauge collapses to a single cell so the name
-	// column keeps usable room.
-	rowGlyphOnlyMinWidth = 22
+	// cardNarrowMinWidth is the content-column breakpoint (near MinWidth) below
+	// which an agent card compacts its metric labels (Context → Ctx). The
+	// effort gauge keeps its full six cells at every width; only its value
+	// word may be dropped when the line cannot hold it.
+	cardNarrowMinWidth = 22
 
 	// starClickWidth is the clickable area width for the star indicator.
 	starClickWidth = 2

--- a/pkg/tui/components/sidebar/section_visibility_test.go
+++ b/pkg/tui/components/sidebar/section_visibility_test.go
@@ -1,6 +1,7 @@
 package sidebar
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -239,10 +240,19 @@ func TestRenderSections_SectionGapKeepsAgentClickZones(t *testing.T) {
 	lines := s.renderSections(40)
 
 	require.NotEmpty(t, s.agentClickZones)
+	zonesByAgent := map[string][]int{}
 	for lineIdx, agentName := range s.agentClickZones {
 		require.Less(t, lineIdx, len(lines))
-		assert.Contains(t, ansi.Strip(lines[lineIdx-1])+ansi.Strip(lines[lineIdx]), agentName,
-			"click zone %d must map onto a line of agent %q", lineIdx, agentName)
+		zonesByAgent[agentName] = append(zonesByAgent[agentName], lineIdx)
+	}
+	for agentName, zone := range zonesByAgent {
+		slices.Sort(zone)
+		assert.Containsf(t, ansi.Strip(lines[zone[0]]), agentName,
+			"the first zone line of agent %q must carry its name", agentName)
+		for i := 1; i < len(zone); i++ {
+			assert.Equalf(t, zone[0]+i, zone[i],
+				"agent %q's card zones must be contiguous", agentName)
+		}
 	}
 }
 

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -42,6 +42,20 @@ const (
 	ModeCollapsed
 )
 
+// AgentInfoMode selects how the vertical sidebar's Agents section renders
+// each agent. The zero value is the compact roster.
+type AgentInfoMode int
+
+const (
+	// AgentInfoCompact renders each agent as a two-line entry: name with
+	// thinking badge and shortcut, then provider/model with the context
+	// percentage. This is the default.
+	AgentInfoCompact AgentInfoMode = iota
+	// AgentInfoDetailed renders each agent as a mini-card with labeled
+	// Effort / Context / Cost metric lines.
+	AgentInfoDetailed
+)
+
 // SectionVisibility controls which optional sidebar sections are rendered.
 // The zero value shows everything.
 type SectionVisibility struct {
@@ -90,6 +104,9 @@ type Model interface {
 	SetSectionVisibility(v SectionVisibility)
 	// SetSectionGap sets the number of blank lines between sidebar sections.
 	SetSectionGap(lines int)
+	// SetAgentInfoMode selects how the vertical Agents section renders each
+	// agent: the compact two-line roster (default) or detailed mini-cards.
+	SetAgentInfoMode(mode AgentInfoMode)
 	GetSize() (width, height int)
 	LoadFromSession(sess *session.Session)
 	// ResetStreamTracking clears the active-stream stack so a new top-level run
@@ -296,6 +313,7 @@ type model struct {
 	lastTitleClickTime time.Time         // for double-click detection on title
 	sectionVisibility  SectionVisibility // which optional sections are rendered
 	sectionGap         int               // blank lines between sections in vertical mode
+	agentInfoMode      AgentInfoMode     // how the vertical Agents section renders each agent
 
 	// Transfer-box animation: a single animation.Subscription drives the rail
 	// dot while any transfer_task hop is in flight. The frame counts shared
@@ -696,6 +714,15 @@ func (m *model) SetSectionGap(lines int) {
 		return
 	}
 	m.sectionGap = lines
+	m.invalidateCache()
+}
+
+// SetAgentInfoMode selects how the vertical Agents section renders each agent.
+func (m *model) SetAgentInfoMode(mode AgentInfoMode) {
+	if m.agentInfoMode == mode {
+		return
+	}
+	m.agentInfoMode = mode
 	m.invalidateCache()
 }
 
@@ -1796,19 +1823,17 @@ func (m *model) queueSection(contentWidth int) string {
 	return m.renderTab(title, strings.Join(lines, "\n"), contentWidth)
 }
 
-// agentInfo renders the Agents panel: every agent as a compact, borderless
-// mini-card, with a blank separator line between cards. Line 1 shows the
-// agent's name (in its accent color) with the "^N" switch shortcut flush
-// against the right edge; line 2 the indented provider/model; the remaining
-// line(s) carry the labeled Effort / Context / Cost metrics (see
-// renderAgentCard). The current agent is marked with ▶ (or the spinner while
-// it works); the other agents pad that marker column so their names stay
-// aligned. Descriptions are deliberately omitted. While a transfer_task runs,
-// the innermost hop renders as a compact box below the whole roster — after a
-// blank breathing line — so the roster itself stays uninterrupted (see
-// renderTransferPanel). Each content line is owned by its agent
-// (agentLineOwners) so click zones can be registered explicitly (see
-// buildAgentClickZones) and a click on any card line switches to that agent;
+// agentInfo renders the Agents panel: every agent as a multi-line entry —
+// the compact two-line roster (see renderAgentLine) or a detailed mini-card
+// (see renderAgentCard), per the configured AgentInfoMode — with a blank
+// separator line between entries. The current agent is marked with ▶ (or the
+// spinner while it works); the other agents pad that marker column so their
+// names stay aligned. Descriptions are deliberately omitted. While a
+// transfer_task runs, the innermost hop renders as a compact box below the
+// whole roster — after a blank breathing line — so the roster itself stays
+// uninterrupted (see renderTransferPanel). Each content line is owned by its
+// agent (agentLineOwners) so click zones can be registered explicitly (see
+// buildAgentClickZones) and a click on any entry line switches to that agent;
 // separators and the transfer box carry an empty owner so they stay
 // unclickable.
 func (m *model) agentInfo(contentWidth int) string {
@@ -1826,8 +1851,10 @@ func (m *model) agentInfo(contentWidth int) string {
 		agentTitle += " ↔"
 	}
 
-	narrow := contentWidth < cardNarrowMinWidth
-	nameWidth := max(1, contentWidth-agentMarkerWidth-minGap-agentShortcutWidth)
+	renderAgent := m.compactAgentRenderer(contentWidth)
+	if m.agentInfoMode == AgentInfoDetailed {
+		renderAgent = m.detailedAgentRenderer(contentWidth)
+	}
 
 	var bodyLines, owners []string
 	add := func(line, owner string) {
@@ -1835,13 +1862,13 @@ func (m *model) agentInfo(contentWidth int) string {
 		owners = append(owners, owner)
 	}
 	for i, agent := range m.availableAgents {
-		// Separate cards with a blank, unowned line so they stay visually
+		// Separate entries with a blank, unowned line so they stay visually
 		// distinct without being attributed to (or made clickable for) any agent.
 		if len(bodyLines) > 0 {
 			add("", "")
 		}
 		current := agent.Name == currentAgent
-		for _, line := range m.renderAgentCard(agent, i, contentWidth, nameWidth, narrow, current) {
+		for _, line := range renderAgent(agent, i, current) {
 			add(line, agent.Name)
 		}
 	}
@@ -1857,6 +1884,32 @@ func (m *model) agentInfo(contentWidth int) string {
 	m.agentLineOwners = owners
 
 	return m.renderTab(agentTitle, strings.Join(bodyLines, "\n"), contentWidth)
+}
+
+// agentRenderer renders one roster agent's content lines at a layout
+// precomputed for the whole panel.
+type agentRenderer func(agent runtime.AgentDetails, index int, current bool) []string
+
+// compactAgentRenderer precomputes the compact roster's shared column widths
+// once — so every entry aligns and the badge width is not recomputed per
+// agent — and returns the per-agent two-line renderer (see renderAgentLine).
+func (m *model) compactAgentRenderer(contentWidth int) agentRenderer {
+	glyphOnly := contentWidth < rowGlyphOnlyMinWidth
+	badgeWidth := m.badgeColumnWidth(glyphOnly)
+	nameWidth := max(1, contentWidth-agentMarkerWidth-minGap-badgeWidth-1-agentShortcutWidth)
+	return func(agent runtime.AgentDetails, index int, current bool) []string {
+		return m.renderAgentLine(agent, index, contentWidth, nameWidth, badgeWidth, glyphOnly, current)
+	}
+}
+
+// detailedAgentRenderer precomputes the detailed card layout's shared widths
+// and returns the per-agent mini-card renderer (see renderAgentCard).
+func (m *model) detailedAgentRenderer(contentWidth int) agentRenderer {
+	narrow := contentWidth < cardNarrowMinWidth
+	nameWidth := max(1, contentWidth-agentMarkerWidth-minGap-agentShortcutWidth)
+	return func(agent runtime.AgentDetails, index int, current bool) []string {
+		return m.renderAgentCard(agent, index, contentWidth, nameWidth, narrow, current)
+	}
 }
 
 // thinkingKind classifies an agent's raw thinking wire label into the badge
@@ -1899,6 +1952,54 @@ func isAllDigits(s string) bool {
 		}
 	}
 	return true
+}
+
+// thinkingBadge returns the styled right-aligned badge for an agent's thinking
+// label and the compact single-cell form used in the compact roster's
+// glyph-only degradation step. Both are empty when the agent has no thinking
+// configuration. The vocabulary carries no ✻ glyph: the effort gauge is the
+// only visual language for thinking.
+func thinkingBadge(label string) (badge, compact string) {
+	kind, tokens := classifyThinking(label)
+	switch kind {
+	case thinkingNone:
+		return "", ""
+	case thinkingOff:
+		// Capable but disabled: a dim empty gauge, distinct from a non-capable
+		// model (which renders nothing). The compact form is a single empty cell.
+		cell := lipgloss.NewStyle().Foreground(styles.TextMuted).Faint(true).Render(styles.GaugeEmpty)
+		return toolcommon.EffortGaugeEmpty(), cell
+	case thinkingAdaptive:
+		auto := styles.ThinkingBadgeStyle.Render("auto")
+		return auto, auto
+	case thinkingTokens:
+		return styles.ThinkingBadgeStyle.Render(styles.TokenGlyph + " " + toolcommon.FormatTokenCount(tokens)),
+			styles.ThinkingBadgeStyle.Render(styles.TokenGlyph)
+	default: // thinkingLevel
+		level, ok := effort.Parse(label)
+		if !ok {
+			// Unknown/future level word: a plain text badge so it still renders.
+			b := styles.ThinkingBadgeStyle.Render(label)
+			return b, b
+		}
+		return toolcommon.EffortGauge(level), toolcommon.EffortFillStyle(level).Render(styles.GaugeFilled)
+	}
+}
+
+// badgeColumnWidth returns the widest thinking badge across the roster so every
+// compact agent line reserves the same badge column and the badges stay
+// aligned. glyphOnly selects the single-cell compact form used near MinWidth.
+func (m *model) badgeColumnWidth(glyphOnly bool) int {
+	w := 0
+	for _, a := range m.availableAgents {
+		full, compact := thinkingBadge(a.Thinking)
+		b := full
+		if glyphOnly {
+			b = compact
+		}
+		w = max(w, lipgloss.Width(b))
+	}
+	return w
 }
 
 // effortSegment builds the labeled effort metric for an agent's thinking
@@ -1987,7 +2088,68 @@ func padLeft(s string, width int) string {
 	return strings.Repeat(" ", max(0, width-lipgloss.Width(s))) + s
 }
 
-// renderAgentCard renders a single agent as a compact, borderless mini-card:
+// renderAgentLine renders a single agent in the compact roster as two lines:
+//
+//	▶ name            <thinking> ^N
+//	  provider/model         <ctx%>
+//
+// Line 1: the name is left-aligned in its accent color, the thinking badge is
+// right-aligned in a shared column, and the "^N" switch shortcut sits flush
+// against the right edge. The current agent is marked with ▶ (or the spinner
+// while it — or any agent — is working); other agents pad the marker column so
+// the names stay aligned. Line 2: the indented provider/model, left-truncated
+// so its informative tail survives, with the agent's latest known context
+// usage percentage right-aligned once the agent has run (background agent
+// tasks included). The description is omitted. Agents past the 9th have no
+// shortcut.
+func (m *model) renderAgentLine(agent runtime.AgentDetails, index, contentWidth, nameWidth, badgeWidth int, glyphOnly, current bool) []string {
+	agentStyle := styles.AgentAccentStyleFor(agent.Name)
+
+	var marker string
+	switch {
+	case m.workingAgent == agent.Name:
+		marker = agentStyle.Render(m.spinner.RawFrame())
+	case current:
+		marker = agentStyle.Render("▶")
+	}
+	left := padRight(marker, agentMarkerWidth) + agentStyle.Render(toolcommon.TruncateText(agent.Name, nameWidth))
+
+	badge, compact := thinkingBadge(agent.Thinking)
+	if glyphOnly {
+		badge = compact
+	}
+
+	var shortcut string
+	if index >= 0 && index < 9 {
+		shortcut = styles.MutedStyle.Render(fmt.Sprintf("^%d", index+1))
+	}
+
+	right := padLeft(badge, badgeWidth) + " " + padLeft(shortcut, agentShortcutWidth)
+	gap := max(1, contentWidth-lipgloss.Width(left)-lipgloss.Width(right))
+	line1 := left + strings.Repeat(" ", gap) + right
+
+	modelText := agent.Model
+	if agent.Provider != "" {
+		modelText = agent.Provider + "/" + agent.Model
+	}
+	ctxPercent := m.agentContextPercent(agent.Name)
+	ctxStyle := contextGaugeStyle(m.agentContextGaugeLevel(agent.Name), styles.MutedStyle)
+	modelWidth := contentWidth - agentMarkerWidth
+	if ctxPercent != "" {
+		modelWidth -= lipgloss.Width(ctxPercent) + 1
+	}
+	model := toolcommon.TruncateTextLeft(modelText, max(1, modelWidth))
+	line2 := strings.Repeat(" ", agentMarkerWidth) + styles.MutedStyle.Render(model)
+	if ctxPercent != "" {
+		gap := max(1, contentWidth-lipgloss.Width(line2)-lipgloss.Width(ctxPercent))
+		line2 += strings.Repeat(" ", gap) + ctxStyle.Render(ctxPercent)
+	}
+
+	return []string{line1, line2}
+}
+
+// renderAgentCard renders a single agent in the detailed roster as a
+// borderless mini-card:
 //
 //	▶ name                             ^N
 //	  provider/model

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -416,11 +416,12 @@ func (m *model) SetTokenUsage(event *runtime.TokenUsageEvent) {
 	usage := *event.Usage
 	m.sessionUsage[event.SessionID] = &usage
 
-	// Record the per-agent snapshot in the shared session state so the
-	// agent roster and the agent-details dialog can show per-agent context
-	// usage. Background agent tasks reach this path too: their usage
-	// events are forwarded out-of-band by the runtime.
-	m.sessionState.SetAgentUsage(event.AgentName, usage)
+	// Record the per-agent snapshot and the session→agent cost attribution
+	// in the shared session state so the agent roster and the agent-details
+	// dialog can show per-agent context usage and cumulative cost.
+	// Background agent tasks reach this path too: their usage events are
+	// forwarded out-of-band by the runtime.
+	m.sessionState.SetAgentUsage(event.SessionID, event.AgentName, usage)
 
 	// Mark session as having content once we receive token usage
 	m.sessionHasContent = true
@@ -827,6 +828,16 @@ func (m *model) LoadFromSession(sess *session.Session) {
 	if sess == nil {
 		return
 	}
+
+	// A loaded session replaces whatever was displayed: drop the usage
+	// entries of any previously shown session so repeated loads and session
+	// switches cannot leave stale or doubled totals behind.
+	clear(m.sessionUsage)
+
+	// Reseed the per-agent cost state from the restored tree so each agent's
+	// historical spend shows on its card immediately (see SeedRestoredCosts).
+	// Per-agent context stays unknown until the agent runs again.
+	m.sessionState.SeedRestoredCosts(sess)
 
 	// Use TotalCost to include sub-session costs (handles older sessions
 	// where the parent's Cost field did not include sub-session costs).
@@ -1785,20 +1796,21 @@ func (m *model) queueSection(contentWidth int) string {
 	return m.renderTab(title, strings.Join(lines, "\n"), contentWidth)
 }
 
-// agentInfo renders the Agents panel: every agent as a two-line entry, with a
-// blank separator line between entries. Line 1 shows the agent's name (in its
-// accent color), the thinking badge right-aligned, and the "^N" switch shortcut
-// flush against the right edge; line 2 shows the indented provider/model with
-// the agent's latest context usage percentage right-aligned once known. The
-// current agent is marked with ▶ (or the spinner while it works); the other
-// agents pad that marker column so their names stay aligned. Descriptions are
-// deliberately omitted. While a transfer_task runs, the innermost hop renders
-// as a compact box below the whole roster — after a blank breathing line — so
-// the roster itself stays uninterrupted (see renderTransferPanel). Each
-// content line is owned by its agent (agentLineOwners) so click zones can be
-// registered explicitly (see buildAgentClickZones) and a click on either line
-// switches to that agent; separators and the transfer box carry an empty owner
-// so they stay unclickable.
+// agentInfo renders the Agents panel: every agent as a compact, borderless
+// mini-card, with a blank separator line between cards. Line 1 shows the
+// agent's name (in its accent color) with the "^N" switch shortcut flush
+// against the right edge; line 2 the indented provider/model; the remaining
+// line(s) carry the labeled Effort / Context / Cost metrics (see
+// renderAgentCard). The current agent is marked with ▶ (or the spinner while
+// it works); the other agents pad that marker column so their names stay
+// aligned. Descriptions are deliberately omitted. While a transfer_task runs,
+// the innermost hop renders as a compact box below the whole roster — after a
+// blank breathing line — so the roster itself stays uninterrupted (see
+// renderTransferPanel). Each content line is owned by its agent
+// (agentLineOwners) so click zones can be registered explicitly (see
+// buildAgentClickZones) and a click on any card line switches to that agent;
+// separators and the transfer box carry an empty owner so they stay
+// unclickable.
 func (m *model) agentInfo(contentWidth int) string {
 	// Read current agent from session state so sidebar updates when agent is switched
 	currentAgent := m.sessionState.CurrentAgentName()
@@ -1814,11 +1826,8 @@ func (m *model) agentInfo(contentWidth int) string {
 		agentTitle += " ↔"
 	}
 
-	// Compute the shared column widths once so every entry aligns and the badge
-	// width is not recomputed per agent.
-	glyphOnly := contentWidth < rowGlyphOnlyMinWidth
-	badgeWidth := m.badgeColumnWidth(glyphOnly)
-	nameWidth := max(1, contentWidth-agentMarkerWidth-minGap-badgeWidth-1-agentShortcutWidth)
+	narrow := contentWidth < cardNarrowMinWidth
+	nameWidth := max(1, contentWidth-agentMarkerWidth-minGap-agentShortcutWidth)
 
 	var bodyLines, owners []string
 	add := func(line, owner string) {
@@ -1826,14 +1835,13 @@ func (m *model) agentInfo(contentWidth int) string {
 		owners = append(owners, owner)
 	}
 	for i, agent := range m.availableAgents {
-		// Separate entries with a blank, unowned line so the two-line entries stay
-		// visually distinct without being attributed to (or made clickable for)
-		// any agent.
+		// Separate cards with a blank, unowned line so they stay visually
+		// distinct without being attributed to (or made clickable for) any agent.
 		if len(bodyLines) > 0 {
 			add("", "")
 		}
 		current := agent.Name == currentAgent
-		for _, line := range m.renderAgentLine(agent, i, contentWidth, nameWidth, badgeWidth, glyphOnly, current) {
+		for _, line := range m.renderAgentCard(agent, i, contentWidth, nameWidth, narrow, current) {
 			add(line, agent.Name)
 		}
 	}
@@ -1893,52 +1901,79 @@ func isAllDigits(s string) bool {
 	return true
 }
 
-// thinkingBadge returns the styled right-aligned badge for an agent's thinking
-// label and the compact single-cell form used in the glyph-only degradation
-// step. Both are empty when the agent has no thinking configuration. The
-// vocabulary carries no ✻ glyph: the effort gauge is the only visual language
-// for thinking.
-func thinkingBadge(label string) (badge, compact string) {
+// effortSegment builds the labeled effort metric for an agent's thinking
+// label: the full form ("Effort <gauge> <value>") and a minimal fallback
+// ("Effort <gauge>") for widths where the value word does not fit. Both are
+// empty when the agent has no thinking configuration. Effort levels and "off"
+// always carry the full six-cell gauge; adaptive reads "auto" and a token
+// budget keeps the token glyph with its count.
+func effortSegment(label string) metricSegment {
+	prefix := styles.MutedStyle.Render("Effort ")
 	kind, tokens := classifyThinking(label)
 	switch kind {
 	case thinkingNone:
-		return "", ""
+		return metricSegment{}
 	case thinkingOff:
 		// Capable but disabled: a dim empty gauge, distinct from a non-capable
-		// model (which renders nothing). The compact form is a single empty cell.
-		cell := lipgloss.NewStyle().Foreground(styles.TextMuted).Faint(true).Render(styles.GaugeEmpty)
-		return toolcommon.EffortGaugeEmpty(), cell
+		// model (which renders no effort segment at all).
+		gauge := toolcommon.EffortGaugeEmpty()
+		return metricSegment{
+			full:    prefix + gauge + " " + styles.MutedStyle.Faint(true).Render("off"),
+			minimal: prefix + gauge,
+		}
 	case thinkingAdaptive:
-		auto := styles.ThinkingBadgeStyle.Render("auto")
-		return auto, auto
+		auto := prefix + styles.ThinkingBadgeStyle.Render("auto")
+		return metricSegment{full: auto, minimal: auto}
 	case thinkingTokens:
-		return styles.ThinkingBadgeStyle.Render(styles.TokenGlyph + " " + toolcommon.FormatTokenCount(tokens)),
-			styles.ThinkingBadgeStyle.Render(styles.TokenGlyph)
+		return metricSegment{
+			full:    prefix + styles.ThinkingBadgeStyle.Render(styles.TokenGlyph+" "+toolcommon.FormatTokenCount(tokens)),
+			minimal: prefix + styles.ThinkingBadgeStyle.Render(styles.TokenGlyph),
+		}
 	default: // thinkingLevel
 		level, ok := effort.Parse(label)
 		if !ok {
-			// Unknown/future level word: a plain text badge so it still renders.
-			b := styles.ThinkingBadgeStyle.Render(label)
-			return b, b
+			// Unknown/future level word: plain text so it still renders.
+			word := prefix + styles.ThinkingBadgeStyle.Render(label)
+			return metricSegment{full: word, minimal: word}
 		}
-		return toolcommon.EffortGauge(level), toolcommon.EffortFillStyle(level).Render(styles.GaugeFilled)
+		gauge := toolcommon.EffortGauge(level)
+		return metricSegment{
+			full:    prefix + gauge + " " + styles.MutedStyle.Render(label),
+			minimal: prefix + gauge,
+		}
 	}
 }
 
-// badgeColumnWidth returns the widest thinking badge across the roster so every
-// agent line reserves the same badge column and the badges stay aligned.
-// glyphOnly selects the single-cell compact form used near MinWidth.
-func (m *model) badgeColumnWidth(glyphOnly bool) int {
-	w := 0
-	for _, a := range m.availableAgents {
-		full, compact := thinkingBadge(a.Thinking)
-		b := full
-		if glyphOnly {
-			b = compact
-		}
-		w = max(w, lipgloss.Width(b))
+// contextSegment builds the labeled context metric for an agent: the latest
+// known context-fill percentage in the shared warning/critical coloring, or a
+// muted "—" when the agent has not run or its context limit is unknown. The
+// label compacts to "Ctx" at the narrowest breakpoint.
+func (m *model) contextSegment(agentName string, narrow bool) metricSegment {
+	label := "Context"
+	if narrow {
+		label = "Ctx"
 	}
-	return w
+	value := m.agentContextPercent(agentName)
+	if value == "" {
+		s := styles.MutedStyle.Render(label + " " + metricUnknown)
+		return metricSegment{full: s, minimal: s}
+	}
+	style := contextGaugeStyle(m.agentContextGaugeLevel(agentName), styles.MutedStyle)
+	s := styles.MutedStyle.Render(label+" ") + style.Render(value)
+	return metricSegment{full: s, minimal: s}
+}
+
+// costSegment builds the labeled cost metric for an agent: the cumulative
+// cost across every session attributed to it (see service.SessionState
+// AgentCost), or a muted "—" when no cost is attributable. An agent that ran
+// at zero cost reads "$0.00", distinct from the never-ran "—".
+func (m *model) costSegment(agentName string) metricSegment {
+	value := metricUnknown
+	if cost, ok := m.sessionState.AgentCost(agentName); ok {
+		value = toolcommon.FormatCostPrecise(cost)
+	}
+	s := styles.MutedStyle.Render("Cost " + value)
+	return metricSegment{full: s, minimal: s}
 }
 
 // padRight pads a (possibly styled) string with trailing spaces to width.
@@ -1952,21 +1987,23 @@ func padLeft(s string, width int) string {
 	return strings.Repeat(" ", max(0, width-lipgloss.Width(s))) + s
 }
 
-// renderAgentLine renders a single agent as two lines:
+// renderAgentCard renders a single agent as a compact, borderless mini-card:
 //
-//	▶ name            <thinking> ^N
-//	  provider/model         <ctx%>
+//	▶ name                             ^N
+//	  provider/model
+//	  Effort ▰▰▰▰▱▱ high · Context 30% · Cost $0.13
 //
-// Line 1: the name is left-aligned in its accent color, the thinking badge is
-// right-aligned in a shared column, and the "^N" switch shortcut sits flush
-// against the right edge. The current agent is marked with ▶ (or the spinner
-// while it — or any agent — is working); other agents pad the marker column so
-// the names stay aligned. Line 2: the indented provider/model, left-truncated
-// so its informative tail survives, with the agent's latest known context
-// usage percentage right-aligned once the agent has run (background agent
-// tasks included). The description is omitted. Agents past the 9th have no
-// shortcut.
-func (m *model) renderAgentLine(agent runtime.AgentDetails, index, contentWidth, nameWidth, badgeWidth int, glyphOnly, current bool) []string {
+// Line 1: the name is left-aligned in its accent color and the "^N" switch
+// shortcut sits flush against the right edge. The current agent is marked
+// with ▶ (or the spinner while it — or any agent — is working); other agents
+// pad the marker column so the names stay aligned. Line 2: the indented
+// provider/model, left-truncated so its informative tail survives. The
+// remaining line(s) carry the labeled metrics, flowed to the width (see
+// flowMetricLines): effort keeps the full six-cell gauge at every width,
+// context keeps the warning/critical coloring, and cost is the agent's
+// cumulative attributed cost. The description is omitted. Agents past the 9th
+// have no shortcut.
+func (m *model) renderAgentCard(agent runtime.AgentDetails, index, contentWidth, nameWidth int, narrow, current bool) []string {
 	agentStyle := styles.AgentAccentStyleFor(agent.Name)
 
 	var marker string
@@ -1978,17 +2015,11 @@ func (m *model) renderAgentLine(agent runtime.AgentDetails, index, contentWidth,
 	}
 	left := padRight(marker, agentMarkerWidth) + agentStyle.Render(toolcommon.TruncateText(agent.Name, nameWidth))
 
-	badge, compact := thinkingBadge(agent.Thinking)
-	if glyphOnly {
-		badge = compact
-	}
-
 	var shortcut string
 	if index >= 0 && index < 9 {
 		shortcut = styles.MutedStyle.Render(fmt.Sprintf("^%d", index+1))
 	}
-
-	right := padLeft(badge, badgeWidth) + " " + padLeft(shortcut, agentShortcutWidth)
+	right := padLeft(shortcut, agentShortcutWidth)
 	gap := max(1, contentWidth-lipgloss.Width(left)-lipgloss.Width(right))
 	line1 := left + strings.Repeat(" ", gap) + right
 
@@ -1996,20 +2027,93 @@ func (m *model) renderAgentLine(agent runtime.AgentDetails, index, contentWidth,
 	if agent.Provider != "" {
 		modelText = agent.Provider + "/" + agent.Model
 	}
-	ctxPercent := m.agentContextPercent(agent.Name)
-	ctxStyle := contextGaugeStyle(m.agentContextGaugeLevel(agent.Name), styles.MutedStyle)
-	modelWidth := contentWidth - agentMarkerWidth
-	if ctxPercent != "" {
-		modelWidth -= lipgloss.Width(ctxPercent) + 1
-	}
-	model := toolcommon.TruncateTextLeft(modelText, max(1, modelWidth))
+	model := toolcommon.TruncateTextLeft(modelText, max(1, contentWidth-agentMarkerWidth))
 	line2 := strings.Repeat(" ", agentMarkerWidth) + styles.MutedStyle.Render(model)
-	if ctxPercent != "" {
-		gap := max(1, contentWidth-lipgloss.Width(line2)-lipgloss.Width(ctxPercent))
-		line2 += strings.Repeat(" ", gap) + ctxStyle.Render(ctxPercent)
+
+	lines := []string{line1, line2}
+	indent := strings.Repeat(" ", agentMarkerWidth)
+	for _, metricLine := range m.metricLines(agent, contentWidth-agentMarkerWidth, narrow) {
+		lines = append(lines, indent+metricLine)
+	}
+	return lines
+}
+
+// metricUnknown marks a metric whose value cannot be known yet (an agent that
+// never ran, or a context limit the backend does not report) — explicit
+// rather than an unexplained blank, and distinct from a real zero.
+const metricUnknown = "—"
+
+// metricSeparator joins metric segments that share a line. A function so it
+// picks up theme changes dynamically.
+func metricSeparator() string {
+	return styles.MutedStyle.Render(" · ")
+}
+
+// metricSegment is one labeled metric of an agent card. full is the preferred
+// rendering; minimal is the degraded form used when full alone overflows the
+// line (only the effort segment degrades — it drops the value word but never
+// the six-cell gauge). Both empty means the segment is omitted entirely.
+type metricSegment struct {
+	full    string
+	minimal string
+}
+
+// metricLines builds the flowed metric lines of an agent card, fitted to
+// width columns.
+func (m *model) metricLines(agent runtime.AgentDetails, width int, narrow bool) []string {
+	segments := make([]metricSegment, 0, 3)
+	if s := effortSegment(agent.Thinking); s.full != "" {
+		segments = append(segments, s)
+	}
+	segments = append(segments, m.contextSegment(agent.Name, narrow), m.costSegment(agent.Name))
+	return flowMetricLines(segments, width)
+}
+
+// flowMetricLines lays the metric segments out into lines of at most width
+// columns. All segments share one line when they fit — the ideal single
+// metrics line at wide sidebars. Otherwise the first segment (effort, when
+// present) takes a dedicated line, degrading to its minimal form if even
+// alone it overflows, and the remaining segments flow greedily. Segments are
+// never truncated: at the sidebar's minimum width every minimal form fits,
+// and narrower widths auto-collapse the sidebar before this matters.
+func flowMetricLines(segments []metricSegment, width int) []string {
+	if len(segments) == 0 {
+		return nil
+	}
+	if all := joinSegments(segments); lipgloss.Width(all) <= width {
+		return []string{all}
 	}
 
-	return []string{line1, line2}
+	first := segments[0].full
+	if lipgloss.Width(first) > width && segments[0].minimal != "" {
+		first = segments[0].minimal
+	}
+	lines := []string{first}
+
+	current := ""
+	for _, seg := range segments[1:] {
+		switch {
+		case current == "":
+			current = seg.full
+		case lipgloss.Width(current+metricSeparator()+seg.full) <= width:
+			current += metricSeparator() + seg.full
+		default:
+			lines = append(lines, current)
+			current = seg.full
+		}
+	}
+	if current != "" {
+		lines = append(lines, current)
+	}
+	return lines
+}
+
+func joinSegments(segments []metricSegment) string {
+	parts := make([]string, len(segments))
+	for i, seg := range segments {
+		parts[i] = seg.full
+	}
+	return strings.Join(parts, metricSeparator())
 }
 
 // Transfer-box vocabulary: the arrow head matches the handoff tool's

--- a/pkg/tui/components/toolcommon/tokencount.go
+++ b/pkg/tui/components/toolcommon/tokencount.go
@@ -24,3 +24,22 @@ func FormatTokenCount(count int64) string {
 func FormatCostUSD(cost float64) string {
 	return fmt.Sprintf("$%.2f", cost)
 }
+
+// FormatCostPrecise formats a USD amount for cost readouts: two decimals at
+// or above one cent, four decimals for smaller non-zero amounts so sub-cent
+// costs stay visible, and "$0.00" for amounts that round to nothing.
+// Negative amounts keep a leading minus. This is the canonical precise
+// formatter shared by the sidebar roster, the agent inspector and the cost
+// dialog.
+func FormatCostPrecise(cost float64) string {
+	if cost < 0 {
+		return "-" + FormatCostPrecise(-cost)
+	}
+	if cost < 0.0001 {
+		return "$0.00"
+	}
+	if cost < 0.01 {
+		return fmt.Sprintf("$%.4f", cost)
+	}
+	return fmt.Sprintf("$%.2f", cost)
+}

--- a/pkg/tui/dialog/agent_details.go
+++ b/pkg/tui/dialog/agent_details.go
@@ -26,6 +26,7 @@ type agentDetailsDialog struct {
 	agent runtime.AgentDetails
 	cfg   runtime.AgentConfigInfo
 	usage *runtime.Usage
+	cost  *float64
 }
 
 // NewAgentDetailsDialog creates the read-only Agent Inspector: an agent's
@@ -39,9 +40,11 @@ type agentDetailsDialog struct {
 // zero value to omit those sections, e.g. for remote runtimes); usage carries
 // the agent's latest token-usage snapshot (pass nil when the agent has not
 // run). The dialog is opened by right-clicking (or Ctrl+clicking) an agent in
-// the sidebar.
-func NewAgentDetailsDialog(a runtime.AgentDetails, cfg runtime.AgentConfigInfo, usage *runtime.Usage) Dialog {
-	d := &agentDetailsDialog{agent: a, cfg: cfg, usage: usage}
+// the sidebar. cost carries the agent's cumulative attributed cost with the
+// same semantics as the sidebar roster (see service.SessionState AgentCost);
+// pass nil when no cost is attributable.
+func NewAgentDetailsDialog(a runtime.AgentDetails, cfg runtime.AgentConfigInfo, usage *runtime.Usage, cost *float64) Dialog {
+	d := &agentDetailsDialog{agent: a, cfg: cfg, usage: usage, cost: cost}
 	d.readOnlyScrollDialog = newReadOnlyScrollDialog(
 		readOnlyScrollDialogSize{widthPercent: 70, minWidth: 50, maxWidth: 100, heightPercent: 80, heightMax: 40},
 		d.renderLines,
@@ -80,6 +83,9 @@ func (d *agentDetailsDialog) renderLines(contentWidth, _ int) []string {
 	}
 	if l := d.contextLine(); l != "" {
 		lines = append(lines, l)
+	}
+	if d.cost != nil {
+		lines = append(lines, detailField("Cost", toolcommon.FormatCostPrecise(*d.cost)))
 	}
 
 	lines = append(lines, d.inlineList(contentWidth, "Sub-agents", d.cfg.SubAgents)...)

--- a/pkg/tui/dialog/agent_details_test.go
+++ b/pkg/tui/dialog/agent_details_test.go
@@ -24,7 +24,13 @@ func renderAgentDetails(a runtime.AgentDetails, cfg runtime.AgentConfigInfo) str
 // renderAgentDetailsUsage is renderAgentDetails with a token-usage snapshot
 // for the context-usage line.
 func renderAgentDetailsUsage(a runtime.AgentDetails, cfg runtime.AgentConfigInfo, usage *runtime.Usage) string {
-	d := NewAgentDetailsDialog(a, cfg, usage).(*agentDetailsDialog)
+	return renderAgentDetailsCost(a, cfg, usage, nil)
+}
+
+// renderAgentDetailsCost is renderAgentDetailsUsage with the agent's
+// cumulative attributed cost for the cost line (nil when unattributable).
+func renderAgentDetailsCost(a runtime.AgentDetails, cfg runtime.AgentConfigInfo, usage *runtime.Usage, cost *float64) string {
+	d := NewAgentDetailsDialog(a, cfg, usage, cost).(*agentDetailsDialog)
 	return ansi.Strip(strings.Join(d.renderLines(80, 24), "\n"))
 }
 
@@ -110,7 +116,7 @@ func TestAgentDetailsDialog_TitleUsesAgentAccentColor(t *testing.T) {
 	t.Cleanup(func() { styles.SetAgentOrder(nil) })
 
 	titleOf := func(name string) string {
-		d := NewAgentDetailsDialog(runtime.AgentDetails{Name: name, Model: "gpt"}, runtime.AgentConfigInfo{}, nil).(*agentDetailsDialog)
+		d := NewAgentDetailsDialog(runtime.AgentDetails{Name: name, Model: "gpt"}, runtime.AgentConfigInfo{}, nil, nil).(*agentDetailsDialog)
 		return d.renderLines(80, 24)[0] // raw title line, with ANSI styling
 	}
 
@@ -249,6 +255,29 @@ func TestAgentDetailsDialog_ContextUsage(t *testing.T) {
 
 	emptyUsage := renderAgentDetailsUsage(agent, runtime.AgentConfigInfo{}, &runtime.Usage{})
 	assert.NotContains(t, emptyUsage, "Context:", "no context line for an empty snapshot")
+}
+
+// TestAgentDetailsDialog_Cost covers the per-agent cost line: the precise
+// shared formatting (four decimals below one cent, two at or above), the
+// explicit $0.00 for an agent that ran at zero cost, and omission when no
+// cost is attributable to the agent.
+func TestAgentDetailsDialog_Cost(t *testing.T) {
+	t.Parallel()
+
+	agent := runtime.AgentDetails{Name: "root", Provider: "openai", Model: "gpt-5.4"}
+	costOf := func(c float64) *float64 { return &c }
+
+	cents := renderAgentDetailsCost(agent, runtime.AgentConfigInfo{}, nil, costOf(0.1284))
+	assert.Contains(t, cents, "Cost: $0.13", "amounts at or above one cent use two decimals")
+
+	subCent := renderAgentDetailsCost(agent, runtime.AgentConfigInfo{}, nil, costOf(0.0042))
+	assert.Contains(t, subCent, "Cost: $0.0042", "non-zero amounts below one cent keep four decimals")
+
+	zero := renderAgentDetailsCost(agent, runtime.AgentConfigInfo{}, nil, costOf(0))
+	assert.Contains(t, zero, "Cost: $0.00", "an agent that ran at zero cost reads $0.00")
+
+	noCost := renderAgentDetailsCost(agent, runtime.AgentConfigInfo{}, nil, nil)
+	assert.NotContains(t, noCost, "Cost:", "no cost line when no cost is attributable")
 }
 
 // TestInlineList_NarrowWidth_NoLabelDuplication verifies that when contentWidth

--- a/pkg/tui/dialog/cost.go
+++ b/pkg/tui/dialog/cost.go
@@ -175,6 +175,7 @@ type stat struct {
 
 type costData struct {
 	total             totalUsage
+	agents            []totalUsage
 	models            []totalUsage
 	messages          []totalUsage
 	hasPerMessageData bool
@@ -223,7 +224,22 @@ func (d *costDialog) gatherCostData() costData {
 	data.duration = d.session.Duration()
 	data.messageCount = d.session.MessageCount()
 	modelMap := make(map[string]*totalUsage)
+	agentMap := make(map[string]*totalUsage)
 	msgCounter := 0
+
+	// Aggregation is exact: it sums the per-message records themselves, so it
+	// is immune to the double-counting a sum of cumulative session snapshots
+	// would produce.
+	addAgentUsage := func(label string, cost float64, usage *chat.Usage) {
+		if agentMap[label] == nil {
+			agentMap[label] = &totalUsage{label: label}
+		}
+		if usage != nil {
+			agentMap[label].add(cost, usage)
+			return
+		}
+		agentMap[label].cost += cost
+	}
 
 	addRecord := func(agentName, model string, cost float64, usage *chat.Usage) {
 		data.hasPerMessageData = true
@@ -234,6 +250,10 @@ func (d *costDialog) gatherCostData() costData {
 			modelMap[model] = &totalUsage{label: model}
 		}
 		modelMap[model].add(cost, usage)
+
+		// Records without an agent name stay honestly unattributed instead of
+		// being assigned to some agent arbitrarily.
+		addAgentUsage(cmp.Or(agentName, "(unattributed)"), cost, usage)
 
 		msgCounter++
 		msgLabel := fmt.Sprintf("#%d", msgCounter)
@@ -251,6 +271,9 @@ func (d *costDialog) gatherCostData() costData {
 	addCompactionCost := func(cost float64) {
 		data.hasPerMessageData = true
 		data.total.cost += cost
+		// Summary items carry no agent attribution; keep compaction spend in
+		// its own By Agent bucket rather than crediting an agent for it.
+		addAgentUsage("compaction", cost, nil)
 		data.messages = append(data.messages, totalUsage{label: "compaction", cost: cost})
 	}
 
@@ -299,6 +322,13 @@ func (d *costDialog) gatherCostData() costData {
 	}
 	slices.SortFunc(data.models, func(a, b totalUsage) int {
 		return cmp.Compare(b.cost, a.cost)
+	})
+
+	for _, a := range agentMap {
+		data.agents = append(data.agents, *a)
+	}
+	slices.SortFunc(data.agents, func(a, b totalUsage) int {
+		return cmp.Or(cmp.Compare(b.cost, a.cost), cmp.Compare(a.label, b.label))
 	})
 
 	// Fall back to session-level totals (e.g. past sessions without per-message data).
@@ -369,6 +399,16 @@ func (d *costDialog) buildLines(contentWidth int) []string {
 		lines = append(lines, styledStat(s, labelWidth))
 	}
 	lines = append(lines, "")
+
+	// By Agent
+	if len(data.agents) > 0 {
+		lines = append(lines, sectionStyle().Render("By Agent"), "")
+		labelWidth := usageLabelWidth(data.agents)
+		for _, a := range data.agents {
+			lines = append(lines, d.renderUsageLine(a, data.total.cost, labelWidth, false))
+		}
+		lines = append(lines, "")
+	}
 
 	// By Model
 	if len(data.models) > 0 {
@@ -532,6 +572,15 @@ func (d *costDialog) renderPlainText() string {
 	}
 	lines = append(lines, "")
 
+	// By Agent
+	if len(data.agents) > 0 {
+		lines = append(lines, "By Agent")
+		for _, a := range data.agents {
+			lines = append(lines, a.plainTextLine(""))
+		}
+		lines = append(lines, "")
+	}
+
 	// By Model
 	if len(data.models) > 0 {
 		lines = append(lines, "By Model")
@@ -608,16 +657,7 @@ func accentStyle() lipgloss.Style {
 // ---------------------------------------------------------------------------
 
 func formatCost(cost float64) string {
-	if cost < 0 {
-		return "-" + formatCost(-cost)
-	}
-	if cost < 0.0001 {
-		return "$0.00"
-	}
-	if cost < 0.01 {
-		return fmt.Sprintf("$%.4f", cost)
-	}
-	return fmt.Sprintf("$%.2f", cost)
+	return toolcommon.FormatCostPrecise(cost)
 }
 
 func formatCostPadded(cost float64) string {

--- a/pkg/tui/dialog/cost_test.go
+++ b/pkg/tui/dialog/cost_test.go
@@ -71,11 +71,88 @@ func TestCostDialogView(t *testing.T) {
 	// The title may be split across lines due to narrow width
 	assert.Contains(t, view, "Session Cost")
 	assert.Contains(t, view, "Total")
+	assert.Contains(t, view, "By Agent")
 	assert.Contains(t, view, "By Model")
 	assert.Contains(t, view, "gpt-4o")
 	assert.Contains(t, view, "tokens:")           // total token count line
 	assert.Contains(t, view, "messages:")         // message count in header
 	assert.Contains(t, view, "avg cost/message:") // average cost per message
+}
+
+// TestCostDialogByAgentAggregation verifies the By Agent section aggregates
+// the exact per-message records by agent name, sorts descending by cost,
+// keeps records without an agent honestly unattributed, and books compaction
+// spend in its own bucket instead of crediting an agent for it.
+func TestCostDialogByAgentAggregation(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	addMsg := func(agent string, cost float64, usage chat.Usage) {
+		sess.AddMessage(&session.Message{
+			AgentName: agent,
+			Message: chat.Message{
+				Role:    chat.MessageRoleAssistant,
+				Content: "msg",
+				Model:   "gpt-4o",
+				Usage:   &usage,
+				Cost:    cost,
+			},
+		})
+	}
+	addMsg("root", 0.02, chat.Usage{InputTokens: 1000, OutputTokens: 200})
+	addMsg("developer", 0.10, chat.Usage{InputTokens: 4000, OutputTokens: 800})
+	addMsg("root", 0.03, chat.Usage{InputTokens: 1500, OutputTokens: 300})
+	addMsg("", 0.01, chat.Usage{InputTokens: 500, OutputTokens: 100})
+	sess.Messages = append(sess.Messages, session.Item{Summary: "compacted", Cost: 0.004})
+
+	data := (&costDialog{session: sess}).gatherCostData()
+
+	require.Len(t, data.agents, 4)
+	assert.Equal(t, "developer", data.agents[0].label, "sorted descending by cost")
+	assert.InDelta(t, 0.10, data.agents[0].cost, 1e-9)
+	assert.Equal(t, "root", data.agents[1].label)
+	assert.InDelta(t, 0.05, data.agents[1].cost, 1e-9, "root's two messages add up")
+	assert.Equal(t, int64(2500), data.agents[1].InputTokens, "tokens aggregate per agent")
+	assert.Equal(t, "(unattributed)", data.agents[2].label, "agent-less records stay unattributed")
+	assert.InDelta(t, 0.01, data.agents[2].cost, 1e-9)
+	assert.Equal(t, "compaction", data.agents[3].label, "compaction spend keeps its own bucket")
+	assert.InDelta(t, 0.004, data.agents[3].cost, 1e-9)
+}
+
+// TestCostDialogByAgentRendersBeforeByModel verifies the styled view renders
+// the By Agent section between Total and By Model, and that the clipboard
+// plain text carries it too.
+func TestCostDialogByAgentRendersBeforeByModel(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sess.AddMessage(&session.Message{
+		AgentName: "root",
+		Message: chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: "Hello",
+			Model:   "gpt-4o",
+			Usage:   &chat.Usage{InputTokens: 1000, OutputTokens: 500},
+			Cost:    0.005,
+		},
+	})
+
+	d := NewCostDialog(sess)
+	d.SetSize(100, 50)
+	view := d.View()
+	byAgent := strings.Index(view, "By Agent")
+	byModel := strings.Index(view, "By Model")
+	require.Positive(t, byAgent, "By Agent renders")
+	require.Positive(t, byModel, "By Model renders")
+	assert.Less(t, byAgent, byModel, "By Agent renders before By Model")
+
+	plain := d.(*costDialog).renderPlainText()
+	assert.Contains(t, plain, "By Agent")
+	assert.Contains(t, plain, "root")
+	assert.Contains(t, plain, "By Model")
+	assert.Contains(t, plain, "By Message")
+	assert.Less(t, strings.Index(plain, "By Agent"), strings.Index(plain, "By Model"),
+		"clipboard output keeps the section order")
 }
 
 func TestCostDialogWithToolCalls(t *testing.T) {

--- a/pkg/tui/dialog/settings.go
+++ b/pkg/tui/dialog/settings.go
@@ -35,6 +35,7 @@ const (
 	rowTheme = iota
 	rowPosition
 	rowSpacing
+	rowInfoMode
 	rowSessionPath
 	rowUsage
 	rowAgents
@@ -82,6 +83,14 @@ var spacingLabels = map[messages.SectionSpacing]string{
 	messages.SpacingCompact: "Compact", messages.SpacingNormal: "Normal", messages.SpacingRelaxed: "Relaxed",
 }
 
+var sidebarInfoModes = []messages.SidebarInfoMode{
+	messages.InfoModeCompact, messages.InfoModeDetailed,
+}
+
+var infoModeLabels = map[messages.SidebarInfoMode]string{
+	messages.InfoModeCompact: "Compact", messages.InfoModeDetailed: "Detailed",
+}
+
 var sendModes = []messages.SendMode{messages.SendModeSteer, messages.SendModeQueue}
 
 type sendModeOption struct {
@@ -109,6 +118,7 @@ type settingsDialog struct {
 func NewSettingsDialog(preferences messages.Preferences, showVisuals bool) Dialog {
 	preferences.Layout.SidebarPosition = messages.ParseSidebarPosition(string(preferences.Layout.SidebarPosition))
 	preferences.Layout.SectionSpacing = messages.ParseSectionSpacing(string(preferences.Layout.SectionSpacing))
+	preferences.Layout.SidebarInfoMode = messages.ParseSidebarInfoMode(string(preferences.Layout.SidebarInfoMode))
 	preferences.SendMode = messages.ParseSendMode(string(preferences.SendMode))
 	if preferences.TabTitleMaxLength <= 0 {
 		preferences.TabTitleMaxLength = 20
@@ -217,6 +227,8 @@ func (d *settingsDialog) changeValue(delta int) tea.Cmd {
 			d.current.Layout.SidebarPosition = cycleValue(sidebarPositions, d.current.Layout.SidebarPosition, delta)
 		case rowSpacing:
 			d.current.Layout.SectionSpacing = cycleValue(sectionSpacings, d.current.Layout.SectionSpacing, delta)
+		case rowInfoMode:
+			d.current.Layout.SidebarInfoMode = cycleValue(sidebarInfoModes, d.current.Layout.SidebarInfoMode, delta)
 		case rowSessionPath:
 			d.current.Layout.HideSessionPath = !d.current.Layout.HideSessionPath
 		case rowUsage:
@@ -354,6 +366,7 @@ func (d *settingsDialog) renderAppearanceTab(content *Content, inner int) {
 		content.AddSpace().AddContent(preview).AddSpace().
 			AddContent(d.renderSelectorRow(rowPosition, "Sidebar position", positionLabels[d.current.Layout.SidebarPosition], inner)).
 			AddContent(d.renderSelectorRow(rowSpacing, "Section spacing", spacingLabels[d.current.Layout.SectionSpacing], inner)).
+			AddContent(d.renderSelectorRow(rowInfoMode, "Sidebar info mode", infoModeLabels[d.current.Layout.SidebarInfoMode], inner)).
 			AddContent(styles.MutedStyle.Render("Sidebar sections")).
 			AddContent(d.renderToggleRow(rowSessionPath, "Session path", !d.current.Layout.HideSessionPath)).
 			AddContent(d.renderToggleRow(rowUsage, "Token usage", !d.current.Layout.HideUsage)).

--- a/pkg/tui/dialog/settings_test.go
+++ b/pkg/tui/dialog/settings_test.go
@@ -25,10 +25,17 @@ func TestSettingsDialogNormalizesValues(t *testing.T) {
 
 	d := newTestSettingsDialog(t, messages.LayoutSettings{})
 	assert.Equal(t, messages.SidebarRight, d.current.Layout.SidebarPosition)
+	assert.Equal(t, messages.InfoModeCompact, d.current.Layout.SidebarInfoMode,
+		"empty info mode normalizes to compact")
 
-	raw, ok := NewSettingsDialog(messages.Preferences{SendMode: messages.SendMode("bogus")}, true).(*settingsDialog)
+	raw, ok := NewSettingsDialog(messages.Preferences{
+		SendMode: messages.SendMode("bogus"),
+		Layout:   messages.LayoutSettings{SidebarInfoMode: messages.SidebarInfoMode("bogus")},
+	}, true).(*settingsDialog)
 	require.True(t, ok)
 	assert.Equal(t, messages.SendModeSteer, raw.current.SendMode, "unknown send mode normalizes to steer")
+	assert.Equal(t, messages.InfoModeCompact, raw.current.Layout.SidebarInfoMode,
+		"unknown info mode normalizes to compact")
 }
 
 func TestSettingsDialogNavigation(t *testing.T) {
@@ -45,6 +52,9 @@ func TestSettingsDialogNavigation(t *testing.T) {
 
 	d.Update(down)
 	require.Equal(t, rowSpacing, d.selected[tabAppearance])
+
+	d.Update(down)
+	require.Equal(t, rowInfoMode, d.selected[tabAppearance])
 
 	d.Update(down)
 	require.Equal(t, rowSessionPath, d.selected[tabAppearance])
@@ -89,7 +99,11 @@ func TestSettingsDialogWithoutVisualsTab(t *testing.T) {
 	view := ansi.Strip(d.View())
 	assert.Contains(t, view, "Appearance")
 	assert.NotContains(t, view, "Sidebar position")
+	assert.NotContains(t, view, "Sidebar info mode")
 	assert.Contains(t, view, "Split diff view")
+
+	assert.False(t, d.selectable(tabAppearance, rowInfoMode),
+		"the info mode row is not selectable without a sidebar")
 }
 
 func TestSettingsDialogCyclesPositionAndPreviews(t *testing.T) {
@@ -137,6 +151,64 @@ func TestSettingsDialogCyclesSpacingAndPreviews(t *testing.T) {
 	d.current.Layout.SectionSpacing = messages.SpacingNormal
 	d.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
 	assert.Equal(t, messages.SpacingCompact, d.current.Layout.SectionSpacing)
+}
+
+func TestSettingsDialogCyclesInfoModeAndPreviews(t *testing.T) {
+	t.Parallel()
+
+	d := newTestSettingsDialog(t, messages.LayoutSettings{})
+	require.Equal(t, messages.InfoModeCompact, d.current.Layout.SidebarInfoMode,
+		"the info mode starts at the compact default")
+	d.selected[tabAppearance] = rowInfoMode
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	require.NotNil(t, cmd)
+	msgs := collectMsgs(cmd)
+	require.Len(t, msgs, 1)
+	preview, ok := msgs[0].(messages.PreviewLayoutMsg)
+	require.True(t, ok, "changing the info mode must emit a live preview")
+	assert.Equal(t, messages.InfoModeDetailed, preview.Layout.SidebarInfoMode)
+
+	d.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	assert.Equal(t, messages.InfoModeCompact, d.current.Layout.SidebarInfoMode, "cycling wraps around")
+
+	_, cmd = d.Update(tea.KeyPressMsg{Code: tea.KeyLeft})
+	assert.Equal(t, messages.InfoModeDetailed, d.current.Layout.SidebarInfoMode, "cycling backwards wraps around")
+	msgs = collectMsgs(cmd)
+	require.Len(t, msgs, 1)
+	_, ok = msgs[0].(messages.PreviewLayoutMsg)
+	assert.True(t, ok, "cycling backwards must also emit a live preview")
+}
+
+func TestSettingsDialogAppliesInfoMode(t *testing.T) {
+	t.Parallel()
+
+	d := newTestSettingsDialog(t, messages.LayoutSettings{})
+	d.selected[tabAppearance] = rowInfoMode
+	d.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	msgs := collectMsgs(cmd)
+	require.Len(t, msgs, 2, "apply must close the dialog and emit the settings")
+	applied, ok := msgs[1].(messages.ApplySettingsMsg)
+	require.True(t, ok)
+	assert.Equal(t, messages.InfoModeDetailed, applied.Preferences.Layout.SidebarInfoMode)
+}
+
+func TestSettingsDialogEscapeRestoresInfoMode(t *testing.T) {
+	t.Parallel()
+
+	d := newTestSettingsDialog(t, messages.LayoutSettings{})
+	d.selected[tabAppearance] = rowInfoMode
+	d.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	require.Equal(t, messages.InfoModeDetailed, d.current.Layout.SidebarInfoMode)
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	msgs := collectMsgs(cmd)
+	require.Len(t, msgs, 2)
+	cancel, ok := msgs[1].(messages.CancelLayoutPreviewMsg)
+	require.True(t, ok, "esc after an info mode change must restore the original layout")
+	assert.Equal(t, messages.InfoModeCompact, cancel.Original.SidebarInfoMode)
 }
 
 func TestSettingsDialogTogglesSection(t *testing.T) {
@@ -253,7 +325,7 @@ func TestSettingsDialogApplyWithoutChangesOnlyCloses(t *testing.T) {
 func TestSettingsDialogEscapeRestoresOriginal(t *testing.T) {
 	t.Parallel()
 
-	original := messages.LayoutSettings{SidebarPosition: messages.SidebarLeft, SectionSpacing: messages.SpacingNormal}
+	original := messages.LayoutSettings{SidebarPosition: messages.SidebarLeft, SectionSpacing: messages.SpacingNormal, SidebarInfoMode: messages.InfoModeCompact}
 	d := newTestSettingsDialog(t, original)
 	d.selected[tabAppearance] = rowPosition
 	d.Update(tea.KeyPressMsg{Code: tea.KeyRight})
@@ -295,6 +367,8 @@ func TestSettingsDialogViewShowsVisualsRows(t *testing.T) {
 	assert.Contains(t, view, "Right")
 	assert.Contains(t, view, "Section spacing")
 	assert.Contains(t, view, "Normal")
+	assert.Contains(t, view, "Sidebar info mode")
+	assert.Contains(t, view, "‹ Compact ›", "the info mode selector shows the compact default")
 	assert.Contains(t, view, "Session path")
 	assert.Contains(t, view, "Token usage")
 	assert.Contains(t, view, "Agents")

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -938,6 +938,7 @@ func (m *appModel) handleApplySettings(msg messages.ApplySettingsMsg) (tea.Model
 func (m *appModel) applyLayoutSettings(settings messages.LayoutSettings) (tea.Model, tea.Cmd) {
 	settings.SidebarPosition = messages.ParseSidebarPosition(string(settings.SidebarPosition))
 	settings.SectionSpacing = messages.ParseSectionSpacing(string(settings.SectionSpacing))
+	settings.SidebarInfoMode = messages.ParseSidebarInfoMode(string(settings.SidebarInfoMode))
 	m.layoutSettings = settings
 
 	var cmds []tea.Cmd
@@ -956,6 +957,7 @@ func layoutSettingsFromConfig(l userconfig.LayoutSettings) messages.LayoutSettin
 	return messages.LayoutSettings{
 		SidebarPosition: messages.ParseSidebarPosition(l.SidebarPosition),
 		SectionSpacing:  messages.ParseSectionSpacing(l.SectionSpacing),
+		SidebarInfoMode: messages.ParseSidebarInfoMode(l.SidebarInfoMode),
 		HideSessionPath: l.HideSessionPath,
 		HideUsage:       l.HideUsage,
 		HideAgents:      l.HideAgents,
@@ -1000,7 +1002,10 @@ func savePreferences(p messages.Preferences) error {
 		}
 
 		layout := p.Layout
-		if layout == (messages.LayoutSettings{SidebarPosition: messages.SidebarRight, SectionSpacing: messages.SpacingNormal}) {
+		// Normalize before the default comparison so an unnormalized zero
+		// value ("") and the explicit default ("compact") both clear the entry.
+		layout.SidebarInfoMode = messages.ParseSidebarInfoMode(string(layout.SidebarInfoMode))
+		if layout == (messages.LayoutSettings{SidebarPosition: messages.SidebarRight, SectionSpacing: messages.SpacingNormal, SidebarInfoMode: messages.InfoModeCompact}) {
 			s.Layout = nil
 			return nil
 		}
@@ -1012,8 +1017,12 @@ func savePreferences(p messages.Preferences) error {
 		if layout.SectionSpacing == messages.SpacingNormal {
 			spacing = ""
 		}
+		infoMode := string(layout.SidebarInfoMode)
+		if layout.SidebarInfoMode == messages.InfoModeCompact {
+			infoMode = ""
+		}
 		s.Layout = &userconfig.LayoutSettings{
-			SidebarPosition: position, SectionSpacing: spacing,
+			SidebarPosition: position, SectionSpacing: spacing, SidebarInfoMode: infoMode,
 			HideSessionPath: layout.HideSessionPath, HideUsage: layout.HideUsage,
 			HideAgents: layout.HideAgents, HideTools: layout.HideTools, HideTodos: layout.HideTodos,
 		}

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -364,19 +364,24 @@ func (m *appModel) handleSwitchAgent(agentName string) (tea.Model, tea.Cmd) {
 // handleShowAgentDetails opens the read-only agent-details dialog for the named
 // agent, looking it up in the available-agents roster. The agent's latest
 // token-usage snapshot (if it has run) rides along so the dialog can show its
-// context usage.
+// context usage, as does its cumulative attributed cost (if any).
 func (m *appModel) handleShowAgentDetails(agentName string) (tea.Model, tea.Cmd) {
 	for _, agent := range m.sessionState.AvailableAgents() {
-		if agent.Name == agentName {
-			cfg := m.application.AgentConfigInfo(m.ctx(), agentName)
-			var usage *runtime.Usage
-			if u, ok := m.sessionState.AgentUsage(agentName); ok {
-				usage = &u
-			}
-			return m, core.CmdHandler(dialog.OpenDialogMsg{
-				Model: dialog.NewAgentDetailsDialog(agent, cfg, usage),
-			})
+		if agent.Name != agentName {
+			continue
 		}
+		cfg := m.application.AgentConfigInfo(m.ctx(), agentName)
+		var usage *runtime.Usage
+		if u, ok := m.sessionState.AgentUsage(agentName); ok {
+			usage = &u
+		}
+		var cost *float64
+		if c, ok := m.sessionState.AgentCost(agentName); ok {
+			cost = &c
+		}
+		return m, core.CmdHandler(dialog.OpenDialogMsg{
+			Model: dialog.NewAgentDetailsDialog(agent, cfg, usage, cost),
+		})
 	}
 	return m, nil
 }

--- a/pkg/tui/messages/layout_test.go
+++ b/pkg/tui/messages/layout_test.go
@@ -22,6 +22,25 @@ func TestParseSectionSpacing(t *testing.T) {
 	}
 }
 
+func TestParseSidebarInfoMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		raw  string
+		want SidebarInfoMode
+	}{
+		{"", InfoModeCompact},
+		{"compact", InfoModeCompact},
+		{"detailed", InfoModeDetailed},
+		{"bogus", InfoModeCompact},
+	}
+	for _, tt := range tests {
+		if got := ParseSidebarInfoMode(tt.raw); got != tt.want {
+			t.Errorf("ParseSidebarInfoMode(%q) = %q, want %q", tt.raw, got, tt.want)
+		}
+	}
+}
+
 func TestSectionSpacingBlankLines(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/messages/settings.go
+++ b/pkg/tui/messages/settings.go
@@ -65,13 +65,37 @@ func (s SectionSpacing) BlankLines() int {
 	}
 }
 
+// SidebarInfoMode identifies how the vertical sidebar's Agents section
+// renders each agent.
+type SidebarInfoMode string
+
+const (
+	// InfoModeCompact is the default two-line-per-agent roster.
+	InfoModeCompact SidebarInfoMode = "compact"
+	// InfoModeDetailed renders each agent as a mini-card with labeled
+	// Effort / Context / Cost metrics.
+	InfoModeDetailed SidebarInfoMode = "detailed"
+)
+
+// ParseSidebarInfoMode normalizes a raw info mode string, falling back to
+// InfoModeCompact for empty or unknown values so persisted configs can never
+// break the layout.
+func ParseSidebarInfoMode(raw string) SidebarInfoMode {
+	if SidebarInfoMode(raw) == InfoModeDetailed {
+		return InfoModeDetailed
+	}
+	return InfoModeCompact
+}
+
 // LayoutSettings describes the user-customizable TUI layout: where the
-// sidebar sits, which of its optional sections are rendered, and how much
-// space separates them. The zero value is the default layout (sidebar on
-// the right, everything visible, normal spacing).
+// sidebar sits, which of its optional sections are rendered, how much
+// space separates them, and how the Agents section renders each agent.
+// The zero value is the default layout (sidebar on the right, everything
+// visible, normal spacing, compact agent info).
 type LayoutSettings struct {
 	SidebarPosition SidebarPosition
 	SectionSpacing  SectionSpacing
+	SidebarInfoMode SidebarInfoMode
 	HideSessionPath bool
 	HideUsage       bool
 	HideAgents      bool

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -150,7 +150,8 @@ type Page interface {
 	// SetSidebarSettings applies sidebar display settings
 	SetSidebarSettings(settings SidebarSettings)
 	// SetLayoutSettings applies layout customization (sidebar position,
-	// section spacing, and section visibility) and relayouts the page.
+	// section spacing, section visibility, and agent info mode) and
+	// relayouts the page.
 	SetLayoutSettings(settings msgtypes.LayoutSettings) tea.Cmd
 	// SetSendMode sets what happens to messages sent while the agent is
 	// working: steer into the ongoing stream or queue until the turn ends.
@@ -387,12 +388,13 @@ func WithCommandParser(p *commands.Parser) PageOption {
 }
 
 // WithLayoutSettings applies initial layout customization (sidebar position,
-// section spacing, and section visibility).
+// section spacing, section visibility, and agent info mode).
 func WithLayoutSettings(settings msgtypes.LayoutSettings) PageOption {
 	return func(p *chatPage) {
 		p.layoutSettings = settings
 		p.sidebar.SetSectionVisibility(sectionVisibility(settings))
 		p.sidebar.SetSectionGap(settings.SectionSpacing.BlankLines())
+		p.sidebar.SetAgentInfoMode(agentInfoMode(settings.SidebarInfoMode))
 	}
 }
 
@@ -413,6 +415,15 @@ func sectionVisibility(settings msgtypes.LayoutSettings) sidebar.SectionVisibili
 		HideTools:       settings.HideTools,
 		HideTodos:       settings.HideTodos,
 	}
+}
+
+// agentInfoMode maps the layout's sidebar info mode to the sidebar's
+// agent-roster renderer selection; empty/unknown values fall back to compact.
+func agentInfoMode(mode msgtypes.SidebarInfoMode) sidebar.AgentInfoMode {
+	if msgtypes.ParseSidebarInfoMode(string(mode)) == msgtypes.InfoModeDetailed {
+		return sidebar.AgentInfoDetailed
+	}
+	return sidebar.AgentInfoCompact
 }
 
 // Init initializes the chat page
@@ -1227,6 +1238,7 @@ func (p *chatPage) SetLayoutSettings(settings msgtypes.LayoutSettings) tea.Cmd {
 	p.layoutSettings = settings
 	p.sidebar.SetSectionVisibility(sectionVisibility(settings))
 	p.sidebar.SetSectionGap(settings.SectionSpacing.BlankLines())
+	p.sidebar.SetAgentInfoMode(agentInfoMode(settings.SidebarInfoMode))
 	if p.width <= 0 || p.height <= 0 {
 		return nil
 	}

--- a/pkg/tui/page/chat/layout_position_test.go
+++ b/pkg/tui/page/chat/layout_position_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/tui/components/messages"
 	"github.com/docker/docker-agent/pkg/tui/components/sidebar"
 	msgtypes "github.com/docker/docker-agent/pkg/tui/messages"
@@ -171,6 +172,63 @@ func TestSectionVisibilityMapsAllFields(t *testing.T) {
 		HideTools:       true,
 		HideTodos:       true,
 	}))
+}
+
+func TestAgentInfoModeMapsValues(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, sidebar.AgentInfoCompact, agentInfoMode(""), "the zero value maps to compact")
+	assert.Equal(t, sidebar.AgentInfoCompact, agentInfoMode(msgtypes.InfoModeCompact))
+	assert.Equal(t, sidebar.AgentInfoDetailed, agentInfoMode(msgtypes.InfoModeDetailed))
+	assert.Equal(t, sidebar.AgentInfoCompact, agentInfoMode(msgtypes.SidebarInfoMode("bogus")),
+		"unknown values map to compact")
+}
+
+// TestSetLayoutSettingsForwardsInfoModeToSidebar verifies the info mode
+// reaches the sidebar's roster renderer and can be switched live: the
+// detailed cards carry the "Effort" metric label, the compact roster does not.
+func TestSetLayoutSettingsForwardsInfoModeToSidebar(t *testing.T) {
+	t.Parallel()
+
+	p := newLayoutTestPage(t, msgtypes.SidebarRight)
+	p.sessionState.SetCurrentAgentName("root")
+	p.sidebar.SetTeamInfo([]runtime.AgentDetails{
+		{Name: "root", Provider: "openai", Model: "gpt-4", Thinking: "high"},
+	})
+	p.SetSize(160, 40)
+
+	require.NotContains(t, ansi.Strip(p.View()), "Effort",
+		"the default layout renders the compact roster")
+
+	p.SetLayoutSettings(msgtypes.LayoutSettings{SidebarInfoMode: msgtypes.InfoModeDetailed})
+	assert.Contains(t, ansi.Strip(p.View()), "Effort",
+		"detailed mode renders the labeled agent cards")
+
+	p.SetLayoutSettings(msgtypes.LayoutSettings{})
+	assert.NotContains(t, ansi.Strip(p.View()), "Effort",
+		"switching back live restores the compact roster")
+}
+
+// TestWithLayoutSettingsAppliesInfoMode verifies the initial page option
+// forwards the persisted info mode to the sidebar.
+func TestWithLayoutSettingsAppliesInfoMode(t *testing.T) {
+	t.Parallel()
+
+	sessionState := &service.SessionState{}
+	sessionState.SetCurrentAgentName("root")
+	p := &chatPage{
+		sidebar:      sidebar.New(t.Context(), sessionState),
+		messages:     messages.New(sessionState),
+		sessionState: sessionState,
+	}
+	WithLayoutSettings(msgtypes.LayoutSettings{SidebarInfoMode: msgtypes.InfoModeDetailed})(p)
+	p.sidebar.SetTeamInfo([]runtime.AgentDetails{
+		{Name: "root", Provider: "openai", Model: "gpt-4", Thinking: "high"},
+	})
+	p.SetSize(160, 40)
+
+	assert.Contains(t, ansi.Strip(p.View()), "Effort",
+		"the initial layout option applies the detailed mode")
 }
 
 func TestSetLayoutSettingsBeforeSizingReturnsNil(t *testing.T) {

--- a/pkg/tui/service/sessionstate.go
+++ b/pkg/tui/service/sessionstate.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tui/styles"
@@ -63,6 +64,26 @@ type SessionState struct {
 	// background agent tasks). It backs the per-agent context display in
 	// the sidebar roster and the agent-details dialog.
 	agentUsage map[string]runtime.Usage
+
+	// sessionCost holds the latest cumulative cost snapshot per session ID,
+	// and sessionAgent attributes each of those sessions to the agent that
+	// most recently emitted usage for it. Together they back AgentCost:
+	// summing the latest snapshot per distinct session adds multiple
+	// sub/background sessions of one agent without double-counting the
+	// repeated cumulative snapshots a single session emits.
+	sessionCost  map[string]float64
+	sessionAgent map[string]string
+
+	// Restored-session cost baseline, seeded by SeedRestoredCosts:
+	// restoredAgentCost holds the per-agent historical totals reconstructed
+	// from the restored session tree, restoredBaseline the tree's full cost
+	// (attributed and unattributed alike), and restoredSessionID the restored
+	// root session. Live cumulative snapshots of that root subsume the whole
+	// restored tree, so AgentCost counts them only beyond the baseline; every
+	// other live session counts in full.
+	restoredSessionID string
+	restoredBaseline  float64
+	restoredAgentCost map[string]float64
 }
 
 func NewSessionState(s *session.Session) *SessionState {
@@ -181,10 +202,18 @@ func (s *SessionState) GetCurrentAgent() runtime.AgentDetails {
 	return runtime.AgentDetails{}
 }
 
-// SetAgentUsage records the latest token-usage snapshot for the named agent.
-// Each snapshot carries cumulative totals for the agent's most recent
-// session, so the last write always reflects its current context usage.
-func (s *SessionState) SetAgentUsage(agentName string, usage runtime.Usage) {
+// SetAgentUsage records the latest token-usage snapshot for the named agent
+// and attributes the session's cumulative cost to it. Each snapshot carries
+// cumulative totals for the session that emitted it, so the last write always
+// reflects that session's current context usage and cost.
+//
+// Attribution is last-writer-wins per session: when a session's events start
+// carrying a different agent name (an in-session handoff), the whole
+// session's cumulative cost moves to the new agent. The snapshots carry no
+// per-agent split of a shared session, so this keeps the total honest (never
+// double-counted) at the price of crediting the session's earlier spend to
+// the agent that finished it.
+func (s *SessionState) SetAgentUsage(sessionID, agentName string, usage runtime.Usage) {
 	if agentName == "" {
 		return
 	}
@@ -192,6 +221,15 @@ func (s *SessionState) SetAgentUsage(agentName string, usage runtime.Usage) {
 		s.agentUsage = make(map[string]runtime.Usage)
 	}
 	s.agentUsage[agentName] = usage
+	if sessionID == "" {
+		return
+	}
+	if s.sessionCost == nil {
+		s.sessionCost = make(map[string]float64)
+		s.sessionAgent = make(map[string]string)
+	}
+	s.sessionCost[sessionID] = usage.Cost
+	s.sessionAgent[sessionID] = agentName
 }
 
 // AgentUsage returns the latest token-usage snapshot recorded for the named
@@ -199,4 +237,76 @@ func (s *SessionState) SetAgentUsage(agentName string, usage runtime.Usage) {
 func (s *SessionState) AgentUsage(agentName string) (runtime.Usage, bool) {
 	usage, ok := s.agentUsage[agentName]
 	return usage, ok
+}
+
+// AgentCost returns the cumulative cost currently attributed to the named
+// agent — its restored historical total (see SeedRestoredCosts) plus every
+// live session attributed to it — and whether any cost is attributable to
+// it. A false result means none is (the agent never ran and has no restored
+// spend, or an in-session handoff moved its sessions to another agent) —
+// distinct from a true result with a zero total, which means the agent ran
+// at no cost.
+func (s *SessionState) AgentCost(agentName string) (float64, bool) {
+	total, attributed := s.restoredAgentCost[agentName]
+	for id, owner := range s.sessionAgent {
+		if owner != agentName {
+			continue
+		}
+		cost := s.sessionCost[id]
+		if id == s.restoredSessionID {
+			// Live snapshots of the restored root are cumulative over the
+			// whole restored tree (own + embedded sub-session costs): only
+			// the spend beyond the restored baseline is new.
+			cost = max(0, cost-s.restoredBaseline)
+		}
+		total += cost
+		attributed = true
+	}
+	return total, attributed
+}
+
+// SeedRestoredCosts resets the per-agent usage/cost state and installs the
+// per-agent historical cost reconstructed from a restored session's tree:
+// per-message costs summed by AgentName, recursing into embedded
+// sub-sessions. Replace semantics keep repeated loads and session switches
+// honest — nothing recorded for a previously shown session survives. Costs
+// that carry no agent identity (compaction summaries, agent-less messages)
+// are deliberately left unattributed: they stay part of the aggregate
+// baseline but never appear on an agent. Per-agent context snapshots are not
+// fabricated either; every agent reads as unknown until it runs again.
+func (s *SessionState) SeedRestoredCosts(sess *session.Session) {
+	s.agentUsage = nil
+	s.sessionCost = nil
+	s.sessionAgent = nil
+	s.restoredSessionID = ""
+	s.restoredBaseline = 0
+	s.restoredAgentCost = nil
+	if sess == nil {
+		return
+	}
+	costs := make(map[string]float64)
+	collectAgentCosts(sess, costs)
+	s.restoredSessionID = sess.ID
+	s.restoredBaseline = sess.TotalCost()
+	s.restoredAgentCost = costs
+}
+
+// collectAgentCosts sums the persisted per-message costs by agent name across
+// the session tree, mirroring the /cost dialog's per-message aggregation:
+// only non-system messages with usage data count (so an agent that ran at
+// zero cost is attributed $0, distinct from never-ran), and messages without
+// an agent name stay unattributed.
+func collectAgentCosts(sess *session.Session, costs map[string]float64) {
+	for _, item := range sess.MessagesSnapshot() {
+		switch {
+		case item.IsMessage():
+			msg := item.Message
+			if msg.AgentName == "" || msg.Message.Role == chat.MessageRoleSystem || msg.Message.Usage == nil {
+				continue
+			}
+			costs[msg.AgentName] += msg.Message.Cost
+		case item.IsSubSession():
+			collectAgentCosts(item.SubSession, costs)
+		}
+	}
 }

--- a/pkg/tui/service/sessionstate_test.go
+++ b/pkg/tui/service/sessionstate_test.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
 )
 
 // TestSessionState_AgentUsage covers the per-agent usage snapshot store: set,
@@ -18,17 +20,206 @@ func TestSessionState_AgentUsage(t *testing.T) {
 	_, ok := s.AgentUsage("root")
 	assert.False(t, ok, "no snapshot before any usage is recorded")
 
-	s.SetAgentUsage("root", runtime.Usage{ContextLength: 1000, ContextLimit: 10000})
+	s.SetAgentUsage("session-1", "root", runtime.Usage{ContextLength: 1000, ContextLimit: 10000})
 	usage, ok := s.AgentUsage("root")
 	assert.True(t, ok)
 	assert.Equal(t, int64(1000), usage.ContextLength)
 
-	s.SetAgentUsage("root", runtime.Usage{ContextLength: 2000, ContextLimit: 10000})
+	s.SetAgentUsage("session-1", "root", runtime.Usage{ContextLength: 2000, ContextLimit: 10000})
 	usage, ok = s.AgentUsage("root")
 	assert.True(t, ok)
 	assert.Equal(t, int64(2000), usage.ContextLength, "latest snapshot wins")
 
-	s.SetAgentUsage("", runtime.Usage{ContextLength: 3000})
+	s.SetAgentUsage("session-1", "", runtime.Usage{ContextLength: 3000})
 	_, ok = s.AgentUsage("")
 	assert.False(t, ok, "snapshots without an agent name are dropped")
+}
+
+// TestSessionState_AgentCost covers the cumulative per-agent cost: unknown
+// before any usage, replacement of one session's repeated cumulative
+// snapshots, addition across distinct sessions, and the ran-at-zero-cost case
+// staying distinct from never-ran.
+func TestSessionState_AgentCost(t *testing.T) {
+	t.Parallel()
+
+	s := NewSessionState(nil)
+
+	_, ok := s.AgentCost("root")
+	assert.False(t, ok, "no cost attributable before any usage is recorded")
+
+	// Repeated cumulative snapshots of one session replace, not add.
+	s.SetAgentUsage("session-1", "root", runtime.Usage{Cost: 0.10})
+	s.SetAgentUsage("session-1", "root", runtime.Usage{Cost: 0.30})
+	cost, ok := s.AgentCost("root")
+	assert.True(t, ok)
+	assert.InDelta(t, 0.30, cost, 1e-9)
+
+	// A second session for the same agent (sub-session or background task) adds.
+	s.SetAgentUsage("session-2", "root", runtime.Usage{Cost: 0.05})
+	cost, ok = s.AgentCost("root")
+	assert.True(t, ok)
+	assert.InDelta(t, 0.35, cost, 1e-9)
+
+	// Other agents stay independent.
+	s.SetAgentUsage("session-3", "developer", runtime.Usage{Cost: 0.02})
+	cost, ok = s.AgentCost("developer")
+	assert.True(t, ok)
+	assert.InDelta(t, 0.02, cost, 1e-9)
+
+	// An agent that ran at zero cost is attributed with $0, not unknown.
+	s.SetAgentUsage("session-4", "local", runtime.Usage{Cost: 0})
+	cost, ok = s.AgentCost("local")
+	assert.True(t, ok)
+	assert.Zero(t, cost)
+}
+
+// TestSessionState_AgentCost_SessionHandoffMovesAttribution documents the
+// chosen semantics for a session whose events change agent name mid-stream
+// (an in-session handoff): the latest attribution wins, so the whole
+// session's cumulative cost moves to the new agent. The snapshots carry no
+// per-agent split of a shared session, so this never double-counts — at the
+// price of crediting the earlier spend to the agent that finished the
+// session, and reporting the earlier agent's cost as unknown again when it
+// has no other sessions.
+func TestSessionState_AgentCost_SessionHandoffMovesAttribution(t *testing.T) {
+	t.Parallel()
+
+	s := NewSessionState(nil)
+
+	s.SetAgentUsage("session-1", "root", runtime.Usage{Cost: 0.10})
+	s.SetAgentUsage("session-1", "developer", runtime.Usage{Cost: 0.25})
+
+	cost, ok := s.AgentCost("developer")
+	assert.True(t, ok)
+	assert.InDelta(t, 0.25, cost, 1e-9, "the session's full cumulative cost follows the newest agent")
+
+	_, ok = s.AgentCost("root")
+	assert.False(t, ok, "the previous agent no longer owns any session")
+}
+
+// restoredCostMessage returns a message item as persisted for an assistant
+// response: agent name, per-message cost, and its usage record (present even
+// at zero cost).
+func restoredCostMessage(agentName string, cost float64) session.Item {
+	return session.Item{Message: &session.Message{
+		AgentName: agentName,
+		Message: chat.Message{
+			Role:    chat.MessageRoleAssistant,
+			Content: "done",
+			Cost:    cost,
+			Usage:   &chat.Usage{InputTokens: 100, OutputTokens: 20},
+		},
+	}}
+}
+
+// TestSessionState_SeedRestoredCosts covers the restored-cost seeding: exact
+// per-agent totals from the session tree including nested sub-sessions, the
+// zero-cost vs never-ran distinction, honest non-attribution of agent-less
+// and compaction costs, and the replace/reset semantics of repeated seeding.
+func TestSessionState_SeedRestoredCosts(t *testing.T) {
+	t.Parallel()
+
+	// root ($0.02 + $0.03) and a zero-cost local agent directly in the root
+	// session; developer ($0.05) in a sub-session holding a nested
+	// sub-sub-session for writer ($0.01); an agent-less message ($0.04) and a
+	// compaction summary ($0.02) that both lack agent identity.
+	sess := session.New()
+	sess.Messages = append(sess.Messages,
+		restoredCostMessage("root", 0.02),
+		restoredCostMessage("root", 0.03),
+		restoredCostMessage("local", 0),
+		restoredCostMessage("", 0.04),
+		session.Item{Summary: "compacted", Cost: 0.02},
+	)
+	subSub := session.New()
+	subSub.Messages = append(subSub.Messages, restoredCostMessage("writer", 0.01))
+	sub := session.New(session.WithParentID(sess.ID))
+	sub.Messages = append(sub.Messages, restoredCostMessage("developer", 0.05), session.Item{SubSession: subSub})
+	sess.Messages = append(sess.Messages, session.Item{SubSession: sub})
+
+	s := NewSessionState(nil)
+	// Live state from a previously shown session must not survive the seed.
+	s.SetAgentUsage("old-session", "stale", runtime.Usage{ContextLength: 1000, ContextLimit: 10_000, Cost: 0.50})
+
+	s.SeedRestoredCosts(sess)
+
+	cost, ok := s.AgentCost("root")
+	assert.True(t, ok)
+	assert.InDelta(t, 0.05, cost, 1e-9, "root's own messages add up")
+
+	cost, ok = s.AgentCost("developer")
+	assert.True(t, ok)
+	assert.InDelta(t, 0.05, cost, 1e-9, "sub-session spend attributes to its agent")
+
+	cost, ok = s.AgentCost("writer")
+	assert.True(t, ok)
+	assert.InDelta(t, 0.01, cost, 1e-9, "nested sub-sub-session spend attributes too")
+
+	cost, ok = s.AgentCost("local")
+	assert.True(t, ok)
+	assert.Zero(t, cost, "an agent restored at zero cost is attributed $0, not unknown")
+
+	_, ok = s.AgentCost("idle")
+	assert.False(t, ok, "an agent absent from the restored tree stays unknown")
+
+	_, ok = s.AgentCost("stale")
+	assert.False(t, ok, "seeding clears the previously shown session's cost state")
+	_, ok = s.AgentUsage("stale")
+	assert.False(t, ok, "seeding clears usage snapshots too; context is not fabricated")
+
+	// Re-seeding the same session replaces rather than accumulates.
+	s.SeedRestoredCosts(sess)
+	cost, ok = s.AgentCost("root")
+	assert.True(t, ok)
+	assert.InDelta(t, 0.05, cost, 1e-9, "repeated seeding does not double values")
+
+	// Seeding with nil resets everything.
+	s.SeedRestoredCosts(nil)
+	_, ok = s.AgentCost("root")
+	assert.False(t, ok)
+}
+
+// TestSessionState_SeedRestoredCosts_LiveSnapshotsAddOnlyNewSpend verifies
+// the interplay of the restored baseline with subsequent live cumulative
+// snapshots: the restored root session's snapshots cover the whole restored
+// tree (own + embedded sub-session costs), so only spend beyond the baseline
+// is attributed to the live agent, while a fresh live sub-session counts in
+// full.
+func TestSessionState_SeedRestoredCosts_LiveSnapshotsAddOnlyNewSpend(t *testing.T) {
+	t.Parallel()
+
+	// Restored tree: root $0.10, embedded developer sub-session $0.05,
+	// unattributed compaction $0.01 — a $0.16 baseline.
+	sess := session.New()
+	sess.Messages = append(sess.Messages,
+		restoredCostMessage("root", 0.10),
+		session.Item{Summary: "compacted", Cost: 0.01},
+	)
+	sub := session.New(session.WithParentID(sess.ID))
+	sub.Messages = append(sub.Messages, restoredCostMessage("developer", 0.05))
+	sess.Messages = append(sess.Messages, session.Item{SubSession: sub})
+
+	s := NewSessionState(nil)
+	s.SeedRestoredCosts(sess)
+
+	// The root session resumes: its live snapshot is cumulative over the
+	// restored tree plus $0.02 of new spend.
+	s.SetAgentUsage(sess.ID, "root", runtime.Usage{Cost: 0.18})
+	cost, ok := s.AgentCost("root")
+	assert.True(t, ok)
+	assert.InDelta(t, 0.12, cost, 1e-9, "restored total plus only the new spend")
+
+	cost, ok = s.AgentCost("developer")
+	assert.True(t, ok)
+	assert.InDelta(t, 0.05, cost, 1e-9, "restored sub-session spend keeps its agent")
+
+	// A later cumulative snapshot of the same session replaces, not adds.
+	s.SetAgentUsage(sess.ID, "root", runtime.Usage{Cost: 0.20})
+	cost, _ = s.AgentCost("root")
+	assert.InDelta(t, 0.14, cost, 1e-9)
+
+	// A fresh live sub-session is new spend in full.
+	s.SetAgentUsage("live-sub", "developer", runtime.Usage{Cost: 0.03})
+	cost, _ = s.AgentCost("developer")
+	assert.InDelta(t, 0.08, cost, 1e-9)
 }

--- a/pkg/tui/settings_persistence_test.go
+++ b/pkg/tui/settings_persistence_test.go
@@ -23,18 +23,19 @@ func TestLayoutSettingsFromConfig(t *testing.T) {
 	t.Parallel()
 
 	assert.Equal(t,
-		messages.LayoutSettings{SidebarPosition: messages.SidebarRight, SectionSpacing: messages.SpacingNormal},
+		messages.LayoutSettings{SidebarPosition: messages.SidebarRight, SectionSpacing: messages.SpacingNormal, SidebarInfoMode: messages.InfoModeCompact},
 		layoutSettingsFromConfig(userconfig.LayoutSettings{}),
-		"empty config falls back to the default position and spacing")
+		"empty config falls back to the default position, spacing and info mode")
 
 	assert.Equal(t,
-		messages.LayoutSettings{SidebarPosition: messages.SidebarRight, SectionSpacing: messages.SpacingNormal},
-		layoutSettingsFromConfig(userconfig.LayoutSettings{SidebarPosition: "bogus", SectionSpacing: "bogus"}),
+		messages.LayoutSettings{SidebarPosition: messages.SidebarRight, SectionSpacing: messages.SpacingNormal, SidebarInfoMode: messages.InfoModeCompact},
+		layoutSettingsFromConfig(userconfig.LayoutSettings{SidebarPosition: "bogus", SectionSpacing: "bogus", SidebarInfoMode: "bogus"}),
 		"unknown values fall back to the defaults")
 
 	got := layoutSettingsFromConfig(userconfig.LayoutSettings{
 		SidebarPosition: "bottom",
 		SectionSpacing:  "compact",
+		SidebarInfoMode: "detailed",
 		HideSessionPath: true,
 		HideUsage:       true,
 		HideAgents:      true,
@@ -44,6 +45,7 @@ func TestLayoutSettingsFromConfig(t *testing.T) {
 	assert.Equal(t, messages.LayoutSettings{
 		SidebarPosition: messages.SidebarBottom,
 		SectionSpacing:  messages.SpacingCompact,
+		SidebarInfoMode: messages.InfoModeDetailed,
 		HideSessionPath: true,
 		HideUsage:       true,
 		HideAgents:      true,
@@ -58,6 +60,7 @@ func TestSaveSettingsToUserConfig_RoundTrip(t *testing.T) {
 	saved := messages.LayoutSettings{
 		SidebarPosition: messages.SidebarLeft,
 		SectionSpacing:  messages.SpacingRelaxed,
+		SidebarInfoMode: messages.InfoModeCompact,
 		HideSessionPath: true,
 		HideTools:       true,
 	}
@@ -114,6 +117,7 @@ func TestSavePreferences_RoundTripAndPreservesExtra(t *testing.T) {
 		Layout: messages.LayoutSettings{
 			SidebarPosition: messages.SidebarBottom,
 			SectionSpacing:  messages.SpacingCompact,
+			SidebarInfoMode: messages.InfoModeDetailed,
 			HideAgents:      true,
 		},
 		SendMode:           messages.SendModeQueue,
@@ -195,6 +199,7 @@ func TestSaveSettingsToUserConfig_HideSessionPathKeepsEntry(t *testing.T) {
 	saved := messages.LayoutSettings{
 		SidebarPosition: messages.SidebarRight,
 		SectionSpacing:  messages.SpacingNormal,
+		SidebarInfoMode: messages.InfoModeCompact,
 		HideSessionPath: true,
 	}
 	require.NoError(t, saveSettingsToUserConfig(saved, messages.SendModeSteer))
@@ -205,4 +210,44 @@ func TestSaveSettingsToUserConfig_HideSessionPathKeepsEntry(t *testing.T) {
 	require.NotNil(t, layout, "hide_session_path alone must keep the layout entry")
 	assert.True(t, layout.HideSessionPath)
 	assert.Equal(t, saved, layoutSettingsFromConfig(userconfig.Get().GetLayout()))
+}
+
+func TestSavePreferences_DetailedInfoModeKeepsEntry(t *testing.T) {
+	setupSettingsConfigTest(t)
+
+	saved := messages.LayoutSettings{
+		SidebarPosition: messages.SidebarRight,
+		SectionSpacing:  messages.SpacingNormal,
+		SidebarInfoMode: messages.InfoModeDetailed,
+	}
+	require.NoError(t, saveSettingsToUserConfig(saved, messages.SendModeSteer))
+
+	cfg, err := userconfig.Load()
+	require.NoError(t, err)
+	layout := cfg.GetSettings().Layout
+	require.NotNil(t, layout, "a detailed info mode alone must keep the layout entry")
+	assert.Equal(t, "detailed", layout.SidebarInfoMode)
+	assert.Empty(t, layout.SidebarPosition, "the default position is not written out")
+	assert.Empty(t, layout.SectionSpacing, "the default spacing is not written out")
+	assert.Equal(t, saved, layoutSettingsFromConfig(userconfig.Get().GetLayout()))
+}
+
+func TestSavePreferences_CompactInfoModeClearsEntry(t *testing.T) {
+	setupSettingsConfigTest(t)
+
+	require.NoError(t, saveSettingsToUserConfig(messages.LayoutSettings{
+		SidebarPosition: messages.SidebarRight,
+		SectionSpacing:  messages.SpacingNormal,
+		SidebarInfoMode: messages.InfoModeDetailed,
+	}, messages.SendModeSteer))
+	require.NoError(t, saveSettingsToUserConfig(messages.LayoutSettings{
+		SidebarPosition: messages.SidebarRight,
+		SectionSpacing:  messages.SpacingNormal,
+		SidebarInfoMode: messages.InfoModeCompact,
+	}, messages.SendModeSteer))
+
+	cfg, err := userconfig.Load()
+	require.NoError(t, err)
+	assert.Nil(t, cfg.GetSettings().Layout,
+		"the default layout with an explicit compact info mode clears the config entry")
 }

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -123,6 +123,10 @@ type LayoutSettings struct {
 	// SectionSpacing controls the blank space between sidebar sections:
 	// "normal" (default), "compact", or "relaxed".
 	SectionSpacing string `yaml:"section_spacing,omitempty"`
+	// SidebarInfoMode controls how the sidebar's Agents section renders each
+	// agent: "compact" (default, two lines per agent) or "detailed"
+	// (mini-cards with labeled effort/context/cost metrics).
+	SidebarInfoMode string `yaml:"sidebar_info_mode,omitempty"`
 	// HideSessionPath hides the working directory (session path) line in the sidebar.
 	HideSessionPath bool `yaml:"hide_session_path,omitempty"`
 	// HideUsage hides the token usage section in the sidebar.

--- a/pkg/userconfig/userconfig_test.go
+++ b/pkg/userconfig/userconfig_test.go
@@ -235,6 +235,7 @@ func TestSettings_LayoutRoundTrip(t *testing.T) {
 			Layout: &LayoutSettings{
 				SidebarPosition: "left",
 				SectionSpacing:  "compact",
+				SidebarInfoMode: "detailed",
 				HideSessionPath: true,
 				HideUsage:       true,
 				HideTodos:       true,
@@ -247,6 +248,7 @@ func TestSettings_LayoutRoundTrip(t *testing.T) {
 	data, err := os.ReadFile(configFile)
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "hide_session_path: true")
+	assert.Contains(t, string(data), "sidebar_info_mode: detailed")
 
 	loaded, err := loadFrom(configFile, "")
 	require.NoError(t, err)
@@ -254,6 +256,7 @@ func TestSettings_LayoutRoundTrip(t *testing.T) {
 	layout := loaded.GetSettings().GetLayout()
 	assert.Equal(t, "left", layout.SidebarPosition)
 	assert.Equal(t, "compact", layout.SectionSpacing)
+	assert.Equal(t, "detailed", layout.SidebarInfoMode)
 	assert.True(t, layout.HideSessionPath)
 	assert.True(t, layout.HideUsage)
 	assert.False(t, layout.HideAgents)


### PR DESCRIPTION
## Summary

- add a `Sidebar info mode` selector to `/settings`, with the existing compact roster as the default and a detailed per-agent view as an opt-in
- keep the compact mode identical to the current two-line agent roster
- retain the full six-cell effort gauge while explicitly labeling effort, context, and cost in detailed mode
- aggregate cumulative cost per agent without counting repeated session snapshots twice
- restore historical per-agent costs from persisted session trees
- add per-agent cost to the Agent Inspector and a `By Agent` section to `/cost`

## Settings

`/settings` → `Appearance` now includes:

```text
Sidebar info mode                         ‹ Compact ›
```

| Mode | Behavior |
|---|---|
| Compact | Default. Preserves the existing two-line agent roster with effort badge and context percentage. |
| Detailed | Shows responsive agent cards with labeled Effort, Context, and Cost metrics. |

The selection previews immediately across tabs. Apply persists it as `settings.layout.sidebar_info_mode: detailed`; Cancel restores the previous mode. Compact is omitted from the config because it is the default.

## Preview

The previews below use ANSI-stripped output.

### Compact mode, default sidebar width

```text
Agents ────────────────────────────────

▶ root                        ▰▰▰▰▱▱ ^1
  anthropic/claude-opus-4-8         30%

  helper                      ▱▱▱▱▱▱ ^2
  openai/gpt-5.4-mini               91%

  budget                      ◉ 8.2K ^3
  openai/gpt-4o

  plain                              ^4
  google/gemini-flash
```

### Detailed mode, default sidebar width

```text
Agents ────────────────────────────────

▶ root                               ^1
  anthropic/claude-opus-4-8
  Effort ▰▰▰▰▱▱ high
  Context 30% · Cost $0.13

  helper                             ^2
  openai/gpt-5.4-mini
  Effort ▱▱▱▱▱▱ off
  Context 91% · Cost $0.02

  budget                             ^3
  openai/gpt-4o
  Effort ◉ 8.2K · Context — · Cost —

  plain                              ^4
  google/gemini-flash
  Context — · Cost —
```

### Detailed mode, minimum sidebar width

At the 20-column minimum width, the complete effort gauge remains visible and metrics flow onto separate lines.

```text
Agents ────────────

▶ root           ^1
  …/claude-opus-4-8
  Effort ▰▰▰▰▱▱
  Ctx 30%
  Cost $0.13

  helper         ^2
  …nai/gpt-5.4-mini
  Effort ▱▱▱▱▱▱ off
  Ctx 91%
  Cost $0.02

  budget         ^3
  openai/gpt-4o
  Effort ◉ 8.2K
  Ctx — · Cost —

  plain          ^4
  …gle/gemini-flash
  Ctx — · Cost —
```

At wider sidebar sizes, all three detailed metrics share one line:

```text
▶ root                                             ^1
  anthropic/claude-opus-4-8
  Effort ▰▰▰▰▱▱ high · Context 30% · Cost $0.13
```

## Behavior

| Area | Behavior |
|---|---|
| Default UX | Compact mode preserves the current roster and vertical density |
| Effort | Detailed mode keeps the full six-cell gauge and its readable value when space permits |
| Context | Detailed mode uses an explicit label and preserves warning and critical coloring |
| Cost | Aggregates the latest cumulative snapshot of each distinct session |
| Unknown values | Uses `—`, distinct from an agent that ran at `$0.00` |
| Sub-cent costs | Uses four decimals below one cent |
| Restored sessions | Reconstructs historical per-agent costs from persisted messages and nested sub-sessions |
| Agent Inspector | Displays the agent's context and cumulative attributed cost in both sidebar modes |
| `/cost` | Adds `By Agent` before `By Model`, with separate unattributed and compaction buckets |
| Collapsed sidebar | Unchanged by the info mode setting |

## Validation

| Check | Result |
|---|---|
| `task build` | pass |
| `task test` | pass |
| `task lint` | pass |
| Focused race tests | pass |
| Adversarial review | pass, no blockers |

Proxy variables were unset for the full test and lint runs because the local proxy intercepted private-address SSRF tests and Go module downloads.

## Known limitations

- live cost attribution after an in-session handoff follows the latest agent because cumulative session events do not expose an exact per-agent split
- historical per-agent costs cannot be reconstructed for remote sessions that do not persist per-message attribution
