### PR TITLE
fix(codeql): go/path-injection in pkg/server/session_manager.go:542

### DIFF
--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -539,14 +539,18 @@ func (sm *SessionManager) CreateSession(ctx context.Context, sessionTemplate *se
 		if err != nil {
 			return nil, err
 		}
-		info, err := os.Stat(absWd)
+		resolvedWd, err := sm.resolveWithinRoot(absWd)
+		if err != nil {
+			return nil, err
+		}
+		info, err := os.Stat(resolvedWd)
 		if err != nil {
 			return nil, err
 		}
 		if !info.IsDir() {
 			return nil, errors.New("working directory must be a directory")
 		}
-		opts = append(opts, session.WithWorkingDir(absWd))
+		opts = append(opts, session.WithWorkingDir(resolvedWd))
 	}
 
 	if sessionTemplate.Permissions != nil {
@@ -568,6 +572,50 @@ func (sm *SessionManager) CreateSession(ctx context.Context, sessionTemplate *se
 	}
 
 	return sess, sm.sessionStore.AddSession(ctx, sess)
+}
+
+// workingDirRoot returns the absolute directory that user-supplied session
+// working directories must stay within. It uses the server's configured
+// working directory, falling back to the process working directory.
+func (sm *SessionManager) workingDirRoot() (string, error) {
+	root := ""
+	if sm.runConfig != nil {
+		root = strings.TrimSpace(sm.runConfig.WorkingDir)
+	}
+	if root == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		root = wd
+	}
+	return filepath.Abs(root)
+}
+
+// resolveWithinRoot canonicalises absPath via filepath.EvalSymlinks and
+// verifies the result lies inside the server root directory. This prevents a
+// user-supplied working directory from escaping to arbitrary filesystem
+// locations (go/path-injection, CodeQL alert #57).
+func (sm *SessionManager) resolveWithinRoot(absPath string) (string, error) {
+	// Resolve symlinks on the target; it must exist because the caller
+	// will stat it immediately after.
+	resolvedPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return "", err
+	}
+	root, err := sm.workingDirRoot()
+	if err != nil {
+		return "", err
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(resolvedRoot, resolvedPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("working directory %q is outside the permitted root %q", absPath, root)
+	}
+	return resolvedPath, nil
 }
 
 // Sentinel errors returned by ForkSession. Matched via errors.Is by

--- a/pkg/server/session_workingdir_test.go
+++ b/pkg/server/session_workingdir_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +17,7 @@ import (
 func TestCreateSession_WorkingDirValidation(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	root := t.TempDir()
 	rc := &config.RuntimeConfig{Config: config.Config{WorkingDir: root}}
 
@@ -111,7 +110,7 @@ func TestResolveWithinRoot(t *testing.T) {
 
 	root := t.TempDir()
 	rc := &config.RuntimeConfig{Config: config.Config{WorkingDir: root}}
-	sm := NewSessionManager(context.Background(), config.Sources{}, session.NewInMemorySessionStore(), 0, rc)
+	sm := NewSessionManager(t.Context(), config.Sources{}, session.NewInMemorySessionStore(), 0, rc)
 
 	t.Run("path equal to root is allowed", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/server/session_workingdir_test.go
+++ b/pkg/server/session_workingdir_test.go
@@ -1,0 +1,178 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+// TestCreateSession_WorkingDirValidation covers the path-containment guard
+// introduced to address go/path-injection (CodeQL alert #57).
+func TestCreateSession_WorkingDirValidation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	root := t.TempDir()
+	rc := &config.RuntimeConfig{Config: config.Config{WorkingDir: root}}
+
+	newSM := func() *SessionManager {
+		return NewSessionManager(ctx, config.Sources{}, session.NewInMemorySessionStore(), 0, rc)
+	}
+
+	t.Run("empty WorkingDir is accepted without applying a root constraint", func(t *testing.T) {
+		t.Parallel()
+		sm := newSM()
+		created, err := sm.CreateSession(ctx, &session.Session{})
+		require.NoError(t, err)
+		assert.Empty(t, created.WorkingDir)
+	})
+
+	t.Run("WorkingDir equal to root is accepted", func(t *testing.T) {
+		t.Parallel()
+		sm := newSM()
+		created, err := sm.CreateSession(ctx, &session.Session{WorkingDir: root})
+		require.NoError(t, err)
+		resolvedRoot, err := filepath.EvalSymlinks(root)
+		require.NoError(t, err)
+		assert.Equal(t, resolvedRoot, created.WorkingDir)
+	})
+
+	t.Run("WorkingDir inside root is accepted and symlink-resolved", func(t *testing.T) {
+		t.Parallel()
+		sub := filepath.Join(root, "sub")
+		require.NoError(t, os.Mkdir(sub, 0o755))
+
+		sm := newSM()
+		created, err := sm.CreateSession(ctx, &session.Session{WorkingDir: sub})
+		require.NoError(t, err)
+		resolvedSub, err := filepath.EvalSymlinks(sub)
+		require.NoError(t, err)
+		assert.Equal(t, resolvedSub, created.WorkingDir)
+	})
+
+	t.Run("WorkingDir outside root is rejected", func(t *testing.T) {
+		t.Parallel()
+		outside := t.TempDir() // different temp dir, not under root
+		sm := newSM()
+		_, err := sm.CreateSession(ctx, &session.Session{WorkingDir: outside})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "outside the permitted root")
+	})
+
+	t.Run("WorkingDir /etc is rejected", func(t *testing.T) {
+		t.Parallel()
+		sm := newSM()
+		_, err := sm.CreateSession(ctx, &session.Session{WorkingDir: "/etc"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "outside the permitted root")
+	})
+
+	t.Run("non-existent WorkingDir is rejected", func(t *testing.T) {
+		t.Parallel()
+		sm := newSM()
+		_, err := sm.CreateSession(ctx, &session.Session{WorkingDir: filepath.Join(root, "does-not-exist")})
+		require.Error(t, err)
+	})
+
+	t.Run("WorkingDir that is a file (not dir) is rejected", func(t *testing.T) {
+		t.Parallel()
+		f := filepath.Join(root, "afile.txt")
+		require.NoError(t, os.WriteFile(f, []byte("x"), 0o644))
+
+		sm := newSM()
+		_, err := sm.CreateSession(ctx, &session.Session{WorkingDir: f})
+		require.Error(t, err)
+		assert.EqualError(t, err, "working directory must be a directory")
+	})
+
+	t.Run("symlink inside root pointing outside root is rejected", func(t *testing.T) {
+		t.Parallel()
+		outside := t.TempDir()
+		link := filepath.Join(root, "escape-link")
+		require.NoError(t, os.Symlink(outside, link))
+
+		sm := newSM()
+		_, err := sm.CreateSession(ctx, &session.Session{WorkingDir: link})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "outside the permitted root")
+	})
+}
+
+// TestResolveWithinRoot exercises the containment helper directly.
+func TestResolveWithinRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	rc := &config.RuntimeConfig{Config: config.Config{WorkingDir: root}}
+	sm := NewSessionManager(context.Background(), config.Sources{}, session.NewInMemorySessionStore(), 0, rc)
+
+	t.Run("path equal to root is allowed", func(t *testing.T) {
+		t.Parallel()
+		resolvedRoot, err := filepath.EvalSymlinks(root)
+		require.NoError(t, err)
+		got, err := sm.resolveWithinRoot(root)
+		require.NoError(t, err)
+		assert.Equal(t, resolvedRoot, got)
+	})
+
+	t.Run("subpath is allowed", func(t *testing.T) {
+		t.Parallel()
+		sub := filepath.Join(root, "child")
+		require.NoError(t, os.Mkdir(sub, 0o755))
+		resolvedSub, err := filepath.EvalSymlinks(sub)
+		require.NoError(t, err)
+		got, err := sm.resolveWithinRoot(sub)
+		require.NoError(t, err)
+		assert.Equal(t, resolvedSub, got)
+	})
+
+	t.Run("sibling outside root is rejected", func(t *testing.T) {
+		t.Parallel()
+		sibling := t.TempDir()
+		_, err := sm.resolveWithinRoot(sibling)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "outside the permitted root")
+	})
+
+	t.Run("non-existent path returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := sm.resolveWithinRoot(filepath.Join(root, "ghost"))
+		require.Error(t, err)
+	})
+
+	t.Run("symlink inside root pointing outside root is rejected", func(t *testing.T) {
+		t.Parallel()
+		outside := t.TempDir()
+		link := filepath.Join(root, "evil-link")
+		require.NoError(t, os.Symlink(outside, link))
+
+		_, err := sm.resolveWithinRoot(link)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "outside the permitted root")
+	})
+
+	t.Run("dot-dot traversal that resolves outside root is rejected", func(t *testing.T) {
+		t.Parallel()
+		// Build a sub-dir so that three ".." hops escape root and land at a
+		// real ancestor directory (/tmp or similar). filepath.Abs cleans the
+		// ".." components; the result is an existing path outside root, so
+		// this exercises the containment check itself (not just EvalSymlinks
+		// failing on a non-existent path).
+		sub := filepath.Join(root, "dotdot-child")
+		require.NoError(t, os.Mkdir(sub, 0o755))
+		// sub = <tmpdir>/dotdot-child; three '..' → <tmpdir parent> (e.g. /tmp)
+		escaped, err := filepath.Abs(filepath.Join(sub, "..", "..", ".."))
+		require.NoError(t, err)
+
+		_, err = sm.resolveWithinRoot(escaped)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "outside the permitted root")
+	})
+}


### PR DESCRIPTION
The `WorkingDir` field supplied in the POST /api/sessions request body was resolved with `filepath.Abs` and passed directly to `os.Stat` without checking whether it lies within any permitted scope. An authenticated caller could set `WorkingDir` to `/etc`, `/root`, or any other directory and cause the AI agent to operate on arbitrary filesystem locations — a horizontal privilege escalation risk in multi-user deployments (CodeQL rule `go/path-injection`, alert #57, line 542).

The fix adds two helpers to `SessionManager`: `workingDirRoot` (returns the server's configured `WorkingDir` from `runConfig`, falling back to the process working directory) and `resolveWithinRoot` (calls `filepath.EvalSymlinks` on both the candidate path and the root to defeat symlink escapes, then uses `filepath.Rel` to verify the result does not escape the root via `../` components or an absolute path on a different drive). The tainted `absWd` now passes through `resolveWithinRoot` before reaching `os.Stat`, breaking the alerted data flow. Symlink-escape, sibling-directory, and dot-dot traversal attacks are each covered by the new `pkg/server/session_workingdir_test.go` test file.