### PR TITLE
fix(tui): show usage and team roster in the collapsed sidebar band from startup

### DIFF
--- a/pkg/tui/components/sidebar/collapsed_view.go
+++ b/pkg/tui/components/sidebar/collapsed_view.go
@@ -31,8 +31,8 @@ func (vm CollapsedViewModel) LineCount() int {
 	lines += vm.titleSectionLines()
 
 	// Path + usage metadata row. The two share one line only when both are
-	// present and fit; a missing part (e.g. hidden session path, no usage
-	// yet) is skipped so the row never renders blank.
+	// present and fit; a missing part (e.g. hidden session path or hidden
+	// usage) is skipped so the row never renders blank.
 	switch {
 	case vm.WorkingDir != "" && vm.UsageSummary != "" && vm.WdAndUsageOnOneLine:
 		lines++
@@ -91,7 +91,7 @@ func RenderCollapsedView(vm CollapsedViewModel) string {
 	// Working directory + usage line(s). WorkingDir arrives pre-styled
 	// (accent block + primary text) to match the vertical Session tab.
 	// The two share one line only when both are present and fit; a missing
-	// part (e.g. hidden session path, no usage yet) is skipped so the row
+	// part (e.g. hidden session path or hidden usage) is skipped so the row
 	// never renders blank. Mirrors LineCount.
 	switch {
 	case vm.WorkingDir != "" && vm.UsageSummary != "" && vm.WdAndUsageOnOneLine:

--- a/pkg/tui/components/sidebar/section_visibility_test.go
+++ b/pkg/tui/components/sidebar/section_visibility_test.go
@@ -173,6 +173,28 @@ func TestCollapsedInfoLine_ShowsAgentsToolsTodos(t *testing.T) {
 	assert.NotEmpty(t, vm.InfoLine, "band view model carries the info line")
 }
 
+// TestCollapsedInfoLine_ShowsTeamRoster verifies the band lists every team
+// agent by name (not a bare "+N" count), so a team run keeps its roster
+// visible when the sidebar sits at the top or bottom.
+func TestCollapsedInfoLine_ShowsTeamRoster(t *testing.T) {
+	t.Parallel()
+
+	s := newTestSidebar(t)
+	s.sessionState.SetCurrentAgentName("root")
+	s.SetTeamInfo([]runtime.AgentDetails{
+		{Name: "root", Provider: "openai", Model: "gpt-4"},
+		{Name: "planner", Provider: "openai", Model: "gpt-4"},
+		{Name: "reviewer", Provider: "openai", Model: "gpt-4"},
+	})
+	_ = s.SetAgentInfo("root", "openai/gpt-4", "")
+
+	info := ansi.Strip(s.collapsedInfoLine(120))
+	assert.Contains(t, info, "▶ root openai/gpt-4", "current agent leads with its model")
+	assert.Contains(t, info, "planner")
+	assert.Contains(t, info, "reviewer")
+	assert.NotContains(t, info, "+2", "roster names replace the bare count")
+}
+
 func TestCollapsedInfoLine_HonorsVisibility(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -1422,22 +1422,28 @@ func (m *model) collapsedInfoLine(contentWidth int) string {
 	return strings.Join(parts, styles.MutedStyle.Render(" · "))
 }
 
-// agentSummaryCollapsed renders the current agent (in its accent color) with
-// its model and the number of other agents in the team.
+// agentSummaryCollapsed renders the team roster for the band: the current
+// agent (in its accent color) with its model, then the other agents' names
+// in their own accent colors, so the whole team stays visible like in the
+// vertical Agents section.
 func (m *model) agentSummaryCollapsed() string {
 	name := m.sessionState.CurrentAgentName()
 	if name == "" {
 		return ""
 	}
 
-	summary := styles.AgentAccentStyleFor(name).Render("▶ " + name)
+	var summary strings.Builder
+	summary.WriteString(styles.AgentAccentStyleFor(name).Render("▶ " + name))
 	if m.agentModel != "" {
-		summary += styles.MutedStyle.Render(" " + m.agentModel)
+		summary.WriteString(styles.MutedStyle.Render(" " + m.agentModel))
 	}
-	if n := len(m.availableAgents); n > 1 {
-		summary += styles.MutedStyle.Render(fmt.Sprintf(" +%d", n-1))
+	for _, agent := range m.availableAgents {
+		if agent.Name == name {
+			continue
+		}
+		summary.WriteString(styles.MutedStyle.Render(" · ") + styles.AgentAccentStyleFor(agent.Name).Render(agent.Name))
 	}
-	return summary
+	return summary.String()
 }
 
 // transferSummaryCollapsed renders the visible transfer presentation for the
@@ -1758,12 +1764,11 @@ func (m *model) tokenUsageLine() string {
 	return line
 }
 
-// tokenUsageSummary returns the usage line for the collapsed band, empty
-// until any usage has been recorded.
+// tokenUsageSummary returns the usage line for the collapsed band. It
+// renders even before any usage has been recorded ("◉ 0 $0.00"), matching
+// the vertical Token Usage tab so the band carries the context/cost reading
+// from startup.
 func (m *model) tokenUsageSummary() string {
-	if len(m.sessionUsage) == 0 {
-		return ""
-	}
 	return m.tokenUsageLine()
 }
 

--- a/pkg/tui/components/sidebar/token_usage_test.go
+++ b/pkg/tui/components/sidebar/token_usage_test.go
@@ -205,14 +205,19 @@ func TestTokenUsageSummary_MultipleSessions_ShowsActiveSessionTokens(t *testing.
 	assert.Contains(t, summary, "(30%)")
 }
 
-func TestTokenUsageSummary_Empty(t *testing.T) {
+// TestTokenUsageSummary_NoUsageYet_ShowsZeroLine verifies the collapsed band
+// carries the usage line from startup (before any message is sent), matching
+// the vertical Token Usage tab (#top-band startup parity).
+func TestTokenUsageSummary_NoUsageYet_ShowsZeroLine(t *testing.T) {
 	t.Parallel()
 
 	sess := session.New()
 	sessionState := service.NewSessionState(sess)
 	m := New(t.Context(), sessionState).(*model)
 
-	assert.Empty(t, m.tokenUsageSummary())
+	summary := ansi.Strip(m.tokenUsageSummary())
+	assert.Contains(t, summary, styles.TokenGlyph+" 0")
+	assert.Contains(t, summary, "$0.00")
 }
 
 // TestTokenUsageTab_ShowsTokenGlyph verifies the vertical Token Usage tab line


### PR DESCRIPTION
With the sidebar rendered as a band (`sidebar_position: top` or `bottom`), two pieces of information shown by the vertical sidebar were missing:

| Issue | Cause | Fix |
|---|---|---|
| Context/cost absent at startup, only appearing after the first message | `tokenUsageSummary()` returned `""` while `sessionUsage` was empty, unlike the vertical Token Usage tab which always renders | The band renders the same usage line unconditionally (`◉ 0 $0.00` before any usage); the hide-usage setting is still honored |
| Team roster not visible when running a multi-agent config | `agentSummaryCollapsed()` showed only the current agent plus a bare `+N` count | The band lists every team agent by name in its accent color, after the current agent and its model |

### Band rendering, before

```
 New session
 █ ~/repo (main)
 ▶ root openai/gpt-3.5-turbo +2 · █ 1 tool
```

### Band rendering, after

```
 New session
 █ ~/repo (main)                                  ◉ 0 $0.00
 ▶ root openai/gpt-3.5-turbo · planner · reviewer · █ 1 tool
```

### Notes

- `CollapsedViewModel.LineCount` and `RenderCollapsedView` derive from the same view model, so the band height accounts for the extra content (including wrapping) with no layout change.
- Behavior verified end to end with the tuitest harness (top sidebar, simple agent and team) at startup.

### Tests

- `TestTokenUsageSummary_Empty` replaced by `TestTokenUsageSummary_NoUsageYet_ShowsZeroLine` (the band now shows the zero line).
- New `TestCollapsedInfoLine_ShowsTeamRoster` pins the roster names in the band and the removal of the `+N` count.
