### PR TITLE
feat: config flavors — named YAML patches enabled at run time via --flavor

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -120,6 +120,13 @@
       "additionalProperties": {
         "$ref": "#/definitions/BudgetConfig"
       }
+    },
+    "flavors": {
+      "type": "object",
+      "description": "Named YAML patches applied on top of the rest of the document when enabled at run time (e.g. 'docker agent run --flavor <name>'). Each flavor is a partial config document merged with JSON Merge Patch semantics: objects merge recursively, scalars and arrays replace, null deletes a key. A key ending in '+' appends its items to the existing array (e.g. 'toolsets+:'); a key ending in '-' removes entries — from an object by key name, from an array by scalar equality or partial object match (e.g. 'toolsets-: [{type: shell}]'). Enabled flavors are applied in the order they were requested; requested flavors not defined here are ignored.",
+      "additionalProperties": {
+        "type": ["object", "null"]
+      }
     }
   },
   "additionalProperties": false,

--- a/cmd/root/agent_picker.go
+++ b/cmd/root/agent_picker.go
@@ -100,7 +100,7 @@ type agentChoice struct {
 // show a name and description. A ref that fails to load is still listed (with
 // the error surfaced) so the user can see what went wrong instead of it
 // silently disappearing.
-func loadAgentChoices(ctx context.Context, refs []string, env environment.Provider) []agentChoice {
+func loadAgentChoices(ctx context.Context, refs []string, env environment.Provider, flavors []string) []agentChoice {
 	choices := make([]agentChoice, 0, len(refs))
 	for _, ref := range refs {
 		choice := agentChoice{ref: ref}
@@ -116,7 +116,7 @@ func loadAgentChoices(ctx context.Context, refs []string, env environment.Provid
 			choice.yaml = string(raw)
 		}
 
-		cfg, err := config.Load(ctx, source)
+		cfg, err := config.Load(ctx, source, config.WithFlavors(flavors...))
 		if err != nil {
 			choice.err = err
 			choices = append(choices, choice)
@@ -144,7 +144,7 @@ func loadAgentChoices(ctx context.Context, refs []string, env environment.Provid
 // always matches what will run; the returned value is authoritative. When
 // only a single ref is supplied there is nothing to choose, so it is
 // returned directly without showing any UI (the board button included).
-func selectAgentRef(ctx context.Context, refs []string, env environment.Provider, initialLean bool) (ref string, lean bool, err error) {
+func selectAgentRef(ctx context.Context, refs []string, env environment.Provider, initialLean bool, flavors []string) (ref string, lean bool, err error) {
 	if len(refs) == 0 {
 		return "", false, errors.New("no agent refs to choose from")
 	}
@@ -152,7 +152,7 @@ func selectAgentRef(ctx context.Context, refs []string, env environment.Provider
 		return refs[0], initialLean, nil
 	}
 
-	choices := loadAgentChoices(ctx, refs, env)
+	choices := loadAgentChoices(ctx, refs, env, flavors)
 	m := newAgentPickerModel(choices)
 	m.leanMode = initialLean
 

--- a/cmd/root/debug.go
+++ b/cmd/root/debug.go
@@ -97,7 +97,7 @@ func (f *debugFlags) runDebugConfigCommand(cmd *cobra.Command, args []string) (c
 		return err
 	}
 
-	cfg, err := config.Load(cmd.Context(), agentSource)
+	cfg, err := config.Load(cmd.Context(), agentSource, config.WithFlavors(f.runConfig.Flavors...))
 	if err != nil {
 		return err
 	}

--- a/cmd/root/debug_oauth.go
+++ b/cmd/root/debug_oauth.go
@@ -176,7 +176,7 @@ func newDebugOAuthLoginCmd() *cobra.Command {
 				return err
 			}
 
-			cfg, err := config.Load(ctx, agentSource)
+			cfg, err := config.Load(ctx, agentSource, config.WithFlavors(flags.runConfig.Flavors...))
 			if err != nil {
 				return err
 			}

--- a/cmd/root/flags.go
+++ b/cmd/root/flags.go
@@ -29,6 +29,7 @@ const (
 func addRuntimeConfigFlags(cmd *cobra.Command, runConfig *config.RuntimeConfig) {
 	addGatewayFlags(cmd, runConfig, userconfig.Load)
 	cmd.PersistentFlags().StringSliceVar(&runConfig.EnvFiles, "env-from-file", nil, "Set environment variables from file")
+	cmd.PersistentFlags().StringArrayVar(&runConfig.Flavors, "flavor", nil, "Enable a config flavor, a YAML patch defined under the config's 'flavors' section (repeatable, applied in order)")
 	cmd.PersistentFlags().BoolVar(&runConfig.GlobalCodeMode, "code-mode-tools", false, "Provide a single tool to call other tools via Javascript")
 	cmd.PersistentFlags().StringVar(&runConfig.WorkingDir, "working-dir", "", "Set the working directory for the session (applies to tools and relative paths)")
 	cmd.PersistentFlags().StringArrayVar(&runConfig.HookPreToolUse, "hook-pre-tool-use", nil, "Add a pre-tool-use hook command that runs before every tool call (repeatable)")

--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -254,7 +254,7 @@ func (f *runExecFlags) runRunCommand(cmd *cobra.Command, args []string) (command
 		// would otherwise use (--lean, or the user-config default applied in
 		// applyUserSettings) so the checkbox never lies about the run mode.
 		initialLean := f.lean || (!f.leanChanged && userconfig.Get().Lean && !f.tour)
-		chosen, lean, err := selectAgentRef(ctx, refs, f.runConfig.EnvProvider(), initialLean)
+		chosen, lean, err := selectAgentRef(ctx, refs, f.runConfig.EnvProvider(), initialLean, f.runConfig.Flavors)
 		if err != nil {
 			if errors.Is(err, errAgentPickerCancelled) {
 				cli.NewPrinter(cmd.OutOrStdout()).Println("Agent selection cancelled.")
@@ -290,7 +290,7 @@ func (f *runExecFlags) runRunCommand(cmd *cobra.Command, args []string) (command
 		if len(args) > 0 {
 			agentRef = args[0]
 		}
-		f.sandbox, agentCfg = resolveSandboxDefault(ctx, agentRef, f.sandbox)
+		f.sandbox, agentCfg = resolveSandboxDefault(ctx, agentRef, f.sandbox, f.runConfig.Flavors)
 	}
 
 	out := cli.NewPrinter(cmd.OutOrStdout())

--- a/cmd/root/run_autodiscovery_test.go
+++ b/cmd/root/run_autodiscovery_test.go
@@ -100,7 +100,7 @@ func TestDiscoverRunAgentArgs(t *testing.T) {
 			0o644))
 
 		args, discovered := (&runExecFlags{}).discoverRunAgentArgs(nil)
-		got, cfg := resolveSandboxDefault(t.Context(), args[0], false)
+		got, cfg := resolveSandboxDefault(t.Context(), args[0], false, nil)
 
 		assert.True(t, discovered)
 		assert.True(t, got)

--- a/cmd/root/sandbox.go
+++ b/cmd/root/sandbox.go
@@ -42,11 +42,11 @@ import (
 // The agent config (if any) loaded along the way is returned so
 // runInSandbox can reuse it without paying the resolve+load cost a
 // second time. cfg is nil when agentRef is empty or fails to load.
-func resolveSandboxDefault(ctx context.Context, agentRef string, current bool) (bool, *latestcfg.Config) {
+func resolveSandboxDefault(ctx context.Context, agentRef string, current bool, flavors []string) (bool, *latestcfg.Config) {
 	if agentRef == "" {
 		return current, nil
 	}
-	cfg := loadAgentConfig(ctx, agentRef)
+	cfg := loadAgentConfig(ctx, agentRef, flavors)
 	if current {
 		return current, cfg
 	}
@@ -81,7 +81,7 @@ func agentNetworkAllowlist(ctx context.Context, cfg *latestcfg.Config) []string 
 // agentRef and loads the YAML, returning nil on any failure so
 // callers fall through to the normal path that will surface a
 // proper error from the eventual load.
-func loadAgentConfig(ctx context.Context, agentRef string) *latestcfg.Config {
+func loadAgentConfig(ctx context.Context, agentRef string, flavors []string) *latestcfg.Config {
 	if agentRef == "" {
 		return nil
 	}
@@ -89,7 +89,7 @@ func loadAgentConfig(ctx context.Context, agentRef string) *latestcfg.Config {
 	if err != nil {
 		return nil
 	}
-	cfg, err := config.Load(ctx, source)
+	cfg, err := config.Load(ctx, source, config.WithFlavors(flavors...))
 	if err != nil {
 		return nil
 	}
@@ -156,6 +156,7 @@ func runInSandbox(ctx context.Context, cmd *cobra.Command, args []string, runCon
 			EnvProvider: envProvider,
 			HostCwd:     wd,
 			Workspace:   wd,
+			Flavors:     runConfig.Flavors,
 		})
 		if err != nil {
 			slog.WarnContext(ctx, "docker-agent kit build failed; continuing without kit", "error", err)
@@ -205,7 +206,7 @@ func runInSandbox(ctx context.Context, cmd *cobra.Command, args []string, runCon
 	// Resolve env vars the agent needs and forward them into the sandbox.
 	// Docker Desktop proxies well-known API keys automatically; this handles
 	// any additional vars (e.g. MCP tool secrets).
-	envFlags, envVars := sandbox.EnvForAgent(ctx, agentRef, envProvider)
+	envFlags, envVars := sandbox.EnvForAgent(ctx, agentRef, envProvider, runConfig.Flavors)
 
 	// Forward the gateway by name so a URL with credentials never
 	// shows up in the slog'd `docker sandbox exec` argv. We do not

--- a/cmd/root/sandbox_test.go
+++ b/cmd/root/sandbox_test.go
@@ -316,7 +316,7 @@ func TestResolveSandboxDefault(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, cfg := resolveSandboxDefault(t.Context(), tt.agentRef, tt.current)
+			got, cfg := resolveSandboxDefault(t.Context(), tt.agentRef, tt.current, nil)
 			assert.Equal(t, tt.want, got)
 			assert.Equal(t, tt.wantCfg, cfg != nil)
 		})
@@ -354,18 +354,18 @@ func TestPeekAgentSandbox(t *testing.T) {
 			path := filepath.Join(dir, "agent.yaml")
 			require.NoError(t, os.WriteFile(path, []byte(tt.yaml), 0o600))
 
-			cfg := loadAgentConfig(t.Context(), path)
+			cfg := loadAgentConfig(t.Context(), path, nil)
 			got := cfg != nil && cfg.Runtime != nil && cfg.Runtime.Sandbox
 			assert.Equal(t, tt.want, got)
 		})
 	}
 
 	t.Run("empty ref", func(t *testing.T) {
-		assert.Nil(t, loadAgentConfig(t.Context(), ""))
+		assert.Nil(t, loadAgentConfig(t.Context(), "", nil))
 	})
 
 	t.Run("unresolvable ref", func(t *testing.T) {
-		assert.Nil(t, loadAgentConfig(t.Context(), "/nonexistent/agent.yaml"))
+		assert.Nil(t, loadAgentConfig(t.Context(), "/nonexistent/agent.yaml", nil))
 	})
 }
 
@@ -381,7 +381,7 @@ func TestAgentNetworkAllowlist(t *testing.T) {
 		"agents:\n  root:\n    model: openai/gpt-4o\n    description: t\n    instruction: t\n"
 	require.NoError(t, os.WriteFile(path, []byte(yamlBody), 0o600))
 
-	cfg := loadAgentConfig(t.Context(), path)
+	cfg := loadAgentConfig(t.Context(), path, nil)
 	require.NotNil(t, cfg)
 	assert.Equal(t, []string{"api.example.com", "registry.npmjs.org:443"},
 		agentNetworkAllowlist(t.Context(), cfg))
@@ -403,7 +403,7 @@ func TestAgentNetworkAllowlist_FiltersMalformed(t *testing.T) {
 		"agents:\n  root:\n    model: openai/gpt-4o\n    description: t\n    instruction: t\n"
 	require.NoError(t, os.WriteFile(path, []byte(yamlBody), 0o600))
 
-	cfg := loadAgentConfig(t.Context(), path)
+	cfg := loadAgentConfig(t.Context(), path, nil)
 	require.NotNil(t, cfg)
 	assert.Equal(t, []string{"api.example.com", "registry.npmjs.org:443"},
 		agentNetworkAllowlist(t.Context(), cfg))

--- a/docs/configuration/flavors/index.md
+++ b/docs/configuration/flavors/index.md
@@ -1,0 +1,172 @@
+---
+title: "Flavors"
+description: "Ship one agent file with named variants, enabled at run time as YAML patches."
+keywords: docker agent, ai agents, configuration, yaml, flavors, patch, variants, overrides
+weight: 95
+canonical: https://docs.docker.com/ai/docker-agent/configuration/flavors/
+---
+
+_Ship one agent file with named variants, enabled at run time as YAML patches._
+
+## Overview
+
+A flavor is a named YAML patch declared in the agent file itself, under the
+top-level `flavors` section. Enabling a flavor applies its patch on top of the
+rest of the document before the config is parsed, so one file can carry
+several variants — a cheaper model for local runs, extra tools for CI, a more
+verbose instruction for debugging — without duplicating the whole config.
+
+```yaml
+agents:
+  root:
+    model: claude
+    instruction: You are a helpful assistant.
+
+models:
+  claude:
+    provider: anthropic
+    model: claude-sonnet-4-5
+
+flavors:
+  cheap:
+    models:
+      claude:
+        model: claude-3-5-haiku-latest
+```
+
+Enable flavors with the repeatable `--flavor` flag:
+
+```bash
+$ docker agent run agent.yaml --flavor cheap
+```
+
+The flag works on every command that runs an agent — `run`, `chat`, `eval`,
+`serve api`, `serve a2a`, `serve mcp` — and order matters: patches apply in
+the order the flavors are requested, each on top of the previous result.
+
+```bash
+$ docker agent run agent.yaml --flavor cheap --flavor verbose
+```
+
+Flavors the file does not define are ignored (with a debug log), so you can
+enable the same flavor set across a fleet of agents and each file only reacts
+to the names it declares. External sub-agents loaded from OCI or URL
+references receive the same enabled flavors.
+
+## Merge Semantics
+
+Patches follow [JSON Merge Patch](https://www.rfc-editor.org/rfc/rfc7386)
+semantics, with two extensions for arrays:
+
+| Patch value | Effect |
+| --- | --- |
+| Object | Merged recursively into the existing object. |
+| Scalar or array | Replaces the existing value. |
+| `null` | Deletes the key. |
+| Key ending in `+` | Appends the items to the existing array. |
+| Key ending in `-` | Removes matching entries from an array or object. |
+
+### Merging and replacing
+
+An object patch only touches the keys it names — siblings survive:
+
+```yaml
+flavors:
+  verbose:
+    agents:
+      root:
+        instruction: Explain your reasoning in detail.  # model, tools, ... unchanged
+```
+
+### Deleting a key
+
+Set it to `null`:
+
+```yaml
+flavors:
+  no-limit:
+    models:
+      claude:
+        max_tokens: null
+```
+
+### Appending to an array
+
+Plain arrays replace wholesale. To add entries instead, suffix the key
+with `+`:
+
+```yaml
+agents:
+  root:
+    toolsets:
+      - type: think
+
+flavors:
+  with-shell:
+    agents:
+      root:
+        toolsets+:
+          - type: shell
+```
+
+With `--flavor with-shell` the root agent gets both `think` and `shell`.
+
+### Removing entries
+
+Suffix the key with `-`. Each item in the patch value selects what to remove:
+
+- From an **array**: a scalar removes equal elements; an object removes every
+  element it partially matches (all of the matcher's keys must be present
+  with matching values).
+- From an **object**: items are key names to drop.
+
+```yaml
+flavors:
+  slim:
+    agents:
+      root:
+        toolsets-:
+          - type: shell   # drop every shell toolset, however configured
+        sub_agents-:
+          - checker       # drop by value
+    models-:
+      - spare             # drop the named model definition
+```
+
+> [!NOTE]
+> The `+` and `-` suffixes are reserved inside flavor patches: a patch cannot
+> set a literal key ending in either character. Base documents are unaffected.
+
+## Inspecting the Result
+
+`docker agent debug config` prints the config exactly as the runtime sees it,
+flavors applied:
+
+```bash
+$ docker agent debug config agent.yaml --flavor cheap --flavor with-shell
+```
+
+## HCL
+
+Flavors work in [HCL configs](../hcl/index.md) too, as labeled blocks. The
+append/remove operators need quoted attribute names inside object
+expressions:
+
+```hcl
+flavors "with-shell" {
+  agents = {
+    root = {
+      "toolsets+" = [{ type = "shell" }]
+    }
+  }
+}
+```
+
+## Notes
+
+- Flavors require config schema version 13 or later; older versions reject
+  the `flavors` key with a hint to bump the top-level `version` field.
+- Patches apply before validation, so a flavored config is validated exactly
+  like a hand-written one.
+- `docker agent push` publishes the raw document, `flavors` section included,
+  so consumers of a pushed agent can enable its flavors too.

--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -126,6 +126,7 @@ Models can be referenced inline or defined in the `models` section:
 - [**Permissions**](../permissions/index.md) — control which tools auto-approve, require confirmation, or are blocked.
 - [**Sandbox Mode**](../sandbox/index.md) — run agents in an isolated Docker container for security.
 - [**Structured Output**](../structured-output/index.md) — constrain agent responses to match a specific JSON schema.
+- [**Flavors**](../flavors/index.md) — ship one agent file with named variants, enabled at run time as YAML patches.
 
 ## Environment Variables
 
@@ -294,10 +295,10 @@ For YAML editor autocompletion and validation, use the [Docker Agent JSON Schema
 
 ## Config Versioning
 
-Docker Agent configs are versioned. The current version is `12`. Add the version at the top of your config:
+Docker Agent configs are versioned. The current version is `13`. Add the version at the top of your config:
 
 ```yaml
-version: 12
+version: 13
 
 agents:
   root:

--- a/docs/data/nav.yml
+++ b/docs/data/nav.yml
@@ -46,6 +46,8 @@
       url: /configuration/sandbox/
     - title: Structured Output
       url: /configuration/structured-output/
+    - title: Flavors
+      url: /configuration/flavors/
     - title: Model Routing
       url: /configuration/routing/
     - title: User Settings

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -57,6 +57,7 @@ $ docker agent run [config] [message...] [flags]
 | `--worktree-pr <number\|url>`            | Run the agent in a git worktree checked out on an existing GitHub pull request (PR number, `#123`, or PR URL). Continues the PR's branch so commits push back to it. Requires the [GitHub CLI](https://cli.github.com/) (`gh`). Cannot be combined with `--worktree`, `--remote`, or `--sandbox`. |
 | `--working-dir <path>`                  | Set the working directory for the session (applies to tools and relative paths)                                                           |
 | `--env-from-file <path>`                | Load environment variables from file (repeatable)                                                                                         |
+| `--flavor <name>`                       | Enable a config flavor, a YAML patch defined under the config's `flavors` section (repeatable, applied in order). See [Flavors](../../configuration/flavors/index.md). |
 | `--code-mode-tools`                     | Provide a single tool to call other tools via JavaScript (forces code-mode tools globally)                                                |
 | `--models-gateway <addr>`               | Route model traffic through a gateway. Also reads `DOCKER_AGENT_MODELS_GATEWAY` (legacy `CAGENT_MODELS_GATEWAY`) env var.                  |
 | `--hook-pre-tool-use <cmd>`             | Add a pre-tool-use hook command (repeatable). See [Hooks](../../configuration/hooks/index.md).                                  |
@@ -684,6 +685,7 @@ These flags are accepted by every command that loads an agent (`run`, `run --exe
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `--working-dir <path>`          | Set the working directory for the session (applies to tools and relative paths).                                         |
 | `--env-from-file <path>`        | Load environment variables from file (repeatable).                                                                       |
+| `--flavor <name>`               | Enable a config flavor, a YAML patch defined under the config's `flavors` section (repeatable, applied in order). See [Flavors](../../configuration/flavors/index.md). |
 | `--code-mode-tools`             | Provide a single tool to call other tools via JavaScript (forces code-mode tools globally).                              |
 | `--models-gateway <addr>`       | Route model traffic through a gateway. Reads `DOCKER_AGENT_MODELS_GATEWAY` (legacy `CAGENT_MODELS_GATEWAY`) env var.      |
 | `--hook-pre-tool-use <cmd>`     | Add a pre-tool-use hook command (repeatable). See [Hooks](../../configuration/hooks/index.md).                 |

--- a/examples/flavors.yaml
+++ b/examples/flavors.yaml
@@ -1,0 +1,57 @@
+#!/usr/bin/env docker agent run
+# Flavors are named YAML patches applied on top of the rest of the file when
+# enabled at run time, in the order they are requested:
+#
+#   docker agent run examples/flavors.yaml --flavor cheap --flavor verbose
+#
+# Objects merge recursively, scalars and arrays replace, and a null value
+# deletes a key. A key ending in '+' appends to an existing array; a key
+# ending in '-' removes entries (from an object by key name, from an array by
+# value or partial match). Requested flavors the file does not define are
+# ignored.
+
+agents:
+  root:
+    model: claude
+    description: A helpful AI assistant
+    instruction: |
+      You are a knowledgeable assistant that helps users with various tasks.
+      Be helpful, accurate, and concise in your responses.
+    toolsets:
+      - type: think
+
+models:
+  claude:
+    provider: anthropic
+    model: claude-sonnet-4-5
+
+flavors:
+  # Swap the model for a cheaper one.
+  cheap:
+    models:
+      claude:
+        model: claude-3-5-haiku-latest
+
+  # Tweak the root agent without touching the rest of its definition.
+  verbose:
+    agents:
+      root:
+        instruction: |
+          You are a knowledgeable assistant that helps users with various tasks.
+          Explain your reasoning in detail and cover edge cases.
+
+  # Append to an existing array with the 'key+' suffix: this adds the shell
+  # toolset on top of the ones the agent already declares.
+  with-shell:
+    agents:
+      root:
+        toolsets+:
+          - type: shell
+
+  # Remove entries with the 'key-' suffix: array elements are matched by
+  # value or partial object match.
+  no-think:
+    agents:
+      root:
+        toolsets-:
+          - type: think

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,7 +21,28 @@ import (
 	"github.com/docker/docker-agent/pkg/environment"
 )
 
-func Load(ctx context.Context, source Source) (*latest.Config, error) {
+// LoadOption customizes a single Load call.
+type LoadOption func(*loadOptions)
+
+type loadOptions struct {
+	flavors []string
+}
+
+// WithFlavors enables the named flavor patches for this load. Order matters:
+// patches are applied in the order given. Names the config does not define
+// are ignored with a debug log.
+func WithFlavors(names ...string) LoadOption {
+	return func(o *loadOptions) {
+		o.flavors = append(o.flavors, names...)
+	}
+}
+
+func Load(ctx context.Context, source Source, opts ...LoadOption) (*latest.Config, error) {
+	var options loadOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	data, err := source.Read(ctx)
 	if err != nil {
 		return nil, err
@@ -36,6 +57,12 @@ func Load(ctx context.Context, source Source) (*latest.Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("parsing HCL config file: %w", err)
 		}
+	}
+
+	// Flavor patches rewrite the raw document, so they run before anything
+	// (including the version sniff below) reads it.
+	if data, err = applyFlavors(ctx, data, options.flavors); err != nil {
+		return nil, err
 	}
 
 	var raw struct {

--- a/pkg/config/doc_yaml_test.go
+++ b/pkg/config/doc_yaml_test.go
@@ -32,6 +32,7 @@ var topLevelConfigKeys = map[string]bool{
 	"permissions": true,
 	"budget":      true,
 	"budgets":     true,
+	"flavors":     true,
 }
 
 // TestDocYAMLSnippetsAreValid extracts every ```yaml code block from docs/

--- a/pkg/config/flavors.go
+++ b/pkg/config/flavors.go
@@ -24,8 +24,10 @@ import (
 // appends its sequence to the existing one instead of replacing it (e.g.
 // `toolsets+:` adds entries to an agent's toolsets), and a key ending in `-`
 // removes entries: from a mapping by key name, from a sequence by scalar
-// equality or mapping subset-match. The `flavors` section itself is left in
-// place; the latest schema carries it so parsing still succeeds.
+// equality or mapping subset-match. The `+`/`-` suffixes are reserved inside
+// flavor patches; keys ending in them cannot be set literally. The `flavors`
+// section itself is left in place; the latest schema carries it so parsing
+// still succeeds.
 func applyFlavors(ctx context.Context, data []byte, enabled []string) ([]byte, error) {
 	if len(enabled) == 0 {
 		return data, nil
@@ -123,7 +125,14 @@ func mergePatch(base, patch any) (any, error) {
 			}
 			out[idx].Value = merged
 		default:
-			out = append(out, yaml.MapItem{Key: item.Key, Value: item.Value})
+			// New keys still get the full patch treatment (RFC 7386 merges
+			// object values against an empty object): a freshly added mapping
+			// may itself contain nulls or `+`/`-` keys to normalize.
+			merged, err := mergePatch(nil, item.Value)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, yaml.MapItem{Key: item.Key, Value: merged})
 		}
 	}
 	return out, nil
@@ -178,6 +187,12 @@ func removePatch(out yaml.MapSlice, key string, value any) (yaml.MapSlice, error
 			})
 		})
 	case yaml.MapSlice:
+		for _, matcher := range items {
+			switch matcher.(type) {
+			case yaml.MapSlice, []any:
+				return nil, fmt.Errorf("remove key %q: entries must be key names when removing from a mapping", key+"-")
+			}
+		}
 		out[idx].Value = slices.DeleteFunc(slices.Clone(base), func(entry yaml.MapItem) bool {
 			return slices.Contains(items, entry.Key)
 		})

--- a/pkg/config/flavors.go
+++ b/pkg/config/flavors.go
@@ -1,0 +1,223 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+)
+
+// applyFlavors applies the enabled flavor patches from the document's
+// top-level `flavors` section onto the raw YAML document, in the order the
+// flavors were requested. Patching happens before version parsing so a patch
+// can touch any part of the document. Enabled flavors that the document does
+// not define are ignored with a debug log, so a set of flavors can be enabled
+// globally and each config only reacts to the ones it declares.
+//
+// Merge semantics follow JSON Merge Patch (RFC 7386): mappings merge
+// recursively, scalars and sequences replace the previous value, and an
+// explicit null deletes the key. As extensions, a mapping key ending in `+`
+// appends its sequence to the existing one instead of replacing it (e.g.
+// `toolsets+:` adds entries to an agent's toolsets), and a key ending in `-`
+// removes entries: from a mapping by key name, from a sequence by scalar
+// equality or mapping subset-match. The `flavors` section itself is left in
+// place; the latest schema carries it so parsing still succeeds.
+func applyFlavors(ctx context.Context, data []byte, enabled []string) ([]byte, error) {
+	if len(enabled) == 0 {
+		return data, nil
+	}
+
+	// yaml.MapSlice keeps document order: agent declaration order is
+	// meaningful (the first agent is the default root), so a plain
+	// map[string]any round-trip would be a behavior change.
+	var doc yaml.MapSlice
+	if err := yaml.UnmarshalWithOptions(data, &doc, yaml.UseOrderedMap()); err != nil {
+		return nil, fmt.Errorf("parsing config file for flavors\n%s", yaml.FormatError(err, true, true))
+	}
+
+	// Snapshot the flavors section so later patches cannot redefine the
+	// flavors applied after them.
+	flavorsValue, _ := lookupKey(doc, "flavors")
+	flavors, _ := flavorsValue.(yaml.MapSlice)
+
+	patched := false
+	for _, name := range enabled {
+		patch, found := lookupKey(flavors, name)
+		if !found {
+			slog.DebugContext(ctx, "Flavor not defined in config; ignoring", "flavor", name)
+			continue
+		}
+		if patch == nil {
+			continue // declared but empty: no-op patch
+		}
+		patchMap, ok := patch.(yaml.MapSlice)
+		if !ok {
+			return nil, fmt.Errorf("flavor %q must be a mapping to merge into the config", name)
+		}
+		result, err := mergePatch(doc, patchMap)
+		if err != nil {
+			return nil, fmt.Errorf("applying flavor %q: %w", name, err)
+		}
+		merged, ok := result.(yaml.MapSlice)
+		if !ok {
+			return nil, fmt.Errorf("applying flavor %q did not produce a mapping", name)
+		}
+		doc = merged
+		patched = true
+	}
+	if !patched {
+		return data, nil
+	}
+
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling config after applying flavors: %w", err)
+	}
+	return out, nil
+}
+
+// mergePatch merges patch into base with JSON Merge Patch (RFC 7386)
+// semantics: mappings merge recursively, a null patch value deletes the key,
+// and any other patch value (scalar, sequence, or mapping replacing a
+// non-mapping) replaces the base value. A string key ending in `+` appends
+// to the base sequence under the un-suffixed key instead of replacing it; a
+// key ending in `-` removes matching entries from the base sequence or
+// mapping under the un-suffixed key.
+func mergePatch(base, patch any) (any, error) {
+	patchMap, ok := patch.(yaml.MapSlice)
+	if !ok {
+		return patch, nil
+	}
+	baseMap, _ := base.(yaml.MapSlice)
+	out := slices.Clone(baseMap)
+	for _, item := range patchMap {
+		if key, ok := item.Key.(string); ok && (strings.HasSuffix(key, "+") || strings.HasSuffix(key, "-")) {
+			op := appendPatch
+			if strings.HasSuffix(key, "-") {
+				op = removePatch
+			}
+			var err error
+			out, err = op(out, key[:len(key)-1], item.Value)
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		idx := slices.IndexFunc(out, func(existing yaml.MapItem) bool {
+			return existing.Key == item.Key
+		})
+		switch {
+		case item.Value == nil:
+			if idx >= 0 {
+				out = slices.Delete(out, idx, idx+1)
+			}
+		case idx >= 0:
+			merged, err := mergePatch(out[idx].Value, item.Value)
+			if err != nil {
+				return nil, err
+			}
+			out[idx].Value = merged
+		default:
+			out = append(out, yaml.MapItem{Key: item.Key, Value: item.Value})
+		}
+	}
+	return out, nil
+}
+
+// appendPatch handles a `key+` patch entry: it appends the patch sequence to
+// the base sequence under key, creating the sequence when key is absent or
+// null. Both sides must be sequences.
+func appendPatch(out yaml.MapSlice, key string, value any) (yaml.MapSlice, error) {
+	items, ok := value.([]any)
+	if !ok {
+		return nil, fmt.Errorf("append key %q: value must be a sequence", key+"+")
+	}
+	idx := slices.IndexFunc(out, func(existing yaml.MapItem) bool {
+		return existing.Key == key
+	})
+	if idx < 0 {
+		return append(out, yaml.MapItem{Key: key, Value: items}), nil
+	}
+	existing, ok := out[idx].Value.([]any)
+	if !ok && out[idx].Value != nil {
+		return nil, fmt.Errorf("append key %q: existing value for %q is not a sequence", key+"+", key)
+	}
+	out[idx].Value = append(slices.Clone(existing), items...)
+	return out, nil
+}
+
+// removePatch handles a `key-` patch entry: it removes matching entries from
+// the base value under key. When the base is a mapping, each item names a key
+// to drop. When it is a sequence, a scalar item removes equal elements and a
+// mapping item removes every element it subset-matches (all of the matcher's
+// keys are present with matching values). A missing or null base is a no-op.
+func removePatch(out yaml.MapSlice, key string, value any) (yaml.MapSlice, error) {
+	items, ok := value.([]any)
+	if !ok {
+		return nil, fmt.Errorf("remove key %q: value must be a sequence", key+"-")
+	}
+	idx := slices.IndexFunc(out, func(existing yaml.MapItem) bool {
+		return existing.Key == key
+	})
+	if idx < 0 {
+		return out, nil
+	}
+
+	switch base := out[idx].Value.(type) {
+	case nil:
+		return out, nil
+	case []any:
+		out[idx].Value = slices.DeleteFunc(slices.Clone(base), func(elem any) bool {
+			return slices.ContainsFunc(items, func(matcher any) bool {
+				return matchesElement(elem, matcher)
+			})
+		})
+	case yaml.MapSlice:
+		out[idx].Value = slices.DeleteFunc(slices.Clone(base), func(entry yaml.MapItem) bool {
+			return slices.Contains(items, entry.Key)
+		})
+	default:
+		return nil, fmt.Errorf("remove key %q: existing value for %q is not a sequence or mapping", key+"-", key)
+	}
+	return out, nil
+}
+
+// matchesElement reports whether a sequence element matches a removal
+// matcher: mappings subset-match (every matcher key must be present in the
+// element with a matching value, recursively), everything else compares by
+// deep equality.
+func matchesElement(elem, matcher any) bool {
+	matcherMap, ok := matcher.(yaml.MapSlice)
+	if !ok {
+		return reflect.DeepEqual(elem, matcher)
+	}
+	elemMap, ok := elem.(yaml.MapSlice)
+	if !ok {
+		return false
+	}
+	for _, want := range matcherMap {
+		idx := slices.IndexFunc(elemMap, func(have yaml.MapItem) bool {
+			return have.Key == want.Key
+		})
+		if idx < 0 || !matchesElement(elemMap[idx].Value, want.Value) {
+			return false
+		}
+	}
+	return true
+}
+
+// lookupKey returns the value for key in an ordered mapping and whether the
+// key is present.
+func lookupKey(m yaml.MapSlice, key string) (any, bool) {
+	for _, item := range m {
+		if item.Key == key {
+			return item.Value, true
+		}
+	}
+	return nil, false
+}

--- a/pkg/config/flavors_test.go
+++ b/pkg/config/flavors_test.go
@@ -40,9 +40,9 @@ flavors:
   empty:
 `
 
-func loadFlavored(t *testing.T, yaml string, flavors ...string) (*latest.Config, error) {
+func loadFlavored(t *testing.T, doc string, flavors ...string) (*latest.Config, error) {
 	t.Helper()
-	return Load(t.Context(), NewBytesSource("config.yaml", []byte(yaml)), WithFlavors(flavors...))
+	return Load(t.Context(), NewBytesSource("config.yaml", []byte(doc)), WithFlavors(flavors...))
 }
 
 func TestFlavorsIgnoredWhenNoneEnabled(t *testing.T) {
@@ -337,4 +337,80 @@ flavors:
 	_, err := loadFlavored(t, config)
 	require.ErrorContains(t, err, "unknown field")
 	require.ErrorContains(t, err, "config version 13")
+}
+
+// A patch adding a brand-new mapping must still get the full merge treatment:
+// nested `+`/`-`/null keys inside it are operators, not literal keys.
+func TestFlavorsOperatorsInsideNewMapping(t *testing.T) {
+	t.Parallel()
+
+	config := `agents:
+  root:
+    model: openai/gpt-5
+    instruction: hello
+flavors:
+  extra-agent:
+    agents:
+      extra:
+        model: openai/gpt-5
+        instruction: extra
+        toolsets+:
+          - type: shell
+        sub_agents-:
+          - nobody
+        description:
+`
+
+	cfg, err := loadFlavored(t, config, "extra-agent")
+	require.NoError(t, err)
+
+	require.Len(t, cfg.Agents, 2)
+	extra := cfg.Agents[1]
+	assert.Equal(t, "extra", extra.Name)
+	require.Len(t, extra.Toolsets, 1)
+	assert.Equal(t, "shell", extra.Toolsets[0].Type)
+	assert.Empty(t, extra.SubAgents)
+	assert.Empty(t, extra.Description)
+}
+
+func TestFlavorsPreserveMultilineStrings(t *testing.T) {
+	t.Parallel()
+
+	config := "agents:\n" +
+		"  root:\n" +
+		"    model: openai/gpt-5\n" +
+		"    instruction: |\n" +
+		"      line one\n" +
+		"      line two: with colon\n" +
+		"flavors:\n" +
+		"  rename:\n" +
+		"    agents:\n" +
+		"      root:\n" +
+		"        description: patched\n"
+
+	cfg, err := loadFlavored(t, config, "rename")
+	require.NoError(t, err)
+	assert.Equal(t, "line one\nline two: with colon\n", cfg.Agents.First().Instruction)
+	assert.Equal(t, "patched", cfg.Agents.First().Description)
+}
+
+func TestFlavorsRemoveMappingEntryMustBeKeyName(t *testing.T) {
+	t.Parallel()
+
+	config := `agents:
+  root:
+    model: claude
+    instruction: hello
+models:
+  claude:
+    provider: anthropic
+    model: claude-sonnet-4-5
+flavors:
+  bad:
+    models-:
+      - provider: anthropic
+`
+
+	_, err := loadFlavored(t, config, "bad")
+	require.ErrorContains(t, err, `remove key "models-": entries must be key names when removing from a mapping`)
 }

--- a/pkg/config/flavors_test.go
+++ b/pkg/config/flavors_test.go
@@ -1,0 +1,340 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/config/latest"
+)
+
+const flavoredConfig = `version: "13"
+agents:
+  root:
+    model: claude
+    description: base description
+    instruction: base instruction
+    sub_agents: [helper]
+  helper:
+    model: claude
+    instruction: helper instruction
+models:
+  claude:
+    provider: anthropic
+    model: claude-sonnet-4-5
+    max_tokens: 1000
+flavors:
+  cheap:
+    models:
+      claude:
+        model: claude-3-5-haiku-latest
+  verbose:
+    agents:
+      root:
+        description: verbose description
+  drop-max-tokens:
+    models:
+      claude:
+        max_tokens: null
+  empty:
+`
+
+func loadFlavored(t *testing.T, yaml string, flavors ...string) (*latest.Config, error) {
+	t.Helper()
+	return Load(t.Context(), NewBytesSource("config.yaml", []byte(yaml)), WithFlavors(flavors...))
+}
+
+func TestFlavorsIgnoredWhenNoneEnabled(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := loadFlavored(t, flavoredConfig)
+	require.NoError(t, err)
+
+	assert.Equal(t, "claude-sonnet-4-5", cfg.Models["claude"].Model)
+	assert.Equal(t, "base description", cfg.Agents.First().Description)
+	assert.Len(t, cfg.Flavors, 4)
+}
+
+func TestFlavorsApplied(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := loadFlavored(t, flavoredConfig, "cheap", "verbose")
+	require.NoError(t, err)
+
+	// Patched values.
+	assert.Equal(t, "claude-3-5-haiku-latest", cfg.Models["claude"].Model)
+	assert.Equal(t, "verbose description", cfg.Agents.First().Description)
+
+	// Untouched siblings survive the merge.
+	assert.Equal(t, "anthropic", cfg.Models["claude"].Provider)
+	assert.Equal(t, "base instruction", cfg.Agents.First().Instruction)
+	assert.Equal(t, []string{"helper"}, cfg.Agents.First().SubAgents)
+
+	// Agent declaration order is preserved: root stays the default agent.
+	assert.Equal(t, "root", cfg.Agents.First().Name)
+}
+
+func TestFlavorsOrderMatters(t *testing.T) {
+	t.Parallel()
+
+	config := flavoredConfig + `  expensive:
+    models:
+      claude:
+        model: claude-opus-4-5
+`
+
+	cfg, err := loadFlavored(t, config, "cheap", "expensive")
+	require.NoError(t, err)
+	assert.Equal(t, "claude-opus-4-5", cfg.Models["claude"].Model)
+
+	cfg, err = loadFlavored(t, config, "expensive", "cheap")
+	require.NoError(t, err)
+	assert.Equal(t, "claude-3-5-haiku-latest", cfg.Models["claude"].Model)
+}
+
+func TestFlavorsNullDeletesKey(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := loadFlavored(t, flavoredConfig, "drop-max-tokens")
+	require.NoError(t, err)
+	assert.Nil(t, cfg.Models["claude"].MaxTokens)
+}
+
+func TestFlavorsUnknownIgnored(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := loadFlavored(t, flavoredConfig, "does-not-exist", "cheap")
+	require.NoError(t, err)
+	assert.Equal(t, "claude-3-5-haiku-latest", cfg.Models["claude"].Model)
+}
+
+func TestFlavorsEmptyIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := loadFlavored(t, flavoredConfig, "empty")
+	require.NoError(t, err)
+	assert.Equal(t, "claude-sonnet-4-5", cfg.Models["claude"].Model)
+}
+
+func TestFlavorsEnabledOnConfigWithoutFlavors(t *testing.T) {
+	t.Parallel()
+
+	config := `agents:
+  root:
+    model: openai/gpt-5
+    instruction: hello
+`
+
+	cfg, err := loadFlavored(t, config, "cheap")
+	require.NoError(t, err)
+	assert.Equal(t, "openai/gpt-5", cfg.Agents.First().Model)
+}
+
+func TestFlavorsMustBeMappings(t *testing.T) {
+	t.Parallel()
+
+	config := `agents:
+  root:
+    model: openai/gpt-5
+    instruction: hello
+flavors:
+  bad: [not, a, mapping]
+`
+
+	_, err := loadFlavored(t, config, "bad")
+	require.ErrorContains(t, err, `flavor "bad" must be a mapping`)
+}
+
+const appendConfig = `agents:
+  root:
+    model: openai/gpt-5
+    instruction: hello
+    toolsets:
+      - type: think
+flavors:
+  with-shell:
+    agents:
+      root:
+        toolsets+:
+          - type: shell
+  with-prompts:
+    agents:
+      root:
+        add_prompt_files+:
+          - extra.md
+  bad-append:
+    agents:
+      root:
+        toolsets+:
+          type: shell
+  scalar-append:
+    agents:
+      root:
+        model+:
+          - extra
+`
+
+func TestFlavorsAppendToArray(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := loadFlavored(t, appendConfig, "with-shell")
+	require.NoError(t, err)
+
+	toolsets := cfg.Agents.First().Toolsets
+	require.Len(t, toolsets, 2)
+	assert.Equal(t, "think", toolsets[0].Type)
+	assert.Equal(t, "shell", toolsets[1].Type)
+}
+
+func TestFlavorsAppendCreatesArray(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := loadFlavored(t, appendConfig, "with-prompts")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"extra.md"}, cfg.Agents.First().AddPromptFiles)
+}
+
+func TestFlavorsAppendRequiresSequencePatch(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadFlavored(t, appendConfig, "bad-append")
+	require.ErrorContains(t, err, `applying flavor "bad-append"`)
+	require.ErrorContains(t, err, `append key "toolsets+": value must be a sequence`)
+}
+
+func TestFlavorsAppendRequiresSequenceBase(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadFlavored(t, appendConfig, "scalar-append")
+	require.ErrorContains(t, err, `existing value for "model" is not a sequence`)
+}
+
+const removeConfig = `agents:
+  root:
+    model: claude
+    instruction: hello
+    sub_agents: [helper, checker]
+    toolsets:
+      - type: think
+      - type: shell
+      - type: script
+        shell:
+          hello:
+            cmd: echo hello
+            description: says hello
+  helper:
+    model: claude
+    instruction: helper
+  checker:
+    model: claude
+    instruction: checker
+models:
+  claude:
+    provider: anthropic
+    model: claude-sonnet-4-5
+  spare:
+    provider: openai
+    model: gpt-5
+flavors:
+  no-shell:
+    agents:
+      root:
+        toolsets-:
+          - type: shell
+  no-checker:
+    agents:
+      root:
+        sub_agents-:
+          - checker
+  no-spare-model:
+    models-:
+      - spare
+  remove-absent:
+    agents:
+      root:
+        handoffs-:
+          - nobody
+  bad-remove:
+    agents:
+      root:
+        toolsets-:
+          type: shell
+  scalar-remove:
+    agents:
+      root:
+        model-:
+          - claude
+`
+
+func TestFlavorsRemoveFromArrayBySubsetMatch(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := loadFlavored(t, removeConfig, "no-shell")
+	require.NoError(t, err)
+
+	toolsets := cfg.Agents.First().Toolsets
+	require.Len(t, toolsets, 2)
+	assert.Equal(t, "think", toolsets[0].Type)
+	assert.Equal(t, "script", toolsets[1].Type)
+}
+
+func TestFlavorsRemoveFromArrayByValue(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := loadFlavored(t, removeConfig, "no-checker")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"helper"}, cfg.Agents.First().SubAgents)
+}
+
+func TestFlavorsRemoveFromMappingByKey(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := loadFlavored(t, removeConfig, "no-spare-model")
+	require.NoError(t, err)
+	assert.NotContains(t, cfg.Models, "spare")
+	assert.Contains(t, cfg.Models, "claude")
+}
+
+func TestFlavorsRemoveAbsentKeyIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := loadFlavored(t, removeConfig, "remove-absent")
+	require.NoError(t, err)
+	assert.Empty(t, cfg.Agents.First().Handoffs)
+}
+
+func TestFlavorsRemoveRequiresSequencePatch(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadFlavored(t, removeConfig, "bad-remove")
+	require.ErrorContains(t, err, `applying flavor "bad-remove"`)
+	require.ErrorContains(t, err, `remove key "toolsets-": value must be a sequence`)
+}
+
+func TestFlavorsRemoveRequiresSequenceOrMappingBase(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadFlavored(t, removeConfig, "scalar-remove")
+	require.ErrorContains(t, err, `existing value for "model" is not a sequence or mapping`)
+}
+
+func TestFlavorsRejectedOnOlderVersions(t *testing.T) {
+	t.Parallel()
+
+	config := `version: "12"
+agents:
+  root:
+    model: openai/gpt-5
+    instruction: hello
+flavors:
+  cheap:
+    agents:
+      root:
+        model: openai/gpt-5-mini
+`
+
+	_, err := loadFlavored(t, config)
+	require.ErrorContains(t, err, "unknown field")
+	require.ErrorContains(t, err, "config version 13")
+}

--- a/pkg/config/hcl/hcl.go
+++ b/pkg/config/hcl/hcl.go
@@ -68,7 +68,7 @@ func LooksLikeHCL(data []byte) bool {
 // topLevelHCLKeywords lists the block names that may legitimately appear at
 // the top level of a docker-agent HCL document.
 var topLevelHCLKeywords = []string{
-	"agent", "model", "provider", "mcp", "rag", "metadata", "permissions", "toolsets",
+	"agent", "model", "provider", "mcp", "rag", "metadata", "permissions", "toolsets", "flavors",
 }
 
 // ToYAML parses an HCL document and returns an equivalent YAML document

--- a/pkg/config/hcl/hcl.go
+++ b/pkg/config/hcl/hcl.go
@@ -152,6 +152,9 @@ var blockRules = map[string]blockRule{
 	// budgets: { tight: { ... } }. The run-wide `budget` block is a
 	// singleton and needs no rule — the 0-label default already covers it.
 	"budgets": {mode: modeMapByLabel, outKey: "budgets"},
+	// Top-level named flavor patches: `flavors "cheap" { ... }` becomes
+	// flavors: { cheap: { ... } }.
+	"flavors": {mode: modeMapByLabel, outKey: "flavors"},
 	// `shell "name" { ... }` is used inside script toolsets as a map of
 	// scripted shell commands.
 	"shell": {mode: modeMapByLabel, outKey: "shell"},

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -58,6 +58,17 @@ type Config struct {
 	// spend more than "tight" allows. Give agents distinct budget names
 	// when you want independent pots.
 	Budgets map[string]BudgetConfig `json:"budgets,omitempty"`
+	// Flavors are named YAML patches applied on top of the rest of the
+	// document when enabled at run time (e.g. `docker agent run --flavor x`).
+	// Patching happens on the raw YAML before parsing, with JSON Merge Patch
+	// semantics (objects merge recursively, scalars and arrays replace, null
+	// deletes) plus `key+` / `key-` extensions that append to or remove from
+	// an existing array or mapping;
+	// enabled flavors are applied in the order they were requested, and
+	// requested flavors not defined here are ignored with a debug log.
+	// The field itself is only carried so the section round-trips; see
+	// config.applyFlavors for the patching logic.
+	Flavors map[string]map[string]any `json:"flavors,omitempty"`
 }
 
 // BudgetConfig caps what a single run may consume before the agent is

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -58,16 +58,11 @@ type Config struct {
 	// spend more than "tight" allows. Give agents distinct budget names
 	// when you want independent pots.
 	Budgets map[string]BudgetConfig `json:"budgets,omitempty"`
-	// Flavors are named YAML patches applied on top of the rest of the
-	// document when enabled at run time (e.g. `docker agent run --flavor x`).
-	// Patching happens on the raw YAML before parsing, with JSON Merge Patch
-	// semantics (objects merge recursively, scalars and arrays replace, null
-	// deletes) plus `key+` / `key-` extensions that append to or remove from
-	// an existing array or mapping;
-	// enabled flavors are applied in the order they were requested, and
-	// requested flavors not defined here are ignored with a debug log.
-	// The field itself is only carried so the section round-trips; see
-	// config.applyFlavors for the patching logic.
+	// Flavors are named YAML patches applied to the raw document at load
+	// time when enabled (e.g. `docker agent run --flavor x`), in request
+	// order; names not defined here are ignored with a debug log. The field
+	// only carries the section so it round-trips — see config.applyFlavors
+	// for the merge semantics.
 	Flavors map[string]map[string]any `json:"flavors,omitempty"`
 }
 

--- a/pkg/config/runtime.go
+++ b/pkg/config/runtime.go
@@ -42,6 +42,10 @@ type Config struct {
 	Models         map[string]latest.ModelConfig
 	Providers      map[string]latest.ProviderConfig
 
+	// Flavors are the config flavor patches to enable when loading agent
+	// configs, applied in order. Names a config does not define are ignored.
+	Flavors []string
+
 	// Hook overrides from user config and CLI flags
 	GlobalHooks      *latest.HooksConfig
 	HookPreToolUse   []string
@@ -92,6 +96,7 @@ func (runConfig *RuntimeConfig) Clone() *RuntimeConfig {
 	clone.envProviderOnce.Do(func() {})    // mark as resolved
 	clone.modelsDevStoreOnce.Do(func() {}) // mark as resolved
 	clone.EnvFiles = slices.Clone(runConfig.EnvFiles)
+	clone.Flavors = slices.Clone(runConfig.Flavors)
 	clone.Models = maps.Clone(runConfig.Models)
 	clone.Providers = maps.Clone(runConfig.Providers)
 	clone.DefaultModel = runConfig.DefaultModel.Clone()

--- a/pkg/sandbox/kit/kit.go
+++ b/pkg/sandbox/kit/kit.go
@@ -98,6 +98,11 @@ type Options struct {
 	// CacheDir is the parent directory under which the kit will be
 	// staged. Empty means "use [paths.GetCacheDir]/sandbox-kits".
 	CacheDir string
+
+	// Flavors are the config flavor patches to enable when loading the
+	// agent config, so the kit stages prompt files and skills for the
+	// flavored configuration the sandboxed run will actually use.
+	Flavors []string
 }
 
 // Result is what [Build] returns.
@@ -395,7 +400,7 @@ func loadConfig(ctx context.Context, opts Options) (*latestcfg.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	return config.Load(ctx, source)
+	return config.Load(ctx, source, config.WithFlavors(opts.Flavors...))
 }
 
 // stageSkills copies every local skill the agent config enables into

--- a/pkg/sandbox/sandbox.go
+++ b/pkg/sandbox/sandbox.go
@@ -311,12 +311,12 @@ var proxyManagedEnvVars = []string{
 //   - envVars: `KEY=VALUE` entries to set on the exec process environment
 //
 // Variables that Docker Desktop already proxies are skipped.
-func EnvForAgent(ctx context.Context, agentRef string, env environment.Provider) (flags, envVars []string) {
+func EnvForAgent(ctx context.Context, agentRef string, env environment.Provider, flavors []string) (flags, envVars []string) {
 	if agentRef == "" {
 		return nil, nil
 	}
 
-	names, err := gatherAgentEnvVars(ctx, agentRef, env)
+	names, err := gatherAgentEnvVars(ctx, agentRef, env, flavors)
 	if err != nil {
 		slog.DebugContext(ctx, "Failed to gather agent env vars for sandbox", "error", err)
 		return nil, nil
@@ -339,13 +339,13 @@ func EnvForAgent(ctx context.Context, agentRef string, env environment.Provider)
 
 // gatherAgentEnvVars resolves the agent config and returns the list of
 // environment variable names required by its models and tools.
-func gatherAgentEnvVars(ctx context.Context, agentRef string, env environment.Provider) ([]string, error) {
+func gatherAgentEnvVars(ctx context.Context, agentRef string, env environment.Provider, flavors []string) ([]string, error) {
 	source, err := config.Resolve(agentRef, env)
 	if err != nil {
 		return nil, fmt.Errorf("resolving agent: %w", err)
 	}
 
-	cfg, err := config.Load(ctx, source)
+	cfg, err := config.Load(ctx, source, config.WithFlavors(flavors...))
 	if err != nil {
 		return nil, fmt.Errorf("loading agent config: %w", err)
 	}

--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -172,7 +172,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 	}
 
 	// Load the agent's configuration
-	cfg, err := config.Load(ctx, agentSource)
+	cfg, err := config.Load(ctx, agentSource, config.WithFlavors(runConfig.Flavors...))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Agent configs are often nearly identical across environments or use-cases — the same tools, the same model, just a different system prompt or a disabled tool. Until now the only way to handle this was to maintain separate YAML files that drift apart over time, or to rely on external templating.

This PR introduces *flavors*: named YAML patches declared in a top-level `flavors` section of an agent config and applied at load time via a repeatable `--flavor` flag. Merge semantics follow JSON Merge Patch (RFC 7386) — objects merge recursively, scalars and arrays replace, `null` deletes a key — with two extensions: a `key+` suffix appends to an existing array, and a `key-` suffix removes entries (from an object by key name, from an array by scalar equality or partial object match). Document order is preserved using `yaml.MapSlice` so the root agent is always the first entry and never silently shifts. Flavors not declared in a config are silently ignored (a debug log is emitted) so the flag is safe to use across a fleet of configs where only some support a given flavor. The `--flavor` flag is wired into every command that loads an agent: `run`, `chat`, `eval`, `serve api/a2a/mcp`, `acp`, `debug`, and the sandbox/kit/agent-picker code paths. External OCI and URL sub-agents receive the same set of enabled flavors.

```yaml
flavors:
  production:
    system_prompt: "You are a helpful assistant. Never reveal internal tooling."
    tools-: [dangerous_tool]
  verbose:
    debug: true
```

```bash
docker-agent run agent.yaml --flavor production --flavor verbose
```

The feature lands on the latest schema only (v13); `agent-schema.json` is updated and HCL gains `flavors "name" {}` block syntax with a detection keyword. An annotated example lives at `examples/flavors.yaml` and a full docs page is added under `docs/configuration/flavors/`. Unit tests in `pkg/config/flavors_test.go` cover merge, order, delete, append, remove, and error paths including regression cases. `task build`, `task test`, and `task lint` all pass; two pre-existing example tests that require Docker Model Runner also fail on `main` and are unrelated to this change.