### PR TITLE
fix(cli): add GitHub Copilot to setup and doctor

### DIFF
--- a/cmd/root/doctor_test.go
+++ b/cmd/root/doctor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/codingharness"
+	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/model/provider/dmr"
@@ -290,6 +291,33 @@ func TestDoctorCommand_JSON(t *testing.T) {
 	assert.Equal(t, "OPENAI_API_KEY", byProvider["openai"].EnvVar)
 	assert.Equal(t, "environment", byProvider["openai"].Source)
 	assert.False(t, byProvider["anthropic"].Found)
+}
+
+func TestDoctorCommand_JSONReportsGitHubCopilot(t *testing.T) {
+	t.Parallel()
+
+	output, err := executeDoctor(t, []string{"--json"}, withDoctorTestEnv(
+		map[string]string{"GH_TOKEN": "gh-token"},
+		[]string{"ai/qwen3:latest"}, nil))
+
+	require.NoError(t, err)
+	assert.NotContains(t, output, "gh-token", "secret values must never be printed")
+
+	var report doctorReport
+	require.NoError(t, json.Unmarshal([]byte(output), &report))
+
+	byProvider := map[string]doctorProviderStatus{}
+	for _, p := range report.Providers {
+		byProvider[p.Provider] = p
+	}
+
+	copilot := byProvider["github-copilot"]
+	assert.True(t, copilot.Found)
+	assert.Equal(t, []string{"GITHUB_TOKEN", "GH_TOKEN"}, copilot.EnvVars)
+	assert.Equal(t, "GH_TOKEN", copilot.EnvVar)
+	assert.Equal(t, "environment", copilot.Source)
+	assert.Equal(t, "github-copilot", report.AutoModel.Provider)
+	assert.Equal(t, config.DefaultModels["github-copilot"], report.AutoModel.Model)
 }
 
 func writeDoctorAgentFile(t *testing.T) string {

--- a/cmd/root/setup_test.go
+++ b/cmd/root/setup_test.go
@@ -201,6 +201,26 @@ func TestSetupWizard_ChatGPTPathRunsBrowserSignIn(t *testing.T) {
 	assert.Contains(t, output, "--model chatgpt/"+config.DefaultModels["chatgpt"])
 }
 
+func TestSetupWizard_CloudPathOffersGitHubCopilot(t *testing.T) {
+	t.Parallel()
+
+	providers := config.CloudProviderEnvVars()
+	idx := slices.IndexFunc(providers, func(p config.ProviderEnvVars) bool { return p.Provider == "github-copilot" })
+	require.GreaterOrEqual(t, idx, 0, "github-copilot must be offered by the wizard")
+
+	store := &fakeSecretStore{name: "config-env-file"}
+	wizard, out, _ := newTestWizard(fmt.Sprintf("1\n%d\n", idx+1), []string{"ghp-token"}, []environment.SecretStore{store}, nil, nil)
+
+	result, err := wizard.run(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, "GITHUB_TOKEN", result.EnvVar)
+	assert.Equal(t, "ghp-token", store.stored["GITHUB_TOKEN"])
+	assert.Equal(t, "github-copilot/"+config.DefaultModels["github-copilot"], result.Model)
+	assert.Contains(t, out.String(), "github-copilot")
+	assert.Contains(t, out.String(), "GITHUB_TOKEN")
+}
+
 func TestSetupWizard_LocalPathWithPulledModels(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/auto.go
+++ b/pkg/config/auto.go
@@ -53,6 +53,7 @@ var cloudProviders = []providerConfig{
 	// source. It is ordered after openai so adding a ChatGPT sign-in never
 	// changes auto-selection for users that already export OPENAI_API_KEY.
 	{"chatgpt", []string{chatgpt.TokenEnvVar}, "sign in with your ChatGPT account: `docker agent setup`", ""},
+	{"github-copilot", []string{"GITHUB_TOKEN", "GH_TOKEN"}, "GITHUB_TOKEN (or GH_TOKEN)", ""},
 	{"google", []string{
 		"GOOGLE_API_KEY",
 		"GEMINI_API_KEY",
@@ -150,6 +151,7 @@ func (e *AutoModelFallbackError) Unwrap() error { return e.Cause }
 var DefaultModels = map[string]string{
 	"openai":         "gpt-5.6",
 	"chatgpt":        "gpt-5.6",
+	"github-copilot": "gpt-5.6",
 	"anthropic":      "claude-sonnet-4-6",
 	"google":         "gemini-3.5-flash",
 	"dmr":            "ai/qwen3:latest",

--- a/pkg/config/auto_test.go
+++ b/pkg/config/auto_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/chatgpt"
 	"github.com/docker/docker-agent/pkg/config/latest"
@@ -35,6 +36,20 @@ func TestAvailableProviders_NoGateway(t *testing.T) {
 				"OPENAI_API_KEY": "test-key",
 			},
 			expectedProvider: "openai",
+		},
+		{
+			name: "github copilot github token present",
+			envVars: map[string]string{
+				"GITHUB_TOKEN": "test-token",
+			},
+			expectedProvider: "github-copilot",
+		},
+		{
+			name: "github copilot gh token present",
+			envVars: map[string]string{
+				"GH_TOKEN": "test-token",
+			},
+			expectedProvider: "github-copilot",
 		},
 		{
 			name: "google api key present",
@@ -461,7 +476,7 @@ func TestDefaultModels(t *testing.T) {
 	t.Parallel()
 
 	// Test that DefaultModels map has all expected providers
-	expectedProviders := []string{"openai", "anthropic", "google", "dmr", "mistral", "openrouter", "baseten", "ovhcloud", "groq", "fireworks", "deepseek", "cerebras", "together", "huggingface", "moonshot", "vercel", "amazon-bedrock", "opencode-zen", "opencode-go"}
+	expectedProviders := []string{"openai", "anthropic", "google", "dmr", "mistral", "openrouter", "baseten", "ovhcloud", "groq", "fireworks", "deepseek", "cerebras", "together", "huggingface", "moonshot", "vercel", "amazon-bedrock", "opencode-zen", "opencode-go", "github-copilot"}
 
 	for _, provider := range expectedProviders {
 		t.Run(provider, func(t *testing.T) {
@@ -473,6 +488,7 @@ func TestDefaultModels(t *testing.T) {
 
 	// Test specific model values
 	assert.Equal(t, "gpt-5.6", DefaultModels["openai"])
+	assert.Equal(t, "gpt-5.6", DefaultModels["github-copilot"])
 	assert.Equal(t, "claude-sonnet-4-6", DefaultModels["anthropic"])
 	assert.Equal(t, "gemini-3.5-flash", DefaultModels["google"])
 	assert.Equal(t, "ai/qwen3:latest", DefaultModels["dmr"])
@@ -497,7 +513,7 @@ func TestAutoModelConfig_IntegrationWithDefaultModels(t *testing.T) {
 	t.Parallel()
 
 	// Verify that AutoModelConfig always returns a model from DefaultModels
-	providers := []string{"openai", "anthropic", "google", "mistral", "openrouter", "baseten", "ovhcloud", "groq", "fireworks", "deepseek", "cerebras", "together", "huggingface", "moonshot", "vercel", "opencode-zen"}
+	providers := []string{"openai", "anthropic", "google", "mistral", "openrouter", "baseten", "ovhcloud", "groq", "fireworks", "deepseek", "cerebras", "together", "huggingface", "moonshot", "vercel", "opencode-zen", "github-copilot"}
 
 	for _, provider := range providers {
 		t.Run(provider, func(t *testing.T) {
@@ -509,6 +525,8 @@ func TestAutoModelConfig_IntegrationWithDefaultModels(t *testing.T) {
 			switch provider {
 			case "openai":
 				envVars["OPENAI_API_KEY"] = "test-key"
+			case "github-copilot":
+				envVars["GITHUB_TOKEN"] = "test-key"
 			case "anthropic":
 				envVars["ANTHROPIC_API_KEY"] = "test-key"
 			case "google":
@@ -1132,6 +1150,7 @@ func TestProviderAPIKeyEnvVars(t *testing.T) {
 
 	// Broad, general-purpose tokens must not be forwarded as model credentials.
 	assert.NotContains(t, vars, "GITHUB_TOKEN")
+	assert.NotContains(t, vars, "GH_TOKEN")
 
 	// The ChatGPT OAuth access token is a subscription credential, not an
 	// API key, and must never be forwarded into isolated environments.
@@ -1154,4 +1173,10 @@ func TestCloudProviderEnvVars(t *testing.T) {
 	// Mutating the returned slices must not corrupt the package table.
 	providers[0].EnvVars[0] = "MUTATED"
 	assert.NotEqual(t, "MUTATED", cloudProviders[0].envVars[0])
+
+	copilotIdx := slices.IndexFunc(providers, func(p ProviderEnvVars) bool {
+		return p.Provider == "github-copilot"
+	})
+	require.GreaterOrEqual(t, copilotIdx, 0)
+	assert.Equal(t, []string{"GITHUB_TOKEN", "GH_TOKEN"}, providers[copilotIdx].EnvVars)
 }

--- a/pkg/config/gather.go
+++ b/pkg/config/gather.go
@@ -244,7 +244,11 @@ func addEnvVarsForModelConfig(ctx context.Context, model *latest.ModelConfig, cu
 	if alias, exists := provider.LookupAlias(model.Provider); exists {
 		// Check built-in aliases
 		if alias.TokenEnvVar != "" {
-			requiredEnv[alias.TokenEnvVar] = true
+			if model.Provider == "github-copilot" {
+				requiredEnv[githubCopilotTokenEnvVar(ctx, env)] = true
+			} else {
+				requiredEnv[alias.TokenEnvVar] = true
+			}
 		}
 		// A templated alias base URL (e.g. Cloudflare's account/gateway-scoped
 		// endpoint) references env vars that must resolve when the provider is
@@ -255,6 +259,16 @@ func addEnvVarsForModelConfig(ctx context.Context, model *latest.ModelConfig, cu
 	} else {
 		addEnvVarsForCoreProvider(ctx, model.Provider, model, requiredEnv, env)
 	}
+}
+
+func githubCopilotTokenEnvVar(ctx context.Context, env environment.Provider) string {
+	if value, _ := env.Get(ctx, "GITHUB_TOKEN"); value != "" {
+		return "GITHUB_TOKEN"
+	}
+	if value, _ := env.Get(ctx, "GH_TOKEN"); value != "" {
+		return "GH_TOKEN"
+	}
+	return "GITHUB_TOKEN"
 }
 
 // addEnvVarsForCoreProvider adds the required env vars for a core provider type.

--- a/pkg/config/gather_alias_env_test.go
+++ b/pkg/config/gather_alias_env_test.go
@@ -52,3 +52,21 @@ func TestGatherEnvVarsForModels_TemplatedAliasBaseURL(t *testing.T) {
 		})
 	}
 }
+
+func TestGatherEnvVarsForModels_GitHubCopilotAcceptsGHToken(t *testing.T) {
+	t.Parallel()
+
+	cfg := &latest.Config{
+		Agents: []latest.AgentConfig{{Name: "a", Model: "m"}},
+		Models: map[string]latest.ModelConfig{
+			"m": {Provider: "github-copilot", Model: "gpt-4.1"},
+		},
+	}
+
+	got := GatherEnvVarsForModels(t.Context(), cfg, environment.NewMapEnvProvider(map[string]string{
+		"GH_TOKEN": "gh-token",
+	}))
+
+	assert.Contains(t, got, "GH_TOKEN")
+	assert.NotContains(t, got, "GITHUB_TOKEN")
+}

--- a/pkg/model/provider/openai/client.go
+++ b/pkg/model/provider/openai/client.go
@@ -77,9 +77,12 @@ func NewClient(ctx context.Context, cfg *latest.ModelConfig, env environment.Pro
 			)
 		case cfg.TokenKey != "":
 			// Explicit token_key configured - use that env var
-			authToken, _ := env.Get(ctx, cfg.TokenKey)
+			authToken, tokenKey := authTokenForTokenKey(ctx, cfg, env)
 			if authToken == "" {
-				return nil, fmt.Errorf("%s environment variable is required", cfg.TokenKey)
+				if cfg.Provider == "github-copilot" && cfg.TokenKey == "GITHUB_TOKEN" {
+					return nil, errors.New("GITHUB_TOKEN or GH_TOKEN environment variable is required")
+				}
+				return nil, fmt.Errorf("%s environment variable is required", tokenKey)
 			}
 			clientOptions = append(clientOptions, option.WithAPIKey(authToken))
 		case isCustomProvider(cfg):
@@ -820,7 +823,7 @@ func (c *Client) buildWSHeaderFn() func(ctx context.Context) (http.Header, error
 		// Resolve the API key using the same logic as the HTTP client.
 		var apiKey string
 		if c.ModelConfig.TokenKey != "" {
-			apiKey, _ = c.Env.Get(ctx, c.ModelConfig.TokenKey)
+			apiKey, _ = authTokenForTokenKey(ctx, &c.ModelConfig, c.Env)
 		}
 		if apiKey == "" {
 			// Fall back to the standard OPENAI_API_KEY env var via the
@@ -841,6 +844,16 @@ func (c *Client) buildWSHeaderFn() func(ctx context.Context) (http.Header, error
 
 		return h, nil
 	}
+}
+
+func authTokenForTokenKey(ctx context.Context, cfg *latest.ModelConfig, env environment.Provider) (string, string) {
+	token, _ := env.Get(ctx, cfg.TokenKey)
+	if token == "" && cfg.Provider == "github-copilot" && cfg.TokenKey == "GITHUB_TOKEN" {
+		if fallback, _ := env.Get(ctx, "GH_TOKEN"); fallback != "" {
+			return fallback, "GH_TOKEN"
+		}
+	}
+	return token, cfg.TokenKey
 }
 
 // getTransport returns the streaming transport preference from ProviderOpts.

--- a/pkg/model/provider/openai/client_auth_test.go
+++ b/pkg/model/provider/openai/client_auth_test.go
@@ -95,3 +95,41 @@ func TestNewClient_NoTokenKeyFallsBackToOSEnv(t *testing.T) {
 
 	assert.Equal(t, "Bearer os-env-key", gotAuth)
 }
+
+func TestNewClient_GitHubCopilotFallsBackToGHToken(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		writeSSEResponse(w)
+	}))
+	defer server.Close()
+
+	cfg := &latest.ModelConfig{
+		Provider: "github-copilot",
+		Model:    "gpt-4.1",
+		BaseURL:  server.URL,
+		TokenKey: "GITHUB_TOKEN",
+	}
+	env := environment.NewMapEnvProvider(map[string]string{
+		"GH_TOKEN": "gh-token",
+	})
+
+	client, err := NewClient(t.Context(), cfg, env)
+	require.NoError(t, err)
+
+	stream, err := client.CreateChatCompletionStream(t.Context(), []chat.Message{
+		{Role: chat.MessageRoleUser, Content: "hello"},
+	}, nil)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	for {
+		if _, err := stream.Recv(); err != nil {
+			break
+		}
+	}
+
+	assert.Equal(t, "Bearer gh-token", gotAuth)
+}


### PR DESCRIPTION
## Summary
- add github-copilot to the cloud provider list used by setup, doctor, and auto-selection
- recognize both GITHUB_TOKEN and GH_TOKEN for GitHub Copilot diagnostics
- fall back to GH_TOKEN when constructing the GitHub Copilot OpenAI-compatible client

Closes #3780

## Tests
- env GOCACHE=/Users/kuifangwu/Projects/docker-agent/.gocache GOMODCACHE=/Users/kuifangwu/Projects/docker-agent/.gomodcache go test ./pkg/config ./cmd/root ./pkg/model/provider/openai