### PR TITLE
fix(tui): don't panic when the terminal reports a degenerate size

### DIFF
--- a/e2e/tui/degenerate_resize_test.go
+++ b/e2e/tui/degenerate_resize_test.go
@@ -17,8 +17,9 @@ func TestChat_DegenerateResizeDoesNotPanic(t *testing.T) {
 
 	d.WaitFor(tuitest.Contains("Type your message here"))
 
-	// Stream an answer while cycling through degenerate sizes so the busy
-	// chrome (working indicator, resize handle suffix) renders too.
+	// Submit a prompt first so the busy chrome (working indicator, resize
+	// handle suffix) can render during the sweep when replay is still
+	// streaming; the sizes themselves are what must never panic.
 	d.Type("What's 2+2?").Enter()
 	for _, size := range [][2]int{{0, 0}, {1, 1}, {2, 2}, {1, 40}, {120, 1}, {3, 3}} {
 		d.Resize(size[0], size[1])

--- a/e2e/tui/degenerate_resize_test.go
+++ b/e2e/tui/degenerate_resize_test.go
@@ -1,0 +1,30 @@
+package tui_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/docker/docker-agent/pkg/tui/tuitest"
+)
+
+// TestChat_DegenerateResizeDoesNotPanic drives the full TUI through
+// degenerate terminal sizes (0x0, 1x1, …) that real terminals and tmux can
+// transiently report. Rendering at those sizes used to panic (negative
+// strings.Repeat count in the resize handle); the TUI must survive and
+// recover once a sane size returns.
+func TestChat_DegenerateResizeDoesNotPanic(t *testing.T) {
+	d := newTUI(t, "testdata/basic.yaml", 120, 40)
+
+	d.WaitFor(tuitest.Contains("Type your message here"))
+
+	// Stream an answer while cycling through degenerate sizes so the busy
+	// chrome (working indicator, resize handle suffix) renders too.
+	d.Type("What's 2+2?").Enter()
+	for _, size := range [][2]int{{0, 0}, {1, 1}, {2, 2}, {1, 40}, {120, 1}, {3, 3}} {
+		d.Resize(size[0], size[1])
+		d.WaitForStable(50 * time.Millisecond)
+	}
+
+	d.Resize(120, 40)
+	d.WaitFor(tuitest.Contains("2 + 2 equals 4."))
+}

--- a/e2e/tui/testdata/cassettes/TestChat_DegenerateResizeDoesNotPanic.yaml
+++ b/e2e/tui/testdata/cassettes/TestChat_DegenerateResizeDoesNotPanic.yaml
@@ -1,0 +1,95 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.openai.com
+        body: '{"messages":[{"content":"You are a knowledgeable assistant that helps users with various tasks.\nBe helpful, accurate, and concise in your responses.\n","role":"system"},{"content":"What''s 2+2?","role":"user"}],"model":"gpt-3.5-turbo","stream_options":{"include_usage":true},"stream":true}'
+        url: https://api.openai.com/v1/chat/completions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: |+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"31MAoT3T"}
+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"2"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"f989QXFJX"}
+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" +"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"LjplBv32"}
+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" "},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"OS4QsUws6"}
+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"2"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"TW89LuVuk"}
+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" equals"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"vrL"}
+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" "},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"T8WY0RY3s"}
+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"4"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"0kTGMpnIE"}
+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"1pmLrWtWp"}
+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"Rsle"}
+
+            data: {"id":"chatcmpl-Cn4xGpdnsbgLIIeH49VdYprjDjc6P","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":41,"completion_tokens":8,"total_tokens":49,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"FdScpa1UzO"}
+
+            data: [DONE]
+
+        headers: {}
+        status: 200 OK
+        code: 200
+        duration: 376.601459ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        host: api.openai.com
+        body: '{"messages":[{"content":"You are a helpful AI assistant that generates concise, descriptive titles for conversations. You will be given up to 2 recent user messages and asked to create a single-line title that captures the main topic. Never use newlines or line breaks in your response.","role":"system"},{"content":"Based on the following recent user messages from a conversation with an AI assistant, generate a short, descriptive title (maximum 50 characters) that captures the main topic or purpose of the conversation. Return ONLY the title text on a single line, nothing else. Do not include any newlines, explanations, or formatting.\n\nRecent user messages:\n1. What''s 2+2?\n\n\n","role":"user"}],"model":"gpt-3.5-turbo","stream_options":{"include_usage":true},"stream":true}'
+        url: https://api.openai.com/v1/chat/completions
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        content_length: -1
+        body: |+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"3praRFP3"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"Simple"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"0Qwz"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" Math"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"j2ifs"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"NiTsH3kiT"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" Addition"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"x"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" of"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"eHDT8Y6"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" "},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ImGlkQ1UD"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"2"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"r0pbd1luX"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" and"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"fbgjGd"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":" "},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"zJqaxx5ri"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{"content":"2"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"irCJfvsMd"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"psUW"}
+
+            data: {"id":"chatcmpl-Cn4xGduSFgxtSBIWwGDKiENMSp67u","object":"chat.completion.chunk","created":1765813154,"model":"gpt-3.5-turbo-0125","service_tier":"default","system_fingerprint":null,"choices":[],"usage":{"prompt_tokens":100,"completion_tokens":10,"total_tokens":110,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"3lP94vJ"}
+
+            data: [DONE]
+
+        headers: {}
+        status: 200 OK
+        code: 200
+        duration: 443.446208ms

--- a/pkg/board/tui/degenerate_size_test.go
+++ b/pkg/board/tui/degenerate_size_test.go
@@ -1,0 +1,64 @@
+package tui
+
+import (
+	"fmt"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/docker/docker-agent/pkg/board"
+	"github.com/docker/docker-agent/pkg/tui/styles"
+)
+
+// TestDegenerateSizesDoNotPanic renders the board — with and without every
+// dialog — at the degenerate terminal sizes (0x0, 1x1, …) that real
+// terminals and tmux can transiently report. Rendering must never panic.
+func TestDegenerateSizesDoNotPanic(t *testing.T) {
+	// Theme colors are only bound after ApplyTheme; not parallel because it
+	// mutates package-level style state.
+	styles.ApplyThemeRef(styles.DefaultThemeRef)
+
+	newModel := func() *model {
+		return &model{
+			columns: []board.Column{{ID: "dev", Name: "Dev"}, {ID: "done", Name: "Done"}},
+			cards: map[string][]*board.Card{
+				"dev":  {{ID: "a", Column: "dev", Title: "Card A", Project: "p1"}},
+				"done": {{ID: "c", Column: "done", Title: "Card C", Project: "p2"}},
+			},
+			projects: []board.Project{{Name: "p1"}, {Name: "p2"}},
+			scroll:   map[string]int{},
+		}
+	}
+
+	sizes := [][2]int{{0, 0}, {1, 1}, {2, 2}, {5, 3}, {0, 40}, {80, 0}}
+	dialogs := map[string]func() dialog{
+		"none":     func() dialog { return nil },
+		"help":     func() dialog { return newHelpDialog() },
+		"card":     func() dialog { return newCardDialog([]board.Project{{Name: "p1"}, {Name: "p2"}}, "") },
+		"prompt":   func() dialog { return newPromptDialog(board.Column{ID: "dev", Name: "Dev"}) },
+		"columns":  func() dialog { return newColumnsDialog([]board.Column{{ID: "dev", Name: "Dev"}}) },
+		"projects": func() dialog { return newProjectsDialog([]board.Project{{Name: "p1"}}) },
+		"diff":     func() dialog { return newDiffDialog("a", "t", "+x\n-y", 3) },
+		"confirm":  func() dialog { return newConfirmDialog(&board.Card{ID: "a", Title: "T"}) },
+	}
+
+	for _, size := range sizes {
+		for name, mk := range dialogs {
+			t.Run(fmt.Sprintf("%dx%d/%s", size[0], size[1], name), func(t *testing.T) {
+				m := newModel()
+				m.dialog = mk()
+				if d, ok := m.dialog.(*projectsDialog); ok {
+					// "a" opens the directory picker: exercise that view too.
+					_, _ = d.Update(tea.KeyPressMsg{Code: 'a', Text: "a"})
+				}
+				_, _ = m.Update(tea.WindowSizeMsg{Width: size[0], Height: size[1]})
+				_ = m.View()
+
+				// The welcome overlay renders on an empty board.
+				m.cards = map[string][]*board.Card{}
+				m.dialog = nil
+				_ = m.View()
+			})
+		}
+	}
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -2753,7 +2753,7 @@ func (m *appModel) renderResizeHandle(width int) string {
 
 	// Always center handle on full width
 	fullLine := lipgloss.PlaceHorizontal(
-		max(0, innerWidth), lipgloss.Center, handle,
+		innerWidth, lipgloss.Center, handle,
 		lipgloss.WithWhitespaceChars("─"),
 		lipgloss.WithWhitespaceStyle(styles.ResizeHandleStyle),
 	)
@@ -2764,14 +2764,12 @@ func (m *appModel) renderResizeHandle(width int) string {
 		// Static indicator: the loop is idle until the user resumes.
 		resumeKey := styles.HighlightWhiteStyle.Render("/pause")
 		suffix := " " + styles.WarningStyle.Render("⏸ Paused") + " (" + resumeKey + " to resume)"
-		suffixWidth := lipgloss.Width(suffix)
-		result = lipgloss.NewStyle().MaxWidth(innerWidth-suffixWidth).Render(fullLine) + suffix
+		result = lineWithSuffix(fullLine, suffix, innerWidth)
 
 	case m.sessionState.PauseState() == service.PausePausing:
 		// The agent is finishing the in-flight request before it pauses.
 		suffix := " " + m.workingSpinner.View() + " " + styles.WarningStyle.Render("Pausing…") + " (finishing current request)"
-		suffixWidth := lipgloss.Width(suffix)
-		result = lipgloss.NewStyle().MaxWidth(innerWidth-suffixWidth).Render(fullLine) + suffix
+		result = lineWithSuffix(fullLine, suffix, innerWidth)
 
 	case m.chatPage.IsWorking():
 		// Truncate right side and append spinner (handle stays centered)
@@ -2782,20 +2780,30 @@ func (m *appModel) renderResizeHandle(width int) string {
 		suffix := " " + m.workingSpinner.View() + " " + styles.SpinnerDotsHighlightStyle.Render(workingText)
 		cancelKeyPart := styles.HighlightWhiteStyle.Render("Esc")
 		suffix += " (" + cancelKeyPart + " to interrupt)"
-		suffixWidth := lipgloss.Width(suffix)
-		result = lipgloss.NewStyle().MaxWidth(innerWidth-suffixWidth).Render(fullLine) + suffix
+		result = lineWithSuffix(fullLine, suffix, innerWidth)
 
 	case m.chatPage.QueueLength() > 0:
 		queueText := fmt.Sprintf("%d queued", m.chatPage.QueueLength())
 		suffix := " " + styles.WarningStyle.Render(queueText) + " "
-		suffixWidth := lipgloss.Width(suffix)
-		result = lipgloss.NewStyle().MaxWidth(innerWidth-suffixWidth).Render(fullLine) + suffix
+		result = lineWithSuffix(fullLine, suffix, innerWidth)
 
 	default:
 		result = fullLine
 	}
 
 	return lipgloss.NewStyle().Padding(0, styles.AppPadding).Render(result)
+}
+
+// lineWithSuffix appends a status suffix to the centered handle line,
+// truncating so the total never exceeds width. lipgloss ignores non-positive
+// MaxWidth values, so a suffix wider than the line must be truncated itself
+// or the row would overflow on narrow terminals.
+func lineWithSuffix(line, suffix string, width int) string {
+	suffixWidth := lipgloss.Width(suffix)
+	if suffixWidth >= width {
+		return lipgloss.NewStyle().MaxWidth(width).Render(suffix)
+	}
+	return lipgloss.NewStyle().MaxWidth(width-suffixWidth).Render(line) + suffix
 }
 
 // View renders the model.

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -2734,11 +2734,12 @@ func (m *appModel) renderLeanWorkingIndicator() string {
 
 // renderResizeHandle renders the draggable separator between content and bottom panel.
 func (m *appModel) renderResizeHandle(width int) string {
-	if width <= 0 {
+	// The terminal can report degenerate sizes (0x0, 1x1) where the padded
+	// inner width goes negative; there is nothing to draw a handle on.
+	innerWidth := width - appPaddingHorizontal
+	if innerWidth <= 0 {
 		return ""
 	}
-
-	innerWidth := width - appPaddingHorizontal
 
 	// Use brighter style when actively dragging
 	centerStyle := styles.ResizeHandleHoverStyle

--- a/pkg/tui/tui_resize_handle_test.go
+++ b/pkg/tui/tui_resize_handle_test.go
@@ -1,0 +1,25 @@
+package tui
+
+import (
+	"testing"
+)
+
+// TestRenderResizeHandle_TinyWidths guards against a panic (negative
+// strings.Repeat count) when the terminal reports degenerate sizes such as
+// 0x0 or 1x1: the padded inner width goes negative for widths smaller than
+// the app's horizontal padding.
+func TestRenderResizeHandle_TinyWidths(t *testing.T) {
+	t.Parallel()
+
+	m, _ := newTestModel(t)
+
+	for _, width := range []int{-1, 0, 1, appPaddingHorizontal, appPaddingHorizontal + 1, 80} {
+		out := m.renderResizeHandle(width)
+		if width <= appPaddingHorizontal && out != "" {
+			t.Errorf("width %d: expected empty handle, got %q", width, out)
+		}
+		if width > appPaddingHorizontal && out == "" {
+			t.Errorf("width %d: expected a rendered handle", width)
+		}
+	}
+}

--- a/pkg/tui/tui_resize_handle_test.go
+++ b/pkg/tui/tui_resize_handle_test.go
@@ -2,6 +2,11 @@ package tui
 
 import (
 	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/tui/service"
 )
 
 // TestRenderResizeHandle_TinyWidths guards against a panic (negative
@@ -15,11 +20,39 @@ func TestRenderResizeHandle_TinyWidths(t *testing.T) {
 
 	for _, width := range []int{-1, 0, 1, appPaddingHorizontal, appPaddingHorizontal + 1, 80} {
 		out := m.renderResizeHandle(width)
-		if width <= appPaddingHorizontal && out != "" {
-			t.Errorf("width %d: expected empty handle, got %q", width, out)
-		}
-		if width > appPaddingHorizontal && out == "" {
-			t.Errorf("width %d: expected a rendered handle", width)
+		if width <= appPaddingHorizontal {
+			assert.Empty(t, out, "width %d", width)
+		} else {
+			assert.NotEmpty(t, out, "width %d", width)
 		}
 	}
+}
+
+// TestRenderResizeHandle_SuffixNeverOverflows pins that a status suffix wider
+// than the handle line is truncated instead of overflowing the row on narrow
+// terminals.
+func TestRenderResizeHandle_SuffixNeverOverflows(t *testing.T) {
+	t.Parallel()
+
+	m, _ := newTestModel(t)
+	m.sessionState = &service.SessionState{}
+	m.sessionState.SetPauseState(service.PausePaused)
+
+	for _, width := range []int{5, 10, 20, 80, 200} {
+		out := m.renderResizeHandle(width)
+		assert.LessOrEqual(t, lipgloss.Width(out), width, "width %d", width)
+	}
+}
+
+func TestLineWithSuffix(t *testing.T) {
+	t.Parallel()
+
+	// The suffix fits: the line is truncated to make room.
+	out := lineWithSuffix("──────────", " ok", 8)
+	assert.Equal(t, "───── ok", out)
+	assert.Equal(t, 8, lipgloss.Width(out))
+
+	// The suffix alone is too wide: it is truncated and the line dropped.
+	out = lineWithSuffix("──────────", " a very long status", 8)
+	assert.Equal(t, 8, lipgloss.Width(out))
 }


### PR DESCRIPTION
When a terminal reports a degenerate size (0×0 or 1×1), the resize handle in `pkg/tui/tui.go` computed a negative repeat count for `strings.Repeat`, crashing the TUI with `panic: strings: negative Repeat count`. The existing `width <= 0` guard did not account for the horizontal padding subtracted afterwards, so any width narrower than `appPaddingHorizontal` slipped through and produced a negative inner width.

The fix adds a guard on the padded inner width itself. A follow-up commit also handles the status suffix: `lipgloss` ignores non-positive `MaxWidth`, so a paused/working suffix wider than the terminal could overflow the row on very narrow terminals. The suffix logic is extracted into a `lineWithSuffix` helper that truncates the suffix when the terminal is too narrow to accommodate it.

Both fixes are covered by a unit test over tiny widths (`pkg/tui/tui_resize_handle_test.go`), a full-TUI e2e resize cycle through degenerate sizes (`e2e/tui/degenerate_resize_test.go`), and a board-TUI render sweep across degenerate sizes × all dialogs (`pkg/board/tui/degenerate_size_test.go`). All three tests were verified to panic on main without the fix.