### PR TITLE
fix(codeql): go/incorrect-integer-conversion in pkg/model/provider/dmr/configure.go:158

### DIFF
--- a/pkg/model/provider/dmr/client_test.go
+++ b/pkg/model/provider/dmr/client_test.go
@@ -3,6 +3,7 @@ package dmr
 import (
 	"encoding/json"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -319,6 +320,15 @@ func TestBuildConfigureRequest(t *testing.T) {
 		assert.Empty(t, req.RawRuntimeFlags)
 		assert.Nil(t, req.KeepAlive)
 		assert.Nil(t, req.VLLM)
+	})
+
+	t.Run("context size above int32 max is clamped", func(t *testing.T) {
+		t.Parallel()
+		contextSize := int64(math.MaxInt32) + 1
+		backendCfg := buildConfigureBackendConfig(&contextSize, nil, nil, nil, nil, nil)
+		req := buildConfigureRequest("ai/qwen3:14B-Q6_K", backendCfg, nil, "")
+		require.NotNil(t, req.ContextSize)
+		assert.Equal(t, int32(math.MaxInt32), *req.ContextSize)
 	})
 }
 

--- a/pkg/model/provider/dmr/client_test.go
+++ b/pkg/model/provider/dmr/client_test.go
@@ -330,6 +330,14 @@ func TestBuildConfigureRequest(t *testing.T) {
 		require.NotNil(t, req.ContextSize)
 		assert.Equal(t, int32(math.MaxInt32), *req.ContextSize)
 	})
+
+	t.Run("negative context size is ignored", func(t *testing.T) {
+		t.Parallel()
+		contextSize := int64(-1)
+		backendCfg := buildConfigureBackendConfig(&contextSize, nil, nil, nil, nil, nil)
+		req := buildConfigureRequest("ai/qwen3:14B-Q6_K", backendCfg, nil, "")
+		assert.Nil(t, req.ContextSize, "negative context size should be ignored")
+	})
 }
 
 func TestConfigureModelViaAPI(t *testing.T) {

--- a/pkg/model/provider/dmr/configure.go
+++ b/pkg/model/provider/dmr/configure.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -155,7 +156,12 @@ func buildConfigureBackendConfig(contextSize *int64, runtimeFlags []string, spec
 		KeepAlive:    keepAlive,
 	}
 	if contextSize != nil {
-		cs := int32(*contextSize) //nolint:gosec // user-configured context size; realistic values fit in int32
+		v := *contextSize
+		if v > math.MaxInt32 {
+			slog.Warn("context_size exceeds int32 max; clamping to math.MaxInt32", "requested", v, "clamped", int32(math.MaxInt32))
+			v = math.MaxInt32
+		}
+		cs := int32(v)
 		cfg.ContextSize = &cs
 	}
 	if specOpts != nil {

--- a/pkg/model/provider/dmr/configure.go
+++ b/pkg/model/provider/dmr/configure.go
@@ -157,12 +157,17 @@ func buildConfigureBackendConfig(contextSize *int64, runtimeFlags []string, spec
 	}
 	if contextSize != nil {
 		v := *contextSize
-		if v > math.MaxInt32 {
-			slog.Warn("context_size exceeds int32 max; clamping to math.MaxInt32", "requested", v, "clamped", int32(math.MaxInt32))
-			v = math.MaxInt32
+		switch {
+		case v > math.MaxInt32:
+			slog.Warn("context_size exceeds int32 max; clamping", "requested", v, "clamped", math.MaxInt32)
+			cs := int32(math.MaxInt32)
+			cfg.ContextSize = &cs
+		case v >= 0:
+			cs := int32(v) // 0 ≤ v ≤ math.MaxInt32 is guaranteed by the two guards
+			cfg.ContextSize = &cs
+		default:
+			slog.Warn("context_size is negative; ignoring", "requested", v)
 		}
-		cs := int32(v)
-		cfg.ContextSize = &cs
 	}
 	if specOpts != nil {
 		cfg.Speculative = &speculativeDecodingRequest{


### PR DESCRIPTION
An int64 value from `strconv.ParseInt` (via `parseInt64Value`) was narrowed directly to int32 in `buildConfigureBackendConfig` without an upper-bound check, triggering CodeQL rule `go/incorrect-integer-conversion`. While context window sizes in excess of 2^31−1 are practically unreachable, a value that large would silently wrap to a negative int32, causing model invocation failures. The fix adds an explicit guard — if the int64 exceeds `math.MaxInt32`, the value is clamped to `math.MaxInt32` and a warning is logged; the `int32` conversion then operates on a provably in-range value. The now-redundant `//nolint:gosec` directive is removed (confirmed by running golangci-lint with gosec enabled). A new test subcase covers the clamp path.