### PR TITLE
fix(desktop): force token refresh when Docker Desktop returns an expired JWT

### DIFF
--- a/pkg/desktop/login.go
+++ b/pkg/desktop/login.go
@@ -117,6 +117,7 @@ func forceTokenRefresh(ctx context.Context) string {
 		token := runTokenRefresh(ctx)
 
 		refreshState.Lock()
+		defer refreshState.Unlock()
 		refreshState.result = token
 		backoff := refreshCooldown
 		if token == "" {
@@ -124,7 +125,6 @@ func forceTokenRefresh(ctx context.Context) string {
 		}
 		refreshState.nextAttempt = time.Now().Add(backoff)
 		refreshState.inflight = nil
-		refreshState.Unlock()
 		close(done)
 	}()
 
@@ -144,7 +144,7 @@ func awaitRefresh(ctx context.Context, done <-chan struct{}) string {
 
 func runTokenRefresh(ctx context.Context) string {
 	slog.DebugContext(ctx, "Docker Desktop returned an expired token, forcing a refresh")
-	if err := ClientBackend.Post(ctx, "/registry/credstore-updated"); err != nil {
+	if err := postRefreshNudge(ctx); err != nil {
 		slog.DebugContext(ctx, "Failed to trigger Docker Desktop token refresh", "error", err)
 		return ""
 	}
@@ -164,4 +164,12 @@ func runTokenRefresh(ctx context.Context) string {
 		case <-ticker.C:
 		}
 	}
+}
+
+// postRefreshNudge caps the POST to a slice of the refresh budget so a slow
+// Desktop can't consume it all and starve the polling loop that follows.
+func postRefreshNudge(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, refreshBudget/3)
+	defer cancel()
+	return ClientBackend.Post(ctx, "/registry/credstore-updated")
 }

--- a/pkg/desktop/login.go
+++ b/pkg/desktop/login.go
@@ -2,6 +2,11 @@ package desktop
 
 import (
 	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 type DockerHubInfo struct {
@@ -9,9 +14,19 @@ type DockerHubInfo struct {
 	Email    string `json:"email,omitempty"`
 }
 
+// GetToken returns Docker Desktop's access token. Desktop's newer auth stack
+// (auth v2) serves whatever its in-memory token source holds and never
+// refreshes on GET, so a stuck background refresher makes it return the same
+// expired JWT forever. When that happens we force a refresh on Desktop's side.
 func GetToken(ctx context.Context) string {
-	var token string
-	_ = ClientBackend.Get(ctx, "/registry/token", &token)
+	token := fetchToken(ctx)
+	if token == "" || !tokenExpired(token) {
+		return token
+	}
+
+	if fresh := forceTokenRefresh(ctx); fresh != "" {
+		return fresh
+	}
 	return token
 }
 
@@ -19,4 +34,80 @@ func GetUserInfo(ctx context.Context) DockerHubInfo {
 	var info DockerHubInfo
 	_ = ClientBackend.Get(ctx, "/registry/info", &info)
 	return info
+}
+
+func fetchToken(ctx context.Context) string {
+	var token string
+	_ = ClientBackend.Get(ctx, "/registry/token", &token)
+	return token
+}
+
+// tokenExpired reports whether the JWT's exp claim is in the past.
+// Tokens that don't parse or carry no exp claim are treated as valid.
+func tokenExpired(token string) bool {
+	parsed, _, err := jwt.NewParser().ParseUnverified(token, jwt.MapClaims{})
+	if err != nil {
+		return false
+	}
+	exp, err := parsed.Claims.GetExpirationTime()
+	if err != nil || exp == nil {
+		return false
+	}
+	return exp.Before(time.Now())
+}
+
+var refreshState struct {
+	sync.Mutex
+
+	lastAttempt time.Time
+}
+
+// Vars, not consts, so tests can shorten them.
+var (
+	refreshCooldown     = 30 * time.Second
+	refreshPollBudget   = 10 * time.Second
+	refreshPollInterval = 500 * time.Millisecond
+)
+
+// forceTokenRefresh nudges Docker Desktop to reload its session from the OS
+// credential store and refresh it — the same hook the Docker CLI triggers
+// after `docker login`. Desktop handles it asynchronously, so we poll until a
+// non-expired token shows up. Returns "" if no fresh token was obtained.
+func forceTokenRefresh(ctx context.Context) string {
+	refreshState.Lock()
+	defer refreshState.Unlock()
+
+	if time.Since(refreshState.lastAttempt) < refreshCooldown {
+		// A concurrent caller may have just refreshed; re-check once
+		// instead of nudging Desktop again.
+		if token := fetchToken(ctx); token != "" && !tokenExpired(token) {
+			return token
+		}
+		return ""
+	}
+	refreshState.lastAttempt = time.Now()
+
+	slog.DebugContext(ctx, "Docker Desktop returned an expired token, forcing a refresh")
+	if err := ClientBackend.Post(ctx, "/registry/credstore-updated"); err != nil {
+		slog.DebugContext(ctx, "Failed to trigger Docker Desktop token refresh", "error", err)
+		return ""
+	}
+
+	deadline := time.After(refreshPollBudget)
+	ticker := time.NewTicker(refreshPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ""
+		case <-deadline:
+			slog.DebugContext(ctx, "Docker Desktop did not deliver a fresh token in time")
+			return ""
+		case <-ticker.C:
+			if token := fetchToken(ctx); token != "" && !tokenExpired(token) {
+				return token
+			}
+		}
+	}
 }

--- a/pkg/desktop/login.go
+++ b/pkg/desktop/login.go
@@ -42,7 +42,8 @@ func fetchToken(ctx context.Context) string {
 	return token
 }
 
-// tokenExpired reports whether the JWT's exp claim is in the past.
+// tokenExpired reports whether the JWT's exp claim is in the past, with
+// leeway for clock skew between this machine and the token issuer.
 // Tokens that don't parse or carry no exp claim are treated as valid.
 func tokenExpired(token string) bool {
 	parsed, _, err := jwt.NewParser().ParseUnverified(token, jwt.MapClaims{})
@@ -53,61 +54,114 @@ func tokenExpired(token string) bool {
 	if err != nil || exp == nil {
 		return false
 	}
-	return exp.Before(time.Now())
+	return exp.Before(time.Now().Add(-expiryLeeway))
 }
+
+const expiryLeeway = 30 * time.Second
 
 var refreshState struct {
 	sync.Mutex
 
-	lastAttempt time.Time
+	nextAttempt time.Time     // earliest time a new refresh may start
+	inflight    chan struct{} // closed when the in-flight refresh completes
+	result      string        // token produced by the last refresh, "" if none
 }
 
 // Vars, not consts, so tests can shorten them.
 var (
-	refreshCooldown     = 30 * time.Second
-	refreshPollBudget   = 10 * time.Second
-	refreshPollInterval = 500 * time.Millisecond
+	refreshCooldown       = 30 * time.Second
+	refreshFailureBackoff = 2 * time.Minute
+	refreshBudget         = 10 * time.Second
+	refreshPollInterval   = 500 * time.Millisecond
 )
 
 // forceTokenRefresh nudges Docker Desktop to reload its session from the OS
 // credential store and refresh it — the same hook the Docker CLI triggers
 // after `docker login`. Desktop handles it asynchronously, so we poll until a
 // non-expired token shows up. Returns "" if no fresh token was obtained.
+//
+// Refreshes are singleflighted: one goroutine talks to Desktop while
+// concurrent callers wait for its result (or bail out when their own context
+// is canceled). Attempts are rate-limited so a persistently stale Desktop
+// doesn't stall every request.
 func forceTokenRefresh(ctx context.Context) string {
 	refreshState.Lock()
-	defer refreshState.Unlock()
 
-	if time.Since(refreshState.lastAttempt) < refreshCooldown {
-		// A concurrent caller may have just refreshed; re-check once
-		// instead of nudging Desktop again.
-		if token := fetchToken(ctx); token != "" && !tokenExpired(token) {
+	if inflight := refreshState.inflight; inflight != nil {
+		refreshState.Unlock()
+		return awaitRefresh(ctx, inflight)
+	}
+
+	if time.Now().Before(refreshState.nextAttempt) {
+		// Rate-limited, but a refresh may have just completed: reuse its
+		// result if still valid.
+		token := refreshState.result
+		refreshState.Unlock()
+		if token != "" && !tokenExpired(token) {
 			return token
 		}
 		return ""
 	}
-	refreshState.lastAttempt = time.Now()
 
+	done := make(chan struct{})
+	refreshState.inflight = done
+	refreshState.Unlock()
+
+	go func() {
+		// Detached from the caller: the refresh benefits all requests, so a
+		// single canceled request must not abort it. refreshBudget bounds the
+		// whole attempt (POST + polling).
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), refreshBudget)
+		defer cancel()
+
+		token := runTokenRefresh(ctx)
+
+		refreshState.Lock()
+		refreshState.result = token
+		backoff := refreshCooldown
+		if token == "" {
+			backoff = refreshFailureBackoff
+		}
+		refreshState.nextAttempt = time.Now().Add(backoff)
+		refreshState.inflight = nil
+		refreshState.Unlock()
+		close(done)
+	}()
+
+	return awaitRefresh(ctx, done)
+}
+
+func awaitRefresh(ctx context.Context, done <-chan struct{}) string {
+	select {
+	case <-done:
+		refreshState.Lock()
+		defer refreshState.Unlock()
+		return refreshState.result
+	case <-ctx.Done():
+		return ""
+	}
+}
+
+func runTokenRefresh(ctx context.Context) string {
 	slog.DebugContext(ctx, "Docker Desktop returned an expired token, forcing a refresh")
 	if err := ClientBackend.Post(ctx, "/registry/credstore-updated"); err != nil {
 		slog.DebugContext(ctx, "Failed to trigger Docker Desktop token refresh", "error", err)
 		return ""
 	}
 
-	deadline := time.After(refreshPollBudget)
 	ticker := time.NewTicker(refreshPollInterval)
 	defer ticker.Stop()
 
 	for {
+		// Check right away: Desktop may have refreshed synchronously.
+		if token := fetchToken(ctx); token != "" && !tokenExpired(token) {
+			return token
+		}
 		select {
 		case <-ctx.Done():
-			return ""
-		case <-deadline:
 			slog.DebugContext(ctx, "Docker Desktop did not deliver a fresh token in time")
 			return ""
 		case <-ticker.C:
-			if token := fetchToken(ctx); token != "" && !tokenExpired(token) {
-				return token
-			}
 		}
 	}
 }

--- a/pkg/desktop/login_test.go
+++ b/pkg/desktop/login_test.go
@@ -43,7 +43,7 @@ func TestGetToken(t *testing.T) {
 		assert.Equal(t, 1, backend.refreshes())
 	})
 
-	t.Run("cooldown prevents repeated refresh nudges", func(t *testing.T) {
+	t.Run("backoff prevents repeated refresh nudges", func(t *testing.T) {
 		backend := &fakeBackend{token: expired}
 		installFakeBackend(t, backend)
 
@@ -52,14 +52,46 @@ func TestGetToken(t *testing.T) {
 		assert.Equal(t, 1, backend.refreshes())
 	})
 
-	t.Run("cooldown path picks up token refreshed by another caller", func(t *testing.T) {
+	t.Run("rate-limited caller reuses last refresh result", func(t *testing.T) {
 		backend := &fakeBackend{token: expired}
+		backend.onRefresh = func() { backend.setToken(valid) }
 		installFakeBackend(t, backend)
 
-		assert.Equal(t, expired, GetToken(t.Context()))
-		backend.setToken(valid)
+		assert.Equal(t, valid, GetToken(t.Context()))
+
+		// Desktop regressed to an expired token, but a new nudge is
+		// rate-limited: the cached result of the last refresh is reused.
+		backend.setToken(makeToken(t, time.Now().Add(-time.Minute)))
 		assert.Equal(t, valid, GetToken(t.Context()))
 		assert.Equal(t, 1, backend.refreshes())
+	})
+
+	t.Run("concurrent callers share a single refresh", func(t *testing.T) {
+		backend := &fakeBackend{token: expired}
+		backend.onRefresh = func() { backend.setToken(valid) }
+		installFakeBackend(t, backend)
+
+		var wg sync.WaitGroup
+		for range 8 {
+			wg.Go(func() {
+				assert.Equal(t, valid, GetToken(t.Context()))
+			})
+		}
+		wg.Wait()
+		assert.Equal(t, 1, backend.refreshes())
+	})
+
+	t.Run("canceled caller returns promptly with stale token", func(t *testing.T) {
+		backend := &fakeBackend{token: expired}
+		installFakeBackend(t, backend)
+		refreshBudget = time.Second
+
+		ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		assert.Equal(t, expired, GetToken(ctx))
+		assert.Less(t, time.Since(start), 500*time.Millisecond)
 	})
 
 	t.Run("non-JWT token returned as-is", func(t *testing.T) {
@@ -81,6 +113,7 @@ func TestGetToken(t *testing.T) {
 
 func TestTokenExpired(t *testing.T) {
 	assert.False(t, tokenExpired(makeToken(t, time.Now().Add(time.Minute))))
+	assert.False(t, tokenExpired(makeToken(t, time.Now().Add(-10*time.Second))), "within clock-skew leeway")
 	assert.True(t, tokenExpired(makeToken(t, time.Now().Add(-time.Minute))))
 	assert.False(t, tokenExpired("not-a-jwt"))
 }
@@ -149,18 +182,43 @@ func installFakeBackend(t *testing.T, backend *fakeBackend) {
 	ClientBackend = newRawClient(ln.dial)
 	t.Cleanup(func() { ClientBackend = oldClient })
 
-	oldCooldown, oldBudget, oldInterval := refreshCooldown, refreshPollBudget, refreshPollInterval
-	refreshPollBudget = 100 * time.Millisecond
+	oldCooldown, oldBackoff, oldBudget, oldInterval := refreshCooldown, refreshFailureBackoff, refreshBudget, refreshPollInterval
+	refreshCooldown = time.Hour
+	refreshFailureBackoff = time.Hour
+	refreshBudget = 150 * time.Millisecond
 	refreshPollInterval = 5 * time.Millisecond
 	t.Cleanup(func() {
-		refreshCooldown, refreshPollBudget, refreshPollInterval = oldCooldown, oldBudget, oldInterval
+		refreshCooldown, refreshFailureBackoff, refreshBudget, refreshPollInterval = oldCooldown, oldBackoff, oldBudget, oldInterval
 	})
 
 	func() {
 		refreshState.Lock()
 		defer refreshState.Unlock()
-		refreshState.lastAttempt = time.Time{}
+		refreshState.nextAttempt = time.Time{}
+		refreshState.inflight = nil
+		refreshState.result = ""
 	}()
+
+	// Runs first on cleanup (LIFO): a detached refresh goroutine must finish
+	// before the fake backend and globals are torn down.
+	t.Cleanup(func() { drainInflightRefresh(t) })
+}
+
+func drainInflightRefresh(t *testing.T) {
+	t.Helper()
+
+	refreshState.Lock()
+	inflight := refreshState.inflight
+	refreshState.Unlock()
+
+	if inflight == nil {
+		return
+	}
+	select {
+	case <-inflight:
+	case <-time.After(5 * time.Second):
+		t.Fatal("in-flight token refresh did not finish")
+	}
 }
 
 // memListener is an in-memory net.Listener fed by its dial method, so the

--- a/pkg/desktop/login_test.go
+++ b/pkg/desktop/login_test.go
@@ -1,0 +1,207 @@
+package desktop
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetToken(t *testing.T) {
+	valid := makeToken(t, time.Now().Add(time.Hour))
+	expired := makeToken(t, time.Now().Add(-time.Hour))
+
+	t.Run("valid token returned as-is", func(t *testing.T) {
+		backend := &fakeBackend{token: valid}
+		installFakeBackend(t, backend)
+
+		assert.Equal(t, valid, GetToken(t.Context()))
+		assert.Equal(t, 0, backend.refreshes())
+	})
+
+	t.Run("expired token triggers forced refresh", func(t *testing.T) {
+		backend := &fakeBackend{token: expired}
+		backend.onRefresh = func() { backend.setToken(valid) }
+		installFakeBackend(t, backend)
+
+		assert.Equal(t, valid, GetToken(t.Context()))
+		assert.Equal(t, 1, backend.refreshes())
+	})
+
+	t.Run("stale token returned when refresh does not help", func(t *testing.T) {
+		backend := &fakeBackend{token: expired}
+		installFakeBackend(t, backend)
+
+		assert.Equal(t, expired, GetToken(t.Context()))
+		assert.Equal(t, 1, backend.refreshes())
+	})
+
+	t.Run("cooldown prevents repeated refresh nudges", func(t *testing.T) {
+		backend := &fakeBackend{token: expired}
+		installFakeBackend(t, backend)
+
+		assert.Equal(t, expired, GetToken(t.Context()))
+		assert.Equal(t, expired, GetToken(t.Context()))
+		assert.Equal(t, 1, backend.refreshes())
+	})
+
+	t.Run("cooldown path picks up token refreshed by another caller", func(t *testing.T) {
+		backend := &fakeBackend{token: expired}
+		installFakeBackend(t, backend)
+
+		assert.Equal(t, expired, GetToken(t.Context()))
+		backend.setToken(valid)
+		assert.Equal(t, valid, GetToken(t.Context()))
+		assert.Equal(t, 1, backend.refreshes())
+	})
+
+	t.Run("non-JWT token returned as-is", func(t *testing.T) {
+		backend := &fakeBackend{token: "not-a-jwt"}
+		installFakeBackend(t, backend)
+
+		assert.Equal(t, "not-a-jwt", GetToken(t.Context()))
+		assert.Equal(t, 0, backend.refreshes())
+	})
+
+	t.Run("empty token returned as-is", func(t *testing.T) {
+		backend := &fakeBackend{}
+		installFakeBackend(t, backend)
+
+		assert.Empty(t, GetToken(t.Context()))
+		assert.Equal(t, 0, backend.refreshes())
+	})
+}
+
+func TestTokenExpired(t *testing.T) {
+	assert.False(t, tokenExpired(makeToken(t, time.Now().Add(time.Minute))))
+	assert.True(t, tokenExpired(makeToken(t, time.Now().Add(-time.Minute))))
+	assert.False(t, tokenExpired("not-a-jwt"))
+}
+
+func makeToken(t *testing.T, exp time.Time) string {
+	t.Helper()
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"exp": exp.Unix()}).SignedString([]byte("secret"))
+	require.NoError(t, err)
+	return token
+}
+
+// fakeBackend emulates Docker Desktop's backend API: GET /registry/token
+// serves the current token; POST /registry/credstore-updated triggers
+// onRefresh (Desktop's async AutoLogin).
+type fakeBackend struct {
+	mu           sync.Mutex
+	token        string
+	refreshCalls int
+	onRefresh    func()
+}
+
+func (b *fakeBackend) setToken(token string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.token = token
+}
+
+func (b *fakeBackend) refreshes() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.refreshCalls
+}
+
+func (b *fakeBackend) handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /registry/token", func(w http.ResponseWriter, _ *http.Request) {
+		b.mu.Lock()
+		token := b.token
+		b.mu.Unlock()
+		_ = json.NewEncoder(w).Encode(token)
+	})
+	mux.HandleFunc("POST /registry/credstore-updated", func(http.ResponseWriter, *http.Request) {
+		b.mu.Lock()
+		b.refreshCalls++
+		onRefresh := b.onRefresh
+		b.mu.Unlock()
+		if onRefresh != nil {
+			onRefresh()
+		}
+	})
+	return mux
+}
+
+func installFakeBackend(t *testing.T, backend *fakeBackend) {
+	t.Helper()
+
+	ln := newMemListener()
+	server := &http.Server{Handler: backend.handler()}
+	go func() { _ = server.Serve(ln) }()
+	t.Cleanup(func() {
+		_ = server.Close()
+		_ = ln.Close()
+	})
+
+	oldClient := ClientBackend
+	ClientBackend = newRawClient(ln.dial)
+	t.Cleanup(func() { ClientBackend = oldClient })
+
+	oldCooldown, oldBudget, oldInterval := refreshCooldown, refreshPollBudget, refreshPollInterval
+	refreshPollBudget = 100 * time.Millisecond
+	refreshPollInterval = 5 * time.Millisecond
+	t.Cleanup(func() {
+		refreshCooldown, refreshPollBudget, refreshPollInterval = oldCooldown, oldBudget, oldInterval
+	})
+
+	func() {
+		refreshState.Lock()
+		defer refreshState.Unlock()
+		refreshState.lastAttempt = time.Time{}
+	}()
+}
+
+// memListener is an in-memory net.Listener fed by its dial method, so the
+// RawClient can talk to a fake backend without a real socket.
+type memListener struct {
+	conns  chan net.Conn
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newMemListener() *memListener {
+	return &memListener{
+		conns:  make(chan net.Conn),
+		closed: make(chan struct{}),
+	}
+}
+
+func (l *memListener) Accept() (net.Conn, error) {
+	select {
+	case conn := <-l.conns:
+		return conn, nil
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *memListener) Close() error {
+	l.once.Do(func() { close(l.closed) })
+	return nil
+}
+
+func (l *memListener) Addr() net.Addr {
+	return &net.UnixAddr{Name: "mem", Net: "unix"}
+}
+
+func (l *memListener) dial(context.Context) (net.Conn, error) {
+	clientSide, serverSide := net.Pipe()
+	select {
+	case l.conns <- serverSide:
+		return clientSide, nil
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}

--- a/pkg/desktop/raw_client.go
+++ b/pkg/desktop/raw_client.go
@@ -3,6 +3,7 @@ package desktop
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -56,6 +57,28 @@ func (c *RawClient) Get(ctx context.Context, endpoint string, v any) error {
 
 	if err := json.Unmarshal(buf, &v); err != nil {
 		return err
+	}
+	return nil
+}
+
+func (c *RawClient) Post(ctx context.Context, endpoint string) error {
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://localhost"+endpoint, http.NoBody)
+	if err != nil {
+		return err
+	}
+
+	response, err := c.client().Do(req)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	_, _ = io.Copy(io.Discard, response.Body)
+
+	if response.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("POST %s: %s", endpoint, response.Status)
 	}
 	return nil
 }


### PR DESCRIPTION
Docker Desktop's auth v2 stack (behind the `SIGN_IN_V2` feature flag) never refreshes the JWT it holds on a `GET /registry/token` request — it returns whatever its in-memory token source currently contains. When Desktop's background refresher stalls on a permanent 4xx (e.g. a PAT/hub token error), it keeps serving the same expired JWT indefinitely, and retrying the endpoint from docker-agent's side never helps.

`desktop.GetToken` now parses the JWT `exp` claim (with 30s clock-skew leeway). When the token is expired, it forces a Desktop-side refresh by `POST`ing `/registry/credstore-updated` — the same hook the Docker CLI triggers after `docker login`, which makes Desktop reload its session from the OS credential store and issue a fresh token — then polls `GET /registry/token` until a non-expired token appears. A single detached goroutine performs the refresh under a hard 10s budget; concurrent callers share its result via singleflight and can bail on their own context cancellation, falling back to the stale token (preserving the previous behavior). After a successful refresh a 30s cooldown applies; after failure, a 2-minute backoff. Non-JWT tokens, empty tokens, and tokens without an `exp` claim pass through unchanged. `raw_client.go` gains a `Post` method to support the new endpoint.

Tests use an in-memory fake Desktop backend over `net.Pipe` and cover refresh success and failure, backoff, cached-result reuse, 8-way concurrent refresh sharing, caller cancellation, and non-JWT/empty token pass-through.