### PR TITLE
feat(filesystem): add `.agentsignore` to keep files out of the agent's reach

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -1120,6 +1120,10 @@ func (f *runExecFlags) createSessionSpawner(agentSource config.Source, sessStore
 			t.SetPermissions(permissions.Merge(t.Permissions(), f.globalPermissions))
 		}
 
+		if ignoreRules := permissions.FromAgentsIgnore(f.runConfig.WorkingDir); ignoreRules != nil {
+			t.SetPermissions(permissions.Merge(t.Permissions(), ignoreRules))
+		}
+
 		rtOpts, ctrl, err := f.snapshotRuntimeOpts()
 		if err != nil {
 			return nil, nil, nil, err

--- a/docs/configuration/agentsignore/index.md
+++ b/docs/configuration/agentsignore/index.md
@@ -1,0 +1,105 @@
+---
+title: "Ignoring files"
+description: "Hide files from the agent with a .agentsignore file, using the same syntax as .gitignore."
+keywords: docker agent, ai agents, configuration, agentsignore, gitignore, ignore, secrets
+weight: 75
+canonical: https://docs.docker.com/ai/docker-agent/configuration/agentsignore/
+---
+
+_Hide files from the agent with a `.agentsignore` file, using the same syntax as `.gitignore`._
+
+## Overview
+
+Put a `.agentsignore` file in your project and the agent stops seeing the paths it lists. Matched files are absent from directory listings and searches, and reads, writes and edits targeting them are refused.
+
+```text
+# .agentsignore
+secrets.env
+*.key
+.env.*
+build/
+docs/**/*.draft.md
+!public.key
+```
+
+There is nothing to configure. The file's presence is the opt-in, and it is picked up automatically by the [filesystem toolset](../../tools/filesystem/index.md).
+
+## Syntax
+
+The syntax is `.gitignore` syntax — parsed with the same library git uses, so patterns behave identically to `.gitignore` and `.dockerignore`:
+
+| Pattern | Matches |
+| --- | --- |
+| `secrets.env` | that name at any depth (`secrets.env`, `config/secrets.env`) |
+| `/secrets.env` | that name at the project root only |
+| `*.key` | any file with the extension |
+| `build/` | the directory and everything under it |
+| `docs/**/*.draft.md` | nested matches via `**` |
+| `!public.key` | re-includes a path an earlier pattern excluded |
+| `# comment` | ignored, as are blank lines |
+
+## Where the file is found
+
+The nearest `.agentsignore` at or above the working directory is used, so starting a run in a subdirectory still honours the project's file. Patterns are anchored to the directory containing the file, exactly as git anchors to the directory containing `.gitignore`.
+
+Unlike `.gitignore`, **a git repository is not required** — `.agentsignore` works in any directory.
+
+## What it affects
+
+| Behaviour | Effect |
+| --- | --- |
+| `list_directory`, `directory_tree` | matched entries are omitted |
+| `search_files_content` | matched files are skipped |
+| `read_file`, `read_multiple_files` | refused |
+| `write_file`, `edit_file` | refused, including for files that do not exist yet |
+| `create_directory`, `remove_directory` | refused |
+| `permissions` | matching deny rules are derived automatically, so `/permissions` shows them |
+
+Paths are resolved before matching — symlinks, `./` prefixes and `..` segments are all normalised — so an ignored file cannot be reached by spelling it differently.
+
+The `.agentsignore` file is itself always hidden: it names the very things being kept back, so handing it to the agent would be a map of what to look for.
+
+> [!NOTE]
+> `.agentsignore` is independent of the filesystem toolset's [`ignore_vcs`](../tools/index.md) option. Setting `ignore_vcs: false` turns off `.gitignore` filtering but does **not** un-hide `.agentsignore` entries.
+
+## Relationship to `.gitignore`
+
+They are separate, and they do different amounts of work.
+
+`.gitignore` is respected by default (`ignore_vcs`), but only as a **display filter**: gitignored files are hidden from listings and searches while `read_file` still opens them. That is reasonable for build output, which is noise rather than secret.
+
+`.agentsignore` is for content the agent should not have at all, so it blocks reads and writes as well. Use `.gitignore` for noise, `.agentsignore` for secrets.
+
+## Limits
+
+> [!WARNING]
+> `.agentsignore` governs the filesystem toolset. It is **not** a sandbox.
+>
+> An agent with the [`shell`](../../tools/shell/index.md) toolset can still run `cat secrets.env`, because the shell runs commands the toolset never inspects. The same applies to any toolset that reaches the filesystem on its own, such as [`lsp`](../../tools/lsp/index.md).
+>
+> Treat `.agentsignore` as a strong default that keeps sensitive files out of the agent's view and context — not as a boundary against an agent actively trying to reach them. When you need a real boundary, combine it with [permissions](../permissions/index.md) that restrict `shell`, or run in [sandbox mode](../sandbox/index.md).
+
+The derived permission rules are best-effort for the same reason: permission patterns match the argument string as the model wrote it, without resolving it first, so `./secrets.env` can slip past a rule written for `secrets.env`. The filesystem toolset's own check resolves paths first and is the part that actually enforces.
+
+## Example
+
+```text
+# .agentsignore
+
+# Secrets
+.env
+.env.*
+secrets.env
+*.pem
+*.key
+!public.key          # this one is safe to read
+
+# Credentials directories
+.aws/
+.ssh/
+
+# Large build output the agent doesn't need
+build/
+dist/
+node_modules/
+```

--- a/docs/data/nav.yml
+++ b/docs/data/nav.yml
@@ -40,6 +40,8 @@
       url: /configuration/hooks/
     - title: Permissions
       url: /configuration/permissions/
+    - title: Ignoring Files
+      url: /configuration/agentsignore/
     - title: Sandbox Mode
       url: /configuration/sandbox/
     - title: Structured Output

--- a/pkg/fsx/agentsignore.go
+++ b/pkg/fsx/agentsignore.go
@@ -1,0 +1,157 @@
+package fsx
+
+import (
+	"bufio"
+	"errors"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
+)
+
+const AgentsIgnoreFile = ".agentsignore"
+
+type AgentsIgnoreMatcher struct {
+	root    string
+	matcher gitignore.Matcher
+}
+
+func FindAgentsIgnore(startDir string) string {
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return ""
+	}
+	for {
+		candidate := filepath.Join(dir, AgentsIgnoreFile)
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+func NewAgentsIgnoreMatcher(startDir string) (*AgentsIgnoreMatcher, error) {
+	path := FindAgentsIgnore(startDir)
+	if path == "" {
+		return nil, nil
+	}
+	patterns, err := readAgentsIgnorePatterns(path)
+	if err != nil {
+		return nil, err
+	}
+	if len(patterns) == 0 {
+		return nil, nil
+	}
+	root := filepath.Dir(path)
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		root = resolved
+	}
+	slog.Debug("Loaded .agentsignore", "file", path, "patterns", len(patterns))
+	return &AgentsIgnoreMatcher{root: root, matcher: gitignore.NewMatcher(patterns)}, nil
+}
+
+func readAgentsIgnorePatterns(path string) ([]gitignore.Pattern, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	var patterns []gitignore.Pattern
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		patterns = append(patterns, gitignore.ParsePattern(line, nil))
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return patterns, nil
+}
+
+func ReadAgentsIgnoreGlobs(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	var out []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out, scanner.Err()
+}
+
+func (m *AgentsIgnoreMatcher) Match(path string) bool {
+	if m == nil {
+		return false
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	absPath = resolveExisting(absPath)
+
+	relPath, err := filepath.Rel(m.root, absPath)
+	if err != nil {
+		return false
+	}
+	normalized := filepath.ToSlash(relPath)
+	if normalized == ".." || strings.HasPrefix(normalized, "../") {
+		return false
+	}
+	if normalized == "." {
+		return false
+	}
+	if normalized == AgentsIgnoreFile {
+		return true
+	}
+
+	info, statErr := os.Stat(absPath)
+	isDir := statErr == nil && info.IsDir()
+	return m.matcher.Match(strings.Split(normalized, "/"), isDir)
+}
+
+func resolveExisting(absPath string) string {
+	if resolved, err := filepath.EvalSymlinks(absPath); err == nil {
+		return resolved
+	}
+	dir, rest := filepath.Dir(absPath), filepath.Base(absPath)
+	for dir != filepath.Dir(dir) {
+		if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+			return filepath.Join(resolved, rest)
+		}
+		dir, rest = filepath.Dir(dir), filepath.Join(filepath.Base(dir), rest)
+	}
+	return absPath
+}
+
+func (m *AgentsIgnoreMatcher) Root() string {
+	if m == nil {
+		return ""
+	}
+	return m.root
+}

--- a/pkg/fsx/agentsignore_test.go
+++ b/pkg/fsx/agentsignore_test.go
@@ -1,0 +1,137 @@
+package fsx
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeAgentsIgnore(t *testing.T, dir, body string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, AgentsIgnoreFile), []byte(body), 0o644))
+}
+
+func TestAgentsIgnoreAbsentIsNilAndInert(t *testing.T) {
+	m, err := NewAgentsIgnoreMatcher(t.TempDir())
+	require.NoError(t, err)
+	require.Nil(t, m)
+	assert.False(t, m.Match("/anything"))
+	assert.Empty(t, m.Root())
+}
+
+func TestAgentsIgnoreWorksWithoutGitRepo(t *testing.T) {
+	dir := t.TempDir()
+	writeAgentsIgnore(t, dir, "secrets.env\n")
+
+	m, err := NewAgentsIgnoreMatcher(dir)
+	require.NoError(t, err)
+	require.NotNil(t, m, "a .agentsignore must work outside a git repository")
+	assert.True(t, m.Match(filepath.Join(dir, "secrets.env")))
+}
+
+func TestAgentsIgnoreGitignoreSyntax(t *testing.T) {
+	dir := t.TempDir()
+	writeAgentsIgnore(t, dir, `
+# comment, ignored
+secrets.env
+*.key
+build/
+docs/**/*.draft.md
+!keep.key
+`)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "build", "out"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "docs", "a"), 0o755))
+
+	m, err := NewAgentsIgnoreMatcher(dir)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+
+	for _, tc := range []struct {
+		path string
+		want bool
+		why  string
+	}{
+		{"secrets.env", true, "exact name"},
+		{"sub/secrets.env", true, "bare name matches at any depth"},
+		{"id.key", true, "glob"},
+		{"keep.key", false, "negation re-includes"},
+		{"build", true, "directory itself"},
+		{"build/out", true, "inside an ignored directory"},
+		{"docs/a/spec.draft.md", true, "double-star glob"},
+		{"docs/a/spec.md", false, "not matched"},
+		{"README.md", false, "unrelated file"},
+	} {
+		got := m.Match(filepath.Join(dir, tc.path))
+		assert.Equalf(t, tc.want, got, "%s (%s)", tc.path, tc.why)
+	}
+}
+
+func TestAgentsIgnoreHidesItself(t *testing.T) {
+	dir := t.TempDir()
+	writeAgentsIgnore(t, dir, "secrets.env\n")
+
+	m, err := NewAgentsIgnoreMatcher(dir)
+	require.NoError(t, err)
+	assert.True(t, m.Match(filepath.Join(dir, AgentsIgnoreFile)))
+}
+
+func TestAgentsIgnoreFoundFromSubdirectory(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "a", "b")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+	writeAgentsIgnore(t, root, "secrets.env\n")
+
+	m, err := NewAgentsIgnoreMatcher(sub)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.True(t, m.Match(filepath.Join(root, "secrets.env")),
+		"patterns anchor to the file's directory, not the start directory")
+}
+
+func TestAgentsIgnoreDoesNotMatchOutsideItsTree(t *testing.T) {
+	root := t.TempDir()
+	other := t.TempDir()
+	writeAgentsIgnore(t, root, "secrets.env\n")
+
+	m, err := NewAgentsIgnoreMatcher(root)
+	require.NoError(t, err)
+	assert.False(t, m.Match(filepath.Join(other, "secrets.env")))
+}
+
+func TestAgentsIgnoreResolvesSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	writeAgentsIgnore(t, dir, "secrets.env\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "secrets.env"), []byte("k=v"), 0o600))
+
+	link := filepath.Join(dir, "alias.txt")
+	if err := os.Symlink(filepath.Join(dir, "secrets.env"), link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	m, err := NewAgentsIgnoreMatcher(dir)
+	require.NoError(t, err)
+	assert.True(t, m.Match(link), "a symlink to an ignored file must stay ignored")
+}
+
+func TestAgentsIgnoreEmptyYieldsNoMatcher(t *testing.T) {
+	dir := t.TempDir()
+	writeAgentsIgnore(t, dir, "# just a comment\n\n   \n")
+
+	m, err := NewAgentsIgnoreMatcher(dir)
+	require.NoError(t, err)
+	assert.Nil(t, m)
+}
+
+func TestReadAgentsIgnoreGlobs(t *testing.T) {
+	dir := t.TempDir()
+	writeAgentsIgnore(t, dir, "# comment\n\nsecrets.env\n  *.key  \n!keep.key\n")
+
+	globs, err := ReadAgentsIgnoreGlobs(filepath.Join(dir, AgentsIgnoreFile))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"secrets.env", "*.key", "!keep.key"}, globs,
+		"comments and blanks are dropped, order and negation preserved")
+}

--- a/pkg/permissions/agentsignore.go
+++ b/pkg/permissions/agentsignore.go
@@ -1,0 +1,65 @@
+package permissions
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/docker-agent/pkg/fsx"
+)
+
+var pathToolArgs = []struct {
+	tool string
+	arg  string
+}{
+	{"read_file", "path"},
+	{"read_multiple_files", "paths"},
+	{"write_file", "path"},
+	{"edit_file", "path"},
+	{"create_directory", "path"},
+	{"remove_directory", "path"},
+	{"list_directory", "path"},
+	{"directory_tree", "path"},
+	{"search_files_content", "path"},
+}
+
+func FromAgentsIgnore(startDir string) *Checker {
+	path := fsx.FindAgentsIgnore(startDir)
+	if path == "" {
+		return nil
+	}
+	patterns, err := fsx.ReadAgentsIgnoreGlobs(path)
+	if err != nil || len(patterns) == 0 {
+		return nil
+	}
+
+	var deny []string
+	for _, p := range patterns {
+		for _, glob := range permissionGlobsFor(p) {
+			for _, t := range pathToolArgs {
+				deny = append(deny, t.tool+":"+t.arg+"="+glob)
+			}
+		}
+	}
+	if len(deny) == 0 {
+		return nil
+	}
+	return NewCheckerFromRules(nil, nil, deny)
+}
+
+func permissionGlobsFor(pattern string) []string {
+	p := strings.TrimSpace(pattern)
+	if p == "" || strings.HasPrefix(p, "#") || strings.HasPrefix(p, "!") {
+		return nil
+	}
+	p = strings.TrimSuffix(p, "/")
+	p = strings.TrimPrefix(p, "/")
+	if p == "" {
+		return nil
+	}
+	base := filepath.ToSlash(p)
+	globs := []string{base, base + "/*"}
+	if !strings.Contains(base, "/") {
+		globs = append(globs, "*/"+base, "*/"+base+"/*")
+	}
+	return globs
+}

--- a/pkg/permissions/agentsignore.go
+++ b/pkg/permissions/agentsignore.go
@@ -12,7 +12,11 @@ var pathToolArgs = []struct {
 	arg  string
 }{
 	{"read_file", "path"},
-	{"read_multiple_files", "paths"},
+	// read_multiple_files is intentionally omitted: its "paths" argument is an
+	// array, not a scalar string. The permission evaluator formats arrays as
+	// "[elem1 elem2]", so a scalar glob like "secrets.env" can never match.
+	// Per-path enforcement for read_multiple_files happens in the filesystem
+	// layer (resolveAndCheckPath called for each element) and is unaffected.
 	{"write_file", "path"},
 	{"edit_file", "path"},
 	{"create_directory", "path"},
@@ -49,6 +53,15 @@ func FromAgentsIgnore(startDir string) *Checker {
 func permissionGlobsFor(pattern string) []string {
 	p := strings.TrimSpace(pattern)
 	if p == "" || strings.HasPrefix(p, "#") || strings.HasPrefix(p, "!") {
+		// NOTE: negation patterns (e.g. "!public.key") are intentionally dropped
+		// here because a deny-list cannot express "except this path". The
+		// filesystem layer re-includes negated paths correctly (gitignore
+		// semantics), so actual access is unaffected. However, the advisory
+		// /permissions display may show a path as denied even when the agent
+		// can actually reach it — for example, if ".agentsignore" contains
+		// "*.key" and "!public.key", the display will flag public.key as
+		// blocked even though the filesystem layer permits it. This is a
+		// known limitation of the advisory permission layer.
 		return nil
 	}
 	p = strings.TrimSuffix(p, "/")

--- a/pkg/permissions/agentsignore_test.go
+++ b/pkg/permissions/agentsignore_test.go
@@ -1,0 +1,85 @@
+package permissions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/fsx"
+)
+
+func writeIgnore(t *testing.T, dir, body string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, fsx.AgentsIgnoreFile), []byte(body), 0o644))
+}
+
+func TestFromAgentsIgnoreAbsent(t *testing.T) {
+	assert.Nil(t, FromAgentsIgnore(t.TempDir()))
+}
+
+func TestFromAgentsIgnoreNoPatterns(t *testing.T) {
+	dir := t.TempDir()
+	writeIgnore(t, dir, "# nothing here\n\n")
+	assert.Nil(t, FromAgentsIgnore(dir))
+}
+
+func TestFromAgentsIgnoreDeniesReadAndWrite(t *testing.T) {
+	dir := t.TempDir()
+	writeIgnore(t, dir, "secrets.env\n")
+
+	c := FromAgentsIgnore(dir)
+	require.NotNil(t, c)
+
+	for _, tool := range []string{"read_file", "write_file", "edit_file"} {
+		assert.Equalf(t, Deny, c.CheckWithArgs(tool, map[string]any{"path": "secrets.env"}),
+			"%s on an ignored path must be denied", tool)
+	}
+	assert.Equal(t, Ask, c.CheckWithArgs("read_file", map[string]any{"path": "README.md"}),
+		"unignored paths are untouched")
+}
+
+func TestFromAgentsIgnoreCoversNestedPaths(t *testing.T) {
+	dir := t.TempDir()
+	writeIgnore(t, dir, "secrets.env\n")
+
+	c := FromAgentsIgnore(dir)
+	require.NotNil(t, c)
+	assert.Equal(t, Deny, c.CheckWithArgs("read_file", map[string]any{"path": "config/secrets.env"}))
+}
+
+func TestFromAgentsIgnoreDirectoryCoversContents(t *testing.T) {
+	dir := t.TempDir()
+	writeIgnore(t, dir, "build/\n")
+
+	c := FromAgentsIgnore(dir)
+	require.NotNil(t, c)
+	assert.Equal(t, Deny, c.CheckWithArgs("read_file", map[string]any{"path": "build/out.bin"}))
+}
+
+func TestFromAgentsIgnoreSkipsNegations(t *testing.T) {
+	dir := t.TempDir()
+	writeIgnore(t, dir, "!keep.key\n")
+
+	assert.Nil(t, FromAgentsIgnore(dir),
+		"a negation-only file must not produce a deny rule for keep.key")
+}
+
+func TestPermissionGlobsFor(t *testing.T) {
+	for _, tc := range []struct {
+		pattern string
+		want    []string
+	}{
+		{"secrets.env", []string{"secrets.env", "secrets.env/*", "*/secrets.env", "*/secrets.env/*"}},
+		{"build/", []string{"build", "build/*", "*/build", "*/build/*"}},
+		{"docs/notes.md", []string{"docs/notes.md", "docs/notes.md/*"}},
+		{"!keep.key", nil},
+		{"# comment", nil},
+		{"", nil},
+		{"/", nil},
+	} {
+		assert.Equalf(t, tc.want, permissionGlobsFor(tc.pattern), "pattern %q", tc.pattern)
+	}
+}

--- a/pkg/tools/builtin/filesystem/agentsignore_test.go
+++ b/pkg/tools/builtin/filesystem/agentsignore_test.go
@@ -1,0 +1,152 @@
+package filesystem
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/fsx"
+)
+
+func ignoreProject(t *testing.T, ignoreBody string, files map[string]string) (string, *ToolSet) {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, fsx.AgentsIgnoreFile), []byte(ignoreBody), 0o644))
+	for name, content := range files {
+		full := filepath.Join(dir, name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0o644))
+	}
+
+	ts, err := CreateToolSet(latest.Toolset{Type: "filesystem"}, &config.RuntimeConfig{
+		Config: config.Config{WorkingDir: dir},
+	})
+	require.NoError(t, err)
+	fsts, ok := ts.(*ToolSet)
+	require.True(t, ok)
+	return dir, fsts
+}
+
+func TestAgentsIgnoreBlocksRead(t *testing.T) {
+	dir, ts := ignoreProject(t, "secrets.env\n", map[string]string{
+		"secrets.env": "API_KEY=super-secret",
+		"README.md":   "hello",
+	})
+
+	_, err := ts.resolveAndCheckPath(filepath.Join(dir, "secrets.env"))
+	require.Error(t, err, "an ignored file must not be readable")
+	assert.Contains(t, err.Error(), fsx.AgentsIgnoreFile)
+	assert.NotContains(t, err.Error(), "API_KEY", "the error must not leak contents")
+
+	_, err = ts.resolveAndCheckPath(filepath.Join(dir, "README.md"))
+	assert.NoError(t, err, "unignored files stay readable")
+}
+
+func TestAgentsIgnoreBlocksWrite(t *testing.T) {
+	dir, ts := ignoreProject(t, "secrets.env\nbuild/\n", nil)
+
+	for _, target := range []string{"secrets.env", "build/artifact.bin"} {
+		_, err := ts.resolveAndCheckPath(filepath.Join(dir, target))
+		assert.Errorf(t, err, "writing %s must be refused", target)
+	}
+}
+
+func TestAgentsIgnoreBlocksCreationOfMissingPath(t *testing.T) {
+	dir, ts := ignoreProject(t, "*.key\n", nil)
+
+	_, err := ts.resolveAndCheckPath(filepath.Join(dir, "id_rsa.key"))
+	require.Error(t, err, "creating a new ignored file must be refused")
+}
+
+func TestAgentsIgnoreHidesFromListing(t *testing.T) {
+	dir, ts := ignoreProject(t, "secrets.env\n", map[string]string{
+		"secrets.env": "k=v",
+		"README.md":   "hello",
+	})
+
+	assert.True(t, ts.shouldIgnorePath(filepath.Join(dir, "secrets.env")))
+	assert.False(t, ts.shouldIgnorePath(filepath.Join(dir, "README.md")))
+}
+
+func TestAgentsIgnoreAppliesWhenIgnoreVCSDisabled(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, fsx.AgentsIgnoreFile), []byte("secrets.env\n"), 0o644))
+
+	off := false
+	ts, err := CreateToolSet(latest.Toolset{Type: "filesystem", IgnoreVCS: &off}, &config.RuntimeConfig{
+		Config: config.Config{WorkingDir: dir},
+	})
+	require.NoError(t, err)
+	fsts := ts.(*ToolSet)
+
+	assert.True(t, fsts.shouldIgnorePath(filepath.Join(dir, "secrets.env")),
+		"ignore_vcs: false must not disable .agentsignore")
+	_, err = fsts.resolveAndCheckPath(filepath.Join(dir, "secrets.env"))
+	require.Error(t, err)
+}
+
+func TestAgentsIgnoreHidesItself(t *testing.T) {
+	dir, ts := ignoreProject(t, "secrets.env\n", nil)
+
+	_, err := ts.resolveAndCheckPath(filepath.Join(dir, fsx.AgentsIgnoreFile))
+	require.Error(t, err, ".agentsignore must not be readable by the agent")
+}
+
+func TestNoAgentsIgnoreLeavesBehaviourUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "secrets.env"), []byte("k=v"), 0o644))
+
+	ts, err := CreateToolSet(latest.Toolset{Type: "filesystem"}, &config.RuntimeConfig{
+		Config: config.Config{WorkingDir: dir},
+	})
+	require.NoError(t, err)
+	fsts := ts.(*ToolSet)
+
+	require.Nil(t, fsts.agentsIgnore)
+	_, err = fsts.resolveAndCheckPath(filepath.Join(dir, "secrets.env"))
+	assert.NoError(t, err, "without the file nothing is newly blocked")
+}
+
+func TestAgentsIgnoreBlocksRelativePath(t *testing.T) {
+	dir, ts := ignoreProject(t, "secrets.env\n", map[string]string{"secrets.env": "k=v"})
+
+	for _, form := range []string{"secrets.env", "./secrets.env", "sub/../secrets.env"} {
+		_, err := ts.resolveAndCheckPath(filepath.Join(dir, form))
+		assert.Errorf(t, err, "%q must be blocked regardless of spelling", form)
+	}
+}
+
+func TestAgentsIgnoreNegationReIncludes(t *testing.T) {
+	dir, ts := ignoreProject(t, "*.key\n!public.key\n", map[string]string{
+		"private.key": "secret",
+		"public.key":  "shareable",
+	})
+
+	_, err := ts.resolveAndCheckPath(filepath.Join(dir, "private.key"))
+	require.Error(t, err)
+
+	_, err = ts.resolveAndCheckPath(filepath.Join(dir, "public.key"))
+	assert.NoError(t, err, "! negation must re-include, as in .gitignore")
+}
+
+func TestAgentsIgnoreUnreadableFileIsAnError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses file permissions")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, fsx.AgentsIgnoreFile)
+	require.NoError(t, os.WriteFile(path, []byte("secrets.env\n"), 0o644))
+	require.NoError(t, os.Chmod(path, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+
+	_, err := CreateToolSet(latest.Toolset{Type: "filesystem"}, &config.RuntimeConfig{
+		Config: config.Config{WorkingDir: dir},
+	})
+	require.Error(t, err, "an unreadable .agentsignore must fail loudly")
+	assert.Contains(t, err.Error(), fsx.AgentsIgnoreFile)
+}

--- a/pkg/tools/builtin/filesystem/filesystem.go
+++ b/pkg/tools/builtin/filesystem/filesystem.go
@@ -101,6 +101,7 @@ type ToolSet struct {
 	// that resolve under one of the listed roots, even when the path also
 	// matches the allow-list. nil means "no deny-list".
 	denyList *pathRootSet
+	agentsIgnore *fsx.AgentsIgnoreMatcher
 }
 
 // Verify interface compliance
@@ -121,6 +122,12 @@ func WithPostEditCommands(postEditCommands []PostEditConfig) Opt {
 func WithIgnoreVCS(ignoreVCS bool) Opt {
 	return func(t *ToolSet) {
 		t.ignoreVCS = ignoreVCS
+	}
+}
+
+func WithAgentsIgnore(m *fsx.AgentsIgnoreMatcher) Opt {
+	return func(t *ToolSet) {
+		t.agentsIgnore = m
 	}
 }
 
@@ -185,6 +192,14 @@ func CreateToolSet(toolset latest.Toolset, runConfig *config.RuntimeConfig) (too
 		ignoreVCS = *toolset.IgnoreVCS
 	}
 	opts = append(opts, WithIgnoreVCS(ignoreVCS))
+
+	matcher, err := fsx.NewAgentsIgnoreMatcher(wd)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", fsx.AgentsIgnoreFile, err)
+	}
+	if matcher != nil {
+		opts = append(opts, WithAgentsIgnore(matcher))
+	}
 
 	if len(toolset.AllowList) > 0 {
 		opts = append(opts, WithAllowList(toolset.AllowList))
@@ -638,6 +653,9 @@ func (t *ToolSet) resolveAndCheckPath(path string) (string, error) {
 	}
 
 	resolved := t.resolvePath(path)
+	if t.agentsIgnore.Match(resolved) {
+		return "", fmt.Errorf("path %q is excluded by %s", path, fsx.AgentsIgnoreFile)
+	}
 	if t.allowList == nil && t.denyList == nil {
 		return resolved, nil
 	}
@@ -803,6 +821,10 @@ func (t *ToolSet) initGitignoreMatcher() {
 
 // shouldIgnorePath checks if a path should be ignored based on VCS rules
 func (t *ToolSet) shouldIgnorePath(path string) bool {
+	if t.agentsIgnore.Match(path) {
+		return true
+	}
+
 	if !t.ignoreVCS {
 		return false
 	}

--- a/pkg/tools/builtin/filesystem/filesystem.go
+++ b/pkg/tools/builtin/filesystem/filesystem.go
@@ -100,7 +100,7 @@ type ToolSet struct {
 	// denyList, when non-nil, rejects every filesystem operation on paths
 	// that resolve under one of the listed roots, even when the path also
 	// matches the allow-list. nil means "no deny-list".
-	denyList *pathRootSet
+	denyList     *pathRootSet
 	agentsIgnore *fsx.AgentsIgnoreMatcher
 }
 


### PR DESCRIPTION

Adds a `.agentsignore` file — same syntax as `.gitignore` and `.dockerignore` — whose entries the agent cannot list, read, or write.

```text
# .agentsignore
.env
.env.*
*.pem
*.key
!public.key
.aws/
build/
```

Drop it in the project. There is nothing to configure: the file's presence is the opt-in.

Closes #3742.

## Why this doesn't already exist

Three mechanisms are adjacent and none of them does it:

| | Syntax | Blocks read/write? | Why it isn't enough |
| --- | --- | --- | --- |
| `.gitignore` (`ignore_vcs`) | gitignore | **No** | Display filter only — hides from listings while `read_file` still opens the file |
| `allow_list` / `deny_list` | literal dir roots | Yes | No globs at all: `vendor/**` means a directory literally named `**`. Can't express `*.pem` |
| `permissions` | globs | Advisory | Matches the raw argument string with no path resolution, so `./secrets.env` defeats a rule for `secrets.env` |

The one with the right syntax can't enforce; the one that enforces has the wrong syntax.

The `.gitignore` gap is worth stating precisely, because it is the gap this closes: `shouldIgnorePath` (`filesystem.go:805`) has exactly three callsites — `handleListDirectory`, `handleDirectoryTree`, `handleSearchFilesContent`. `handleReadFile`, `handleWriteFile` and `handleEditFile` never call it. **`read_file secrets.env` succeeds today on a gitignored file.** There's a regression test for that now.

## What it does

| Behaviour | Effect |
| --- | --- |
| `list_directory`, `directory_tree` | matched entries omitted |
| `search_files_content` | matched files skipped |
| `read_file`, `read_multiple_files` | refused |
| `write_file`, `edit_file` | refused — including paths that don't exist yet |
| `create_directory`, `remove_directory` | refused |
| `/permissions` | matching deny rules derived automatically |

Paths are resolved before matching — symlinks, `./`, `..` — so an ignored file can't be reached by spelling it differently. The `.agentsignore` file hides itself: it names exactly what's being kept back.

## Implementation

**`pkg/fsx/agentsignore.go`** — `AgentsIgnoreMatcher`, built with go-git's `gitignore.ParsePattern`/`NewMatcher`, so `!` negation, `**`, trailing-slash directories and anchoring behave identically to `.gitignore`. Two deliberate differences from the existing `VCSMatcher`:

- **No git repo required.** `VCSMatcher` returns nothing outside a repository, which would silently disable the feature in exactly the scratch directories where secrets sit unprotected.
- **Not cached process-globally.** `VCSMatcher`'s cache has no invalidation, so an edited `.gitignore` never takes effect. This matcher lives with its toolset.

**`pkg/tools/builtin/filesystem/filesystem.go`** — two touchpoints:

- `resolveAndCheckPath` (the chokepoint every path-taking handler already funnels through) → blocks read/write/edit/mkdir/rmdir in one place.
- `shouldIgnorePath` → suppresses listings and searches. Checked **before** the `ignore_vcs` guard, so `ignore_vcs: false` disables `.gitignore` filtering without silently un-hiding `.agentsignore` entries.

**`pkg/permissions/agentsignore.go`** — derives deny rules from the patterns; `cmd/root/run.go` merges them into the team checker so the ignore list shows up in `/permissions`. Negations are skipped deliberately: a permission list can't express "except this", and emitting `keep.key` without its `!` would deny the very path the author re-included.

A malformed or unreadable `.agentsignore` is a **hard error** at toolset construction, not a warning. Continuing past it would leave the agent reading files the author believed were hidden.

## Limits

`.agentsignore` governs the filesystem toolset. An agent with `shell` can still run `cat secrets.env` — `shell.go:192` execs the command without inspecting it. `lsp` reads *and writes* files directly (`lsp.go:1405`, `:1426`).

Closing those means command inspection (brittle; `base64`, `xxd` and heredocs evade it) or real sandboxing, which the project already offers separately. The framing in the docs is: a strong default that keeps sensitive files out of the agent's view and context, to be paired with `permissions` or sandbox mode when a genuine boundary is needed.

The derived permission rules are best-effort for the same reason — they match unresolved argument strings. The filesystem toolset's check is the part that actually enforces.

I'd rather ship this honestly scoped than imply a guarantee it can't keep. Happy to reshape if you'd prefer it wired elsewhere.

## Verification

Run on the real `go.mod` with the `go1.26.5` toolchain.

- `go test ./pkg/fsx/ ./pkg/permissions/ ./pkg/tools/builtin/filesystem/ ./cmd/root/` → passing, no regressions
- `golangci-lint run` over every touched package → **0 issues**
- `markdownlint-cli2` from `docs/` → **0 errors, 115 files**
- `TestDocYAMLSnippetsAreValid` → passing

Tests cover: the gitignore-syntax surface (bare names at depth, `*` globs, `**`, `build/`, `!` negation, comments); read blocked; write blocked; **creation of a not-yet-existing ignored path blocked**; hidden from listings; unaffected by `ignore_vcs: false`; self-hiding; relative and `..` spellings blocked; no file ⇒ behaviour unchanged; unreadable file ⇒ hard error.

One bug the tests caught during development, worth noting because it would have been invisible in review: `filepath.EvalSymlinks` fails outright on a path that doesn't exist, leaving it unresolved and therefore incomparable with the resolved root — so **writes to new ignored paths would have been silently allowed** on any platform where the project root is itself a symlink (macOS `/var` → `/private/var`). Fixed by resolving the deepest existing ancestor and re-appending the remainder (`resolveExisting`).

Proxy variables were unset for the test and lint runs — the local proxy intercepts the private-address SSRF tests and Go module downloads.

## Try it

```bash
cd your-project
printf 'secrets.env\n*.key\n' > .agentsignore
echo 'API_KEY=hunter2' > secrets.env

docker agent run ./agent.yaml "read secrets.env and tell me what is in it"
# → refused: path "secrets.env" is excluded by .agentsignore
```
