### PR TITLE
fix(tui): guard backgroundAt against infinite loop on invalid UTF-8

### DIFF
--- a/pkg/tui/components/messages/copyfeedback.go
+++ b/pkg/tui/components/messages/copyfeedback.go
@@ -104,6 +104,9 @@ func backgroundAt(line string, col int) color.Color {
 	var state byte
 	for w := 0; line != "" && w <= col; {
 		seq, width, n, newState := ansi.DecodeSequence(line, state, p)
+		if n == 0 {
+			break // invalid input that cannot be decoded; avoid spinning forever
+		}
 		if ansi.HasCsiPrefix(seq) && p.Command() == 'm' {
 			bg = applySGRBackground(bg, p.Params())
 		}

--- a/pkg/tui/components/messages/copyfeedback_test.go
+++ b/pkg/tui/components/messages/copyfeedback_test.go
@@ -74,14 +74,15 @@ func TestBackgroundAt(t *testing.T) {
 		col  int
 		want color.Color
 	}{
-		"plain text":              {line: "hello", col: 2, want: nil},
-		"truecolor background":    {line: "\x1b[48;2;1;2;3mhello\x1b[m", col: 2, want: rgb(1, 2, 3)},
-		"basic background":        {line: "\x1b[41mhello\x1b[m", col: 0, want: ansi.Red},
-		"bright background":       {line: "\x1b[102mhello\x1b[m", col: 0, want: ansi.BrightGreen},
-		"indexed background":      {line: "\x1b[48;5;10mhello\x1b[m", col: 0, want: ansi.IndexedColor(10)},
-		"reset before column":     {line: "\x1b[41mab\x1b[mcd", col: 3, want: nil},
-		"bg 49 clears background": {line: "\x1b[41mab\x1b[49mcd", col: 3, want: nil},
-		"fg only keeps outer bg":  {line: "\x1b[48;2;1;2;3m  \x1b[38;5;8mhello", col: 4, want: rgb(1, 2, 3)},
+		"plain text":               {line: "hello", col: 2, want: nil},
+		"truecolor background":     {line: "\x1b[48;2;1;2;3mhello\x1b[m", col: 2, want: rgb(1, 2, 3)},
+		"basic background":         {line: "\x1b[41mhello\x1b[m", col: 0, want: ansi.Red},
+		"bright background":        {line: "\x1b[102mhello\x1b[m", col: 0, want: ansi.BrightGreen},
+		"indexed background":       {line: "\x1b[48;5;10mhello\x1b[m", col: 0, want: ansi.IndexedColor(10)},
+		"reset before column":      {line: "\x1b[41mab\x1b[mcd", col: 3, want: nil},
+		"bg 49 clears background":  {line: "\x1b[41mab\x1b[49mcd", col: 3, want: nil},
+		"fg only keeps outer bg":   {line: "\x1b[48;2;1;2;3m  \x1b[38;5;8mhello", col: 4, want: rgb(1, 2, 3)},
+		"invalid utf-8 terminates": {line: "\x1b[41m\x80\x80hello", col: 4, want: ansi.Red},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
`ansi.DecodeSequence` can return `n == 0` when it encounters invalid UTF-8, such as an isolated continuation byte. The `backgroundAt` function in the copy-feedback component loops over ANSI sequences until it has consumed the full input, but it never checked for this case — meaning a single bad byte would cause the loop to spin forever and freeze the TUI.

The fix adds an early `break` when `n == 0`, preventing the infinite loop regardless of what byte sequence is fed in. A regression test case, "invalid utf-8 terminates", is added to `TestBackgroundAt` to cover this path.

This follows up on review feedback from #3797 (https://github.com/docker/docker-agent/pull/3797#discussion_r3637121162).