### PR TITLE
chore: bump github.com/anthropics/anthropic-sdk-go from v1.58.0 to v1.58.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/a2aproject/a2a-go v0.3.15
 	github.com/alecthomas/chroma/v2 v2.27.0
 	github.com/alpkeskin/gotoon v0.1.1
-	github.com/anthropics/anthropic-sdk-go v1.58.0
+	github.com/anthropics/anthropic-sdk-go v1.58.1
 	github.com/atotto/clipboard v0.1.4
 	github.com/aws/aws-sdk-go-v2 v1.43.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.31

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,8 @@ github.com/alpkeskin/gotoon v0.1.1 h1:GQOVwMfWKINnfEA6slrXHJaJYDwnUFmrPlXOtnuja1
 github.com/alpkeskin/gotoon v0.1.1/go.mod h1:XRTz8RM4tz8M2nB37MNRN8rHF4YgeYd8nIXmoU0B0+M=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
-github.com/anthropics/anthropic-sdk-go v1.58.0 h1:WbvzpIbFpd/eR6H4KK84j7VLuRJnIfKKyAptR1C49EI=
-github.com/anthropics/anthropic-sdk-go v1.58.0/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
+github.com/anthropics/anthropic-sdk-go v1.58.1 h1:ReZ+Inn6WBDOXUGY64ue7zA1uDoW8FFSzMU/lViFd4E=
+github.com/anthropics/anthropic-sdk-go v1.58.1/go.mod h1:3EfIfmFqxH6rbiLcIP4tPFyXL/IHakx2wDG4OU+TIEI=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/apparentlymart/go-textseg/v17 v17.0.1 h1:bpMXRgQ5cEoRNuQke1a80/Nl6w3G5eoIbWo9f3gXkAs=


### PR DESCRIPTION
Bumps `github.com/anthropics/anthropic-sdk-go` from v1.58.0 to v1.58.1. This is a patch release with no breaking changes, so no code migration is needed.

As part of this work, `google.golang.org/adk` was also evaluated for a bump to v1.5.0, but that upgrade was skipped. v1.5.0 deprecates `google.golang.org/adk/server/adka2a` in favor of `adka2a/v2`, which triggers staticcheck SA1019 errors in `pkg/a2a/executor_wrapper.go` and `pkg/a2a/server.go`. That migration is worth doing but goes beyond a routine dependency bump.

| Module | From | To | Status |
|--------|------|----|--------|
| `github.com/anthropics/anthropic-sdk-go` | v1.58.0 | v1.58.1 | bumped |
| `google.golang.org/adk` | v1.2.0 | v1.5.0 | skipped — lint failure (deprecated `adka2a` package, requires migration to `adka2a/v2`) |