### PR TITLE
feat(server): resolve agent-switch slash commands in RunSession

### DIFF
--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -1534,6 +1534,7 @@ func (sm *SessionManager) applyRunModelOverride(ctx context.Context, rs *activeR
 // expanding an instruction-only command doesn't silently rewrite text
 // existing HTTP callers send as literal user input.
 func (sm *SessionManager) applyAgentSwitchCommands(ctx context.Context, rt runtime.Runtime, messages []api.Message) error {
+	originalAgent := rt.CurrentAgentName(ctx)
 	for i := range messages {
 		if messages[i].Role != chat.MessageRoleUser {
 			continue
@@ -1542,12 +1543,20 @@ func (sm *SessionManager) applyAgentSwitchCommands(ctx context.Context, rt runti
 		if !ok || cmd.Agent == "" {
 			continue
 		}
+		// Resolve against the agent that owns the command definition:
+		// the target sub-agent typically doesn't re-declare the routing
+		// command in its own table.
+		resolved := runtime.ResolveCommand(ctx, rt, messages[i].Content)
 		if cmd.Agent != rt.CurrentAgentName(ctx) {
 			if err := rt.SetCurrentAgent(ctx, cmd.Agent); err != nil {
+				// Undo any earlier successful switch in this batch so
+				// the session isn't stuck on a mid-batch agent after
+				// the caller aborts the turn.
+				_ = rt.SetCurrentAgent(ctx, originalAgent)
 				return fmt.Errorf("switch agent to %q: %w", cmd.Agent, err)
 			}
 		}
-		messages[i].Content = runtime.ResolveCommand(ctx, rt, messages[i].Content)
+		messages[i].Content = resolved
 	}
 	return nil
 }

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -894,6 +894,13 @@ func (sm *SessionManager) RunSession(ctx context.Context, sessionID, agentFilena
 		return nil, err
 	}
 
+	if err := sm.applyAgentSwitchCommands(ctx, runtimeSession.runtime, messages); err != nil {
+		undoModelOverride(ctx, prevOverride, hadPrevOverride)
+		runtimeSession.streaming.Unlock()
+		cancel()
+		return nil, err
+	}
+
 	// Now that we hold the streaming lock, it is safe to mutate the session.
 	// Collect user messages for potential title generation
 	var userMessages []string
@@ -1520,6 +1527,29 @@ func (sm *SessionManager) applyRunModelOverride(ctx context.Context, rs *activeR
 		}
 	}
 	return prevOverride, hadPrev, undo, nil
+}
+
+// applyAgentSwitchCommands is the HTTP analogue of
+// pkg/cli/runner.PrepareUserMessage. Scoped to agent-switch commands so
+// expanding an instruction-only command doesn't silently rewrite text
+// existing HTTP callers send as literal user input.
+func (sm *SessionManager) applyAgentSwitchCommands(ctx context.Context, rt runtime.Runtime, messages []api.Message) error {
+	for i := range messages {
+		if messages[i].Role != chat.MessageRoleUser {
+			continue
+		}
+		cmd, _, ok := runtime.LookupCommand(ctx, rt, messages[i].Content)
+		if !ok || cmd.Agent == "" {
+			continue
+		}
+		if cmd.Agent != rt.CurrentAgentName(ctx) {
+			if err := rt.SetCurrentAgent(ctx, cmd.Agent); err != nil {
+				return fmt.Errorf("switch agent to %q: %w", cmd.Agent, err)
+			}
+		}
+		messages[i].Content = runtime.ResolveCommand(ctx, rt, messages[i].Content)
+	}
+	return nil
 }
 
 // applyStoredOverrides applies the persisted per-agent model overrides on

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -1533,8 +1533,20 @@ func (sm *SessionManager) applyRunModelOverride(ctx context.Context, rs *activeR
 // pkg/cli/runner.PrepareUserMessage. Scoped to agent-switch commands so
 // expanding an instruction-only command doesn't silently rewrite text
 // existing HTTP callers send as literal user input.
+//
+// Two-pass: resolve every message against the pre-batch agent first,
+// then apply switches. This keeps each message's interpretation
+// consistent regardless of how earlier messages in the same batch might
+// have mutated the runtime.
 func (sm *SessionManager) applyAgentSwitchCommands(ctx context.Context, rt runtime.Runtime, messages []api.Message) error {
 	originalAgent := rt.CurrentAgentName(ctx)
+
+	type pending struct {
+		idx     int
+		target  string
+		content string
+	}
+	var switches []pending
 	for i := range messages {
 		if messages[i].Role != chat.MessageRoleUser {
 			continue
@@ -1543,20 +1555,24 @@ func (sm *SessionManager) applyAgentSwitchCommands(ctx context.Context, rt runti
 		if !ok || cmd.Agent == "" {
 			continue
 		}
-		// Resolve against the agent that owns the command definition:
-		// the target sub-agent typically doesn't re-declare the routing
-		// command in its own table.
-		resolved := runtime.ResolveCommand(ctx, rt, messages[i].Content)
-		if cmd.Agent != rt.CurrentAgentName(ctx) {
-			if err := rt.SetCurrentAgent(ctx, cmd.Agent); err != nil {
-				// Undo any earlier successful switch in this batch so
-				// the session isn't stuck on a mid-batch agent after
-				// the caller aborts the turn.
-				_ = rt.SetCurrentAgent(ctx, originalAgent)
-				return fmt.Errorf("switch agent to %q: %w", cmd.Agent, err)
+		switches = append(switches, pending{
+			idx:     i,
+			target:  cmd.Agent,
+			content: runtime.ResolveCommand(ctx, rt, messages[i].Content),
+		})
+	}
+
+	for _, s := range switches {
+		if s.target != rt.CurrentAgentName(ctx) {
+			if err := rt.SetCurrentAgent(ctx, s.target); err != nil {
+				if rbErr := rt.SetCurrentAgent(ctx, originalAgent); rbErr != nil {
+					slog.WarnContext(ctx, "failed to restore agent after switch error; session may be on wrong agent",
+						"original_agent", originalAgent, "stuck_on", s.target, "err", rbErr)
+				}
+				return fmt.Errorf("switch agent to %q: %w", s.target, err)
 			}
 		}
-		messages[i].Content = resolved
+		messages[s.idx].Content = s.content
 	}
 	return nil
 }

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -23,6 +24,7 @@ import (
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/concurrent"
 	"github.com/docker/docker-agent/pkg/config"
+	"github.com/docker/docker-agent/pkg/config/types"
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/session/sqlitestore"
@@ -1980,4 +1982,170 @@ func TestBatchDeleteSessions_ToleratesNilRuntimeCancel(t *testing.T) {
 	assert.Empty(t, failed)
 	_, ok := sm.runtimeSessions.Load(sess.ID)
 	assert.False(t, ok, "the runtime entry must still be deregistered")
+}
+
+type commandFakeRuntime struct {
+	fakeRuntime
+
+	mu           sync.Mutex
+	currentAgent string
+	commands     types.Commands
+	setCalls     []string
+	setErr       error
+}
+
+func (r *commandFakeRuntime) CurrentAgentName(context.Context) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.currentAgent
+}
+
+func (r *commandFakeRuntime) CurrentAgentInfo(context.Context) runtime.CurrentAgentInfo {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return runtime.CurrentAgentInfo{Name: r.currentAgent, Commands: r.commands}
+}
+
+func (r *commandFakeRuntime) SetCurrentAgent(_ context.Context, name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.setCalls = append(r.setCalls, name)
+	if r.setErr != nil {
+		return r.setErr
+	}
+	r.currentAgent = name
+	return nil
+}
+
+func (r *commandFakeRuntime) CurrentAgentTools(context.Context) ([]tools.Tool, error) {
+	return nil, nil
+}
+
+func TestApplyAgentSwitchCommands_SwitchesAndStripsPrefix(t *testing.T) {
+	t.Parallel()
+
+	rt := &commandFakeRuntime{
+		currentAgent: "root",
+		commands: types.Commands{
+			"plan": types.Command{Agent: "planner"},
+		},
+	}
+	sm := &SessionManager{}
+	messages := []api.Message{
+		{Role: chat.MessageRoleUser, Content: "/plan explain X"},
+	}
+
+	require.NoError(t, sm.applyAgentSwitchCommands(t.Context(), rt, messages))
+
+	assert.Equal(t, []string{"planner"}, rt.setCalls)
+	assert.Equal(t, "planner", rt.currentAgent)
+	assert.Equal(t, "explain X", messages[0].Content)
+}
+
+// TestApplyAgentSwitchCommands_SkipsSetWhenAlreadyOnTarget: callers rely on
+// this idempotence to re-assert the desired agent every turn instead of
+// tracking applied state themselves.
+func TestApplyAgentSwitchCommands_SkipsSetWhenAlreadyOnTarget(t *testing.T) {
+	t.Parallel()
+
+	rt := &commandFakeRuntime{
+		currentAgent: "planner",
+		commands: types.Commands{
+			"plan": types.Command{Agent: "planner"},
+		},
+	}
+	sm := &SessionManager{}
+	messages := []api.Message{
+		{Role: chat.MessageRoleUser, Content: "/plan another step"},
+	}
+
+	require.NoError(t, sm.applyAgentSwitchCommands(t.Context(), rt, messages))
+
+	assert.Empty(t, rt.setCalls)
+	assert.Equal(t, "planner", rt.currentAgent)
+	assert.Equal(t, "another step", messages[0].Content)
+}
+
+// TestApplyAgentSwitchCommands_LeavesInstructionCommandsAlone: rewriting
+// instruction-expansion commands here would silently reinterpret text that
+// existing HTTP callers may be sending as literal user input.
+func TestApplyAgentSwitchCommands_LeavesInstructionCommandsAlone(t *testing.T) {
+	t.Parallel()
+
+	rt := &commandFakeRuntime{
+		currentAgent: "root",
+		commands: types.Commands{
+			"help": types.Command{Instruction: "Give me help on ${args}"},
+		},
+	}
+	sm := &SessionManager{}
+	messages := []api.Message{
+		{Role: chat.MessageRoleUser, Content: "/help me"},
+	}
+
+	require.NoError(t, sm.applyAgentSwitchCommands(t.Context(), rt, messages))
+
+	assert.Empty(t, rt.setCalls, "instruction-expansion commands must not switch agents")
+	assert.Equal(t, "root", rt.currentAgent)
+	assert.Equal(t, "/help me", messages[0].Content, "content must be preserved verbatim")
+}
+
+func TestApplyAgentSwitchCommands_PassesThroughUnknownCommands(t *testing.T) {
+	t.Parallel()
+
+	rt := &commandFakeRuntime{
+		currentAgent: "root",
+		commands:     types.Commands{"plan": types.Command{Agent: "planner"}},
+	}
+	sm := &SessionManager{}
+	messages := []api.Message{
+		{Role: chat.MessageRoleUser, Content: "/random-command with args"},
+	}
+
+	require.NoError(t, sm.applyAgentSwitchCommands(t.Context(), rt, messages))
+
+	assert.Empty(t, rt.setCalls)
+	assert.Equal(t, "/random-command with args", messages[0].Content)
+}
+
+// TestApplyAgentSwitchCommands_IgnoresNonUserRoles: only user-authored
+// input should be able to steer the active agent.
+func TestApplyAgentSwitchCommands_IgnoresNonUserRoles(t *testing.T) {
+	t.Parallel()
+
+	rt := &commandFakeRuntime{
+		currentAgent: "root",
+		commands:     types.Commands{"plan": types.Command{Agent: "planner"}},
+	}
+	sm := &SessionManager{}
+	messages := []api.Message{
+		{Role: chat.MessageRoleAssistant, Content: "/plan should not switch"},
+	}
+
+	require.NoError(t, sm.applyAgentSwitchCommands(t.Context(), rt, messages))
+
+	assert.Empty(t, rt.setCalls)
+	assert.Equal(t, "/plan should not switch", messages[0].Content)
+}
+
+// TestApplyAgentSwitchCommands_PropagatesSetCurrentAgentError: a failed
+// switch must surface so RunSession can refuse the turn instead of
+// silently proceeding on the wrong agent with a rewritten message.
+func TestApplyAgentSwitchCommands_PropagatesSetCurrentAgentError(t *testing.T) {
+	t.Parallel()
+
+	boom := errors.New("no such agent")
+	rt := &commandFakeRuntime{
+		currentAgent: "root",
+		commands:     types.Commands{"plan": types.Command{Agent: "planner"}},
+		setErr:       boom,
+	}
+	sm := &SessionManager{}
+	messages := []api.Message{
+		{Role: chat.MessageRoleUser, Content: "/plan explain X"},
+	}
+
+	err := sm.applyAgentSwitchCommands(t.Context(), rt, messages)
+	require.ErrorIs(t, err, boom)
+	assert.Equal(t, "/plan explain X", messages[0].Content, "content must be untouched when the switch failed")
 }

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -2185,6 +2185,39 @@ func TestApplyAgentSwitchCommands_ResolvesUsingPreSwitchAgent(t *testing.T) {
 	assert.Equal(t, "explain X", messages[0].Content)
 }
 
+// TestApplyAgentSwitchCommands_MultiBatchLookupUsesPreBatchAgent: each
+// message's command lookup must consult the agent that owned the
+// session at the start of the batch, not whichever agent an earlier
+// switch has left the runtime on. Otherwise a batch like
+// [/plan …, /build …] silently drops the second prefix when the
+// target sub-agent doesn't re-declare `/build` in its own table.
+func TestApplyAgentSwitchCommands_MultiBatchLookupUsesPreBatchAgent(t *testing.T) {
+	t.Parallel()
+
+	rt := &commandFakeRuntime{
+		currentAgent: "root",
+		commandsByAgent: map[string]types.Commands{
+			"root": {
+				"plan":  types.Command{Agent: "planner"},
+				"build": types.Command{Agent: "root"},
+			},
+			"planner": {},
+		},
+	}
+	sm := &SessionManager{}
+	messages := []api.Message{
+		{Role: chat.MessageRoleUser, Content: "/plan step one"},
+		{Role: chat.MessageRoleUser, Content: "/build step two"},
+	}
+
+	require.NoError(t, sm.applyAgentSwitchCommands(t.Context(), rt, messages))
+
+	assert.Equal(t, "step one", messages[0].Content)
+	assert.Equal(t, "step two", messages[1].Content, "/build must be recognized against root's table even after /plan already switched the runtime")
+	assert.Equal(t, "root", rt.currentAgent)
+	assert.Equal(t, []string{"planner", "root"}, rt.setCalls)
+}
+
 // TestApplyAgentSwitchCommands_RollsBackOnBatchFailure: a failed switch
 // mid-batch must not leave the runtime pointing at the intermediate
 // agent — the caller aborts the turn, so the next request would arrive

--- a/pkg/server/session_manager_test.go
+++ b/pkg/server/session_manager_test.go
@@ -1987,11 +1987,13 @@ func TestBatchDeleteSessions_ToleratesNilRuntimeCancel(t *testing.T) {
 type commandFakeRuntime struct {
 	fakeRuntime
 
-	mu           sync.Mutex
-	currentAgent string
-	commands     types.Commands
-	setCalls     []string
-	setErr       error
+	mu              sync.Mutex
+	currentAgent    string
+	commands        types.Commands            // used when commandsByAgent lookup misses
+	commandsByAgent map[string]types.Commands // per-agent tables; real multi-agent runtimes look like this
+	setCalls        []string
+	setErr          error
+	setErrForAgent  map[string]error // per-target-agent failure; falls back to setErr
 }
 
 func (r *commandFakeRuntime) CurrentAgentName(context.Context) string {
@@ -2003,13 +2005,20 @@ func (r *commandFakeRuntime) CurrentAgentName(context.Context) string {
 func (r *commandFakeRuntime) CurrentAgentInfo(context.Context) runtime.CurrentAgentInfo {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return runtime.CurrentAgentInfo{Name: r.currentAgent, Commands: r.commands}
+	cmds := r.commands
+	if per, ok := r.commandsByAgent[r.currentAgent]; ok {
+		cmds = per
+	}
+	return runtime.CurrentAgentInfo{Name: r.currentAgent, Commands: cmds}
 }
 
 func (r *commandFakeRuntime) SetCurrentAgent(_ context.Context, name string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.setCalls = append(r.setCalls, name)
+	if err, ok := r.setErrForAgent[name]; ok {
+		return err
+	}
 	if r.setErr != nil {
 		return r.setErr
 	}
@@ -2148,4 +2157,64 @@ func TestApplyAgentSwitchCommands_PropagatesSetCurrentAgentError(t *testing.T) {
 	err := sm.applyAgentSwitchCommands(t.Context(), rt, messages)
 	require.ErrorIs(t, err, boom)
 	assert.Equal(t, "/plan explain X", messages[0].Content, "content must be untouched when the switch failed")
+}
+
+// TestApplyAgentSwitchCommands_ResolvesUsingPreSwitchAgent: routing
+// commands live on the source agent (`/plan` on root, targeting planner)
+// and are not re-declared on the destination. Resolving after the switch
+// would leak the prefix into history.
+func TestApplyAgentSwitchCommands_ResolvesUsingPreSwitchAgent(t *testing.T) {
+	t.Parallel()
+
+	rt := &commandFakeRuntime{
+		currentAgent: "root",
+		commandsByAgent: map[string]types.Commands{
+			"root":    {"plan": types.Command{Agent: "planner"}},
+			"planner": {},
+		},
+	}
+	sm := &SessionManager{}
+	messages := []api.Message{
+		{Role: chat.MessageRoleUser, Content: "/plan explain X"},
+	}
+
+	require.NoError(t, sm.applyAgentSwitchCommands(t.Context(), rt, messages))
+
+	assert.Equal(t, []string{"planner"}, rt.setCalls)
+	assert.Equal(t, "planner", rt.currentAgent)
+	assert.Equal(t, "explain X", messages[0].Content)
+}
+
+// TestApplyAgentSwitchCommands_RollsBackOnBatchFailure: a failed switch
+// mid-batch must not leave the runtime pointing at the intermediate
+// agent — the caller aborts the turn, so the next request would arrive
+// on the wrong agent otherwise.
+func TestApplyAgentSwitchCommands_RollsBackOnBatchFailure(t *testing.T) {
+	t.Parallel()
+
+	boom := errors.New("no such agent")
+	rt := &commandFakeRuntime{
+		currentAgent: "root",
+		commandsByAgent: map[string]types.Commands{
+			"root": {
+				"plan": types.Command{Agent: "planner"},
+				"bad":  types.Command{Agent: "nonexistent"},
+			},
+			"planner": {
+				"plan": types.Command{Agent: "planner"},
+				"bad":  types.Command{Agent: "nonexistent"},
+			},
+		},
+		setErrForAgent: map[string]error{"nonexistent": boom},
+	}
+	sm := &SessionManager{}
+	messages := []api.Message{
+		{Role: chat.MessageRoleUser, Content: "/plan step one"},
+		{Role: chat.MessageRoleUser, Content: "/bad step two"},
+	}
+
+	err := sm.applyAgentSwitchCommands(t.Context(), rt, messages)
+	require.ErrorIs(t, err, boom)
+	assert.Equal(t, "root", rt.currentAgent, "runtime must be restored to the pre-batch agent")
+	assert.Equal(t, []string{"planner", "nonexistent", "root"}, rt.setCalls)
 }


### PR DESCRIPTION
Host applications driving the runtime over HTTP had no way to trigger a mid-session agent switch: only the interactive CLI/TUI runners resolved slash commands (via `PrepareUserMessage`) before appending them to the session. Anyone else — REST clients, Electron hosts, custom orchestrators — could only invoke the target agent via the `POST /api/sessions/:id/agent/:agent/:agent_name` two-segment route, whose semantics only actually take effect on the first turn of a session (the cached runtime silently ignores it on turn 2+).

This PR closes that gap on the HTTP side. `SessionManager.RunSession` now runs each incoming user message through `LookupCommand` / `ResolveCommand` before appending, mirroring what the CLI already does:

```
POST /api/sessions/:id/agent/root
body: {"messages":[{"role":"user","content":"/plan design a login flow"}]}
         │
         ▼
    RunSession
         │
         ▼
    applyAgentSwitchCommands
         │
         ├─ LookupCommand("/plan design a login flow")  →  {Agent: "planner"}, rest: "design a login flow"
         ├─ current agent is "root", target is "planner" ➜ SetCurrentAgent("planner")
         └─ replace message content with "design a login flow"
         │
         ▼
    session stores clean history:
      user: "design a login flow"       ◄── no routing prefix leaks in
    runtime runs turn as `planner`
```

**Scope is intentionally narrow: only commands whose `Agent` field is set are resolved here.** Instruction-expansion commands (those declaring an `Instruction`) pass through unchanged, so an existing caller that happens to send text starting with `/` is not silently reinterpreted server-side. The blast radius of the change is limited to configs that already declared `commands.<x>.agent: <name>`, which today are the tightly-controlled agent-switching commands.

Idempotence is a design choice: when the target agent is already current, `SetCurrentAgent` is skipped. That lets host applications re-assert the desired agent on every turn (e.g. by always prefixing the outgoing message with `/plan` or `/build` depending on a UI toggle) without paying for a no-op switch or tracking per-session applied state client-side.
