### PR TITLE
fix(tui): keep copy label background under "copied" flash

### DIFF
--- a/pkg/tui/components/messages/copyfeedback.go
+++ b/pkg/tui/components/messages/copyfeedback.go
@@ -1,11 +1,11 @@
 package messages
 
 import (
+	"image/color"
 	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/docker/docker-agent/pkg/tui/components/markdown"
@@ -80,11 +80,10 @@ func (m *model) applyCopiedFlash(lines []string, viewportStartLine int) []string
 	end := start + ansi.StringWidth(label)
 
 	style := styles.SuccessStyle.Bold(true)
-	if f.codeBlock {
-		// Keep the code block's background band intact behind the swap.
-		if bg := styles.MarkdownStyle().CodeBlock.BackgroundColor; bg != nil {
-			style = style.Background(lipgloss.Color(*bg))
-		}
+	// Keep whatever band the copy label sat on (user message background,
+	// code block background) intact behind the swap.
+	if bg := backgroundAt(line, start); bg != nil {
+		style = style.Background(bg)
 	}
 
 	result := make([]string, len(lines))
@@ -93,4 +92,51 @@ func (m *model) applyCopiedFlash(lines []string, viewportStartLine int) []string
 		style.Render(types.CopiedFeedbackLabel) +
 		ansi.Cut(line, end, ansi.StringWidth(plain))
 	return result
+}
+
+// backgroundAt returns the SGR background color in effect at the given cell
+// column of a rendered line, or nil when none is set.
+func backgroundAt(line string, col int) color.Color {
+	p := ansi.GetParser()
+	defer ansi.PutParser(p)
+
+	var bg color.Color
+	var state byte
+	for w := 0; line != "" && w <= col; {
+		seq, width, n, newState := ansi.DecodeSequence(line, state, p)
+		if ansi.HasCsiPrefix(seq) && p.Command() == 'm' {
+			bg = applySGRBackground(bg, p.Params())
+		}
+		w += width
+		state = newState
+		line = line[n:]
+	}
+	return bg
+}
+
+// applySGRBackground folds one SGR sequence's background-related parameters
+// into the current background, ignoring everything else.
+func applySGRBackground(bg color.Color, params ansi.Params) color.Color {
+	if len(params) == 0 {
+		return nil // bare ESC[m is a full reset
+	}
+	for i := 0; i < len(params); i++ {
+		switch param := params[i].Param(0); {
+		case param == 0 || param == 49:
+			bg = nil
+		case param >= 40 && param <= 47:
+			bg = ansi.Black + ansi.BasicColor(param-40)
+		case param >= 100 && param <= 107:
+			bg = ansi.BrightBlack + ansi.BasicColor(param-100)
+		case param == 48:
+			var c color.Color
+			n := ansi.ReadStyleColor(params[i:], &c)
+			if n == 0 {
+				return bg // malformed extended color; stop parsing this sequence
+			}
+			bg = c
+			i += n - 1
+		}
+	}
+	return bg
 }

--- a/pkg/tui/components/messages/copyfeedback_test.go
+++ b/pkg/tui/components/messages/copyfeedback_test.go
@@ -1,0 +1,92 @@
+package messages
+
+import (
+	"image/color"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/tui/components/markdown"
+	"github.com/docker/docker-agent/pkg/tui/service"
+	"github.com/docker/docker-agent/pkg/tui/types"
+)
+
+// The transient "copied" confirmation must keep the background band the copy
+// label sat on: the user message band and the code block band.
+func TestCopiedFlashKeepsUserMessageBackground(t *testing.T) {
+	t.Parallel()
+
+	sessionPos := 0
+	userMsg := &types.Message{
+		Type:            types.MessageTypeUser,
+		Content:         "copy me",
+		SessionPosition: &sessionPos,
+	}
+	m := hoverActionModel(t, userMsg)
+	m.handleMouseMotion(tea.MouseMotionMsg{X: 5, Y: 1})
+	m.View()
+
+	line, col := findLabel(t, m, types.MessageCopyLabel)
+	wantBg := backgroundAt(strings.Split(m.View(), "\n")[line], col)
+	require.NotNil(t, wantBg, "the user message copy label must sit on a background band")
+
+	m.handleMouseClick(tea.MouseClickMsg{X: col, Y: line, Button: tea.MouseLeft})
+
+	after := strings.Split(m.View(), "\n")[line]
+	require.Contains(t, ansi.Strip(after), types.CopiedFeedbackLabel)
+	assert.Equal(t, wantBg, backgroundAt(after, col),
+		"the copied label must keep the copy label's background")
+}
+
+func TestCopiedFlashKeepsCodeBlockBackground(t *testing.T) {
+	t.Parallel()
+
+	m := NewScrollableView(80, 40, &service.SessionState{}).(*model)
+	m.SetSize(80, 40)
+	m.AddShellOutputMessage("total 0")
+	m.renderDirty = true
+	m.View()
+	m.ensureAllItemsRendered()
+
+	line, col := findLabel(t, m, markdown.CodeBlockCopyIcon)
+	wantBg := backgroundAt(strings.Split(m.View(), "\n")[line], col)
+	require.NotNil(t, wantBg, "the code block copy icon must sit on the code block band")
+
+	m.handleMouseClick(tea.MouseClickMsg{X: col, Y: line, Button: tea.MouseLeft})
+
+	after := strings.Split(m.View(), "\n")[line]
+	require.Contains(t, ansi.Strip(after), types.CopiedFeedbackLabel)
+	assert.Equal(t, wantBg, backgroundAt(after, col),
+		"the copied label must keep the code block background")
+}
+
+func TestBackgroundAt(t *testing.T) {
+	t.Parallel()
+
+	rgb := func(r, g, b uint8) color.Color { return color.RGBA{R: r, G: g, B: b, A: 0xff} }
+
+	cases := map[string]struct {
+		line string
+		col  int
+		want color.Color
+	}{
+		"plain text":              {line: "hello", col: 2, want: nil},
+		"truecolor background":    {line: "\x1b[48;2;1;2;3mhello\x1b[m", col: 2, want: rgb(1, 2, 3)},
+		"basic background":        {line: "\x1b[41mhello\x1b[m", col: 0, want: ansi.Red},
+		"bright background":       {line: "\x1b[102mhello\x1b[m", col: 0, want: ansi.BrightGreen},
+		"indexed background":      {line: "\x1b[48;5;10mhello\x1b[m", col: 0, want: ansi.IndexedColor(10)},
+		"reset before column":     {line: "\x1b[41mab\x1b[mcd", col: 3, want: nil},
+		"bg 49 clears background": {line: "\x1b[41mab\x1b[49mcd", col: 3, want: nil},
+		"fg only keeps outer bg":  {line: "\x1b[48;2;1;2;3m  \x1b[38;5;8mhello", col: 4, want: rgb(1, 2, 3)},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, backgroundAt(tc.line, tc.col))
+		})
+	}
+}


### PR DESCRIPTION
When a user clicks a copy button, the label briefly swaps to a \"copied\" confirmation. For code blocks, the background of that flash was already forced to match the code block's band. For user-message copy labels, which sit on the `BackgroundAlt` band, no such fix existed, so the transient label rendered with a transparent background and punched a visible hole in the colored band.

The fix introduces `backgroundAt(line, col)`, which walks the ANSI SGR escape sequences of a rendered line and returns the background color in effect at the given column — handling truecolor, 256-indexed, basic, and bright colors, plus resets. The \"copied\" flash now calls this helper for all copy labels, replacing the code-block-only special case with a single, general path.

New regression tests cover the user-message band case, the code-block band case, and a table-driven suite for `backgroundAt` itself.