### PR TITLE
fix(tui): match slash command value, not just label, in inline completion

### DIFF
--- a/pkg/tui/components/completion/completion.go
+++ b/pkg/tui/components/completion/completion.go
@@ -420,8 +420,11 @@ func (c *manager) filterItems(query string) {
 		var score int
 
 		if c.matchMode == MatchPrefix {
-			// Prefix matching: label must start with query (case-insensitive)
-			if strings.HasPrefix(strings.ToLower(item.Label), lowerQuery) {
+			// Prefix matching: label or value (e.g. a slash command whose label
+			// doesn't share its prefix, like "/settings" -> "Preferences") must
+			// start with the query (case-insensitive).
+			if strings.HasPrefix(strings.ToLower(item.Label), lowerQuery) ||
+				strings.HasPrefix(strings.ToLower(strings.TrimPrefix(item.Value, "/")), lowerQuery) {
 				matched = true
 				score = 1000 - len(item.Label) // Shorter labels rank higher
 			}

--- a/pkg/tui/components/completion/completion_test.go
+++ b/pkg/tui/components/completion/completion_test.go
@@ -6,6 +6,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCompletionManagerStaysOpenWithNoResults(t *testing.T) {
@@ -88,6 +89,68 @@ func TestCompletionManagerStaysOpenWithNoResults(t *testing.T) {
 
 		view := m.View()
 		assert.Contains(t, view, "No results", "should show no results message")
+	})
+}
+
+func TestCompletionManagerMatchPrefixMatchesValue(t *testing.T) {
+	t.Parallel()
+
+	settingsItem := Item{Label: "Preferences", Value: "/settings"}
+	exitItem := Item{Label: "exit", Value: "/exit"}
+
+	t.Run("query matching the slash command surfaces a mismatched label", func(t *testing.T) {
+		t.Parallel()
+
+		m := New().(*manager)
+		m.Update(OpenMsg{
+			Items:     []Item{settingsItem, exitItem},
+			MatchMode: MatchPrefix,
+		})
+
+		m.Update(QueryMsg{Query: "settings"})
+		require.Len(t, m.filteredItems, 1)
+		assert.Equal(t, "Preferences", m.filteredItems[0].Label)
+	})
+
+	t.Run("a prefix of the slash command still matches", func(t *testing.T) {
+		t.Parallel()
+
+		m := New().(*manager)
+		m.Update(OpenMsg{
+			Items:     []Item{settingsItem, exitItem},
+			MatchMode: MatchPrefix,
+		})
+
+		m.Update(QueryMsg{Query: "set"})
+		require.Len(t, m.filteredItems, 1)
+		assert.Equal(t, "Preferences", m.filteredItems[0].Label)
+	})
+
+	t.Run("label prefix matching still works", func(t *testing.T) {
+		t.Parallel()
+
+		m := New().(*manager)
+		m.Update(OpenMsg{
+			Items:     []Item{settingsItem, exitItem},
+			MatchMode: MatchPrefix,
+		})
+
+		m.Update(QueryMsg{Query: "exi"})
+		require.Len(t, m.filteredItems, 1)
+		assert.Equal(t, "exit", m.filteredItems[0].Label)
+	})
+
+	t.Run("query matching neither label nor value is filtered out", func(t *testing.T) {
+		t.Parallel()
+
+		m := New().(*manager)
+		m.Update(OpenMsg{
+			Items:     []Item{settingsItem, exitItem},
+			MatchMode: MatchPrefix,
+		})
+
+		m.Update(QueryMsg{Query: "zzz"})
+		assert.Empty(t, m.filteredItems)
 	})
 }
 

--- a/pkg/tui/components/editor/completions/command_test.go
+++ b/pkg/tui/components/editor/completions/command_test.go
@@ -1,0 +1,81 @@
+package completions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tui/commands"
+	"github.com/docker/docker-agent/pkg/tui/components/completion"
+)
+
+// categoriesWithSettings mirrors the real "Settings" category, whose
+// "Preferences" label doesn't share a prefix with its "/settings" slash
+// command — the case that exposed the inline-completion bug.
+func categoriesWithSettings() []commands.Category {
+	return []commands.Category{
+		{
+			Name: "Session",
+			Commands: []commands.Item{
+				{ID: "session.exit", Label: "Exit", SlashCommand: "/exit"},
+			},
+		},
+		{
+			Name: "Settings",
+			Commands: []commands.Item{
+				{ID: "settings.open", Label: "Preferences", SlashCommand: "/settings"},
+			},
+		},
+	}
+}
+
+func TestCommandCompletionItems(t *testing.T) {
+	t.Parallel()
+
+	items := NewCommandCompletion(categoriesWithSettings()).Items()
+
+	require.Len(t, items, 2)
+	labels := map[string]string{}
+	for _, item := range items {
+		labels[item.Label] = item.Value
+	}
+	assert.Equal(t, "/settings", labels["Preferences"])
+	assert.Equal(t, "/exit", labels["Exit"])
+}
+
+// TestCommandCompletionMatchesSettingsQuery exercises the full pipeline the
+// editor uses: items from commandCompletion.Items(), filtered by the
+// completion manager in the command completion's own MatchMode. It guards
+// against a regression where typing "/settings" (trigger stripped to
+// "settings") failed to surface the settings command because filtering only
+// looked at Label ("Preferences"), never at Value ("/settings").
+func TestCommandCompletionMatchesSettingsQuery(t *testing.T) {
+	t.Parallel()
+
+	cmdCompletion := NewCommandCompletion(categoriesWithSettings())
+
+	for _, query := range []string{"settings", "set", "s"} {
+		t.Run(query, func(t *testing.T) {
+			t.Parallel()
+
+			m := completion.New()
+			m.Update(completion.OpenMsg{
+				Items:     cmdCompletion.Items(),
+				MatchMode: cmdCompletion.MatchMode(),
+			})
+			_, cmd := m.Update(completion.QueryMsg{Query: query})
+			require.NotNil(t, cmd)
+
+			view := m.View()
+			assert.Contains(t, view, "Preferences", "settings command should appear for query %q", query)
+		})
+	}
+}
+
+func TestCommandCompletionMatchModeIsPrefix(t *testing.T) {
+	t.Parallel()
+
+	c := NewCommandCompletion(nil)
+	assert.Equal(t, completion.MatchPrefix, c.MatchMode())
+}


### PR DESCRIPTION
Prefix matching for the command palette's inline completion only checked
Item.Label, so commands whose label doesn't share a prefix with its slash
command (e.g. "/settings" -> "Preferences") never surfaced while typing
the actual slash command.