### PR TITLE
fix(tui): label settings command consistently

### DIFF
--- a/pkg/tui/commands/commands.go
+++ b/pkg/tui/commands/commands.go
@@ -389,7 +389,7 @@ func builtInSettingsCommands() []Item {
 	return []Item{
 		{
 			ID:           "settings.open",
-			Label:        "Preferences",
+			Label:        "Settings",
 			SlashCommand: "/settings",
 			Description:  "Manage appearance, behavior, and notification preferences",
 			Category:     "Settings",

--- a/pkg/tui/commands/commands_test.go
+++ b/pkg/tui/commands/commands_test.go
@@ -258,3 +258,22 @@ func TestRemoveByIDsDropsSnapshotCommands(t *testing.T) {
 	assert.Nil(t, parser.Parse("/snapshots"))
 	require.NotNil(t, parser.Parse("/exit"))
 }
+
+// TestSettingsCommandLabel guards against the palette/completion UI labeling
+// /settings as "Preferences" again; the settings dialog is titled "Settings".
+func TestSettingsCommandLabel(t *testing.T) {
+	t.Parallel()
+
+	var settings Item
+	found := false
+	for _, item := range builtInSettingsCommands() {
+		if item.SlashCommand == "/settings" {
+			settings = item
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected a /settings built-in command")
+	assert.Equal(t, "settings.open", settings.ID)
+	assert.Equal(t, "Settings", settings.Label)
+}

--- a/pkg/tui/components/completion/completion.go
+++ b/pkg/tui/components/completion/completion.go
@@ -421,8 +421,8 @@ func (c *manager) filterItems(query string) {
 
 		if c.matchMode == MatchPrefix {
 			// Prefix matching: label or value (e.g. a slash command whose label
-			// doesn't share its prefix, like "/settings" -> "Preferences") must
-			// start with the query (case-insensitive).
+			// doesn't share its prefix, like "/toolset-restart" -> "Restart
+			// Toolset") must start with the query (case-insensitive).
 			if strings.HasPrefix(strings.ToLower(item.Label), lowerQuery) ||
 				strings.HasPrefix(strings.ToLower(strings.TrimPrefix(item.Value, "/")), lowerQuery) {
 				matched = true

--- a/pkg/tui/components/completion/completion_test.go
+++ b/pkg/tui/components/completion/completion_test.go
@@ -95,7 +95,7 @@ func TestCompletionManagerStaysOpenWithNoResults(t *testing.T) {
 func TestCompletionManagerMatchPrefixMatchesValue(t *testing.T) {
 	t.Parallel()
 
-	settingsItem := Item{Label: "Preferences", Value: "/settings"}
+	toolsetItem := Item{Label: "Restart Toolset", Value: "/toolset-restart"}
 	exitItem := Item{Label: "exit", Value: "/exit"}
 
 	t.Run("query matching the slash command surfaces a mismatched label", func(t *testing.T) {
@@ -103,13 +103,13 @@ func TestCompletionManagerMatchPrefixMatchesValue(t *testing.T) {
 
 		m := New().(*manager)
 		m.Update(OpenMsg{
-			Items:     []Item{settingsItem, exitItem},
+			Items:     []Item{toolsetItem, exitItem},
 			MatchMode: MatchPrefix,
 		})
 
-		m.Update(QueryMsg{Query: "settings"})
+		m.Update(QueryMsg{Query: "toolset-restart"})
 		require.Len(t, m.filteredItems, 1)
-		assert.Equal(t, "Preferences", m.filteredItems[0].Label)
+		assert.Equal(t, "Restart Toolset", m.filteredItems[0].Label)
 	})
 
 	t.Run("a prefix of the slash command still matches", func(t *testing.T) {
@@ -117,13 +117,13 @@ func TestCompletionManagerMatchPrefixMatchesValue(t *testing.T) {
 
 		m := New().(*manager)
 		m.Update(OpenMsg{
-			Items:     []Item{settingsItem, exitItem},
+			Items:     []Item{toolsetItem, exitItem},
 			MatchMode: MatchPrefix,
 		})
 
-		m.Update(QueryMsg{Query: "set"})
+		m.Update(QueryMsg{Query: "tool"})
 		require.Len(t, m.filteredItems, 1)
-		assert.Equal(t, "Preferences", m.filteredItems[0].Label)
+		assert.Equal(t, "Restart Toolset", m.filteredItems[0].Label)
 	})
 
 	t.Run("label prefix matching still works", func(t *testing.T) {
@@ -131,7 +131,7 @@ func TestCompletionManagerMatchPrefixMatchesValue(t *testing.T) {
 
 		m := New().(*manager)
 		m.Update(OpenMsg{
-			Items:     []Item{settingsItem, exitItem},
+			Items:     []Item{toolsetItem, exitItem},
 			MatchMode: MatchPrefix,
 		})
 
@@ -145,7 +145,7 @@ func TestCompletionManagerMatchPrefixMatchesValue(t *testing.T) {
 
 		m := New().(*manager)
 		m.Update(OpenMsg{
-			Items:     []Item{settingsItem, exitItem},
+			Items:     []Item{toolsetItem, exitItem},
 			MatchMode: MatchPrefix,
 		})
 

--- a/pkg/tui/components/editor/completions/command_test.go
+++ b/pkg/tui/components/editor/completions/command_test.go
@@ -10,21 +10,17 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/components/completion"
 )
 
-// categoriesWithSettings mirrors the real "Settings" category, whose
-// "Preferences" label doesn't share a prefix with its "/settings" slash
-// command — the case that exposed the inline-completion bug.
-func categoriesWithSettings() []commands.Category {
+// categoriesWithToolsetRestart mirrors the real "Session" category's
+// "Restart Toolset" command, whose label doesn't share a prefix with its
+// "/toolset-restart" slash command — the case that exposed the
+// inline-completion bug.
+func categoriesWithToolsetRestart() []commands.Category {
 	return []commands.Category{
 		{
 			Name: "Session",
 			Commands: []commands.Item{
 				{ID: "session.exit", Label: "Exit", SlashCommand: "/exit"},
-			},
-		},
-		{
-			Name: "Settings",
-			Commands: []commands.Item{
-				{ID: "settings.open", Label: "Preferences", SlashCommand: "/settings"},
+				{ID: "session.toolset.restart", Label: "Restart Toolset", SlashCommand: "/toolset-restart"},
 			},
 		},
 	}
@@ -33,29 +29,29 @@ func categoriesWithSettings() []commands.Category {
 func TestCommandCompletionItems(t *testing.T) {
 	t.Parallel()
 
-	items := NewCommandCompletion(categoriesWithSettings()).Items()
+	items := NewCommandCompletion(categoriesWithToolsetRestart()).Items()
 
 	require.Len(t, items, 2)
 	labels := map[string]string{}
 	for _, item := range items {
 		labels[item.Label] = item.Value
 	}
-	assert.Equal(t, "/settings", labels["Preferences"])
+	assert.Equal(t, "/toolset-restart", labels["Restart Toolset"])
 	assert.Equal(t, "/exit", labels["Exit"])
 }
 
-// TestCommandCompletionMatchesSettingsQuery exercises the full pipeline the
-// editor uses: items from commandCompletion.Items(), filtered by the
+// TestCommandCompletionMatchesToolsetRestartQuery exercises the full pipeline
+// the editor uses: items from commandCompletion.Items(), filtered by the
 // completion manager in the command completion's own MatchMode. It guards
-// against a regression where typing "/settings" (trigger stripped to
-// "settings") failed to surface the settings command because filtering only
-// looked at Label ("Preferences"), never at Value ("/settings").
-func TestCommandCompletionMatchesSettingsQuery(t *testing.T) {
+// against a regression where typing "/toolset-restart" (trigger stripped to
+// "toolset-restart") failed to surface the command because filtering only
+// looked at Label ("Restart Toolset"), never at Value ("/toolset-restart").
+func TestCommandCompletionMatchesToolsetRestartQuery(t *testing.T) {
 	t.Parallel()
 
-	cmdCompletion := NewCommandCompletion(categoriesWithSettings())
+	cmdCompletion := NewCommandCompletion(categoriesWithToolsetRestart())
 
-	for _, query := range []string{"settings", "set", "s"} {
+	for _, query := range []string{"toolset-restart", "tool", "t"} {
 		t.Run(query, func(t *testing.T) {
 			t.Parallel()
 
@@ -68,7 +64,7 @@ func TestCommandCompletionMatchesSettingsQuery(t *testing.T) {
 			require.NotNil(t, cmd)
 
 			view := m.View()
-			assert.Contains(t, view, "Preferences", "settings command should appear for query %q", query)
+			assert.Contains(t, view, "Restart Toolset", "toolset-restart command should appear for query %q", query)
 		})
 	}
 }

--- a/pkg/tui/tui_leanmode_test.go
+++ b/pkg/tui/tui_leanmode_test.go
@@ -29,7 +29,7 @@ func leanModeTestCategories(context.Context, tea.Model) []commands.Category {
 		{
 			Name: "Settings",
 			Commands: []commands.Item{
-				{ID: "settings.open", Label: "Preferences", SlashCommand: "/settings", Immediate: true, Execute: noop},
+				{ID: "settings.open", Label: "Settings", SlashCommand: "/settings", Immediate: true, Execute: noop},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- label the `/settings` command as `Settings` in the command palette and inline completion
- add regression coverage for the user-facing label
- retain value-prefix completion coverage with the existing `/toolset-restart` command

## Validation

- `task build`
- `task lint`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy task test`
