### PR TITLE
fix(server): make session WorkingDir containment opt-in

### DIFF
--- a/cmd/root/flags.go
+++ b/cmd/root/flags.go
@@ -2,6 +2,7 @@ package root
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -61,6 +62,9 @@ func sessionDBPath(flagValue string) string {
 func setupWorkingDirectory(workingDir string) error {
 	if workingDir == "" {
 		return nil
+	}
+	if strings.TrimSpace(workingDir) == "" {
+		return errors.New("--working-dir: value is empty after trimming whitespace")
 	}
 
 	absWd, err := filepath.Abs(workingDir)

--- a/cmd/root/flags_test.go
+++ b/cmd/root/flags_test.go
@@ -412,3 +412,24 @@ func TestEnvFromFileErrorsAbortPreRun(t *testing.T) {
 		assert.Contains(t, err.Error(), "bad.env")
 	})
 }
+
+// TestSetupWorkingDirectory: whitespace-only --working-dir is a
+// misconfiguration and must fail loudly, not silently disable containment.
+func TestSetupWorkingDirectory(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty is a no-op", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, setupWorkingDirectory(""))
+	})
+
+	t.Run("whitespace-only is rejected", func(t *testing.T) {
+		t.Parallel()
+		err := setupWorkingDirectory("   ")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--working-dir")
+
+		err = setupWorkingDirectory("\t\n")
+		require.Error(t, err)
+	})
+}

--- a/pkg/server/session_manager.go
+++ b/pkg/server/session_manager.go
@@ -574,31 +574,22 @@ func (sm *SessionManager) CreateSession(ctx context.Context, sessionTemplate *se
 	return sess, sm.sessionStore.AddSession(ctx, sess)
 }
 
-// workingDirRoot returns the absolute directory that user-supplied session
-// working directories must stay within. It uses the server's configured
-// working directory, falling back to the process working directory.
+// workingDirRoot returns the absolute containment root, or "" when
+// --working-dir was not set and containment is disabled.
 func (sm *SessionManager) workingDirRoot() (string, error) {
-	root := ""
-	if sm.runConfig != nil {
-		root = strings.TrimSpace(sm.runConfig.WorkingDir)
+	if sm.runConfig == nil {
+		return "", nil
 	}
+	root := strings.TrimSpace(sm.runConfig.WorkingDir)
 	if root == "" {
-		wd, err := os.Getwd()
-		if err != nil {
-			return "", err
-		}
-		root = wd
+		return "", nil
 	}
 	return filepath.Abs(root)
 }
 
-// resolveWithinRoot canonicalises absPath via filepath.EvalSymlinks and
-// verifies the result lies inside the server root directory. This prevents a
-// user-supplied working directory from escaping to arbitrary filesystem
-// locations (go/path-injection, CodeQL alert #57).
+// resolveWithinRoot canonicalises absPath and, when a root is configured,
+// rejects paths that escape it (go/path-injection, CodeQL alert #57).
 func (sm *SessionManager) resolveWithinRoot(absPath string) (string, error) {
-	// Resolve symlinks on the target; it must exist because the caller
-	// will stat it immediately after.
 	resolvedPath, err := filepath.EvalSymlinks(absPath)
 	if err != nil {
 		return "", err
@@ -606,6 +597,9 @@ func (sm *SessionManager) resolveWithinRoot(absPath string) (string, error) {
 	root, err := sm.workingDirRoot()
 	if err != nil {
 		return "", err
+	}
+	if root == "" {
+		return resolvedPath, nil
 	}
 	resolvedRoot, err := filepath.EvalSymlinks(root)
 	if err != nil {

--- a/pkg/server/session_workingdir_test.go
+++ b/pkg/server/session_workingdir_test.go
@@ -104,6 +104,53 @@ func TestCreateSession_WorkingDirValidation(t *testing.T) {
 	})
 }
 
+// TestCreateSession_WorkingDirNoRootConfigured: no --working-dir → no containment.
+func TestCreateSession_WorkingDirNoRootConfigured(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	newSM := func(rc *config.RuntimeConfig) *SessionManager {
+		return NewSessionManager(ctx, config.Sources{}, session.NewInMemorySessionStore(), 0, rc)
+	}
+
+	elsewhere := t.TempDir()
+
+	t.Run("nil runConfig accepts any directory", func(t *testing.T) {
+		t.Parallel()
+		sm := newSM(nil)
+		created, err := sm.CreateSession(ctx, &session.Session{WorkingDir: elsewhere})
+		require.NoError(t, err)
+		resolved, err := filepath.EvalSymlinks(elsewhere)
+		require.NoError(t, err)
+		assert.Equal(t, resolved, created.WorkingDir)
+	})
+
+	t.Run("empty runConfig.WorkingDir accepts any directory", func(t *testing.T) {
+		t.Parallel()
+		sm := newSM(&config.RuntimeConfig{})
+		created, err := sm.CreateSession(ctx, &session.Session{WorkingDir: elsewhere})
+		require.NoError(t, err)
+		resolved, err := filepath.EvalSymlinks(elsewhere)
+		require.NoError(t, err)
+		assert.Equal(t, resolved, created.WorkingDir)
+	})
+
+	t.Run("whitespace-only runConfig.WorkingDir accepts any directory", func(t *testing.T) {
+		t.Parallel()
+		sm := newSM(&config.RuntimeConfig{Config: config.Config{WorkingDir: "   "}})
+		_, err := sm.CreateSession(ctx, &session.Session{WorkingDir: elsewhere})
+		require.NoError(t, err)
+	})
+
+	t.Run("non-existent WorkingDir is still rejected", func(t *testing.T) {
+		t.Parallel()
+		sm := newSM(&config.RuntimeConfig{})
+		_, err := sm.CreateSession(ctx, &session.Session{WorkingDir: filepath.Join(elsewhere, "does-not-exist")})
+		require.Error(t, err)
+	})
+}
+
 // TestResolveWithinRoot exercises the containment helper directly.
 func TestResolveWithinRoot(t *testing.T) {
 	t.Parallel()
@@ -174,4 +221,31 @@ func TestResolveWithinRoot(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "outside the permitted root")
 	})
+}
+
+// TestResolveWithinRoot_NoRootConfigured: no root → canonicalise, no containment.
+func TestResolveWithinRoot_NoRootConfigured(t *testing.T) {
+	t.Parallel()
+
+	unrelated := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(unrelated)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name string
+		rc   *config.RuntimeConfig
+	}{
+		{"nil runConfig", nil},
+		{"empty WorkingDir", &config.RuntimeConfig{}},
+		{"whitespace WorkingDir", &config.RuntimeConfig{Config: config.Config{WorkingDir: "   "}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sm := NewSessionManager(t.Context(), config.Sources{}, session.NewInMemorySessionStore(), 0, tc.rc)
+			got, err := sm.resolveWithinRoot(unrelated)
+			require.NoError(t, err)
+			assert.Equal(t, resolved, got)
+		})
+	}
 }


### PR DESCRIPTION
## Why

#3758 added a containment check for user-supplied `working_dir` on
`POST /api/sessions`. When no `--working-dir` was configured it fell
back to `os.Getwd()` as the permitted root — i.e. the process's current
directory at launch became a hard boundary for every session.

That breaks any deployment where docker-agent runs as a long-lived
daemon and clients legitimately create sessions targeting arbitrary
paths on the host: every session outside the launch directory is
rejected with

```
working directory "…" is outside the permitted root "…"
```

`--working-dir`'s documented purpose (`cmd/root/flags.go`) is a default
cwd for tool execution — not a sandbox root. Overloading it as one
makes the check unusable for the majority of callers, who don't set it
and don't want containment.

## What changes

Make containment **opt-in**:

```
--working-dir set     → root = that path         → containment enforced
--working-dir unset   → root = ""                → path canonicalised only
```

`resolveWithinRoot` still runs `filepath.EvalSymlinks` on the candidate
in both branches, so the CodeQL data-flow that alert #57 flagged
remains broken. Multi-user / hosted deployments that need containment
opt in by passing `--working-dir`.
