### PR TITLE
fix: propagate HTTP error statuses in API tool

### DIFF
--- a/cmd/root/agent_picker_test.go
+++ b/cmd/root/agent_picker_test.go
@@ -4,10 +4,8 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -89,23 +87,6 @@ func TestParseAgentPickerRefsDefaults(t *testing.T) {
 	assert.Equal(t, []string{"coder"}, parseAgentPickerRefs("coder"))
 }
 
-func TestAgentRefsInDirSkipsNonRegularFiles(t *testing.T) {
-	t.Parallel()
-
-	if runtime.GOOS == "windows" {
-		t.Skip("no mkfifo on Windows")
-	}
-
-	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "real.yaml"), nil, 0o644))
-	require.NoError(t, syscall.Mkfifo(filepath.Join(dir, "fifo.yaml"), 0o644))
-	// A symlink to a regular config file is kept.
-	require.NoError(t, os.Symlink(filepath.Join(dir, "real.yaml"), filepath.Join(dir, "link.yaml")))
-
-	want := []string{filepath.Join(dir, "link.yaml"), filepath.Join(dir, "real.yaml")}
-	assert.Equal(t, want, agentRefsInDir(dir))
-}
-
 func TestPrependAgentRef(t *testing.T) {
 	t.Parallel()
 
@@ -132,14 +113,14 @@ func TestAgentPickerCardShowsDescriptionForLocalConfigs(t *testing.T) {
 
 	// Local config files show the description as the title, with the path
 	// demoted to the detail line.
-	card := ansi.Strip(m.renderCard(agentChoice{ref: "/tmp/agents/gopher.yaml", description: "Golang expert"}, 70, false))
-	assert.Less(t, strings.Index(card, "Golang expert"), strings.Index(card, "/tmp/agents/gopher.yaml"))
+	card := ansi.Strip(m.renderCard(agentChoice{ref: filepath.FromSlash("/tmp/agents/gopher.yaml"), description: "Golang expert"}, 70, false))
+	assert.Less(t, strings.Index(card, "Golang expert"), strings.Index(card, filepath.FromSlash("/tmp/agents/gopher.yaml")))
 
 	// Without a description the path remains the title; same for descriptions
 	// that sanitize to nothing.
 	for _, desc := range []string{"", "  \n\t ", "\x1b\x07"} {
-		card = ansi.Strip(m.renderCard(agentChoice{ref: "/tmp/agents/gopher.yaml", description: desc}, 70, false))
-		assert.Contains(t, card, "/tmp/agents/gopher.yaml")
+		card = ansi.Strip(m.renderCard(agentChoice{ref: filepath.FromSlash("/tmp/agents/gopher.yaml"), description: desc}, 70, false))
+		assert.Contains(t, card, filepath.FromSlash("/tmp/agents/gopher.yaml"))
 	}
 
 	// Non-path refs keep the ref as title with the description below.

--- a/cmd/root/agent_picker_unix_test.go
+++ b/cmd/root/agent_picker_unix_test.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package root
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentRefsInDirSkipsNonRegularFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "real.yaml"), nil, 0o644))
+	require.NoError(t, syscall.Mkfifo(filepath.Join(dir, "fifo.yaml"), 0o644))
+	// A symlink to a regular config file is kept.
+	require.NoError(t, os.Symlink(filepath.Join(dir, "real.yaml"), filepath.Join(dir, "link.yaml")))
+
+	want := []string{filepath.Join(dir, "link.yaml"), filepath.Join(dir, "real.yaml")}
+	assert.Equal(t, want, agentRefsInDir(dir))
+}

--- a/cmd/root/sandbox_cmd_test.go
+++ b/cmd/root/sandbox_cmd_test.go
@@ -29,7 +29,7 @@ func TestSandboxAllowDenyList(t *testing.T) {
 
 	cfg, err := userconfig.Load()
 	require.NoError(t, err)
-	assert.Equal(t, []string{"api.example.com", "registry.npmjs.org:443"}, cfg.SandboxAllowlist)
+	assert.ElementsMatch(t, []string{"api.example.com", "registry.npmjs.org:443"}, cfg.SandboxAllowlist)
 
 	stdout.Reset()
 	root.SetArgs([]string{"sandbox", "list"})

--- a/pkg/tools/builtin/api/api.go
+++ b/pkg/tools/builtin/api/api.go
@@ -88,6 +88,10 @@ func (t *ToolSet) callTool(ctx context.Context, toolCall tools.ToolCall, _ tools
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
+	if resp.StatusCode >= 400 {
+		return tools.ResultError(fmt.Sprintf("API request failed with status %d %s: %s", resp.StatusCode, http.StatusText(resp.StatusCode), limitOutput(string(body)))), nil
+	}
+
 	return tools.ResultSuccess(limitOutput(string(body))), nil
 }
 

--- a/pkg/tools/builtin/api/api_test.go
+++ b/pkg/tools/builtin/api/api_test.go
@@ -320,3 +320,27 @@ func (p *testEnvProvider) Get(_ context.Context, name string) (string, bool) {
 func testExpander() *js.Expander {
 	return js.NewJsExpander(noopEnvProvider{})
 }
+
+func TestAPITool_ErrorStatusCode(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"internal server error"}`))
+	}))
+	t.Cleanup(func() {
+		server.Close()
+	})
+
+	tool := newAPIToolForTest(latest.APIToolConfig{
+		Method:   http.MethodGet,
+		Endpoint: server.URL,
+	}, testExpander())
+
+	result, err := tool.callTool(t.Context(), tools.ToolCall{}, tools.NopRuntime{})
+	require.NoError(t, err)
+
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Output, "API request failed with status 500")
+	assert.Contains(t, result.Output, "internal server error")
+}


### PR DESCRIPTION
## Overview

This PR addresses a logic bug in the api tool where HTTP error responses (4xx and 5xx status codes) were previously swallowed and treated as successful executions. Additionally, it resolves a couple of test suite regressions related to Windows compatibility and unordered slice assertions.

## Changes Included

### Bug Fixes
* API Tool Error Propagation: Updated pkg/tools/builtin/api/api.go to explicitly check resp.StatusCode. If the status code is >= 400, the tool now properly returns a tools.ResultError containing the status code, the status text, and the truncated response body.
* API Tool Tests: Added TestAPITool_ErrorStatusCode to verify that 500 Internal Server Error responses correctly generate an error result instead of a success object.

### Testing and CI Improvements
* Windows Compatibility for Mkfifo: Extracted the TestAgentRefsInDirSkipsNonRegularFiles test (which uses syscall.Mkfifo) out of agent_picker_test.go and into a dedicated agent_picker_unix_test.go file with a //go:build !windows directive. This cleanly resolves cross-platform compilation and test execution issues on Windows.
* Cross-Platform Paths: Updated hardcoded Unix-style paths in agent_picker_test.go to use filepath.FromSlash to ensure the tests pass smoothly on Windows environments.
* Unordered Matching: Switched from assert.Equal to assert.ElementsMatch in sandbox_cmd_test.go for SandboxAllowlist assertions, preventing flaky test failures caused by non-deterministic map or slice ordering.
