### PR TITLE
feat(tui): open the /cost dialog when clicking the sidebar cost reading

### DIFF
--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -337,6 +337,11 @@ type model struct {
 
 	// Agent click zones: maps content line index to agent name for click detection
 	agentClickZones map[int]string // content line -> agent name
+	// Token Usage click zone: half-open content-line range [start, end) of the
+	// vertical Token Usage section, recorded while rendering. Empty when the
+	// section is hidden.
+	usageZoneStart int
+	usageZoneEnd   int
 	// agentLineOwners records, per rendered agent-section body line, which agent
 	// emitted it (empty for blank separators). It is produced during agentInfo
 	// rendering so click zones can be registered explicitly rather than inferred
@@ -760,6 +765,7 @@ const (
 	ClickTitle      // Click on the title area (use double-click to edit)
 	ClickWorkingDir // Click on the working directory line
 	ClickAgent      // Click on an agent name in the sidebar
+	ClickUsage      // Click on the token usage / cost reading
 )
 
 // HandleClick checks if click is on the star or title and returns true if it was
@@ -800,6 +806,26 @@ func (m *model) HandleClickType(x, y int) (ClickResult, string) {
 		vm := m.computeCollapsedViewModel(m.contentWidth(false))
 		wdStartY := vm.titleSectionLines()
 		wdLines := linesNeeded(lipgloss.Width(vm.WorkingDir), vm.ContentWidth)
+
+		// The usage reading either shares the working dir line (right-aligned)
+		// or takes its own line(s) right after it. Mirrors RenderCollapsedView.
+		if vm.UsageSummary != "" {
+			usageWidth := lipgloss.Width(vm.UsageSummary)
+			if vm.WorkingDir != "" && vm.WdAndUsageOnOneLine {
+				if y == wdStartY && adjustedX >= vm.ContentWidth-usageWidth {
+					return ClickUsage, ""
+				}
+			} else {
+				usageStartY := wdStartY
+				if vm.WorkingDir != "" {
+					usageStartY += wdLines
+				}
+				if y >= usageStartY && y < usageStartY+linesNeeded(usageWidth, vm.ContentWidth) {
+					return ClickUsage, ""
+				}
+			}
+		}
+
 		if m.workingDirectory != "" && !m.sectionVisibility.HideSessionPath && y >= wdStartY && y < wdStartY+wdLines {
 			return ClickWorkingDir, ""
 		}
@@ -828,6 +854,11 @@ func (m *model) HandleClickType(x, y int) (ClickResult, string) {
 	// A hidden session path renders no line and must not keep a hit target.
 	if m.workingDirectory != "" && !m.sectionVisibility.HideSessionPath && contentY == verticalStarY+titleLines+1 {
 		return ClickWorkingDir, ""
+	}
+
+	// Check if click is on the Token Usage section
+	if contentY >= m.usageZoneStart && contentY < m.usageZoneEnd {
+		return ClickUsage, ""
 	}
 
 	// Check if click is on an agent name
@@ -1608,8 +1639,12 @@ func (m *model) renderSections(contentWidth int) []string {
 	}
 
 	appendSection(m.sessionInfo(contentWidth))
+	// Track the Token Usage section's line range (title included) so a click
+	// on it can open the cost dialog.
+	m.usageZoneStart, m.usageZoneEnd = 0, 0
 	if !m.sectionVisibility.HideUsage {
-		appendSection(m.tokenUsage(contentWidth))
+		m.usageZoneStart = appendSection(m.tokenUsage(contentWidth))
+		m.usageZoneEnd = len(lines)
 	}
 	appendSection(m.queueSection(contentWidth))
 

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -115,7 +115,7 @@ type Model interface {
 	ResetStreamTracking()
 	// HandleClick checks if click is on the star or title and returns true if handled
 	HandleClick(x, y int) bool
-	// HandleClickType returns the type of click (star, title, agent, or none).
+	// HandleClickType returns the type of click (see ClickResult).
 	// For ClickAgent, the second return value is the agent name.
 	HandleClickType(x, y int) (ClickResult, string)
 	// IsCollapsed returns whether the sidebar is collapsed
@@ -776,7 +776,7 @@ func (m *model) HandleClick(x, y int) bool {
 	return result != ClickNone
 }
 
-// HandleClickType returns what was clicked (star, title, working dir, agent, or nothing).
+// HandleClickType returns what was clicked (see ClickResult).
 // For ClickAgent, the second return value is the agent name.
 func (m *model) HandleClickType(x, y int) (ClickResult, string) {
 	// Account for left padding
@@ -837,6 +837,12 @@ func (m *model) HandleClickType(x, y int) (ClickResult, string) {
 	scrollOffset := m.scrollview.ScrollOffset()
 	contentY := y + scrollOffset // Convert viewport Y to content Y
 	titleLines := m.titleLineCount()
+
+	// The scrollbar and its gap are not content: clicks there must reach the
+	// scrollview, not the content click zones.
+	if m.cachedNeedsScrollbar && adjustedX >= m.contentWidth(true) {
+		return ClickNone, ""
+	}
 
 	// Check if click is within the title area
 	if contentY >= verticalStarY && contentY < verticalStarY+titleLines {

--- a/pkg/tui/components/sidebar/title_edit_test.go
+++ b/pkg/tui/components/sidebar/title_edit_test.go
@@ -368,9 +368,10 @@ func TestSidebar_HandleClickType_HiddenPath_Collapsed(t *testing.T) {
 
 	paddingLeft := m.layoutCfg.PaddingLeft
 
-	// The row after the title must not keep a copyable hit target.
+	// The row after the title must not keep a copyable hit target; with the
+	// path hidden the usage reading moves up into that row instead.
 	result, _ := sb.HandleClickType(paddingLeft+3, m.titleLineCount())
-	assert.Equal(t, ClickNone, result, "a hidden path must not be clickable")
+	assert.Equal(t, ClickUsage, result, "a hidden path must not be clickable; the usage line takes the row")
 
 	result, _ = sb.HandleClickType(paddingLeft+3, 0)
 	assert.Equal(t, ClickTitle, result, "the title stays clickable")

--- a/pkg/tui/components/sidebar/usage_click_test.go
+++ b/pkg/tui/components/sidebar/usage_click_test.go
@@ -64,6 +64,36 @@ func TestSidebar_HandleClickType_Usage_Vertical_Hidden(t *testing.T) {
 	}
 }
 
+// TestSidebar_HandleClickType_Usage_Vertical_ScrollbarNotUsage verifies that
+// when the vertical sidebar overflows, a click on the scrollbar column beside
+// a Token Usage row is not swallowed as ClickUsage.
+func TestSidebar_HandleClickType_Usage_Vertical_ScrollbarNotUsage(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	sb := New(t.Context(), sessionState)
+
+	m := sb.(*model)
+	m.sessionHasContent = true
+	m.titleGenerated = true
+	m.sessionTitle = "Test"
+	m.width = 40
+	m.height = 4 // force overflow so the scrollbar renders
+
+	_ = sb.View()
+
+	require.True(t, m.cachedNeedsScrollbar, "the sidebar must overflow for this test")
+	require.Less(t, m.usageZoneStart, m.usageZoneEnd)
+
+	paddingLeft := m.layoutCfg.PaddingLeft
+	scrollbarX := paddingLeft + m.contentWidth(true) // first non-content column
+	for y := m.usageZoneStart; y < m.usageZoneEnd; y++ {
+		result, _ := sb.HandleClickType(scrollbarX, y)
+		assert.Equalf(t, ClickNone, result, "scrollbar column beside usage line %d must not be clickable content", y)
+	}
+}
+
 // TestSidebar_HandleClickType_Usage_Collapsed_SharedLine verifies the
 // right-aligned usage reading on the shared path/usage row reports
 // ClickUsage while the path part keeps reporting ClickWorkingDir.

--- a/pkg/tui/components/sidebar/usage_click_test.go
+++ b/pkg/tui/components/sidebar/usage_click_test.go
@@ -1,0 +1,145 @@
+package sidebar
+
+import (
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tui/service"
+)
+
+// TestSidebar_HandleClickType_Usage_Vertical verifies that a click anywhere
+// on the vertical Token Usage section (title included) reports ClickUsage.
+func TestSidebar_HandleClickType_Usage_Vertical(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	sb := New(t.Context(), sessionState)
+
+	m := sb.(*model)
+	m.sessionHasContent = true
+	m.titleGenerated = true
+	m.sessionTitle = "Test"
+	m.width = 40
+	m.height = 50
+
+	// Force a render to record the usage click zone
+	_ = sb.View()
+
+	require.Less(t, m.usageZoneStart, m.usageZoneEnd, "the usage zone must be recorded")
+	assert.Contains(t, ansi.Strip(m.cachedLines[m.usageZoneStart]), "Token Usage")
+
+	paddingLeft := m.layoutCfg.PaddingLeft
+	for y := m.usageZoneStart; y < m.usageZoneEnd; y++ {
+		result, _ := sb.HandleClickType(paddingLeft+2, y)
+		assert.Equalf(t, ClickUsage, result, "line %d of the usage section should report ClickUsage", y)
+	}
+}
+
+// TestSidebar_HandleClickType_Usage_Vertical_Hidden verifies a hidden usage
+// section leaves no stale click zone behind.
+func TestSidebar_HandleClickType_Usage_Vertical_Hidden(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	sb := New(t.Context(), sessionState)
+
+	m := sb.(*model)
+	m.width = 40
+	m.height = 50
+	m.SetSectionVisibility(SectionVisibility{HideUsage: true})
+
+	_ = sb.View()
+
+	paddingLeft := m.layoutCfg.PaddingLeft
+	for y := range len(m.cachedLines) {
+		result, _ := sb.HandleClickType(paddingLeft+2, y)
+		assert.NotEqualf(t, ClickUsage, result, "hidden usage must not be clickable (line %d)", y)
+	}
+}
+
+// TestSidebar_HandleClickType_Usage_Collapsed_SharedLine verifies the
+// right-aligned usage reading on the shared path/usage row reports
+// ClickUsage while the path part keeps reporting ClickWorkingDir.
+func TestSidebar_HandleClickType_Usage_Collapsed_SharedLine(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	sb := New(t.Context(), sessionState)
+
+	m := sb.(*model)
+	m.sessionHasContent = true
+	m.titleGenerated = true
+	m.mode = ModeCollapsed
+	m.width = 80
+	m.sessionTitle = "Hi"
+	m.workingDirectory = "~/projects/myapp"
+
+	vm := m.computeCollapsedViewModel(m.contentWidth(false))
+	require.True(t, vm.WdAndUsageOnOneLine, "path and usage must share one line at this width")
+	require.NotEmpty(t, vm.UsageSummary)
+
+	paddingLeft := m.layoutCfg.PaddingLeft
+	rowY := vm.titleSectionLines()
+	usageX := vm.ContentWidth - lipgloss.Width(vm.UsageSummary)
+
+	result, _ := sb.HandleClickType(paddingLeft+usageX+1, rowY)
+	assert.Equal(t, ClickUsage, result, "click on the usage reading should report ClickUsage")
+
+	result, _ = sb.HandleClickType(paddingLeft+3, rowY)
+	assert.Equal(t, ClickWorkingDir, result, "the path part of the row stays a working dir target")
+}
+
+// TestSidebar_HandleClickType_Usage_Collapsed_OwnLine verifies the usage
+// reading is clickable when it takes its own row (no session path).
+func TestSidebar_HandleClickType_Usage_Collapsed_OwnLine(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	sb := New(t.Context(), sessionState)
+
+	m := sb.(*model)
+	m.sessionHasContent = true
+	m.titleGenerated = true
+	m.mode = ModeCollapsed
+	m.width = 50
+	m.sessionTitle = "Hi"
+	m.workingDirectory = ""
+
+	vm := m.computeCollapsedViewModel(m.contentWidth(false))
+	require.NotEmpty(t, vm.UsageSummary)
+
+	paddingLeft := m.layoutCfg.PaddingLeft
+	result, _ := sb.HandleClickType(paddingLeft+3, vm.titleSectionLines())
+	assert.Equal(t, ClickUsage, result, "click on the usage row should report ClickUsage")
+}
+
+// TestSidebar_HandleClickType_Usage_Collapsed_Hidden verifies a hidden usage
+// section keeps no hit target in the collapsed band.
+func TestSidebar_HandleClickType_Usage_Collapsed_Hidden(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	sb := New(t.Context(), sessionState)
+
+	m := sb.(*model)
+	m.mode = ModeCollapsed
+	m.width = 50
+	m.sessionTitle = "Hi"
+	m.SetSectionVisibility(SectionVisibility{HideUsage: true})
+
+	paddingLeft := m.layoutCfg.PaddingLeft
+	for y := range 6 {
+		result, _ := sb.HandleClickType(paddingLeft+3, y)
+		assert.NotEqualf(t, ClickUsage, result, "hidden usage must not be clickable (line %d)", y)
+	}
+}

--- a/pkg/tui/page/chat/hittest.go
+++ b/pkg/tui/page/chat/hittest.go
@@ -18,6 +18,7 @@ const (
 	TargetSidebarTitle
 	TargetSidebarWorkingDir
 	TargetSidebarAgent
+	TargetSidebarUsage
 	TargetSidebarContent
 	TargetMessages
 )
@@ -132,6 +133,8 @@ func (h *HitTest) sidebarClickTarget(x, y int) MouseTarget {
 	case sidebar.ClickAgent:
 		h.AgentName = agentName
 		return TargetSidebarAgent
+	case sidebar.ClickUsage:
+		return TargetSidebarUsage
 	default:
 		return TargetSidebarContent
 	}

--- a/pkg/tui/page/chat/input_handlers.go
+++ b/pkg/tui/page/chat/input_handlers.go
@@ -152,6 +152,11 @@ func (p *chatPage) handleMouseClick(msg tea.MouseClickMsg) (layout.Model, tea.Cm
 			return p, cmd
 		}
 
+	case TargetSidebarUsage:
+		if msg.Button == tea.MouseLeft {
+			return p, core.CmdHandler(msgtypes.ShowCostDialogMsg{})
+		}
+
 	case TargetMessages:
 		if !p.messages.IsMouseOnScrollbar(msg.X, msg.Y) {
 			cmd := p.routeMouseEvent(msg, msg.Y)


### PR DESCRIPTION
The sidebar already displays token usage and estimated cost, but there was no way to click into the detail view — users had to know about the `/cost` command to see the breakdown. This makes the cost reading interactive, consistent with how other sidebar elements behave.

Clicking the token usage/cost reading in the sidebar now opens the `/cost` dialog, the same dialog triggered by typing `/cost` in the input. A new `ClickUsage` hit-test result was added to the sidebar's hit-testing logic. The vertical Token Usage section records its line range while rendering, and the collapsed band correctly hit-tests the usage reading in both layouts: when it shares the working-directory row (right-aligned) and when it occupies its own row. The chat page maps the new `TargetSidebarUsage` to `ShowCostDialogMsg` on left-click.

A follow-up fix ensures clicks on the sidebar scrollbar column and gap are never swallowed by the content click zones (usage, agents, title), so scrollbar-driven scrolling continues to work correctly. The fix also refreshes stale doc comments on `ClickResult` variants. New tests cover vertical mode, collapsed shared-line, collapsed own-line, hidden-usage, and the scrollbar regression.