### PR TITLE
feat: add X-Cagent-Compacting header for session-compaction LLM calls

### DIFF
--- a/pkg/model/provider/anthropic/client.go
+++ b/pkg/model/provider/anthropic/client.go
@@ -115,7 +115,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			baseURL := fmt.Sprintf("%s://%s%s/", url.Scheme, url.Host, url.Path)
 
 			// Configure a custom HTTP client to inject headers and query params used by the Gateway.
-			httpOptions := base.GatewayHTTPOptions(url, "https://api.anthropic.com/", cfg, globalOptions.GeneratingTitle())
+			httpOptions := base.GatewayHTTPOptions(url, "https://api.anthropic.com/", cfg, &globalOptions)
 
 			gatewayHTTPClient := httpclient.NewHTTPClient(ctx, httpOptions...)
 			globalOptions.WrapTransport(ctx, gatewayHTTPClient)

--- a/pkg/model/provider/base/gateway.go
+++ b/pkg/model/provider/base/gateway.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/httpclient"
+	"github.com/docker/docker-agent/pkg/model/provider/options"
 )
 
 // VerifyDockerGatewayAuth fails fast when gateway targets a trusted Docker
@@ -42,8 +43,9 @@ func GatewayAuthToken(ctx context.Context, env environment.Provider, gateway str
 // GatewayHTTPOptions builds the httpclient options shared by all
 // gateway-mode provider clients: the proxied base URL (the provider's public
 // endpoint unless the model overrides base_url), provider/model identity,
-// the gateway's query parameters, and the title-generation marker.
-func GatewayHTTPOptions(gatewayURL *url.URL, defaultBaseURL string, cfg *latest.ModelConfig, generatingTitle bool) []httpclient.Opt {
+// the gateway's query parameters, and the title-generation / compaction
+// markers.
+func GatewayHTTPOptions(gatewayURL *url.URL, defaultBaseURL string, cfg *latest.ModelConfig, modelOpts *options.ModelOptions) []httpclient.Opt {
 	opts := []httpclient.Opt{
 		httpclient.WithProxiedBaseURL(cmp.Or(cfg.BaseURL, defaultBaseURL)),
 		httpclient.WithProvider(cfg.Provider),
@@ -51,8 +53,11 @@ func GatewayHTTPOptions(gatewayURL *url.URL, defaultBaseURL string, cfg *latest.
 		httpclient.WithModelName(cfg.Name),
 		httpclient.WithQuery(gatewayURL.Query()),
 	}
-	if generatingTitle {
+	if modelOpts.GeneratingTitle() {
 		opts = append(opts, httpclient.WithHeader("X-Cagent-GeneratingTitle", "1"))
+	}
+	if modelOpts.Compacting() {
+		opts = append(opts, httpclient.WithHeader("X-Cagent-Compacting", "1"))
 	}
 	return opts
 }

--- a/pkg/model/provider/base/gateway.go
+++ b/pkg/model/provider/base/gateway.go
@@ -44,8 +44,11 @@ func GatewayAuthToken(ctx context.Context, env environment.Provider, gateway str
 // gateway-mode provider clients: the proxied base URL (the provider's public
 // endpoint unless the model overrides base_url), provider/model identity,
 // the gateway's query parameters, and the title-generation / compaction
-// markers.
+// markers. A nil modelOpts is treated as zero options (no markers).
 func GatewayHTTPOptions(gatewayURL *url.URL, defaultBaseURL string, cfg *latest.ModelConfig, modelOpts *options.ModelOptions) []httpclient.Opt {
+	if modelOpts == nil {
+		modelOpts = &options.ModelOptions{}
+	}
 	opts := []httpclient.Opt{
 		httpclient.WithProxiedBaseURL(cmp.Or(cfg.BaseURL, defaultBaseURL)),
 		httpclient.WithProvider(cfg.Provider),

--- a/pkg/model/provider/base/gateway_test.go
+++ b/pkg/model/provider/base/gateway_test.go
@@ -119,4 +119,13 @@ func TestGatewayHTTPOptions(t *testing.T) {
 		assert.Equal(t, "1", o.Header.Get("X-Cagent-Compacting"))
 		assert.Empty(t, o.Header.Get("X-Cagent-GeneratingTitle"))
 	})
+
+	t.Run("nil model options adds no markers", func(t *testing.T) {
+		t.Parallel()
+		cfg := &latest.ModelConfig{Provider: "openai", Model: "gpt-4o"}
+		o := apply(GatewayHTTPOptions(gatewayURL, "https://api.openai.com/v1", cfg, nil))
+		assert.Equal(t, "https://api.openai.com/v1", o.Header.Get("X-Cagent-Forward"))
+		assert.Empty(t, o.Header.Get("X-Cagent-GeneratingTitle"))
+		assert.Empty(t, o.Header.Get("X-Cagent-Compacting"))
+	})
 }

--- a/pkg/model/provider/base/gateway_test.go
+++ b/pkg/model/provider/base/gateway_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/httpclient"
+	"github.com/docker/docker-agent/pkg/model/provider/options"
 )
 
 type fakeEnv map[string]string
@@ -84,26 +85,38 @@ func TestGatewayHTTPOptions(t *testing.T) {
 	t.Run("default base URL and identity headers", func(t *testing.T) {
 		t.Parallel()
 		cfg := &latest.ModelConfig{Provider: "openai", Model: "gpt-4o", Name: "smart"}
-		o := apply(GatewayHTTPOptions(gatewayURL, "https://api.openai.com/v1", cfg, false))
+		o := apply(GatewayHTTPOptions(gatewayURL, "https://api.openai.com/v1", cfg, &options.ModelOptions{}))
 		assert.Equal(t, "https://api.openai.com/v1", o.Header.Get("X-Cagent-Forward"))
 		assert.Equal(t, "openai", o.Header.Get("X-Cagent-Provider"))
 		assert.Equal(t, "gpt-4o", o.Header.Get("X-Cagent-Model"))
 		assert.Equal(t, "smart", o.Header.Get("X-Cagent-Model-Name"))
 		assert.Equal(t, "pro", o.Query.Get("tier"))
 		assert.Empty(t, o.Header.Get("X-Cagent-GeneratingTitle"))
+		assert.Empty(t, o.Header.Get("X-Cagent-Compacting"))
 	})
 
 	t.Run("model base_url overrides the default", func(t *testing.T) {
 		t.Parallel()
 		cfg := &latest.ModelConfig{Provider: "openai", Model: "gpt-4o", BaseURL: "https://example.com/v1"}
-		o := apply(GatewayHTTPOptions(gatewayURL, "https://api.openai.com/v1", cfg, false))
+		o := apply(GatewayHTTPOptions(gatewayURL, "https://api.openai.com/v1", cfg, &options.ModelOptions{}))
 		assert.Equal(t, "https://example.com/v1", o.Header.Get("X-Cagent-Forward"))
 	})
 
 	t.Run("title generation marker", func(t *testing.T) {
 		t.Parallel()
 		cfg := &latest.ModelConfig{Provider: "openai", Model: "gpt-4o"}
-		o := apply(GatewayHTTPOptions(gatewayURL, "https://api.openai.com/v1", cfg, true))
+		modelOpts := options.Apply(options.WithGeneratingTitle())
+		o := apply(GatewayHTTPOptions(gatewayURL, "https://api.openai.com/v1", cfg, &modelOpts))
 		assert.Equal(t, "1", o.Header.Get("X-Cagent-GeneratingTitle"))
+		assert.Empty(t, o.Header.Get("X-Cagent-Compacting"))
+	})
+
+	t.Run("compaction marker", func(t *testing.T) {
+		t.Parallel()
+		cfg := &latest.ModelConfig{Provider: "openai", Model: "gpt-4o"}
+		modelOpts := options.Apply(options.WithCompacting())
+		o := apply(GatewayHTTPOptions(gatewayURL, "https://api.openai.com/v1", cfg, &modelOpts))
+		assert.Equal(t, "1", o.Header.Get("X-Cagent-Compacting"))
+		assert.Empty(t, o.Header.Get("X-Cagent-GeneratingTitle"))
 	})
 }

--- a/pkg/model/provider/dmr/client.go
+++ b/pkg/model/provider/dmr/client.go
@@ -135,9 +135,10 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, opts ...options.Opt
 		"llamacpp", parsed.llamaCpp,
 		"vllm", parsed.vllm,
 	)
-	// Skip model configuration when generating titles to avoid reconfiguring the model
-	// with different settings (e.g., smaller max_tokens) that would affect the main agent.
-	if !globalOptions.GeneratingTitle() {
+	// Skip model configuration for title-generation and compaction clones to
+	// avoid reconfiguring the model with different settings (e.g., smaller
+	// max_tokens) that would affect the main agent.
+	if !globalOptions.GeneratingTitle() && !globalOptions.Compacting() {
 		if err := configureModel(ctx, httpClient, baseURL, cfg.Model, backendCfg, parsed.mode, parsed.rawRuntimeFlags); err != nil {
 			slog.DebugContext(ctx, "model configure via API skipped or failed", "error", err)
 		}

--- a/pkg/model/provider/gemini/client.go
+++ b/pkg/model/provider/gemini/client.go
@@ -152,7 +152,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			}
 			baseURL := fmt.Sprintf("%s://%s%s/", url.Scheme, url.Host, url.Path)
 
-			httpOptions := base.GatewayHTTPOptions(url, "https://generativelanguage.googleapis.com/", cfg, globalOptions.GeneratingTitle())
+			httpOptions := base.GatewayHTTPOptions(url, "https://generativelanguage.googleapis.com/", cfg, &globalOptions)
 
 			httpOpts := genai.HTTPOptions{
 				BaseURL: baseURL,

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -160,7 +160,7 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			baseURL := fmt.Sprintf("%s://%s%s/v1/", url.Scheme, url.Host, url.Path)
 
 			// Configure a custom HTTP client to inject headers and query params used by the Gateway.
-			httpOptions := base.GatewayHTTPOptions(url, "https://api.openai.com/v1", cfg, globalOptions.GeneratingTitle())
+			httpOptions := base.GatewayHTTPOptions(url, "https://api.openai.com/v1", cfg, &globalOptions)
 
 			gatewayHTTPClient := httpclient.NewHTTPClient(ctx, httpOptions...)
 			globalOptions.WrapTransport(ctx, gatewayHTTPClient)

--- a/pkg/model/provider/options/options.go
+++ b/pkg/model/provider/options/options.go
@@ -13,6 +13,7 @@ type ModelOptions struct {
 	gateway          string
 	structuredOutput *latest.StructuredOutput
 	generatingTitle  bool
+	compacting       bool
 	noThinking       bool
 	maxTokens        int64
 	providers        map[string]latest.ProviderConfig
@@ -31,6 +32,10 @@ func (c *ModelOptions) StructuredOutput() *latest.StructuredOutput {
 
 func (c *ModelOptions) GeneratingTitle() bool {
 	return c.generatingTitle
+}
+
+func (c *ModelOptions) Compacting() bool {
+	return c.compacting
 }
 
 func (c *ModelOptions) MaxTokens() int64 {
@@ -117,6 +122,12 @@ func WithGeneratingTitle() Opt {
 	}
 }
 
+func WithCompacting() Opt {
+	return func(cfg *ModelOptions) {
+		cfg.compacting = true
+	}
+}
+
 func WithMaxTokens(maxTokens int64) Opt {
 	return func(cfg *ModelOptions) {
 		cfg.maxTokens = maxTokens
@@ -198,6 +209,9 @@ func FromModelOptions(m ModelOptions) []Opt {
 	}
 	if m.generatingTitle {
 		out = append(out, WithGeneratingTitle())
+	}
+	if m.compacting {
+		out = append(out, WithCompacting())
 	}
 	if m.noThinking {
 		out = append(out, WithNoThinking())

--- a/pkg/model/provider/options/options_test.go
+++ b/pkg/model/provider/options/options_test.go
@@ -68,6 +68,20 @@ func TestFromModelOptions_RoundTripsTransportWrapper(t *testing.T) {
 	assert.NotNil(t, result)
 }
 
+func TestFromModelOptions_RoundTripsCompacting(t *testing.T) {
+	t.Parallel()
+	var src ModelOptions
+	WithCompacting()(&src)
+	require.True(t, src.Compacting())
+
+	var dst ModelOptions
+	for _, o := range FromModelOptions(src) {
+		o(&dst)
+	}
+	assert.True(t, dst.Compacting())
+	assert.False(t, dst.GeneratingTitle())
+}
+
 func TestFromModelOptions_NilWrapperNotIncluded(t *testing.T) {
 	t.Parallel()
 	// A ModelOptions with no transport wrapper should not add a

--- a/pkg/runtime/compactor/compactor.go
+++ b/pkg/runtime/compactor/compactor.go
@@ -202,6 +202,7 @@ func RunLLM(ctx context.Context, args LLMArgs) (result *Result, err error) {
 	summaryModel := provider.CloneWithOptions(ctx, baseModel,
 		options.WithStructuredOutput(nil),
 		options.WithMaxTokens(summaryTokenBudget(args.ContextLimit)),
+		options.WithCompacting(),
 	)
 	compactionAgent := agent.New("root", "", agent.WithModel(summaryModel))
 


### PR DESCRIPTION
Session-compaction (summary) LLM calls are currently indistinguishable from ordinary chat completions at the AI gateway layer. This means gateway-side policies — rate limiting, routing, cost attribution — cannot treat them differently from user-facing conversation turns. Adding an explicit marker gives the gateway a reliable signal it can act on, mirroring the already-established `X-Cagent-GeneratingTitle` pattern.

The change introduces an `X-Cagent-Compacting: 1` HTTP header on gateway-bound requests that originate from the compactor. A new `WithCompacting()` option and `Compacting()` getter are added to `pkg/model/provider/options`, and `FromModelOptions` ensures the flag survives provider cloning. `GatewayHTTPOptions` in the base gateway is refactored to accept `*options.ModelOptions` instead of a bare `generatingTitle bool`, which lets it emit both the title and compacting headers from a single options struct and treat a nil pointer as zero options. The anthropic, openai, and gemini gateway clients are updated accordingly, and the compactor clones its summary model with `options.WithCompacting()`. The DMR client's skip-reconfiguration guard is extended to cover compaction clones, which also override `max_tokens`.

No breaking changes. The new header is purely additive; gateways that do not inspect it are unaffected.