### PR TITLE
feat(config): make oauth clientId optional for remote MCP toolsets

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -3089,11 +3089,11 @@
     },
     "RemoteOAuthConfig": {
       "type": "object",
-      "description": "OAuth configuration for remote MCP servers that do not support Dynamic Client Registration (RFC 7591)",
+      "description": "OAuth configuration for remote MCP servers. Set clientId for servers that do not support Dynamic Client Registration (RFC 7591); other fields tune the flow and also apply when the client is registered dynamically",
       "properties": {
         "clientId": {
           "type": "string",
-          "description": "OAuth client ID"
+          "description": "OAuth client ID. When omitted, docker-agent uses Dynamic Client Registration or prompts interactively"
         },
         "clientSecret": {
           "type": "string",
@@ -3116,10 +3116,7 @@
           "type": "string",
           "description": "Optional OAuth redirect URI used in place of http://127.0.0.1:{callbackPort}/callback. The literal placeholder ${callbackPort} is replaced with the actual local callback port at runtime. The external URL is expected to redirect the browser back to the local callback server."
         }
-      },
-      "required": [
-        "clientId"
-      ]
+      }
     }
   }
 }

--- a/docs/features/remote-mcp/index.md
+++ b/docs/features/remote-mcp/index.md
@@ -116,13 +116,16 @@ toolsets:
 
 | Field          | Type            | Required | Description                                                                                      |
 | -------------- | --------------- | -------- | ------------------------------------------------------------------------------------------------ |
-| `clientId`     | string          | ✓        | OAuth client ID registered with the remote MCP server.                                           |
-| `clientSecret` | string          | ✗        | OAuth client secret. Omit for public clients using PKCE.                                         |
+| `clientId`     | string          | ✗        | OAuth client ID registered with the remote MCP server. When omitted, Docker Agent uses Dynamic Client Registration or prompts interactively. |
+| `clientSecret` | string          | ✗        | OAuth client secret. Requires `clientId`. Omit for public clients using PKCE.                    |
 | `callbackPort` | integer         | ✗        | Local port to receive the OAuth redirect. If omitted, Docker Agent picks a random free port.    |
 | `scopes`       | array[string]   | ✗        | Scopes to request during the authorization step. Values are server-specific.                     |
 | `callbackRedirectURL` | string   | ✗        | Custom OAuth redirect URI. Useful when the auth server requires HTTPS or a pre-registered URL. The literal placeholder `${callbackPort}` is replaced with the actual local callback port. See below.            |
 
 Secrets should be stored in a credential helper or environment variable rather than committed — see [Secrets](../../guides/secrets/index.md) for interpolation patterns.
+
+> [!TIP]
+> The `oauth:` block also works **without** `clientId`. Use it to pin the callback port, request specific scopes, or set a custom redirect URL while still letting Docker Agent obtain the client ID via Dynamic Client Registration (or the interactive prompt).
 
 ### Custom redirect URI (`callbackRedirectURL`)
 

--- a/examples/atlassian-expert.yaml
+++ b/examples/atlassian-expert.yaml
@@ -13,3 +13,5 @@ agents:
         remote:
           url: https://mcp.atlassian.com/v1/mcp/authv2
           transport_type: streamable
+          oauth:
+            callbackRedirectURL: "https://ai-backend-service.docker.com/callback?port=${callbackPort}"

--- a/pkg/config/latest/types.go
+++ b/pkg/config/latest/types.go
@@ -1664,8 +1664,11 @@ type Remote struct {
 	OAuth         *RemoteOAuthConfig `json:"oauth,omitempty"`
 }
 
-// RemoteOAuthConfig holds explicit OAuth credentials for remote MCP servers
-// that do not support Dynamic Client Registration (RFC 7591).
+// RemoteOAuthConfig tunes the OAuth flow for remote MCP servers. ClientID
+// (and optional ClientSecret) supply explicit credentials for servers that
+// do not support Dynamic Client Registration (RFC 7591); when ClientID is
+// omitted, docker-agent falls back to DCR or an interactive prompt while
+// still honoring CallbackPort, Scopes and CallbackRedirectURL.
 type RemoteOAuthConfig struct {
 	ClientID     string   `json:"clientId"`
 	ClientSecret string   `json:"clientSecret,omitempty"`

--- a/pkg/config/latest/validate.go
+++ b/pkg/config/latest/validate.go
@@ -396,8 +396,8 @@ func (t *Toolset) validate() error {
 			if t.Remote.URL == "" {
 				return errors.New("oauth requires remote url to be set")
 			}
-			if t.Remote.OAuth.ClientID == "" {
-				return errors.New("oauth requires clientId to be set")
+			if t.Remote.OAuth.ClientID == "" && t.Remote.OAuth.ClientSecret != "" {
+				return errors.New("oauth clientSecret requires clientId to be set")
 			}
 			if t.Remote.OAuth.CallbackPort != 0 && (t.Remote.OAuth.CallbackPort < 1 || t.Remote.OAuth.CallbackPort > 65535) {
 				return errors.New("oauth callbackPort must be between 1 and 65535")

--- a/pkg/config/latest/validate_test.go
+++ b/pkg/config/latest/validate_test.go
@@ -267,7 +267,9 @@ func TestToolsetValidateOAuth(t *testing.T) {
 	}{
 		{name: "minimal oauth", toolset: remote(&RemoteOAuthConfig{ClientID: "client"})},
 		{name: "oauth without remote url", toolset: Toolset{Type: "mcp", Command: "server", Remote: Remote{OAuth: &RemoteOAuthConfig{ClientID: "client"}}}, wantErr: "oauth requires remote url to be set"},
-		{name: "missing clientId", toolset: remote(&RemoteOAuthConfig{}), wantErr: "oauth requires clientId to be set"},
+		{name: "missing clientId falls back to dynamic registration", toolset: remote(&RemoteOAuthConfig{})},
+		{name: "clientSecret without clientId", toolset: remote(&RemoteOAuthConfig{ClientSecret: "secret"}), wantErr: "oauth clientSecret requires clientId to be set"},
+		{name: "callback settings without clientId", toolset: remote(&RemoteOAuthConfig{CallbackPort: 8765, CallbackRedirectURL: "https://redirect.example.com/cb"})},
 		{name: "callback port unset", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackPort: 0})},
 		{name: "callback port lower bound", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackPort: 1})},
 		{name: "callback port upper bound", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackPort: 65535})},


### PR DESCRIPTION
Some OAuth providers support Dynamic Client Registration (RFC 7591) or an interactive credential prompt, so hard-requiring `clientId` in the remote MCP `oauth` block prevents users from using those flows even though the runtime already handles them. It also blocked a common pattern where you want to pin the callback port or supply a custom redirect URL without pre-registering a client.

This change drops `clientId` from the `required` list in both the JSON schema and the `latest` config package. When `clientId` is absent, the runtime falls back to dynamic registration or prompts interactively; `callbackPort`, `scopes`, and `callbackRedirectURL` continue to be honored as before. As a guard-rail, specifying `clientSecret` without a `clientId` is now rejected with a clear validation error, since a secret is meaningless without a corresponding client identity. Frozen older config versions (`v0`, `v1`, …) are untouched.

The docs and the `atlassian-expert` example have been updated to reflect the new optionality.