### PR TITLE
feat(tui): add argument completion for /drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 
 
+## [Unreleased]
+
+## What's New
+
+- Adds argument completion for the `/drop` slash command: pressing <kbd>Tab</kbd> after `/drop ` opens a popup listing the session's currently attached file paths, so selecting one fills the exact path and it resolves via the exact-match branch of file resolution. Reuses the argument-completion hook shipped earlier for `/toolset-restart`
+
+
 ## [v1.111.0] - 2026-07-17
 
 This release adds a new scheduler toolset, inline Mermaid diagram rendering, model switching in the lean TUI, project config autodiscovery, and a range of bug fixes and performance improvements across the agent, TUI, and server.


### PR DESCRIPTION
## Summary

Adds the missing CHANGELOG entry for the `/drop` argument completion.

The actual implementation (`App.AttachedFiles()`, `dropCandidates`, `attachDropCompletion`, the popup wiring, tests, and docs) already landed on `main` in commit `4488ae57` via PR #3728 — this PR is the follow-up that documents the feature in the CHANGELOG, which that commit omitted.

## Why

CHANGELOG should notable list changes; the `/drop` Tab completion shipped in the v1.111.0 window but was never recorded.

## What's changed

- Adds a `[Unreleased]` section at the top of `CHANGELOG.md`, reusing the argument-completion hook shipped earlier for `/toolset-restart`.

## Notes

- No production code changes; docs + tests already merged upstream.
- **Credit for the implementation belongs to the original author** (merged in #3728). This PR only back-fills the CHANGELOG entry.

Fixes #3732