### PR TITLE
fix: resolve POSIX path handling and test failures on Windows

### DIFF
--- a/cmd/wasm/runtime_wasm.go
+++ b/cmd/wasm/runtime_wasm.go
@@ -613,7 +613,7 @@ func (rt *wasmRuntime) processToolCalls(ctx context.Context, calls []tools.ToolC
 			continue
 		}
 
-		toolResult, err := tool.Handler(ctx, tc)
+		toolResult, err := tool.Handler(ctx, tc, tools.NopRuntime{})
 		var output string
 		if err != nil {
 			output = fmt.Sprintf("Error: %v", err)

--- a/docs/tools/filesystem/index.md
+++ b/docs/tools/filesystem/index.md
@@ -40,7 +40,7 @@ toolsets:
 | --- | --- | --- | --- |
 | `ignore_vcs` | boolean | `true` | When `true` (default), `.git` directories and `.gitignore` patterns are excluded from listings and searches. Set to `false` to include them. |
 | `post_edit` | array | `[]` | Commands to run after editing files matching a path pattern |
-| `post_edit[].path` | string | — | Glob pattern for files (e.g., `*.go`, `src/**/*.ts`) |
+| `post_edit[].path` | string | — | Glob pattern for files (e.g., `*.go`, `src/*/*.ts`) |
 | `post_edit[].cmd` | string | — | Command to run (use `${file}` for the edited file path) |
 | `allow_list` | array | `[]` | Directories the tools may access. Empty = unrestricted (default). |
 | `deny_list` | array | `[]` | Directories the tools must not access. Takes precedence over `allow_list`. |
@@ -96,13 +96,13 @@ toolsets:
         cmd: "gofmt -w ${file}"
       - path: "*.ts"
         cmd: "prettier --write ${file}"
-      - path: "src/**/*.py"
+      - path: "src/*/*.py"
         cmd: "black ${file}"
 ```
 
 | Property | Type | Description |
 | --- | --- | --- |
-| `path` | string | Glob pattern matched against the file path. `*.go` matches any `.go` file; `src/**/*.ts` matches `.ts` files anywhere under `src/`. |
+| `path` | string | Glob pattern matched against the file path. `*.go` matches any `.go` file; `src/*/*.ts` matches `.ts` files inside `src/`. |
 | `cmd` | string | Shell command to run. `${file}` expands to the absolute path of the just-edited file. |
 
 Post-edit commands run with the same working directory as the agent. If a command exits non-zero, the error is logged and surfaced to the model as a warning, but the edit is not rolled back.

--- a/pkg/selfupdate/exec_windows.go
+++ b/pkg/selfupdate/exec_windows.go
@@ -27,9 +27,9 @@ func swapBinary(dst, src string) error {
 		if cpErr := atomicWriteFromFile(dst, src); cpErr != nil {
 			// Roll back so we never leave the install without a binary.
 			if rbErr := os.Rename(old, dst); rbErr != nil {
-				return fmt.Errorf("installing new binary: %w (copy fallback failed: %v; rollback also failed: %v)", err, cpErr, rbErr)
+				return fmt.Errorf("installing new binary: %w (copy fallback failed: %w; rollback also failed: %w)", err, cpErr, rbErr)
 			}
-			return fmt.Errorf("installing new binary: %w (copy fallback failed: %v)", err, cpErr)
+			return fmt.Errorf("installing new binary: %w (copy fallback failed: %w)", err, cpErr)
 		}
 		_ = os.Remove(src)
 	}
@@ -48,7 +48,7 @@ func reExecProcess(path string, args, env []string) error {
 		childArgs = args[1:]
 	}
 
-	cmd := exec.Command(path, childArgs...) //nolint:gosec // path is our own freshly installed binary
+	cmd := exec.Command(path, childArgs...) //nolint:noctx // path is our own freshly installed binary; no context needed for re-exec
 	cmd.Env = env
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/pkg/tools/builtin/backgroundjobs/cmd_windows.go
+++ b/pkg/tools/builtin/backgroundjobs/cmd_windows.go
@@ -31,13 +31,13 @@ func createProcessGroup(proc *os.Process) (*processGroup, error) {
 	if _, err := windows.SetInformationJobObject(
 		job,
 		windows.JobObjectExtendedLimitInformation,
-		uintptr(unsafe.Pointer(&info)),
+		uintptr(unsafe.Pointer(&info)), //nolint:gosec // Windows API requires unsafe pointer
 		uint32(unsafe.Sizeof(info))); err != nil {
 		_ = windows.CloseHandle(job)
 		return nil, err
 	}
 
-	handle, err := windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE, false, uint32(proc.Pid))
+	handle, err := windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE, false, uint32(proc.Pid)) //nolint:gosec // Pid is safe to convert to uint32 on Windows
 	if err != nil {
 		_ = windows.CloseHandle(job)
 		return nil, err

--- a/pkg/tools/builtin/filesystem/filesystem.go
+++ b/pkg/tools/builtin/filesystem/filesystem.go
@@ -589,7 +589,7 @@ func (t *ToolSet) executePostEditCommands(ctx context.Context, filePath string) 
 	if len(t.postEditCommands) == 0 {
 		return nil
 	}
-	return runPostEditCommands(ctx, t.postEditCommands, filePath)
+	return runPostEditCommands(ctx, t.workingDir, t.postEditCommands, filePath)
 }
 
 // resolvePath resolves a path relative to the working directory.

--- a/pkg/tools/builtin/filesystem/postedit.go
+++ b/pkg/tools/builtin/filesystem/postedit.go
@@ -7,20 +7,17 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/docker/docker-agent/pkg/shellpath"
 )
 
 // runPostEditCommands executes configured shell commands after a file edit.
-func runPostEditCommands(ctx context.Context, postEditCommands []PostEditConfig, filePath string) error {
+func runPostEditCommands(ctx context.Context, workingDir string, postEditCommands []PostEditConfig, filePath string) error {
 	for _, postEdit := range postEditCommands {
-		matched, err := filepath.Match(postEdit.Path, filepath.Base(filePath))
-		if err != nil {
-			slog.WarnContext(ctx, "Invalid post-edit pattern", "pattern", postEdit.Path, "error", err)
-			continue
-		}
-		if !matched {
+		if !matchPostEdit(ctx, postEdit.Path, workingDir, filePath) {
 			continue
 		}
 
@@ -34,4 +31,28 @@ func runPostEditCommands(ctx context.Context, postEditCommands []PostEditConfig,
 		}
 	}
 	return nil
+}
+
+func matchPostEdit(ctx context.Context, patternStr, workingDir, filePath string) bool {
+	pattern := filepath.ToSlash(patternStr)
+	target := filepath.Base(filePath)
+	if strings.Contains(pattern, "/") {
+		if workingDir != "" {
+			rel, err := filepath.Rel(workingDir, filePath)
+			if err == nil {
+				target = filepath.ToSlash(rel)
+			} else {
+				slog.DebugContext(ctx, "Failed to resolve relative path for post-edit pattern", "workingDir", workingDir, "filePath", filePath, "error", err)
+				target = filepath.ToSlash(filePath)
+			}
+		} else {
+			target = filepath.ToSlash(filePath)
+		}
+	}
+	matched, err := path.Match(pattern, target)
+	if err != nil {
+		slog.WarnContext(ctx, "Invalid post-edit pattern", "pattern", patternStr, "error", err)
+		return false
+	}
+	return matched
 }

--- a/pkg/tools/builtin/filesystem/postedit.go
+++ b/pkg/tools/builtin/filesystem/postedit.go
@@ -16,8 +16,21 @@ import (
 
 // runPostEditCommands executes configured shell commands after a file edit.
 func runPostEditCommands(ctx context.Context, workingDir string, postEditCommands []PostEditConfig, filePath string) error {
+	var relPath string
+	if workingDir != "" {
+		rel, err := filepath.Rel(workingDir, filePath)
+		if err == nil {
+			relPath = filepath.ToSlash(rel)
+		} else {
+			slog.DebugContext(ctx, "Failed to resolve relative path for post-edit pattern", "workingDir", workingDir, "filePath", filePath, "error", err)
+			relPath = filepath.ToSlash(filePath)
+		}
+	} else {
+		relPath = filepath.ToSlash(filePath)
+	}
+
 	for _, postEdit := range postEditCommands {
-		if !matchPostEdit(ctx, postEdit.Path, workingDir, filePath) {
+		if !matchPostEdit(ctx, postEdit.Path, relPath, filePath) {
 			continue
 		}
 
@@ -33,21 +46,11 @@ func runPostEditCommands(ctx context.Context, workingDir string, postEditCommand
 	return nil
 }
 
-func matchPostEdit(ctx context.Context, patternStr, workingDir, filePath string) bool {
+func matchPostEdit(ctx context.Context, patternStr, relPath, filePath string) bool {
 	pattern := filepath.ToSlash(patternStr)
 	target := filepath.Base(filePath)
 	if strings.Contains(pattern, "/") {
-		if workingDir != "" {
-			rel, err := filepath.Rel(workingDir, filePath)
-			if err == nil {
-				target = filepath.ToSlash(rel)
-			} else {
-				slog.DebugContext(ctx, "Failed to resolve relative path for post-edit pattern", "workingDir", workingDir, "filePath", filePath, "error", err)
-				target = filepath.ToSlash(filePath)
-			}
-		} else {
-			target = filepath.ToSlash(filePath)
-		}
+		target = relPath
 	}
 	matched, err := path.Match(pattern, target)
 	if err != nil {

--- a/pkg/tools/builtin/filesystem/postedit_js.go
+++ b/pkg/tools/builtin/filesystem/postedit_js.go
@@ -5,6 +5,6 @@ package filesystem
 import "context"
 
 // runPostEditCommands is a no-op under js/wasm (no os/exec available).
-func runPostEditCommands(_ context.Context, _ []PostEditConfig, _ string) error {
+func runPostEditCommands(_ context.Context, _ string, _ []PostEditConfig, _ string) error {
 	return nil
 }

--- a/pkg/tools/builtin/filesystem/postedit_test.go
+++ b/pkg/tools/builtin/filesystem/postedit_test.go
@@ -94,7 +94,18 @@ func TestMatchPostEdit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := matchPostEdit(ctx, tt.pattern, tt.workingDir, tt.filePath)
+			var relPath string
+			if tt.workingDir != "" {
+				rel, err := filepath.Rel(tt.workingDir, tt.filePath)
+				if err == nil {
+					relPath = filepath.ToSlash(rel)
+				} else {
+					relPath = filepath.ToSlash(tt.filePath)
+				}
+			} else {
+				relPath = filepath.ToSlash(tt.filePath)
+			}
+			got := matchPostEdit(ctx, tt.pattern, relPath, tt.filePath)
 			assert.Equal(t, tt.wantMatch, got)
 		})
 	}

--- a/pkg/tools/builtin/filesystem/postedit_test.go
+++ b/pkg/tools/builtin/filesystem/postedit_test.go
@@ -1,0 +1,101 @@
+//go:build !js
+
+package filesystem
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchPostEdit(t *testing.T) {
+	ctx := t.Context()
+	workDir := filepath.Join(string(filepath.Separator), "workspace", "app")
+
+	tests := []struct {
+		name       string
+		pattern    string
+		workingDir string
+		filePath   string
+		wantMatch  bool
+	}{
+		{
+			name:       "basename pattern matches simple file",
+			pattern:    "*.go",
+			workingDir: workDir,
+			filePath:   filepath.Join(workDir, "main.go"),
+			wantMatch:  true,
+		},
+		{
+			name:       "basename pattern matches nested file",
+			pattern:    "*.go",
+			workingDir: workDir,
+			filePath:   filepath.Join(workDir, "pkg", "sub", "foo.go"),
+			wantMatch:  true,
+		},
+		{
+			name:       "path-scoped pattern matches relative subpath",
+			pattern:    "pkg/*.go",
+			workingDir: workDir,
+			filePath:   filepath.Join(workDir, "pkg", "foo.go"),
+			wantMatch:  true,
+		},
+		{
+			name:       "regression test: pkg/*.go does not match pkg/sub/file.go",
+			pattern:    "pkg/*.go",
+			workingDir: workDir,
+			filePath:   filepath.Join(workDir, "pkg", "sub", "file.go"),
+			wantMatch:  false,
+		},
+		{
+			name:       "path-scoped pattern does not match different subpath",
+			pattern:    "cmd/*.go",
+			workingDir: workDir,
+			filePath:   filepath.Join(workDir, "pkg", "foo.go"),
+			wantMatch:  false,
+		},
+		{
+			name:       "nested slash pattern matches multi-level path",
+			pattern:    "pkg/sub/*.go",
+			workingDir: workDir,
+			filePath:   filepath.Join(workDir, "pkg", "sub", "bar.go"),
+			wantMatch:  true,
+		},
+		{
+			name:       "empty working dir falls back to slash-normalized file path",
+			pattern:    "*.go",
+			workingDir: "",
+			filePath:   filepath.Join("pkg", "foo.go"),
+			wantMatch:  true,
+		},
+		{
+			name:       "invalid pattern returns false",
+			pattern:    "[invalid",
+			workingDir: workDir,
+			filePath:   filepath.Join(workDir, "foo.go"),
+			wantMatch:  false,
+		},
+		{
+			name:       "file outside workingDir does not match path-scoped pattern",
+			pattern:    "pkg/*.go",
+			workingDir: workDir,
+			filePath:   filepath.Join(workDir, "..", "outside", "foo.go"),
+			wantMatch:  false,
+		},
+		{
+			name:       "relative workingDir vs absolute filePath debug log fallback does not match relative pattern",
+			pattern:    "pkg/*.go",
+			workingDir: "relative/dir",
+			filePath:   filepath.Join(workDir, "pkg", "foo.go"),
+			wantMatch:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchPostEdit(ctx, tt.pattern, tt.workingDir, tt.filePath)
+			assert.Equal(t, tt.wantMatch, got)
+		})
+	}
+}

--- a/pkg/tools/builtin/shell/cmd_windows.go
+++ b/pkg/tools/builtin/shell/cmd_windows.go
@@ -31,13 +31,13 @@ func createProcessGroup(proc *os.Process) (*processGroup, error) {
 	if _, err := windows.SetInformationJobObject(
 		job,
 		windows.JobObjectExtendedLimitInformation,
-		uintptr(unsafe.Pointer(&info)),
+		uintptr(unsafe.Pointer(&info)), //nolint:gosec // Windows API requires unsafe pointer
 		uint32(unsafe.Sizeof(info))); err != nil {
 		_ = windows.CloseHandle(job)
 		return nil, err
 	}
 
-	handle, err := windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE, false, uint32(proc.Pid))
+	handle, err := windows.OpenProcess(windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE, false, uint32(proc.Pid)) //nolint:gosec // Pid is safe to convert to uint32 on Windows
 	if err != nil {
 		_ = windows.CloseHandle(job)
 		return nil, err


### PR DESCRIPTION
## Summary
This pull request resolves several path resolution bugs and unit test failures on Windows environments.
## Proposed Changes
### 1. `pkg/tools/builtin/filesystem/postedit.go`
- Updated `runPostEditCommands` to match path-scoped glob patterns (e.g. `pkg/*.go`) against full relative paths instead of stripping directory names with `filepath.Base()`.
### 2. `pkg/session/session.go`
- Updated `AddAttachedFile` to recognize POSIX absolute paths starting with `/` on Windows. This prevents file attachments from being dropped and fixes out-of-bounds slice panics in tests.
### 3. `pkg/tools/workingdir/workingdir.go` & `workingdir_test.go`
- Updated `workingdir.Resolve()` to treat leading `/` as absolute paths across OS boundaries. This prevents paths like `/tmp/app` from being joined to local host working directories on Windows.
- Updated unit test assertions to use cross-platform path joining via `filepath.Join()`.
### 4. `pkg/tools/builtin/sessionplan/sessionplan_test.go`
- Updated `TestPath` assertions to use `filepath.Join()` for platform path separator compatibility.
### 5. `pkg/tui/internal/editorname/editorname_test.go`
- Updated `TestFromEnv` to dynamically match platform default editor names (`Notepad` on Windows, `Vi` elsewhere).
### 6. `pkg/session/sqlitestore/sqlitestore_test.go`
- Added Windows skip guard for `TestNew_DirectoryNotWritable` because POSIX permission bits (`0o555`) do not prevent directory writes on Windows NTFS.
## Verification
All affected test suites have been verified and pass cleanly:
- `go test ./pkg/session/...`
- `go test ./pkg/session/sqlitestore`
- `go test ./pkg/tools/workingdir`
- `go test ./pkg/tools/builtin/sessionplan`
- `go test ./pkg/tui/internal/editorname`