### PR TITLE
fix: A2A error handling + cross-platform test stability

### DIFF
--- a/pkg/paths/paths_test.go
+++ b/pkg/paths/paths_test.go
@@ -34,11 +34,11 @@ func TestOverrides(t *testing.T) {
 			assert.NotEmpty(t, original)
 
 			tt.set(tt.custom)
-			assert.Equal(t, tt.custom, tt.get())
+			assert.Equal(t, filepath.Clean(tt.custom), tt.get())
 
 			// Empty string restores the default.
 			tt.set("")
-			assert.Equal(t, original, tt.get())
+			assert.Equal(t, filepath.Clean(original), tt.get())
 		})
 	}
 }

--- a/pkg/runtime/agent_delegation_test.go
+++ b/pkg/runtime/agent_delegation_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -36,9 +37,11 @@ func TestBuildTaskSystemMessage(t *testing.T) {
 	})
 
 	t.Run("with attached files", func(t *testing.T) {
-		msg := buildTaskSystemMessage("do the thing", "", []string{"/abs/foo.go", "/abs/bar.go"})
+		fooPath, _ := filepath.Abs("/abs/foo.go")
+		barPath, _ := filepath.Abs("/abs/bar.go")
+		msg := buildTaskSystemMessage("do the thing", "", []string{fooPath, barPath})
 		assert.Contains(t, msg, "<task>\ndo the thing\n</task>")
-		assert.Contains(t, msg, "<attached_files>\n- /abs/foo.go\n- /abs/bar.go\n</attached_files>")
+		assert.Contains(t, msg, "<attached_files>\n- "+fooPath+"\n- "+barPath+"\n</attached_files>")
 	})
 }
 
@@ -225,10 +228,13 @@ func TestSubSessionConfig_InheritsAgentLimits(t *testing.T) {
 func TestSubSessionInheritsAttachedFiles(t *testing.T) {
 	t.Parallel()
 
+	fooPath, _ := filepath.Abs("/abs/foo.go")
+	barPath, _ := filepath.Abs("/abs/bar.go")
+
 	parent := session.New(session.WithUserMessage("hello"))
-	parent.AddAttachedFile("/abs/foo.go")
-	parent.AddAttachedFile("/abs/bar.go")
-	parent.AddAttachedFile("/abs/foo.go") // duplicate, should be ignored
+	parent.AddAttachedFile(fooPath)
+	parent.AddAttachedFile(barPath)
+	parent.AddAttachedFile(fooPath) // duplicate, should be ignored
 
 	childAgent := agent.New("worker", "")
 	cfg := SubSessionConfig{
@@ -240,7 +246,7 @@ func TestSubSessionInheritsAttachedFiles(t *testing.T) {
 	s := newSubSession(parent, cfg, childAgent)
 
 	// Child session inherits parent's attached files (deduplicated, ordered).
-	assert.Equal(t, []string{"/abs/foo.go", "/abs/bar.go"}, s.AttachedFilesSnapshot())
+	assert.Equal(t, []string{fooPath, barPath}, s.AttachedFilesSnapshot())
 
 	// The system message lists them so the sub-agent sees them up-front.
 	sysMsg := s.GetMessages(childAgent)
@@ -250,7 +256,7 @@ func TestSubSessionInheritsAttachedFiles(t *testing.T) {
 		joined.WriteString(m.Content)
 		joined.WriteString("\n")
 	}
-	assert.Contains(t, joined.String(), "<attached_files>\n- /abs/foo.go\n- /abs/bar.go\n</attached_files>")
+	assert.Contains(t, joined.String(), "<attached_files>\n- "+fooPath+"\n- "+barPath+"\n</attached_files>")
 }
 
 func TestSubSessionWithoutAttachedFilesOmitsBlock(t *testing.T) {

--- a/pkg/runtime/session_compaction_test.go
+++ b/pkg/runtime/session_compaction_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -109,6 +110,10 @@ func TestSessionGetMessages_SummaryWithoutFirstKeptEntry(t *testing.T) {
 func TestDoCompactBeforeHookDeniesSkipsCompaction(t *testing.T) {
 	t.Parallel()
 
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test relying on POSIX shell commands on Windows")
+	}
+
 	denyingHooks := &latest.HooksConfig{
 		BeforeCompaction: []latest.HookDefinition{
 			{Type: "command", Command: "echo 'denied for safety' >&2; exit 2", Timeout: 5},
@@ -162,6 +167,10 @@ func TestDoCompactBeforeHookDeniesSkipsCompaction(t *testing.T) {
 // summarization (no new model call).
 func TestDoCompactBeforeHookSuppliesSummary(t *testing.T) {
 	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test relying on POSIX shell commands on Windows")
+	}
 
 	const customSummary = "custom hook-supplied summary"
 	jsonOutput := `{"hook_specific_output":{"hook_event_name":"before_compaction","summary":"` + customSummary + `"}}`
@@ -234,6 +243,10 @@ func TestDoCompactBeforeHookSuppliesSummary(t *testing.T) {
 // express "compacted from X to Y").
 func TestDoCompactAfterHookFires(t *testing.T) {
 	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test relying on POSIX shell commands on Windows")
+	}
 
 	dir := t.TempDir()
 	logFile := dir + "/after.log"

--- a/pkg/sandbox/sandbox_test.go
+++ b/pkg/sandbox/sandbox_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,7 +42,7 @@ func TestCheckAvailable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeDir := t.TempDir()
 			if tt.script != "" {
-				require.NoError(t, os.WriteFile(filepath.Join(fakeDir, "docker"), []byte(tt.script), 0o755))
+				writeMockScript(t, fakeDir, "docker", tt.script)
 			}
 			t.Setenv("PATH", fakeDir)
 
@@ -103,8 +105,8 @@ func TestForWorkspace(t *testing.T) {
 	// the OS validates each freshly written binary on first run.
 	fakeDir := t.TempDir()
 	dataFile := filepath.Join(fakeDir, "ls.json")
-	script := fmt.Sprintf("#!/bin/sh\ncat %q\n", dataFile)
-	require.NoError(t, os.WriteFile(filepath.Join(fakeDir, "docker"), []byte(script), 0o755))
+	script := fmt.Sprintf("cat %q", dataFile)
+	writeMockScript(t, fakeDir, "docker", script)
 	// Prepend (not replace) so the fake "docker" wins while the script
 	// can still resolve "cat".
 	t.Setenv("PATH", fakeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -140,7 +142,7 @@ func TestExisting_HasWorkspace(t *testing.T) {
 
 func TestNewBackend_PrefersSbx(t *testing.T) {
 	fakeDir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(fakeDir, "sbx"), []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	writeMockScript(t, fakeDir, "sbx", "exit 0")
 	t.Setenv("PATH", fakeDir)
 
 	// When sbx is available and preferred, CheckAvailable uses sbx.
@@ -152,7 +154,7 @@ func TestNewBackend_PrefersSbx(t *testing.T) {
 func TestNewBackend_FallsBackToDocker(t *testing.T) {
 	fakeDir := t.TempDir()
 	// Only docker is available, no sbx.
-	require.NoError(t, os.WriteFile(filepath.Join(fakeDir, "docker"), []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	writeMockScript(t, fakeDir, "docker", "exit 0")
 	t.Setenv("PATH", fakeDir)
 
 	backend := sandbox.NewBackend(true)
@@ -163,9 +165,12 @@ func TestNewBackend_FallsBackToDocker(t *testing.T) {
 func TestForWorkspace_SbxBackend(t *testing.T) {
 	fakeDir := t.TempDir()
 	jsonData := `{"sandboxes":[{"name":"my-sbx","workspaces":["/my/project"]}]}`
-	script := fmt.Sprintf("#!/bin/sh\necho '%s'\n", jsonData)
-	require.NoError(t, os.WriteFile(filepath.Join(fakeDir, "sbx"), []byte(script), 0o755))
-	t.Setenv("PATH", fakeDir)
+	dataFile := filepath.Join(fakeDir, "sbx_data.json")
+	require.NoError(t, os.WriteFile(dataFile, []byte(jsonData), 0o600))
+	script := fmt.Sprintf("cat %q", dataFile)
+	writeMockScript(t, fakeDir, "sbx", script)
+	// Prepend so fake "sbx" wins while the script can still resolve "cat".
+	t.Setenv("PATH", fakeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	backend := sandbox.NewBackend(true)
 	got := backend.ForWorkspace(t.Context(), "/my/project")
@@ -280,4 +285,29 @@ func TestAllowHosts_SkipsEmptyEntries(t *testing.T) {
 
 	backend := sandbox.NewBackend(false)
 	require.NoError(t, backend.AllowHosts(t.Context(), "sandbox-x", []string{"", "   ", "\t"}))
+}
+
+// writeMockScript writes a mock executable script to the given directory.
+// On Windows, it converts the POSIX shell script to a basic .bat script.
+//
+// Limitations:
+//   - String-replace of "cat " -> "type " could mis-translate if a future script
+//     embeds "cat" in a different context (e.g. a filename).
+//   - The "#!/bin/sh\n" prefix strip is vestigial as some callers omit it.
+//   - Replaces "exit 0" with "exit /b 0" but leaves plain "exit" untouched.
+//
+// This helper covers exactly the mock scripts currently used by the sandbox tests.
+func writeMockScript(t *testing.T, dir, name, script string) {
+	t.Helper()
+	script = strings.TrimPrefix(script, "#!/bin/sh\n")
+
+	if runtime.GOOS == "windows" {
+		name += ".bat"
+		script = strings.ReplaceAll(script, "cat ", "type ")
+		script = strings.ReplaceAll(script, "exit 0", "exit /b 0")
+		script = "@echo off\n" + script
+	} else {
+		script = "#!/bin/sh\n" + script
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(script), 0o755))
 }

--- a/pkg/tools/a2a/a2a.go
+++ b/pkg/tools/a2a/a2a.go
@@ -186,7 +186,8 @@ func (t *Toolset) Start(ctx context.Context) error {
 	headers := t.expander.ExpandMap(ctx, t.headers)
 	httpClient.Transport = upstream.NewHeaderTransport(base, headers)
 
-	client, err := a2aclient.NewFromCard(ctx, card,
+	client, err := a2aclient.NewFromCard(
+		ctx, card,
 		a2aclient.WithDefaultsDisabled(),
 		a2aclient.WithJSONRPCTransport(httpClient),
 	)
@@ -241,10 +242,11 @@ func (t *Toolset) createHandler() tools.ToolHandler {
 			response.WriteString(extractText(event))
 		}
 
-		result := cmp.Or(response.String(), "No response from agent")
+		if response.Len() == 0 {
+			return tools.ResultError("No response from agent"), nil
+		}
 
-		// TODO(dga): could this be a tool call error?
-		return tools.ResultSuccess(result), nil
+		return tools.ResultSuccess(response.String()), nil
 	}
 }
 

--- a/pkg/tools/a2a/a2a_test.go
+++ b/pkg/tools/a2a/a2a_test.go
@@ -84,3 +84,68 @@ func (testA2AHandler) Execute(ctx context.Context, reqCtx *a2asrv.RequestContext
 func (testA2AHandler) Cancel(context.Context, *a2asrv.RequestContext, eventqueue.Queue) error {
 	return nil
 }
+
+func TestToolSetEmptyStreamReturnsError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(a2asrv.NewJSONRPCHandler(a2asrv.NewHandler(testEmptyA2AHandler{})))
+	t.Cleanup(server.Close)
+
+	cardServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(goa2a.AgentCard{
+			Name:               "test",
+			Description:        "test",
+			URL:                server.URL,
+			Version:            "1.0.0",
+			ProtocolVersion:    string(goa2a.Version),
+			PreferredTransport: goa2a.TransportProtocolJSONRPC,
+			Capabilities:       goa2a.AgentCapabilities{Streaming: true},
+			DefaultInputModes:  []string{"text/plain"},
+			DefaultOutputModes: []string{"text/plain"},
+			Skills: []goa2a.AgentSkill{{
+				ID:          "test",
+				Name:        "test",
+				Description: "test",
+				Tags:        []string{"test"},
+			}},
+		})
+	}))
+	t.Cleanup(cardServer.Close)
+
+	toolSet := NewToolset("test", cardServer.URL, nil, WithAllowPrivateIPs(true))
+
+	if err := toolSet.Start(t.Context()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	toolList, err := toolSet.Tools(t.Context())
+	if err != nil {
+		t.Fatalf("Tools() error = %v", err)
+	}
+	if len(toolList) != 1 {
+		t.Fatalf("Tools() returned %d tools, want 1", len(toolList))
+	}
+
+	result, err := toolList[0].Handler(t.Context(), tools.ToolCall{Function: tools.FunctionCall{Arguments: `{"message":"hello"}`}}, tools.NopRuntime{})
+	if err != nil {
+		t.Fatalf("Handler() error = %v", err)
+	}
+	if !result.IsError || result.Output != "No response from agent" {
+		t.Fatalf("Handler() result = %+v, want output %q with IsError true", result, "No response from agent")
+	}
+}
+
+type testEmptyA2AHandler struct{}
+
+func (testEmptyA2AHandler) Execute(ctx context.Context, reqCtx *a2asrv.RequestContext, queue eventqueue.Queue) error {
+	// Signal task completion with no text — the framework requires at least one
+	// final event; without it the event pipe never closes and the call hangs.
+	event := goa2a.NewStatusUpdateEvent(reqCtx, goa2a.TaskStateCompleted, nil)
+	event.Final = true
+	return queue.Write(ctx, event)
+}
+
+func (testEmptyA2AHandler) Cancel(context.Context, *a2asrv.RequestContext, eventqueue.Queue) error {
+	return nil
+}


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Supersedes #3745 (which can no longer be pushed to its fork branch from CI).

**What changed vs #3745:** Same functional changes, plus lint and test fixes that failed after rebase onto main (post-#3739).

**Lint fixes:**
- `perfsprint`: `fmt.Sprintf("echo %s", jsonData)` → string concatenation (`sandbox_test.go:168`)
- `gci/gofumpt`: remove spaces around `+` in string concatenation (`agent_delegation_test.go:44`)
- `gci/gofmt`: remove trailing tab on blank line in `writeMockScript` (`sandbox_test.go:300`)

**Test fixes:**
- `TestForWorkspace_SbxBackend`: use `cat <datafile>` pattern (same as `TestForWorkspace`) instead of bare `echo`, which stripped JSON double-quotes in the shell script
- `TestToolSetEmptyStreamReturnsError`: `testEmptyA2AHandler.Execute` must emit a final `TaskStateCompleted` event — without it the a2a event pipe never closes, causing the HTTP client to timeout waiting for response headers (30s)

**Functional changes (from #3745):**
- A2A: return `ResultError("No response from agent")` instead of `ResultSuccess("")` when stream yields no text
- Windows: add `writeMockScript` helper for cross-platform sandbox tests
- Windows: skip POSIX shell-dependent compaction tests on Windows
- Fix `filepath.Abs` usage for cross-platform path assertions

Tested locally: all affected tests pass.