### PR TITLE
fix(tui): restyle history-search input on live theme change

### DIFF
--- a/pkg/tui/components/editor/editor.go
+++ b/pkg/tui/components/editor/editor.go
@@ -206,6 +206,18 @@ func WithPlaceholder(placeholder string) Option {
 	}
 }
 
+// searchInputStyles returns the history-search input's styling, muted
+// relative to the main textarea to distinguish search mode. Shared by New
+// and the ThemeChangedMsg handler so both stay in sync with the active theme.
+func searchInputStyles() textinput.Styles {
+	s := styles.DialogInputStyle
+	s.Focused.Text = styles.MutedStyle
+	s.Focused.Placeholder = styles.MutedStyle
+	s.Blurred.Text = styles.MutedStyle
+	s.Blurred.Placeholder = styles.MutedStyle
+	return s
+}
+
 // New creates a new editor component
 func New(hist *history.History, opts ...Option) Editor {
 	ta := textarea.New()
@@ -221,14 +233,7 @@ func New(hist *history.History, opts ...Option) Editor {
 	si := textinput.New()
 	si.Prompt = ""
 	si.Placeholder = "Type to search..."
-
-	// Customize styles for search input
-	s := styles.DialogInputStyle
-	s.Focused.Text = styles.MutedStyle
-	s.Focused.Placeholder = styles.MutedStyle
-	s.Blurred.Text = styles.MutedStyle
-	s.Blurred.Placeholder = styles.MutedStyle
-	si.SetStyles(s)
+	si.SetStyles(searchInputStyles())
 
 	e := &editor{
 		textarea:                      ta,
@@ -715,6 +720,7 @@ func (e *editor) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		return e, nil
 	case messages.ThemeChangedMsg:
 		e.textarea.SetStyles(styles.InputStyle)
+		e.searchInput.SetStyles(searchInputStyles())
 		return e, nil
 	case tea.WindowSizeMsg:
 		e.textarea.SetWidth(msg.Width - 2)

--- a/pkg/tui/components/editor/theme_test.go
+++ b/pkg/tui/components/editor/theme_test.go
@@ -1,0 +1,61 @@
+package editor
+
+import (
+	"image/color"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/history"
+	"github.com/docker/docker-agent/pkg/tui/messages"
+	"github.com/docker/docker-agent/pkg/tui/styles"
+)
+
+func assertColorEqual(t *testing.T, want, got color.Color, msgAndArgs ...any) {
+	t.Helper()
+	wantR, wantG, wantB := styles.ColorToRGB(want)
+	gotR, gotG, gotB := styles.ColorToRGB(got)
+	assert.InDelta(t, wantR, gotR, 0.01, msgAndArgs...)
+	assert.InDelta(t, wantG, gotG, 0.01, msgAndArgs...)
+	assert.InDelta(t, wantB, gotB, 0.01, msgAndArgs...)
+}
+
+// TestThemeChanged_RestylesSearchInput guards against the historySearch input
+// silently keeping stale colors after a live theme switch, since its styles
+// are otherwise only set once in New.
+func TestThemeChanged_RestylesSearchInput(t *testing.T) { //nolint:paralleltest // ApplyTheme mutates package-wide style variables.
+	original := styles.CurrentTheme()
+	t.Cleanup(func() { styles.ApplyTheme(original) })
+
+	tmpDir := t.TempDir()
+	h, err := history.New(tmpDir)
+	require.NoError(t, err)
+
+	e := New(h).(*editor)
+
+	theme := styles.DefaultTheme()
+	theme.Ref = "theme-changed-test"
+	theme.Colors.TextMuted = "#123456"
+	theme.Colors.Placeholder = "#abcdef"
+	styles.ApplyTheme(theme)
+
+	m, _ := e.Update(messages.ThemeChangedMsg{})
+	e = m.(*editor)
+
+	wantMuted := styles.MutedStyle.GetForeground()
+	searchStyles := e.searchInput.Styles()
+	assertColorEqual(t, wantMuted, searchStyles.Focused.Text.GetForeground(),
+		"searchInput focused text should follow the new theme's muted color")
+	assertColorEqual(t, wantMuted, searchStyles.Focused.Placeholder.GetForeground(),
+		"searchInput focused placeholder should follow the new theme's muted color")
+	assertColorEqual(t, wantMuted, searchStyles.Blurred.Text.GetForeground(),
+		"searchInput blurred text should follow the new theme's muted color")
+	assertColorEqual(t, wantMuted, searchStyles.Blurred.Placeholder.GetForeground(),
+		"searchInput blurred placeholder should follow the new theme's muted color")
+
+	// The main textarea keeps getting restyled too, so the fix doesn't
+	// regress the pre-existing behavior.
+	assertColorEqual(t, styles.PlaceholderColor, e.textarea.Styles().Focused.Placeholder.GetForeground(),
+		"textarea placeholder should follow the new theme's placeholder color")
+}


### PR DESCRIPTION
## Summary

Fixes #3784.

The TUI editor did not fully apply live theme changes to its
history-search input. On `messages.ThemeChangedMsg` the editor
reapplied the current theme to its main textarea but left the internal
`searchInput` styled with the theme that was active when the editor was
constructed, producing visibly stale styling (e.g. dark-theme gray text
after switching to the light `catppuccin-latte` theme).

## Changes

- Extract a `searchInputStyles()` helper that builds the customized
  search-input styles (`DialogInputStyle` + muted text/placeholder),
  shared by `New` and the `ThemeChangedMsg` handler so both stay in
  sync with the active theme.
- The `messages.ThemeChangedMsg` handler now reapplies styles to
  `searchInput` in addition to the main textarea.
- Add a focused regression test asserting that `ThemeChangedMsg`
  updates the history-search input's colors (focused/blurred text and
  placeholder) as well as the main textarea. Verified to fail against
  the pre-fix handler and pass with the fix.

## Validation

- `task build` — passes
- `task test` — passes
- `task lint` — 0 issues

## Downstream context

Found while fixing a WCAG contrast issue in Docker Sandboxes' Gordon
assistant (docker/sandboxes#4528).