### PR TITLE
feat(config): add description attribute to models

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -1510,6 +1510,10 @@
           "type": "string",
           "description": "Model name"
         },
+        "description": {
+          "type": "string",
+          "description": "Optional human-readable summary of the model's purpose or strengths (e.g. 'fast and cheap, good for summaries')"
+        },
         "temperature": {
           "type": "number",
           "description": "Sampling temperature",

--- a/docs/concepts/models/index.md
+++ b/docs/concepts/models/index.md
@@ -109,6 +109,7 @@ See the [Model Providers](../../providers/overview/index.md) section for detaile
 | ------------------- | ---------- | ------------------------------------------------- |
 | `provider`          | string     | Provider identifier (required)                    |
 | `model`             | string     | Model name (required)                             |
+| `description`       | string     | Human-readable summary of the model's purpose     |
 | `temperature`       | float      | Randomness: 0.0 (deterministic) to 1.0 (creative) |
 | `max_tokens`        | int        | Maximum response length                           |
 | `top_p`             | float      | Nucleus sampling: 0.0 to 1.0                      |

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -58,7 +58,7 @@ models:
 | `first_available`     | array      | ✗        | Candidate model references tried in order; selects the first whose credentials are configured. Mutually exclusive with other model settings. |
 | `provider`            | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Provider: `openai`, `anthropic`, `google`, `amazon-bedrock`, `dmr`, `mistral`, `xai`, `nebius`, `nvidia`, `minimax`, `baseten`, `ovhcloud`, `groq`, `fireworks`, `deepseek`, `cerebras`, `together`, `huggingface`, `moonshot`, `vercel`, `cloudflare-workers-ai`, `cloudflare-ai-gateway`, `requesty`, `openrouter`, `azure`, `ollama`, `github-copilot`, `chatgpt`, or any [named provider](../../providers/custom/index.md). |
 | `model`               | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Model name (e.g., `gpt-4o`, `claude-sonnet-4-5`, `gemini-3.5-flash`) |
-| `description`         | string     | ✗        | Human-readable summary of the model's purpose or strengths (e.g., "fast and cheap, good for summaries") |
+| `description`         | string     | ✗        | Informational, human-readable summary of the model's purpose or strengths (e.g., "fast and cheap, good for summaries"). Not sent to the model. Can be combined with `first_available` (a selector's description is kept when it resolves). |
 | `temperature`         | float      | ✗        | Sampling randomness. Range is provider-dependent — typically `0.0–2.0` (Anthropic caps at `1.0`). `0.0` is deterministic. |
 | `max_tokens`          | int        | ✗        | Maximum response length in tokens                                                     |
 | `top_p`               | float      | ✗        | Nucleus sampling threshold (`0.0–1.0`)                                                |
@@ -305,7 +305,7 @@ Candidates can be inline `provider/model` references or names from the same `mod
 
 If none of the candidates has credentials configured, Docker Agent reports the missing environment variables grouped by candidate. You only need to configure one group of credentials, not every provider in the list.
 
-A `first_available` model is only a selector. It cannot be combined with `provider`, `model`, `routing`, `token_key`, budgets, sampling options, or other model settings. Put those settings on named candidate models instead:
+A `first_available` model is only a selector. Except for the informational `description`, it cannot be combined with `provider`, `model`, `routing`, `token_key`, budgets, sampling options, or other model settings. Put those settings on named candidate models instead:
 
 ```yaml
 models:

--- a/docs/configuration/models/index.md
+++ b/docs/configuration/models/index.md
@@ -22,6 +22,7 @@ models:
                      # azure, ollama, github-copilot, or a named provider defined
                      # under the top-level `providers:` section.
     model: string # Required: model identifier
+    description: string # Optional: human-readable summary of the model's purpose or strengths
     temperature: float # Optional: 0.0–2.0 (provider-dependent; e.g. Anthropic caps at 1.0)
     max_tokens: integer # Optional: response length limit
     top_p: float # Optional: 0.0–1.0
@@ -57,6 +58,7 @@ models:
 | `first_available`     | array      | ✗        | Candidate model references tried in order; selects the first whose credentials are configured. Mutually exclusive with other model settings. |
 | `provider`            | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Provider: `openai`, `anthropic`, `google`, `amazon-bedrock`, `dmr`, `mistral`, `xai`, `nebius`, `nvidia`, `minimax`, `baseten`, `ovhcloud`, `groq`, `fireworks`, `deepseek`, `cerebras`, `together`, `huggingface`, `moonshot`, `vercel`, `cloudflare-workers-ai`, `cloudflare-ai-gateway`, `requesty`, `openrouter`, `azure`, `ollama`, `github-copilot`, `chatgpt`, or any [named provider](../../providers/custom/index.md). |
 | `model`               | string     | ✓/✗      | Required for regular model definitions; omitted for `first_available` selectors. Model name (e.g., `gpt-4o`, `claude-sonnet-4-5`, `gemini-3.5-flash`) |
+| `description`         | string     | ✗        | Human-readable summary of the model's purpose or strengths (e.g., "fast and cheap, good for summaries") |
 | `temperature`         | float      | ✗        | Sampling randomness. Range is provider-dependent — typically `0.0–2.0` (Anthropic caps at `1.0`). `0.0` is deterministic. |
 | `max_tokens`          | int        | ✗        | Maximum response length in tokens                                                     |
 | `top_p`               | float      | ✗        | Nucleus sampling threshold (`0.0–1.0`)                                                |

--- a/examples/model_descriptions.yaml
+++ b/examples/model_descriptions.yaml
@@ -1,0 +1,26 @@
+# Model Descriptions Example
+#
+# This example demonstrates the optional `description` attribute on models.
+# A description is a human-readable summary of a model's purpose or strengths.
+# It documents why a model is in the config — which one to pick for what —
+# for anyone reading or editing the file.
+
+models:
+  smart:
+    provider: anthropic
+    model: claude-sonnet-4-5
+    description: High-quality reasoning model for complex, multi-step tasks.
+  fast:
+    provider: anthropic
+    model: claude-haiku-4-5
+    description: Fast and cheap; good for summaries, titles, and simple lookups.
+  local:
+    provider: dmr
+    model: ai/qwen3
+    description: Local model; no API key required, keeps data on-machine.
+
+agents:
+  root:
+    model: smart
+    description: An assistant backed by documented models.
+    instruction: You are a helpful assistant.

--- a/pkg/config/first_available.go
+++ b/pkg/config/first_available.go
@@ -60,6 +60,11 @@ func resolveFirstAvailableModel(ctx context.Context, cfg *latest.Config, name st
 
 	slog.DebugContext(ctx, "Resolved first_available model",
 		"model_name", name, "selected", ref, "provider", chosen.Provider, "model", chosen.Model)
+	// The selector's description documents the selection itself; keep it over
+	// the chosen candidate's own description.
+	if m.Description != "" {
+		chosen.Description = m.Description
+	}
 	cfg.Models[name] = chosen
 	return nil
 }

--- a/pkg/config/first_available_test.go
+++ b/pkg/config/first_available_test.go
@@ -37,6 +37,32 @@ func TestResolveFirstAvailableModels_SelectsFirstWithCredentials(t *testing.T) {
 	assert.Empty(t, got.FirstAvailable)
 }
 
+func TestResolveFirstAvailableModels_PreservesSelectorDescription(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Models: map[string]latest.ModelConfig{
+			"smart": {
+				Description: "Best available reasoning model.",
+				FirstAvailable: []string{
+					"openai/gpt-5",
+					"dmr/ai/qwen3",
+				},
+			},
+		},
+	}
+
+	env := environment.NewMapEnvProvider(map[string]string{
+		"OPENAI_API_KEY": "test-key",
+	})
+
+	require.NoError(t, ResolveFirstAvailableModels(t.Context(), cfg, "", env))
+
+	got := cfg.Models["smart"]
+	assert.Equal(t, "openai", got.Provider)
+	assert.Equal(t, "Best available reasoning model.", got.Description)
+}
+
 func TestResolveFirstAvailableModels_FallsBackToLocalProvider(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/latest/description_test.go
+++ b/pkg/config/latest/description_test.go
@@ -1,0 +1,32 @@
+package latest
+
+import (
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModelConfigDescriptionYAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const in = `provider: anthropic
+model: claude-haiku-4-5
+description: Fast and cheap; good for summaries.
+`
+	var f FlexibleModelConfig
+	require.NoError(t, yaml.Unmarshal([]byte(in), &f))
+	assert.Equal(t, "Fast and cheap; good for summaries.", f.Description)
+
+	// A model carrying a description must not collapse to the
+	// "provider/model" shorthand on marshal, or the description would be lost.
+	assert.False(t, f.isShorthandOnly(), "description must defeat shorthand marshalling")
+
+	out, err := yaml.Marshal(f)
+	require.NoError(t, err)
+
+	var rt FlexibleModelConfig
+	require.NoError(t, yaml.Unmarshal(out, &rt))
+	assert.Equal(t, "Fast and cheap; good for summaries.", rt.Description, "description should survive a marshal round-trip; got:\n%s", out)
+}

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -1040,6 +1040,9 @@ type ModelConfig struct {
 	Name     string `json:"-"`
 	Provider string `json:"provider,omitempty"`
 	Model    string `json:"model,omitempty"`
+	// Description is an optional human-readable summary of the model's
+	// purpose or strengths (e.g. "fast and cheap, good for summaries").
+	Description string `json:"description,omitempty"`
 	// DisplayModel holds the original model name from the YAML config, before alias resolution.
 	// When set, provider.ID() returns Provider + "/" + DisplayModel instead of the resolved name.
 	// This ensures the UI shows the user-configured name (e.g., "claude-haiku-4-5")

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -1350,7 +1350,8 @@ func (f FlexibleModelConfig) MarshalYAML() (any, error) {
 
 // isShorthandOnly returns true if only provider and model are set
 func (f *FlexibleModelConfig) isShorthandOnly() bool {
-	return f.Temperature == nil &&
+	return f.Description == "" &&
+		f.Temperature == nil &&
 		f.MaxTokens == nil &&
 		f.TopP == nil &&
 		f.FrequencyPenalty == nil &&


### PR DESCRIPTION
Agent configs can reference multiple models, but there has been no way to annotate what each model is for — why you chose it, what it is good at, or what role it plays in the agent. This PR adds an optional `description` field to `ModelConfig` so authors can attach a short, human-readable summary to any model entry.

The field is purely informational: it is stored in the config, surfaced in tooling, and never sent to the model provider. It works with every model form — inline shorthand strings, full `ModelConfig` objects, and `first_available` selectors. When a `first_available` selector resolves to a concrete model, the selector's own description is preserved on the resolved value so callers always see it. The shorthand marshaller is fixed to carry the description through the round-trip rather than silently dropping it.

Schema, docs, and a worked example (`examples/model_descriptions.yaml`) are all updated. New tests cover the round-trip and the `first_available` resolution path.