### PR TITLE
feat: group session browser by git repo root (worktree-aware)

### DIFF
--- a/pkg/gitroot/gitroot.go
+++ b/pkg/gitroot/gitroot.go
@@ -4,10 +4,16 @@
 package gitroot
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 )
+
+// maxPointerFileSize bounds reads of .git pointer and commondir files. Valid
+// ones hold a single path, so anything larger is treated as malformed rather
+// than read into memory.
+const maxPointerFileSize = 4096
 
 // Root returns the top-level directory of the repository containing dir,
 // walking up parent directories until a .git entry is found. Linked worktrees
@@ -18,7 +24,7 @@ func Root(dir string) string {
 	if dir == "" {
 		return ""
 	}
-	d := dir
+	d := filepath.Clean(dir)
 	for {
 		gitPath := filepath.Join(d, ".git")
 		info, err := os.Stat(gitPath)
@@ -51,24 +57,25 @@ func mainRepoRoot(gitFile, base string) string {
 		return ""
 	}
 	// Linked worktrees carry a commondir file pointing at the main .git dir.
-	data, err := os.ReadFile(filepath.Join(gd, "commondir"))
-	if err != nil {
+	data := readPointerFile(filepath.Join(gd, "commondir"))
+	if data == "" {
 		return ""
 	}
-	common := strings.TrimSpace(string(data))
+	common := data
 	if !filepath.IsAbs(common) {
 		common = filepath.Join(gd, common)
 	}
-	// The main repository root is the parent of its .git dir.
-	return filepath.Dir(filepath.Clean(common))
+	common = filepath.Clean(common)
+	// The main repository root is the parent of its .git dir. A bare
+	// repository is its own common dir (no worktree to strip).
+	if filepath.Base(common) == ".git" {
+		return filepath.Dir(common)
+	}
+	return common
 }
 
 func parseGitdir(gitFile, base string) string {
-	data, err := os.ReadFile(gitFile)
-	if err != nil {
-		return ""
-	}
-	gd, ok := strings.CutPrefix(strings.TrimSpace(string(data)), "gitdir: ")
+	gd, ok := strings.CutPrefix(readPointerFile(gitFile), "gitdir: ")
 	if !ok {
 		return ""
 	}
@@ -76,4 +83,19 @@ func parseGitdir(gitFile, base string) string {
 		gd = filepath.Join(base, gd)
 	}
 	return gd
+}
+
+// readPointerFile reads a small metadata file and returns its trimmed
+// content, or "" when the file is missing or suspiciously large.
+func readPointerFile(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, maxPointerFileSize+1))
+	if err != nil || len(data) > maxPointerFileSize {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
 }

--- a/pkg/gitroot/gitroot.go
+++ b/pkg/gitroot/gitroot.go
@@ -1,0 +1,79 @@
+// Package gitroot resolves a directory to the root of the git repository
+// containing it by reading .git metadata directly, without shelling out to
+// the git binary.
+package gitroot
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Root returns the top-level directory of the repository containing dir,
+// walking up parent directories until a .git entry is found. Linked worktrees
+// resolve to the main repository's root, so every worktree of one repository
+// shares the same root. It returns "" when dir is empty or not inside a
+// repository.
+func Root(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	d := dir
+	for {
+		gitPath := filepath.Join(d, ".git")
+		info, err := os.Stat(gitPath)
+		switch {
+		case err == nil && info.IsDir():
+			return d
+		case err == nil:
+			// A .git file points at the real git dir (worktree or submodule).
+			if root := mainRepoRoot(gitPath, d); root != "" {
+				return root
+			}
+			// A submodule (no commondir) is its own repository.
+			return d
+		}
+
+		parent := filepath.Dir(d)
+		if parent == d {
+			return ""
+		}
+		d = parent
+	}
+}
+
+// mainRepoRoot resolves the main repository root of a linked worktree whose
+// .git file lives at gitFile. It returns "" when the gitdir cannot be parsed
+// or has no commondir file (i.e. it is not a linked worktree).
+func mainRepoRoot(gitFile, base string) string {
+	gd := parseGitdir(gitFile, base)
+	if gd == "" {
+		return ""
+	}
+	// Linked worktrees carry a commondir file pointing at the main .git dir.
+	data, err := os.ReadFile(filepath.Join(gd, "commondir"))
+	if err != nil {
+		return ""
+	}
+	common := strings.TrimSpace(string(data))
+	if !filepath.IsAbs(common) {
+		common = filepath.Join(gd, common)
+	}
+	// The main repository root is the parent of its .git dir.
+	return filepath.Dir(filepath.Clean(common))
+}
+
+func parseGitdir(gitFile, base string) string {
+	data, err := os.ReadFile(gitFile)
+	if err != nil {
+		return ""
+	}
+	gd, ok := strings.CutPrefix(strings.TrimSpace(string(data)), "gitdir: ")
+	if !ok {
+		return ""
+	}
+	if !filepath.IsAbs(gd) {
+		gd = filepath.Join(base, gd)
+	}
+	return gd
+}

--- a/pkg/gitroot/gitroot_test.go
+++ b/pkg/gitroot/gitroot_test.go
@@ -83,6 +83,21 @@ func TestRoot_LinkedWorktreeAbsoluteCommondir(t *testing.T) {
 	assert.Equal(t, repo, Root(wt))
 }
 
+func TestRoot_LinkedWorktreeOfBareRepository(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	// Bare repositories are their own git dir; commondir points straight at them.
+	bare := filepath.Join(base, "project.git")
+	gitdir := filepath.Join(bare, "worktrees", "wt")
+	require.NoError(t, os.MkdirAll(gitdir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(gitdir, "commondir"), []byte("../..\n"), 0o644))
+	wt := filepath.Join(base, "wt")
+	require.NoError(t, os.MkdirAll(wt, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(wt, ".git"), []byte("gitdir: "+gitdir+"\n"), 0o644))
+
+	assert.Equal(t, bare, Root(wt), "bare-repo worktrees resolve to the bare repo, not its parent")
+}
+
 func TestRoot_SubmoduleIsItsOwnRoot(t *testing.T) {
 	t.Parallel()
 	repo := t.TempDir()
@@ -95,6 +110,33 @@ func TestRoot_SubmoduleIsItsOwnRoot(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(sub, ".git"), []byte("gitdir: "+gitdir+"\n"), 0o644))
 
 	assert.Equal(t, sub, Root(sub))
+}
+
+func TestRoot_DanglingGitdirPointer(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".git"),
+		[]byte("gitdir: "+filepath.Join(dir, "missing")+"\n"), 0o644))
+
+	assert.Equal(t, dir, Root(dir), "a dangling gitdir pointer falls back to the dir itself")
+}
+
+func TestRoot_OversizedGitFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	huge := append([]byte("gitdir: "), make([]byte, maxPointerFileSize)...)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".git"), huge, 0o644))
+
+	assert.Equal(t, dir, Root(dir), "oversized .git files are treated as malformed")
+}
+
+func TestRoot_UncleanInput(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	newRepo(t, repo)
+
+	assert.Equal(t, repo, Root(repo+string(filepath.Separator)))
+	assert.Equal(t, repo, Root(filepath.Join(repo, "a", "..")))
 }
 
 func TestRoot_NotARepository(t *testing.T) {

--- a/pkg/gitroot/gitroot_test.go
+++ b/pkg/gitroot/gitroot_test.go
@@ -1,0 +1,118 @@
+package gitroot
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newRepo creates a fake main repository at dir with a .git directory.
+func newRepo(t *testing.T, dir string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+}
+
+// newWorktree links a fake worktree at dir to the main repository at mainDir,
+// mirroring the on-disk layout produced by `git worktree add`.
+func newWorktree(t *testing.T, dir, mainDir string) {
+	t.Helper()
+	gitdir := filepath.Join(mainDir, ".git", "worktrees", filepath.Base(dir))
+	require.NoError(t, os.MkdirAll(gitdir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(gitdir, "commondir"), []byte("../..\n"), 0o644))
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".git"), []byte("gitdir: "+gitdir+"\n"), 0o644))
+}
+
+func TestRoot_MainRepository(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	newRepo(t, repo)
+
+	assert.Equal(t, repo, Root(repo))
+}
+
+func TestRoot_Subdirectory(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	newRepo(t, repo)
+	sub := filepath.Join(repo, "a", "b")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+
+	assert.Equal(t, repo, Root(sub))
+}
+
+func TestRoot_LinkedWorktree(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	repo := filepath.Join(base, "repo")
+	newRepo(t, repo)
+	wt := filepath.Join(base, "wt")
+	newWorktree(t, wt, repo)
+
+	assert.Equal(t, repo, Root(wt))
+}
+
+func TestRoot_LinkedWorktreeSubdirectory(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	repo := filepath.Join(base, "repo")
+	newRepo(t, repo)
+	wt := filepath.Join(base, "wt")
+	newWorktree(t, wt, repo)
+	sub := filepath.Join(wt, "pkg")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+
+	assert.Equal(t, repo, Root(sub))
+}
+
+func TestRoot_LinkedWorktreeAbsoluteCommondir(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	repo := filepath.Join(base, "repo")
+	newRepo(t, repo)
+	gitdir := filepath.Join(repo, ".git", "worktrees", "wt")
+	require.NoError(t, os.MkdirAll(gitdir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(gitdir, "commondir"), []byte(filepath.Join(repo, ".git")+"\n"), 0o644))
+	wt := filepath.Join(base, "wt")
+	require.NoError(t, os.MkdirAll(wt, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(wt, ".git"), []byte("gitdir: "+gitdir+"\n"), 0o644))
+
+	assert.Equal(t, repo, Root(wt))
+}
+
+func TestRoot_SubmoduleIsItsOwnRoot(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	newRepo(t, repo)
+	// Submodule git dirs live under .git/modules and have no commondir file.
+	gitdir := filepath.Join(repo, ".git", "modules", "sub")
+	require.NoError(t, os.MkdirAll(gitdir, 0o755))
+	sub := filepath.Join(repo, "sub")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(sub, ".git"), []byte("gitdir: "+gitdir+"\n"), 0o644))
+
+	assert.Equal(t, sub, Root(sub))
+}
+
+func TestRoot_NotARepository(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, Root(t.TempDir()))
+}
+
+func TestRoot_EmptyDir(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, Root(""))
+}
+
+func TestRoot_UnreadableGitFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// A .git file with unexpected content: treated as the repo root anyway,
+	// matching git's behavior of stopping the upward walk at any .git entry.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".git"), []byte("garbage"), 0o644))
+
+	assert.Equal(t, dir, Root(dir))
+}

--- a/pkg/tui/dialog/session_browser.go
+++ b/pkg/tui/dialog/session_browser.go
@@ -126,15 +126,23 @@ func workspacePathsEqual(a, b string) bool {
 
 // workspaceDisplayDir returns the directory shown in the "This workspace"
 // header. Since sessions group by repository, a dir inside a git repo (or
-// worktree) displays as the repository root. Unlike matcher normalization,
-// symlinks are not resolved so the label stays close to what the user typed.
+// worktree) displays as the repository root. Symlinks are left unresolved so
+// the label stays close to what the user typed, but when the raw path is not
+// in a repo the symlink-resolved path is tried too, keeping the header
+// consistent with the matcher's grouping key.
 func workspaceDisplayDir(dir string) string {
 	dir = strings.TrimSpace(dir)
 	if dir == "" {
 		return ""
 	}
-	if root := gitroot.Root(filepath.Clean(dir)); root != "" {
+	dir = filepath.Clean(dir)
+	if root := gitroot.Root(dir); root != "" {
 		return root
+	}
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		if root := gitroot.Root(resolved); root != "" {
+			return root
+		}
 	}
 	return dir
 }

--- a/pkg/tui/dialog/session_browser.go
+++ b/pkg/tui/dialog/session_browser.go
@@ -15,6 +15,7 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/atotto/clipboard"
 
+	"github.com/docker/docker-agent/pkg/gitroot"
 	pathx "github.com/docker/docker-agent/pkg/path"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tui/components/notification"
@@ -60,7 +61,9 @@ type browserRow struct {
 // workspaceMatcher reports whether a session's working directory belongs to
 // the workspace the browser was opened from. Paths are normalized with
 // filepath.Clean and EvalSymlinks so symlinked variants of the same
-// directory (e.g. /tmp vs /private/tmp on macOS) compare equal.
+// directory (e.g. /tmp vs /private/tmp on macOS) compare equal, then
+// resolved to their git repository root (worktree-aware) so sessions from
+// any subdirectory or worktree of one repository group together.
 // Normalization results are cached because many sessions share the same
 // directory and EvalSymlinks touches the filesystem.
 type workspaceMatcher struct {
@@ -100,6 +103,14 @@ func (m *workspaceMatcher) normalize(dir string) string {
 	if resolved, err := filepath.EvalSymlinks(normalized); err == nil {
 		normalized = resolved
 	}
+	if root := gitroot.Root(normalized); root != "" {
+		// The root comes from .git metadata and may itself be a symlinked
+		// variant of the path (e.g. /var vs /private/var on macOS).
+		if resolved, err := filepath.EvalSymlinks(root); err == nil {
+			root = resolved
+		}
+		normalized = root
+	}
 	m.cache[dir] = normalized
 	return normalized
 }
@@ -111,6 +122,21 @@ func workspacePathsEqual(a, b string) bool {
 		return strings.EqualFold(a, b)
 	}
 	return a == b
+}
+
+// workspaceDisplayDir returns the directory shown in the "This workspace"
+// header. Since sessions group by repository, a dir inside a git repo (or
+// worktree) displays as the repository root. Unlike matcher normalization,
+// symlinks are not resolved so the label stays close to what the user typed.
+func workspaceDisplayDir(dir string) string {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return ""
+	}
+	if root := gitroot.Root(filepath.Clean(dir)); root != "" {
+		return root
+	}
+	return dir
 }
 
 type sessionBrowserDialog struct {
@@ -127,7 +153,7 @@ type sessionBrowserDialog struct {
 
 	// Workspace grouping state
 	workspace       *workspaceMatcher
-	workspaceDir    string // raw directory the browser was opened from, for display
+	workspaceDir    string // workspace root shown in the section header
 	workspaceFilter int    // 0 = all, 1 = this workspace only, 2 = other locations only
 	rows            []browserRow
 	rowForSession   []int // filtered index -> row index
@@ -162,7 +188,7 @@ func NewSessionBrowserDialog(sessions []session.Summary, workspaceDir string) Di
 		sessions:     nonEmptySessions,
 		scrollview:   scrollview.New(scrollview.WithReserveScrollbarSpace(true)),
 		workspace:    newWorkspaceMatcher(workspaceDir),
-		workspaceDir: strings.TrimSpace(workspaceDir),
+		workspaceDir: workspaceDisplayDir(workspaceDir),
 		keyMap: sessionBrowserKeyMap{
 			Up:              key.NewBinding(key.WithKeys("up", "ctrl+k")),
 			Down:            key.NewBinding(key.WithKeys("down", "ctrl+j")),

--- a/pkg/tui/dialog/session_browser_test.go
+++ b/pkg/tui/dialog/session_browser_test.go
@@ -564,6 +564,34 @@ func TestSessionBrowserWorkspaceGitRootNormalization(t *testing.T) {
 	require.Equal(t, base, workspaceDisplayDir(base), "non-repo dirs are shown as-is")
 }
 
+func TestSessionBrowserWorkspaceDisplayDirThroughSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires privileges on Windows")
+	}
+	t.Parallel()
+
+	repo := filepath.Join(t.TempDir(), "repo")
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0o755))
+	sub := filepath.Join(repo, "pkg")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+	link := filepath.Join(t.TempDir(), "link")
+	require.NoError(t, os.Symlink(sub, link))
+
+	// A symlink straight to the repo root sees .git through the link (Stat
+	// follows symlinks) and is shown as-is — it is the repo root, just
+	// spelled the way the user reached it.
+	linkToRoot := filepath.Join(t.TempDir(), "root-link")
+	require.NoError(t, os.Symlink(repo, linkToRoot))
+	require.Equal(t, linkToRoot, workspaceDisplayDir(linkToRoot))
+
+	// A symlink to a subdirectory has no .git on its lexical path, so the
+	// header falls back to the resolved repository root — matching how the
+	// matcher groups these sessions.
+	resolved, err := filepath.EvalSymlinks(repo)
+	require.NoError(t, err)
+	require.Equal(t, resolved, workspaceDisplayDir(link))
+}
+
 func TestSessionBrowserHeaderRowsNotSelectable(t *testing.T) {
 	t.Parallel()
 	dialog := NewSessionBrowserDialog(workspaceTestSessions(), "/work/project")

--- a/pkg/tui/dialog/session_browser_test.go
+++ b/pkg/tui/dialog/session_browser_test.go
@@ -532,6 +532,38 @@ func TestSessionBrowserWorkspaceSymlinkNormalization(t *testing.T) {
 	require.True(t, m.matches(link), "a symlinked session dir should match its resolved workspace")
 }
 
+func TestSessionBrowserWorkspaceGitRootNormalization(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	repo := filepath.Join(base, "repo")
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0o755))
+	sub := filepath.Join(repo, "pkg", "tui")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+
+	// git worktree layout: wt/.git file -> repo/.git/worktrees/wt (with commondir)
+	gitdir := filepath.Join(repo, ".git", "worktrees", "wt")
+	require.NoError(t, os.MkdirAll(gitdir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(gitdir, "commondir"), []byte("../..\n"), 0o644))
+	wt := filepath.Join(base, "wt")
+	require.NoError(t, os.MkdirAll(wt, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(wt, ".git"), []byte("gitdir: "+gitdir+"\n"), 0o644))
+
+	m := newWorkspaceMatcher(repo)
+	require.True(t, m.matches(sub), "a session in a subdirectory should match its repo root")
+	require.True(t, m.matches(wt), "a session in a linked worktree should match the main repo")
+	require.False(t, m.matches(base), "a dir outside the repo should not match")
+
+	// Opening the browser from the worktree also groups main-repo sessions.
+	require.True(t, newWorkspaceMatcher(wt).matches(repo))
+
+	// The "This workspace" header shows the repository root, not the
+	// subdirectory or worktree the browser was opened from.
+	require.Equal(t, repo, workspaceDisplayDir(sub))
+	require.Equal(t, repo, workspaceDisplayDir(wt))
+	require.Equal(t, base, workspaceDisplayDir(base), "non-repo dirs are shown as-is")
+}
+
 func TestSessionBrowserHeaderRowsNotSelectable(t *testing.T) {
 	t.Parallel()
 	dialog := NewSessionBrowserDialog(workspaceTestSessions(), "/work/project")


### PR DESCRIPTION
The past-sessions dialog groups sessions under a "This workspace" header by comparing the current working directory against each session's recorded directory. This breaks with git worktrees: a session started from a worktree, a subdirectory, or the main checkout of the same repository all appear as separate workspaces, even though they share the same codebase.

The fix introduces `pkg/gitroot`, a small package that resolves any directory to its canonical git repository root without shelling out. It walks up the directory tree looking for a `.git` entry. When `.git` is a file (a linked worktree), it reads the `gitdir:` pointer and then follows the `commondir` file to arrive at the main repository root. Bare-repo worktrees resolve to the bare repo directory; submodules are treated as independent roots. The session browser's `workspaceMatcher` now normalizes both the current directory and each stored session directory to their git root (with symlinks resolved first, and results cached), so all worktrees of the same repository fold under one header. The header itself displays the repository root path, consistent with the grouping key.

A follow-up hardening pass bounds `.git` pointer and `commondir` file reads to 4 KiB, cleans the input path before walking, and adds a symlink-resolution fallback so the displayed header stays consistent even when `os.Getwd` returns a symlinked path. The package has thorough tests covering plain repos, subdirectories, linked worktrees with both relative and absolute `commondir` paths, bare-repo worktrees, submodules, dangling and oversized `.git` pointers, and symlinked workspaces.