### PR TITLE
docs: update API and TUI documentation for recent feature additions

### DIFF
--- a/docs/features/api-server/index.md
+++ b/docs/features/api-server/index.md
@@ -37,6 +37,15 @@ All endpoints are under the `/api` prefix.
 | `GET`  | `/api/agents`     | List all available agents         |
 | `GET`  | `/api/agents/:id` | Get an agent's full configuration |
 
+Each agent entry in the `GET /api/agents` response contains:
+
+| Field        | Type            | Description                                                                                   |
+| ------------ | --------------- | --------------------------------------------------------------------------------------------- |
+| `name`       | string          | Agent identifier (config filename without `.yaml`).                                           |
+| `description`| string          | The root agent's `description` field.                                                         |
+| `multi`      | boolean         | `true` when the config defines more than one agent.                                           |
+| `commands`   | array of string | Sorted list of named command keys defined on the root agent. Omitted when no commands exist.  |
+
 ### Sessions
 
 | Method   | Path                                | Description                                             |
@@ -153,7 +162,7 @@ Event types include:
 ```bash
 # 1. List available agents
 $ curl http://localhost:8080/api/agents
-[{"name":"my-agent","multi":false,"description":"A helpful assistant"}]
+[{"name":"my-agent","multi":false,"description":"A helpful assistant","commands":["deploy","review"]}]
 
 # 2. Create a session
 $ curl -X POST http://localhost:8080/api/sessions \

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -195,6 +195,8 @@ While a compaction is running the percentage is replaced by a **"compacting…"*
 
 The thresholds are proportional to the agent's configured `compaction_threshold` (default `0.9`), so a custom value keeps a predictable visual runway. See [Compaction Threshold](../../configuration/models/index.md#delegating-session-compaction) for configuration details.
 
+Clicking the token-usage / cost reading in the sidebar opens the `/cost` dialog directly, so you can see the full cost breakdown without typing the command.
+
 ### Thinking and Tool Details
 
 Reasoning/thinking blocks are collapsed by default and carry a `Thinking` header badge. When collapsed, the TUI shows a short preview and compact tool summaries. Expand a block to see the full thinking content and the real tool renderers, including detailed tool output such as file edit diffs.


### PR DESCRIPTION
Updates docs to reflect two feature PRs merged in the past 36 hours.

## Changes

### API server docs — PR #3761 (Enhance the agents API)

`GET /api/agents` now returns a `commands` field: a sorted list of named command keys defined on the root agent. Added a response-field table to the Agents section and updated the example response to show `commands`.

### TUI guide — PR #3754 (open /cost dialog on sidebar click)

Clicking the token-usage / cost reading in the sidebar now opens the `/cost` dialog. Added one sentence to the Context-Usage Gauge section to document this shortcut.

## Source PRs reviewed

| PR | Title | Doc change? |
| --- | --- | --- |
| #3763 | docs: update CHANGELOG for v1.113.0 | — changelog only |
| #3762 | chore: remove unused TUI code | — internal, no user-facing change |
| #3761 | Enhance the agents API | ✅ yes (this PR) |
| #3760 | fix: attribute compaction summary costs | — internal fix |
| #3759 | chore: bump direct Go dependencies | — no docs needed |
| #3758 | fix(codeql): path-injection | — security fix, no docs |
| #3757 | docs: update CHANGELOG for v1.112.0 | — changelog only |
| #3756 | fix(codeql): integer conversion | — security fix, no docs |
| #3754 | feat(tui): open /cost dialog on sidebar click | ✅ yes (this PR) |
| #3753 | chore: freeze config v12 / open v13 | — internal |
| #3752 | feat: allow configuring compaction\_model on agents | — docs included in PR |
| #3747 | chore: refresh embedded models.dev snapshot | — no docs needed |
| #3743 | feat(filesystem): add .agentsignore | — docs included in PR |
| #3739 | fix: propagate HTTP error statuses in API tool | — bug fix, no docs |
| #3702 | feat(budget): budget caps | — docs included in PR |
| #3641 | feat(tools): add webhook toolset | — docs included in PR |