### PR TITLE
docs: update docs for config v14 and Mermaid state diagram directions

### DIFF
--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -19,7 +19,7 @@ A Docker Agent config has these main sections:
 
 ```bash
 # 1. Version — configuration schema version (optional but recommended)
-version: 12
+version: 14
 
 # 2. Metadata — optional agent metadata for distribution
 metadata:
@@ -295,10 +295,10 @@ For YAML editor autocompletion and validation, use the [Docker Agent JSON Schema
 
 ## Config Versioning
 
-Docker Agent configs are versioned. The current version is `13`. Add the version at the top of your config:
+Docker Agent configs are versioned. The current version is `14`. Add the version at the top of your config:
 
 ```yaml
-version: 13
+version: 14
 
 agents:
   root:

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -219,7 +219,7 @@ The TUI renders Mermaid diagram blocks inline rather than displaying raw syntax.
 | ---------------------------------------------- | ------------------------------------------------- |
 | `graph` / `flowchart`                          | ✅ Rendered inline                                 |
 | `sequenceDiagram`                              | ✅ Rendered inline                                 |
-| `stateDiagram` / `stateDiagram-v2`             | ✅ Rendered inline                                 |
+| `stateDiagram` / `stateDiagram-v2`             | ✅ Rendered inline (supports `direction TD/TB/BT/LR/RL`) |
 | Other types (`classDiagram`, `erDiagram`, …) | Falls back to a syntax-highlighted code block     |
 
 Mermaid rendering works in both the full TUI and the lean TUI. Unsupported or syntactically invalid diagram blocks are displayed as ordinary fenced code blocks — no configuration is required and there is no way to disable it.


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Updates documentation for two merged PRs.

## PR #3774 — freeze config v13 / start v14

The current config schema version is now 14. Updated the Config Versioning section and File Structure example in `docs/configuration/overview/index.md` to reference v14 instead of v13/v12.

## PR #3764 — Mermaid state diagram direction support

State diagrams now render `direction` declarations (TD, TB, BT, LR, RL). Updated the Mermaid support table in `docs/features/tui/index.md` to document this.

## PRs reviewed (no doc change needed)

| PR | Reason |
| --- | --- |
| #3775 | Changelog only |
| #3773 | Internal fix (Desktop JWT refresh) |
| #3772 | Docs already updated in the source PR |
| #3771 | Internal refactor; breaking change is Go SDK API only, not documented |
| #3770 | Library-only API (SetStandaloneSSE), no YAML/user-facing change |
| #3769 | Internal dead code removal |
| #3768 | Docs page added in the source PR |
| #3765 | Was itself a docs PR |
| #3763 | Changelog only |
| #3758 | Security fix, no user-facing change |
| #3756 | Security fix, no user-facing change |