### PR TITLE
fix: use COPY --from for mcp-gateway in template stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,15 +85,8 @@ apt-get install -yy --no-install-recommends vim tmux
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 EOF
+COPY --chmod=0755 --from=docker/mcp-gateway:v2 /docker-mcp /usr/local/lib/docker/cli-plugins/docker-mcp
 USER agent
-# All mcp-gateway releases are prereleases, so "releases/latest" doesn't resolve;
-# fetch the newest tag from the API instead.
-RUN <<EOF
-set -euxo pipefail
-TAG=$(curl -fsSL "https://api.github.com/repos/docker/mcp-gateway/releases?per_page=1" | grep -o '"tag_name": *"[^"]*"' | cut -d '"' -f4)
-mkdir -p ~/.docker/cli-plugins
-curl -fsSL "https://github.com/docker/mcp-gateway/releases/download/${TAG}/docker-mcp-${TARGETOS}-${TARGETARCH}.tar.gz" | tar -C ~/.docker/cli-plugins -xz
-EOF
 ENV DOCKER_AGENT_NO_TOUR=1 \
     DOCKER_AGENT_HIDE_TELEMETRY_BANNER=1 \
     COLORTERM=truecolor \

--- a/docs/configuration/tools/index.md
+++ b/docs/configuration/tools/index.md
@@ -448,6 +448,15 @@ toolsets:
 
 When `defer` is a list of tool names, only those specific tools are deferred; all other tools in the toolset load eagerly. Setting `defer: true` defers the entire toolset.
 
+### Tool Discovery with `search_tool`
+
+When an entire toolset is deferred (`defer: true`), the deferred toolset exposes two built-in tools to the agent:
+
+- **`search_tool`** — Discover available deferred tools by keyword. The search uses **fuzzy matching** against both tool names and descriptions: all characters of the query must appear in the target string in order (but not necessarily adjacently), so a query like `"crfil"` matches `"create_file"`. Returns a list of matching tool names with descriptions.
+- **`add_tool`** — Activate a discovered tool by name so it becomes available for use.
+
+These tools let the agent browse a large toolset on-demand without activating every tool upfront.
+
 See [`examples/deferred.yaml`](https://github.com/docker/docker-agent/blob/main/examples/deferred.yaml) for a complete example.
 
 ## Combined Example

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -92,7 +92,7 @@ Type `/` during a session to see available commands, or press <kbd>Ctrl</kbd>+<k
 | `/pause`           | Pause/resume the runtime loop. While the agent is mid-request, the resize handle shows "Pausing…" until the in-flight request completes; once the loop is blocked the indicator changes to "⏸ Paused". Run `/pause` again to resume. |
 | `/tools`           | Show every toolset (with lifecycle state) and the tools they expose                  |
 | `/skills`          | List skills available to the current agent                                           |
-| `/toolset-restart` | Force a supervisor-driven reconnect of the named toolset (`/toolset-restart <name>`) |
+| `/toolset-restart` | Force a supervisor-driven reconnect of the named toolset (`/toolset-restart <name>`). Press <kbd>Tab</kbd> after `/toolset-restart` and a space to complete a toolset name; non-restartable toolsets are shown dimmed and cannot be selected. |
 | `/permissions`     | Inspect and edit tool permission rules                                               |
 | `/speak`           | Voice input via system speech-to-text (macOS only)                                   |
 | `/exit`            | Exit the application (aliases: `/quit`, `/q`)                                        |
@@ -301,7 +301,7 @@ Each error message includes a clickable **↻ retry** button. Clicking it resume
 Docker Agent automatically saves your sessions. Use `/sessions` to browse past conversations:
 
 - **Browse** past sessions with search and filtering. The search matches against session **titles** and **session IDs** (full UUIDs, dash-less variants, and partial fragments all resolve correctly — useful when jumping back to a session from a copied ID or log).
-- **Workspace grouping**: sessions started in the current directory are listed first under "This workspace", everything else under "Other locations" with its originating directory shown next to each entry; press <kbd>Ctrl</kbd>+<kbd>G</kbd> in the browser to cycle between all, current-directory only, and other-directory views. Restoring a session reopens it in its original directory, so the label always matches where a restore will land
+- **Workspace grouping**: sessions are grouped by **git repository root** (worktree-aware) — sessions from any subdirectory or linked worktree of the same repository are grouped together under "This workspace", and the header shows the repository root path. Sessions outside the current repository appear under "Other locations" with their originating directory. Press <kbd>Ctrl</kbd>+<kbd>G</kbd> in the browser to cycle between all, current-workspace only, and other-directory views. Restoring a session reopens it in its original directory, so the label always matches where a restore will land.
 - **Star** important sessions with `/star`
 - **Branch** conversations by editing any previous user message — preserving the original session history
 - **Resume** sessions with `docker agent run config.yaml --session <id>`
@@ -412,7 +412,7 @@ Run `/settings` to open the settings dialog. Use <kbd>Tab</kbd> to switch betwee
 
 The **Appearance** tab selects the theme and customizes the layout. Layout changes show a live schematic preview and apply immediately to the UI behind the dialog:
 
-- **Sidebar position**: `Right` (default), `Left`, `Top`, or `Bottom`. Left/right keep the full vertical sidebar next to the chat; top/bottom render it as a compact horizontal band above or below the chat (session title, working directory, usage, plus a one-line summary of the current agent, tools, and todos).
+- **Sidebar position**: `Right` (default), `Left`, `Top`, or `Bottom`. Left/right keep the full vertical sidebar next to the chat; top/bottom render it as a compact horizontal band above or below the chat (session title, working directory, token usage, plus a one-line summary of the current agent and its model; in multi-agent configurations all team agents are listed by name after the current agent).
 - **Sidebar info mode**: `Compact` (default) or `Detailed`. Controls how the Agents panel renders agent rows — see [Agents Panel](#agents-panel) for details. Persisted as `settings.layout.sidebar_info_mode: detailed`; compact is the default and omitted from the config.
 - **Section spacing**: `Compact`, `Normal` (default), or `Relaxed`, the number of blank lines between the sidebar sections (1, 2, or 3).
 - **Sidebar sections**: toggle the visibility of the **Session path** (the working directory line, including its git branch) and the **Token usage**, **Agents**, **Tools**, and **Todos** sections. The session title is always shown.


### PR DESCRIPTION
The `template` Docker build stage fetched the latest `docker-mcp` binary via an unauthenticated GitHub API call, which hit rate limits (HTTP 403) on shared CI runners:

```sh
curl -fsSL "https://api.github.com/repos/docker/mcp-gateway/releases?per_page=1"
```

The arm64 runner passed because it uses a different IP pool; the amd64 runner hit the 60 req/hr unauthenticated limit.

**Fix:** replace the 8-line `RUN curl | grep | tar` block with a single `COPY --from=docker/mcp-gateway:v2` instruction — the same pattern already used by the final MCP container stage of the same Dockerfile. No GitHub API calls, no rate-limit exposure.

Fixes the flaky CI failure observed on PR #3741.