### PR TITLE
feat(config): freeze config v14 and start v15 as latest

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/docker/docker-agent/blob/main/agent-schema.json",
   "title": "Docker Agent Configuration",
-  "description": "Configuration schema for Docker Agent v14",
+  "description": "Configuration schema for Docker Agent v15",
   "type": "object",
   "properties": {
     "version": {
@@ -23,7 +23,8 @@
         "11",
         "12",
         "13",
-        "14"
+        "14",
+        "15"
       ],
       "examples": [
         "0",
@@ -40,7 +41,8 @@
         "11",
         "12",
         "13",
-        "14"
+        "14",
+        "15"
       ]
     },
     "providers": {

--- a/pkg/config/v14/auth.go
+++ b/pkg/config/v14/auth.go
@@ -1,0 +1,253 @@
+package v14
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"slices"
+	"strings"
+)
+
+// AuthConfig configures a non-API-key authentication method for a model
+// provider. The Type field is a discriminator: today only
+// "workload_identity_federation" is supported (Anthropic), but the shape
+// leaves room for future schemes.
+//
+// AuthConfig may be set on a [ProviderConfig] (shared by every model that
+// references the provider) or directly on a [ModelConfig] (model-level value
+// always wins). It is mutually exclusive with the legacy
+// `token_key` / `ANTHROPIC_API_KEY` env-var path.
+type AuthConfig struct {
+	// Type discriminates which authentication scheme to use.
+	// Currently supported: "workload_identity_federation".
+	Type string `json:"type" yaml:"type"`
+	// Federation holds the parameters for the workload_identity_federation
+	// scheme. Required when Type == "workload_identity_federation".
+	Federation *FederationAuthConfig `json:"workload_identity_federation,omitempty" yaml:"workload_identity_federation,omitempty"`
+}
+
+// AuthType values accepted by [AuthConfig.Type].
+const (
+	AuthTypeWorkloadIdentityFederation = "workload_identity_federation"
+)
+
+// EffectiveAuth returns the auth that applies to a model: the model's own
+// Auth wins, otherwise the referenced ProviderConfig's Auth.
+func EffectiveAuth(m ModelConfig, providers map[string]ProviderConfig) *AuthConfig {
+	if m.Auth != nil {
+		return m.Auth
+	}
+	if p, ok := providers[m.Provider]; ok {
+		return p.Auth
+	}
+	return nil
+}
+
+// EffectiveProviderType returns the underlying provider type for a model,
+// resolving custom-provider indirection (a model whose `provider:` points
+// to an entry in `providers:` inherits that entry's `provider:` field).
+func EffectiveProviderType(m ModelConfig, providers map[string]ProviderConfig) string {
+	if p, ok := providers[m.Provider]; ok && p.Provider != "" {
+		return p.Provider
+	}
+	return m.Provider
+}
+
+// FederationAuthConfig describes an Anthropic OIDC Federation Rule and the
+// source of the JWT identity token to be exchanged for a short-lived access
+// token.
+//
+// See https://platform.claude.com/docs/en/build-with-claude/workload-identity-federation
+// for the underlying concepts (federation rules, organization IDs, service
+// accounts, target_type=USER vs SERVICE_ACCOUNT).
+type FederationAuthConfig struct {
+	// FederationRuleID identifies the Anthropic OidcFederationRule that
+	// governs token exchange. Required; must start with "fdrl_".
+	FederationRuleID string `json:"federation_rule_id" yaml:"federation_rule_id"`
+	// OrganizationID is the UUID of the Anthropic organization that owns
+	// the federation rule. Required.
+	OrganizationID string `json:"organization_id" yaml:"organization_id"`
+	// ServiceAccountID is the optional expected-target check for federation
+	// rules with target_type=SERVICE_ACCOUNT. Must start with "svac_". Omit
+	// for target_type=USER rules where the principal is derived from the
+	// JWT.
+	ServiceAccountID string `json:"service_account_id,omitempty" yaml:"service_account_id,omitempty"`
+	// IdentityToken describes how to obtain a fresh JWT for each exchange.
+	// Required.
+	IdentityToken *IdentityTokenSourceConfig `json:"identity_token" yaml:"identity_token"`
+}
+
+// IdentityTokenSourceConfig describes one of several ways to obtain a JWT
+// identity token for OIDC federation. Exactly one of File, Env, Command, or
+// URL must be set.
+type IdentityTokenSourceConfig struct {
+	// File reads the token from a file path. The file is re-read on every
+	// federation exchange (suitable for K8s projected SA tokens, SPIFFE
+	// helpers, Vault sidecars and other rotating-on-disk credentials).
+	// Surrounding whitespace is trimmed.
+	File string `json:"file,omitempty" yaml:"file,omitempty"`
+
+	// Env reads the token from the named environment variable. The variable
+	// is resolved through the runtime environment.Provider, so it works
+	// with the standard process env, .env files, and Docker Desktop secret
+	// providers. Surrounding whitespace is trimmed.
+	Env string `json:"env,omitempty" yaml:"env,omitempty"`
+
+	// Command executes a subprocess and uses its stdout as the token.
+	// The first element is the executable; the remainder are arguments.
+	// The command is re-run on every federation exchange. Stderr is logged.
+	// Surrounding whitespace is trimmed from stdout.
+	Command []string `json:"command,omitempty" yaml:"command,omitempty"`
+
+	// URL fetches the token from an HTTP(S) endpoint via GET. ${VAR}
+	// references in the URL are expanded against the runtime environment.
+	// Useful for cloud metadata servers (GCP, Azure IMDS) and the
+	// GitHub Actions OIDC token endpoint.
+	URL string `json:"url,omitempty" yaml:"url,omitempty"`
+	// Headers are sent with the URL request. Values support ${VAR}
+	// expansion against the runtime environment, which lets you inject a
+	// short-lived bearer token (e.g. ACTIONS_ID_TOKEN_REQUEST_TOKEN) without
+	// putting it in the YAML.
+	Headers map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
+	// ResponseField, when set, parses the URL response as JSON and reads
+	// the named top-level field. When empty, the entire response body
+	// (with surrounding whitespace trimmed) is used as the token.
+	// Examples: GitHub Actions returns {"value":"<jwt>"} → "value";
+	// GCP metadata returns the raw JWT → leave empty.
+	ResponseField string `json:"response_field,omitempty" yaml:"response_field,omitempty"`
+}
+
+// EnvVars returns the environment variables that the auth configuration
+// references at runtime. Today this is only meaningful for Workload Identity
+// Federation, whose identity-token source may either name an env var
+// directly (env source) or reference one through ${VAR} expansion in URL
+// or header values.
+func (a *AuthConfig) EnvVars() []string {
+	if a == nil || a.Type != AuthTypeWorkloadIdentityFederation || a.Federation == nil {
+		return nil
+	}
+	src := a.Federation.IdentityToken
+	if src == nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	collect := func(s string) {
+		// We use os.Expand purely as a $VAR / ${VAR} scanner: the mapping
+		// function records the name and returns "" so the resulting string
+		// is discarded. This intentionally does not understand the $$ escape
+		// (literal dollar), which doesn't occur in any real URL we expect.
+		os.Expand(s, func(name string) string {
+			if name != "" {
+				seen[name] = true
+			}
+			return ""
+		})
+	}
+	if src.Env != "" {
+		seen[src.Env] = true
+	}
+	if src.URL != "" {
+		collect(src.URL)
+	}
+	for _, v := range src.Headers {
+		collect(v)
+	}
+	return slices.Sorted(maps.Keys(seen))
+}
+
+// Validate validates an AuthConfig. providerType, when non-empty, is used
+// to enforce that the chosen scheme is supported by the underlying
+// provider (today: WIF requires "anthropic"). Empty providerType skips
+// that check, which is what we want when an [AuthConfig] sits on a
+// [ProviderConfig] that doesn't declare an underlying provider — the
+// per-model check picks it up later.
+func (a *AuthConfig) Validate(providerType string) error {
+	if a == nil {
+		return nil
+	}
+	switch a.Type {
+	case "":
+		return errors.New("auth.type is required")
+	case AuthTypeWorkloadIdentityFederation:
+		if providerType != "" && providerType != "anthropic" {
+			return fmt.Errorf("auth.type %q is only supported with the anthropic provider (got %q)", a.Type, providerType)
+		}
+		if err := a.Federation.validate(); err != nil {
+			return fmt.Errorf("auth: %w", err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported auth.type %q", a.Type)
+	}
+}
+
+func (f *FederationAuthConfig) validate() error {
+	if f == nil {
+		return errors.New("workload_identity_federation block is required when auth.type is workload_identity_federation")
+	}
+	if f.FederationRuleID == "" {
+		return errors.New("federation_rule_id is required")
+	}
+	if !strings.HasPrefix(f.FederationRuleID, "fdrl_") {
+		return fmt.Errorf("federation_rule_id must start with %q (got %q)", "fdrl_", f.FederationRuleID)
+	}
+	if f.OrganizationID == "" {
+		return errors.New("organization_id is required")
+	}
+	if f.ServiceAccountID != "" && !strings.HasPrefix(f.ServiceAccountID, "svac_") {
+		return fmt.Errorf("service_account_id must start with %q when set (got %q)", "svac_", f.ServiceAccountID)
+	}
+	if f.IdentityToken == nil {
+		return errors.New("identity_token is required")
+	}
+	return f.IdentityToken.validate()
+}
+
+func (s *IdentityTokenSourceConfig) validate() error {
+	sources := s.setSources()
+	switch len(sources) {
+	case 0:
+		return errors.New("identity_token requires exactly one of: file, env, command, url")
+	case 1:
+		// ok
+	default:
+		return fmt.Errorf("identity_token must set exactly one of file, env, command, url (got %s)", strings.Join(sources, ", "))
+	}
+	// Headers / response_field are only meaningful with url:
+	if s.URL == "" {
+		if len(s.Headers) > 0 {
+			return errors.New("identity_token.headers can only be used with identity_token.url")
+		}
+		if s.ResponseField != "" {
+			return errors.New("identity_token.response_field can only be used with identity_token.url")
+		}
+	}
+	for i, arg := range s.Command {
+		if arg == "" {
+			return fmt.Errorf("identity_token.command[%d] must not be empty", i)
+		}
+	}
+	return nil
+}
+
+// setSources returns the names of the source fields that are populated.
+func (s *IdentityTokenSourceConfig) setSources() []string {
+	if s == nil {
+		return nil
+	}
+	var names []string
+	if s.File != "" {
+		names = append(names, "file")
+	}
+	if s.Env != "" {
+		names = append(names, "env")
+	}
+	if len(s.Command) > 0 {
+		names = append(names, "command")
+	}
+	if s.URL != "" {
+		names = append(names, "url")
+	}
+	return names
+}

--- a/pkg/config/v14/base_url.go
+++ b/pkg/config/v14/base_url.go
@@ -1,0 +1,17 @@
+package v14
+
+// HasCustomBaseURL reports whether m targets a user-supplied endpoint: a
+// base_url set directly on the model or inherited from a custom provider
+// definition. It must be evaluated on the raw config — after provider
+// defaults are applied a built-in alias default base URL is indistinguishable
+// from a custom one.
+//
+// A custom base_url implies bypass_models_gateway: such endpoints are never
+// routed through a configured models gateway.
+func HasCustomBaseURL(m ModelConfig, providers map[string]ProviderConfig) bool {
+	if m.BaseURL != "" {
+		return true
+	}
+	p, exists := providers[m.Provider]
+	return exists && p.BaseURL != ""
+}

--- a/pkg/config/v14/budget_test.go
+++ b/pkg/config/v14/budget_test.go
@@ -1,0 +1,194 @@
+package v14
+
+import (
+	"testing"
+	"time"
+
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBudgetConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		budget  *BudgetConfig
+		wantErr string
+	}{
+		{name: "nil is valid (unbudgeted)", budget: nil},
+		{name: "empty is valid (no ceilings)", budget: &BudgetConfig{}},
+		{
+			name:   "all limits set",
+			budget: &BudgetConfig{MaxCost: 0.5, MaxTokens: 100000, MaxTime: Duration{Duration: 10 * time.Minute}},
+		},
+		{
+			name:    "negative max_cost",
+			budget:  &BudgetConfig{MaxCost: -1},
+			wantErr: "max_cost must not be negative",
+		},
+		{
+			name:    "negative max_tokens",
+			budget:  &BudgetConfig{MaxTokens: -5},
+			wantErr: "max_tokens must not be negative",
+		},
+		{
+			name:    "negative max_time",
+			budget:  &BudgetConfig{MaxTime: Duration{Duration: -time.Second}},
+			wantErr: "max_time must not be negative",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.budget.validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestConfigValidateRejectsNegativeBudget(t *testing.T) {
+	cfg := Config{
+		Agents: Agents{{Name: "root", Model: "openai/gpt-4o", Description: "d", Instruction: "i"}},
+		Budget: &BudgetConfig{MaxCost: -0.5},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "budget:")
+	assert.Contains(t, err.Error(), "max_cost must not be negative")
+}
+
+func TestBudgetParsesDurationFromYAML(t *testing.T) {
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal([]byte(`
+agents:
+  root:
+    model: openai/gpt-4o
+    description: d
+    instruction: i
+budget:
+  max_cost: 0.50
+  max_tokens: 100000
+  max_time: 10m
+`), &cfg))
+
+	require.NotNil(t, cfg.Budget)
+	assert.InDelta(t, 0.50, cfg.Budget.MaxCost, 1e-9)
+	assert.Equal(t, int64(100000), cfg.Budget.MaxTokens)
+	assert.Equal(t, 10*time.Minute, cfg.Budget.MaxTime.Duration)
+	assert.False(t, cfg.Budget.IsZero())
+}
+
+func TestBudgetAbsentIsUnbudgeted(t *testing.T) {
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal([]byte(`
+agents:
+  root:
+    model: openai/gpt-4o
+    description: d
+    instruction: i
+`), &cfg))
+
+	assert.Nil(t, cfg.Budget)
+	assert.True(t, cfg.Budget.IsZero(), "a nil budget must read as inert, not as a zero ceiling")
+}
+
+func TestNamedBudgetsParseAndBind(t *testing.T) {
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal([]byte(`
+budgets:
+  tight:
+    max_cost: 0.10
+  roomy:
+    max_tokens: 1000000
+    max_time: 30m
+agents:
+  root:
+    model: openai/gpt-4o
+    description: d
+    instruction: i
+    budgets: [tight]
+  developer:
+    model: openai/gpt-4o
+    description: d
+    instruction: i
+    budgets: [tight, roomy]
+`), &cfg))
+
+	require.Len(t, cfg.Budgets, 2)
+	assert.InDelta(t, 0.10, cfg.Budgets["tight"].MaxCost, 1e-9)
+	assert.Equal(t, int64(1000000), cfg.Budgets["roomy"].MaxTokens)
+	assert.Equal(t, 30*time.Minute, cfg.Budgets["roomy"].MaxTime.Duration)
+
+	byName := map[string][]string{}
+	for _, a := range cfg.Agents {
+		byName[a.Name] = a.Budgets
+	}
+	assert.Equal(t, []string{"tight"}, byName["root"])
+	assert.Equal(t, []string{"tight", "roomy"}, byName["developer"])
+}
+
+func TestAgentBudgetsRejectsUnknownName(t *testing.T) {
+	var cfg Config
+	err := yaml.Unmarshal([]byte(`
+budgets:
+  tight:
+    max_cost: 0.10
+agents:
+  root:
+    model: openai/gpt-4o
+    description: d
+    instruction: i
+    budgets: [tihgt]
+`), &cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown budget "tihgt"`)
+}
+
+func TestNamedBudgetValidationNamesTheBudget(t *testing.T) {
+	cfg := Config{
+		Agents:  Agents{{Name: "root", Model: "openai/gpt-4o", Description: "d", Instruction: "i"}},
+		Budgets: map[string]BudgetConfig{"tight": {MaxCost: -1}},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "budgets.tight:")
+	assert.Contains(t, err.Error(), "max_cost must not be negative")
+}
+
+func TestAgentWithoutBudgetsIsValid(t *testing.T) {
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal([]byte(`
+budgets:
+  tight:
+    max_cost: 0.10
+agents:
+  root:
+    model: openai/gpt-4o
+    description: d
+    instruction: i
+`), &cfg))
+	assert.Empty(t, cfg.Agents[0].Budgets)
+}
+
+func TestBudgetPartialLeavesOthersUnlimited(t *testing.T) {
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal([]byte(`
+agents:
+  root:
+    model: openai/gpt-4o
+    description: d
+    instruction: i
+budget:
+  max_time: 30s
+`), &cfg))
+
+	require.NotNil(t, cfg.Budget)
+	assert.Equal(t, 30*time.Second, cfg.Budget.MaxTime.Duration)
+	assert.Zero(t, cfg.Budget.MaxCost)
+	assert.Zero(t, cfg.Budget.MaxTokens)
+	assert.False(t, cfg.Budget.IsZero())
+}

--- a/pkg/config/v14/capabilities_test.go
+++ b/pkg/config/v14/capabilities_test.go
@@ -1,0 +1,94 @@
+package v14
+
+import (
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModelConfigCapabilitiesYAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const in = `provider: ollama
+model: llava
+capabilities:
+  image: true
+  pdf: false
+`
+	var f FlexibleModelConfig
+	require.NoError(t, yaml.Unmarshal([]byte(in), &f))
+
+	require.NotNil(t, f.Capabilities, "capabilities should be parsed")
+	assert.True(t, f.Capabilities.Image)
+	assert.False(t, f.Capabilities.PDF)
+
+	// A model carrying a capabilities override must not collapse to the
+	// "provider/model" shorthand on marshal, or the override would be lost.
+	assert.False(t, f.isShorthandOnly(), "capabilities override must defeat shorthand marshalling")
+
+	out, err := yaml.Marshal(f)
+	require.NoError(t, err)
+
+	var rt FlexibleModelConfig
+	require.NoError(t, yaml.Unmarshal(out, &rt))
+	require.NotNil(t, rt.Capabilities, "capabilities should survive a marshal round-trip; got:\n%s", out)
+	assert.True(t, rt.Capabilities.Image)
+	assert.False(t, rt.Capabilities.PDF)
+}
+
+func TestModelConfigShorthandOnlyWithoutCapabilities(t *testing.T) {
+	t.Parallel()
+
+	const in = `provider: openai
+model: gpt-4o
+`
+	var f FlexibleModelConfig
+	require.NoError(t, yaml.Unmarshal([]byte(in), &f))
+
+	assert.Nil(t, f.Capabilities)
+	assert.True(t, f.isShorthandOnly(), "a bare provider/model must still marshal as shorthand")
+}
+
+func TestModelConfigBypassModelsGatewayYAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const in = `provider: anthropic
+model: claude-sonnet-4-5
+bypass_models_gateway: true
+`
+	var f FlexibleModelConfig
+	require.NoError(t, yaml.Unmarshal([]byte(in), &f))
+	assert.True(t, f.BypassModelsGateway, "bypass_models_gateway should be parsed")
+
+	// A model carrying only the bypass flag (plus provider/model) must not
+	// collapse to the shorthand on marshal, or the flag would be lost.
+	assert.False(t, f.isShorthandOnly(), "bypass_models_gateway must defeat shorthand marshalling")
+
+	out, err := yaml.Marshal(f)
+	require.NoError(t, err)
+
+	var rt FlexibleModelConfig
+	require.NoError(t, yaml.Unmarshal(out, &rt))
+	assert.True(t, rt.BypassModelsGateway, "bypass_models_gateway should survive a marshal round-trip; got:\n%s", out)
+}
+
+func TestModelConfigCloneCopiesCapabilities(t *testing.T) {
+	t.Parallel()
+
+	orig := &ModelConfig{
+		Provider:     "my-proxy",
+		Model:        "gpt-4o",
+		Capabilities: &CapabilitiesConfig{Image: true, PDF: true},
+	}
+
+	clone := orig.Clone()
+	require.NotNil(t, clone.Capabilities)
+	assert.True(t, clone.Capabilities.Image)
+	assert.True(t, clone.Capabilities.PDF)
+
+	// Mutating the clone must not affect the original (deep copy).
+	clone.Capabilities.Image = false
+	assert.True(t, orig.Capabilities.Image, "clone must not share the Capabilities pointer with the original")
+}

--- a/pkg/config/v14/context_size_test.go
+++ b/pkg/config/v14/context_size_test.go
@@ -1,0 +1,52 @@
+package v14
+
+import (
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextSizeFromProviderOpts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		opts map[string]any
+		want int64
+	}{
+		{"absent", map[string]any{}, 0},
+		{"nil map", nil, 0},
+		{"int", map[string]any{"context_size": 32768}, 32768},
+		{"int64", map[string]any{"context_size": int64(65536)}, 65536},
+		{"int32", map[string]any{"context_size": int32(4096)}, 4096},
+		// goccy/go-yaml decodes a positive YAML integer as uint64 (see #3387).
+		{"uint64", map[string]any{"context_size": uint64(262144)}, 262144},
+		{"uint", map[string]any{"context_size": uint(8192)}, 8192},
+		{"float64 (json)", map[string]any{"context_size": float64(8192)}, 8192},
+		{"string decimal", map[string]any{"context_size": " 16384 "}, 16384},
+		{"zero", map[string]any{"context_size": 0}, 0},
+		{"negative", map[string]any{"context_size": int64(-1)}, 0},
+		{"unparseable string", map[string]any{"context_size": "big"}, 0},
+		{"wrong type", map[string]any{"context_size": true}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ContextSizeFromProviderOpts(tt.opts))
+		})
+	}
+}
+
+// TestContextSizeFromProviderOpts_YAMLRoundTrip guards the real decode path:
+// a context_size declared in YAML must resolve to its value. goccy/go-yaml
+// produces uint64 for positive integers, which a naive int/int64 switch drops
+// to 0 (the latent bug behind #3387's failed context_size workaround).
+func TestContextSizeFromProviderOpts_YAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var opts map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte("context_size: 262144\n"), &opts))
+	assert.Equal(t, int64(262144), ContextSizeFromProviderOpts(opts))
+}

--- a/pkg/config/v14/cost_test.go
+++ b/pkg/config/v14/cost_test.go
@@ -1,0 +1,87 @@
+package v14
+
+import (
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCostConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cost    *CostConfig
+		wantErr string
+	}{
+		{name: "nil is valid"},
+		{name: "all zero means priced free", cost: &CostConfig{}},
+		{name: "positive prices", cost: &CostConfig{Input: 2.5, Output: 10, CacheRead: 0.25, CacheWrite: 3.125}},
+		{name: "negative input", cost: &CostConfig{Input: -1}, wantErr: "cost.input must not be negative, got -1"},
+		{name: "negative output", cost: &CostConfig{Output: -0.5}, wantErr: "cost.output must not be negative, got -0.5"},
+		{name: "negative cache_read", cost: &CostConfig{CacheRead: -2}, wantErr: "cost.cache_read must not be negative, got -2"},
+		{name: "negative cache_write", cost: &CostConfig{CacheWrite: -0.1}, wantErr: "cost.cache_write must not be negative, got -0.1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.cost.validate()
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestModelConfigCostYAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const in = `provider: internal-llm
+model: gpt-4o
+cost:
+  input: 1.25
+  output: 5
+  cache_read: 0.125
+  cache_write: 1.5625
+`
+	var f FlexibleModelConfig
+	require.NoError(t, yaml.Unmarshal([]byte(in), &f))
+
+	require.NotNil(t, f.Cost, "cost should be parsed")
+	assert.InEpsilon(t, 1.25, f.Cost.Input, 0.0001)
+	assert.InEpsilon(t, 5.0, f.Cost.Output, 0.0001)
+	assert.InEpsilon(t, 0.125, f.Cost.CacheRead, 0.0001)
+	assert.InEpsilon(t, 1.5625, f.Cost.CacheWrite, 0.0001)
+
+	// A model carrying a cost override must not collapse to the
+	// "provider/model" shorthand on marshal, or the override would be lost.
+	assert.False(t, f.isShorthandOnly(), "cost override must defeat shorthand marshalling")
+
+	out, err := yaml.Marshal(f)
+	require.NoError(t, err)
+
+	var rt FlexibleModelConfig
+	require.NoError(t, yaml.Unmarshal(out, &rt))
+	require.NotNil(t, rt.Cost, "cost should survive a marshal round-trip; got:\n%s", out)
+	assert.InEpsilon(t, 1.25, rt.Cost.Input, 0.0001)
+	assert.InEpsilon(t, 5.0, rt.Cost.Output, 0.0001)
+}
+
+func TestConfigValidateRejectsNegativeCost(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Models: map[string]ModelConfig{
+			"main": {Provider: "openai", Model: "gpt-4o", Cost: &CostConfig{Input: -1}},
+		},
+		Agents: Agents{
+			{Name: "root", Model: "main"},
+		},
+	}
+	require.ErrorContains(t, cfg.Validate(), "models.main: cost.input must not be negative")
+}

--- a/pkg/config/v14/description_test.go
+++ b/pkg/config/v14/description_test.go
@@ -1,0 +1,32 @@
+package v14
+
+import (
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModelConfigDescriptionYAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const in = `provider: anthropic
+model: claude-haiku-4-5
+description: Fast and cheap; good for summaries.
+`
+	var f FlexibleModelConfig
+	require.NoError(t, yaml.Unmarshal([]byte(in), &f))
+	assert.Equal(t, "Fast and cheap; good for summaries.", f.Description)
+
+	// A model carrying a description must not collapse to the
+	// "provider/model" shorthand on marshal, or the description would be lost.
+	assert.False(t, f.isShorthandOnly(), "description must defeat shorthand marshalling")
+
+	out, err := yaml.Marshal(f)
+	require.NoError(t, err)
+
+	var rt FlexibleModelConfig
+	require.NoError(t, yaml.Unmarshal(out, &rt))
+	assert.Equal(t, "Fast and cheap; good for summaries.", rt.Description, "description should survive a marshal round-trip; got:\n%s", out)
+}

--- a/pkg/config/v14/expand_env_test.go
+++ b/pkg/config/v14/expand_env_test.go
@@ -1,0 +1,81 @@
+package v14
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// upper is a stand-in expander: it substitutes ${env.NAME} / ${NAME} markers
+// from a fixed table so the test stays free of pkg/environment.
+func tableExpander(vars map[string]string) func(string) (string, error) {
+	return func(s string) (string, error) {
+		out := s
+		for k, v := range vars {
+			out = strings.ReplaceAll(out, "${env."+k+"}", v)
+			out = strings.ReplaceAll(out, "${"+k+"}", v)
+		}
+		return out, nil
+	}
+}
+
+func TestModelConfig_ExpandEnv(t *testing.T) {
+	t.Parallel()
+
+	vars := map[string]string{
+		"NEMOTRON3_MODEL": "huggingface.co/unsloth/nemotron-3-nano:Q3_K_M",
+		"DMR_BASE_URL":    "http://localhost:12434/engines/v1",
+	}
+
+	t.Run("expands model and base_url", func(t *testing.T) {
+		t.Parallel()
+		m := &ModelConfig{
+			Provider: "dmr",
+			Model:    "${env.NEMOTRON3_MODEL}",
+			BaseURL:  "${DMR_BASE_URL}",
+			TokenKey: "NEMOTRON3_MODEL", // must NOT be expanded: it names a var
+		}
+		require.NoError(t, m.ExpandEnv(tableExpander(vars)))
+		assert.Equal(t, "huggingface.co/unsloth/nemotron-3-nano:Q3_K_M", m.Model)
+		assert.Equal(t, "http://localhost:12434/engines/v1", m.BaseURL)
+		assert.Equal(t, "NEMOTRON3_MODEL", m.TokenKey)
+		assert.Equal(t, "dmr", m.Provider)
+	})
+
+	t.Run("plain values unchanged", func(t *testing.T) {
+		t.Parallel()
+		m := &ModelConfig{Model: "gpt-4o", BaseURL: "https://api.openai.com/v1"}
+		require.NoError(t, m.ExpandEnv(tableExpander(vars)))
+		assert.Equal(t, "gpt-4o", m.Model)
+		assert.Equal(t, "https://api.openai.com/v1", m.BaseURL)
+	})
+
+	t.Run("empty fields and nil expander are no-ops", func(t *testing.T) {
+		t.Parallel()
+		m := &ModelConfig{Model: "${env.NEMOTRON3_MODEL}"}
+		require.NoError(t, m.ExpandEnv(nil))
+		assert.Equal(t, "${env.NEMOTRON3_MODEL}", m.Model)
+
+		empty := &ModelConfig{}
+		require.NoError(t, empty.ExpandEnv(tableExpander(vars)))
+		assert.Empty(t, empty.Model)
+		assert.Empty(t, empty.BaseURL)
+	})
+
+	t.Run("nil receiver is a no-op", func(t *testing.T) {
+		t.Parallel()
+		var m *ModelConfig
+		require.NoError(t, m.ExpandEnv(tableExpander(vars)))
+	})
+
+	t.Run("propagates expander error", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("variable not set")
+		m := &ModelConfig{Model: "${env.MISSING}"}
+		err := m.ExpandEnv(func(string) (string, error) { return "", boom })
+		assert.ErrorIs(t, err, boom)
+	})
+}

--- a/pkg/config/v14/hooks_flexible_test.go
+++ b/pkg/config/v14/hooks_flexible_test.go
@@ -1,0 +1,99 @@
+package v14
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHookDefinitions_UnmarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		yaml    string
+		want    HookDefinitions
+		wantErr string
+	}{
+		{
+			name: "list form",
+			yaml: "stop:\n  - type: command\n    command: echo one\n  - type: command\n    command: echo two\n",
+			want: HookDefinitions{
+				{Type: "command", Command: "echo one"},
+				{Type: "command", Command: "echo two"},
+			},
+		},
+		{
+			name: "single mapping form",
+			yaml: "stop:\n  type: command\n  command: echo one\n",
+			want: HookDefinitions{{Type: "command", Command: "echo one"}},
+		},
+		{
+			name:    "scalar is rejected",
+			yaml:    "stop: echo one\n",
+			wantErr: "hook event must be a hook or a list of hooks",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var cfg HooksConfig
+			err := yaml.Unmarshal([]byte(tt.yaml), &cfg)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, cfg.Stop)
+		})
+	}
+}
+
+func TestHookMatcherConfigs_UnmarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	single := `
+pre_tool_use:
+  matcher: shell
+  hooks:
+    type: command
+    command: echo check
+`
+	var cfg HooksConfig
+	require.NoError(t, yaml.Unmarshal([]byte(single), &cfg))
+	require.Len(t, cfg.PreToolUse, 1)
+	assert.Equal(t, "shell", cfg.PreToolUse[0].Matcher)
+	assert.Equal(t, HookDefinitions{{Type: "command", Command: "echo check"}}, cfg.PreToolUse[0].Hooks)
+
+	var bad HooksConfig
+	err := yaml.Unmarshal([]byte("pre_tool_use: shell\n"), &bad)
+	require.ErrorContains(t, err, "hook event must be a matcher or a list of matchers")
+}
+
+func TestHookDefinitions_UnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	var fromList HooksConfig
+	require.NoError(t, json.Unmarshal([]byte(`{"stop":[{"type":"command","command":"echo one"}]}`), &fromList))
+
+	var fromMapping HooksConfig
+	require.NoError(t, json.Unmarshal([]byte(`{"stop":{"type":"command","command":"echo one"}}`), &fromMapping))
+
+	assert.Equal(t, fromList, fromMapping)
+}
+
+func TestHookDefinitions_MarshalAsList(t *testing.T) {
+	t.Parallel()
+
+	var cfg HooksConfig
+	require.NoError(t, yaml.Unmarshal([]byte("stop:\n  type: command\n  command: echo one\n"), &cfg))
+
+	out, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "stop:\n- type: command\n")
+}

--- a/pkg/config/v14/lifecycle.go
+++ b/pkg/config/v14/lifecycle.go
@@ -1,0 +1,189 @@
+package v14
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// LifecycleConfig configures how the agent supervises a long-running
+// toolset process (MCP server, remote MCP, LSP server).
+//
+// All fields are optional. The simplest usage is to pick a Profile that
+// matches your taste:
+//
+//   - "resilient" (default): auto-restart on failure with exponential
+//     backoff, optional toolset (a missing MCP doesn't block the agent).
+//     This matches the historical docker-agent behaviour.
+//   - "strict": fail fast — Required=true, no auto-restart. Use this in
+//     CI/headless runs where you want the agent to refuse to start if a
+//     dependency is unavailable.
+//   - "best-effort": single attempt, no restart, optional. Use for
+//     experimental MCPs whose flakiness you don't want to amplify with
+//     restart loops.
+//
+// Explicit fields override the profile's defaults, so a user can write:
+//
+//	lifecycle:
+//	  profile: resilient
+//	  max_restarts: 10
+//
+// to get resilient behaviour with a higher restart budget.
+//
+// YAML example with all knobs:
+//
+//	lifecycle:
+//	  profile: resilient        # strict | resilient | best-effort
+//	  required: false           # block agent startup if not Ready in startup_timeout
+//	  startup_timeout: 30s      # max wait for initial Connect+initialize
+//	  call_timeout: 60s         # default per-call timeout (informational)
+//	  restart: on_failure       # never | on_failure | always
+//	  max_restarts: 5           # consecutive attempts; 0 = profile default; -1 = unlimited
+//	  backoff:
+//	    initial: 1s
+//	    max: 32s
+//	    multiplier: 2.0
+//	    jitter: 0.2             # 0..1, 0 disables (default)
+type LifecycleConfig struct {
+	// Profile is a shorthand that picks defaults for all the other fields.
+	// Empty means "resilient". Explicit fields override the profile.
+	Profile string `json:"profile,omitempty" yaml:"profile,omitempty"`
+
+	// Required, when set, indicates the toolset is critical to the agent.
+	//
+	// NOTE: this field is currently informational — the runtime does NOT
+	// yet block agent startup on it. The wiring lives behind a planned
+	// eager-startup commit; until then, callers can read the effective
+	// value via IsRequired() but the supervisor itself does not act on it.
+	//
+	// nil pointer means "use the profile default" (true under "strict",
+	// false otherwise).
+	Required *bool `json:"required,omitempty" yaml:"required,omitempty"`
+
+	// StartupTimeout caps the duration of the initial Connect call.
+	//
+	// Enforced by the supervisor: on expiry the initial Start returns
+	// ErrInitTimeout and the toolset stays stopped (the runtime retries on
+	// the next turn). This bounds a server that hangs mid-handshake rather
+	// than returning an error.
+	//
+	// Zero means "no timeout". The "strict" profile defaults to 30s; other
+	// profiles default to 0.
+	StartupTimeout Duration `json:"startup_timeout,omitzero" yaml:"startup_timeout,omitempty"`
+
+	// CallTimeout is informational; it documents the user's expectation
+	// for individual tool calls. The runtime currently uses the caller's
+	// context for cancellation.
+	CallTimeout Duration `json:"call_timeout,omitzero" yaml:"call_timeout,omitempty"`
+
+	// Restart controls how the supervisor reacts to an unexpected
+	// disconnect: "never", "on_failure" (default), or "always".
+	Restart string `json:"restart,omitempty" yaml:"restart,omitempty"`
+
+	// MaxRestarts is the maximum number of consecutive restart attempts
+	// after a disconnect. 0 = use profile default (5). -1 = unlimited.
+	MaxRestarts int `json:"max_restarts,omitempty" yaml:"max_restarts,omitempty"`
+
+	// Backoff controls the wait between restart attempts.
+	Backoff *BackoffConfig `json:"backoff,omitempty" yaml:"backoff,omitempty"`
+}
+
+// BackoffConfig controls the exponential backoff used between restart
+// attempts. Zero fields fall back to profile defaults (Initial=1s,
+// Max=32s, Multiplier=2.0, Jitter=0).
+type BackoffConfig struct {
+	Initial    Duration `json:"initial,omitzero" yaml:"initial,omitempty"`
+	Max        Duration `json:"max,omitzero" yaml:"max,omitempty"`
+	Multiplier float64  `json:"multiplier,omitempty" yaml:"multiplier,omitempty"`
+	// Jitter is a 0..1 fraction of the computed delay applied as a
+	// uniform random offset. 0 disables jitter (the default).
+	Jitter float64 `json:"jitter,omitempty" yaml:"jitter,omitempty"`
+}
+
+// Lifecycle profile names.
+const (
+	LifecycleProfileResilient  = "resilient"
+	LifecycleProfileStrict     = "strict"
+	LifecycleProfileBestEffort = "best-effort"
+)
+
+// validate checks that LifecycleConfig values are within accepted ranges.
+// Empty fields are accepted and resolved to profile defaults at use time.
+func (l *LifecycleConfig) validate() error {
+	if l == nil {
+		return nil
+	}
+	switch l.Profile {
+	case "", LifecycleProfileResilient, LifecycleProfileStrict, LifecycleProfileBestEffort:
+	default:
+		return fmt.Errorf("lifecycle.profile %q is not supported (want one of: %q, %q, %q)",
+			l.Profile, LifecycleProfileResilient, LifecycleProfileStrict, LifecycleProfileBestEffort)
+	}
+	switch l.Restart {
+	case "", "never", "on_failure", "always":
+	default:
+		return fmt.Errorf("lifecycle.restart %q is not supported (want one of: never, on_failure, always)", l.Restart)
+	}
+	if l.MaxRestarts < -1 {
+		return fmt.Errorf("lifecycle.max_restarts %d must be >= -1 (use -1 for unlimited)", l.MaxRestarts)
+	}
+	if l.Backoff != nil {
+		if l.Backoff.Initial.Duration < 0 {
+			return errors.New("lifecycle.backoff.initial must be non-negative")
+		}
+		if l.Backoff.Max.Duration < 0 {
+			return errors.New("lifecycle.backoff.max must be non-negative")
+		}
+		if l.Backoff.Multiplier < 0 {
+			return errors.New("lifecycle.backoff.multiplier must be non-negative")
+		}
+		if l.Backoff.Jitter < 0 || l.Backoff.Jitter > 1 {
+			return errors.New("lifecycle.backoff.jitter must be between 0 and 1")
+		}
+	}
+	if l.StartupTimeout.Duration < 0 {
+		return errors.New("lifecycle.startup_timeout must be non-negative")
+	}
+	if l.CallTimeout.Duration < 0 {
+		return errors.New("lifecycle.call_timeout must be non-negative")
+	}
+	return nil
+}
+
+// IsRequired returns the effective Required flag for the given profile +
+// explicit override. nil pointer means "use profile default".
+func (l *LifecycleConfig) IsRequired() bool {
+	if l == nil {
+		return profileRequired("")
+	}
+	if l.Required != nil {
+		return *l.Required
+	}
+	return profileRequired(l.Profile)
+}
+
+// EffectiveStartupTimeout returns StartupTimeout, falling back to a
+// profile default when zero. Zero in the result means "no timeout".
+func (l *LifecycleConfig) EffectiveStartupTimeout() time.Duration {
+	if l == nil {
+		return profileStartupTimeout("")
+	}
+	if l.StartupTimeout.Duration > 0 {
+		return l.StartupTimeout.Duration
+	}
+	return profileStartupTimeout(l.Profile)
+}
+
+// profileRequired returns the Required default for the given profile.
+func profileRequired(profile string) bool {
+	return profile == LifecycleProfileStrict
+}
+
+// profileStartupTimeout returns the StartupTimeout default for the given
+// profile. The "strict" profile uses 30s; others use 0 (no timeout).
+func profileStartupTimeout(profile string) time.Duration {
+	if profile == LifecycleProfileStrict {
+		return 30 * time.Second
+	}
+	return 0
+}

--- a/pkg/config/v14/model_ref.go
+++ b/pkg/config/v14/model_ref.go
@@ -1,0 +1,22 @@
+package v14
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParseModelRef parses an inline "provider/model" reference into a
+// ModelConfig. It splits on the first "/", so the model portion may itself
+// contain slashes (e.g. "dmr/ai/qwen3:latest" yields provider "dmr" and model
+// "ai/qwen3:latest"). It returns an error when there is no "/" or when either
+// part is empty.
+//
+//	cfg, err := ParseModelRef("openai/gpt-4o")
+//	// cfg.Provider == "openai", cfg.Model == "gpt-4o"
+func ParseModelRef(ref string) (ModelConfig, error) {
+	providerName, model, ok := strings.Cut(ref, "/")
+	if !ok || providerName == "" || model == "" {
+		return ModelConfig{}, fmt.Errorf("invalid model reference %q: expected 'provider/model' format", ref)
+	}
+	return ModelConfig{Provider: providerName, Model: model}, nil
+}

--- a/pkg/config/v14/parse.go
+++ b/pkg/config/v14/parse.go
@@ -1,10 +1,10 @@
-package latest
+package v14
 
 import (
 	"github.com/goccy/go-yaml"
 
 	"github.com/docker/docker-agent/pkg/config/types"
-	previous "github.com/docker/docker-agent/pkg/config/v14"
+	previous "github.com/docker/docker-agent/pkg/config/v13"
 )
 
 func Register(parsers map[string]func([]byte) (any, error), upgraders *[]func(any, []byte) (any, error)) {

--- a/pkg/config/v14/redact_secrets_test.go
+++ b/pkg/config/v14/redact_secrets_test.go
@@ -1,0 +1,66 @@
+package v14
+
+import (
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactSecretsEnabledDefault(t *testing.T) {
+	t.Parallel()
+
+	tru, fls := true, false
+
+	tests := []struct {
+		name string
+		cfg  *AgentConfig
+		want bool
+	}{
+		{name: "nil receiver defaults to on", cfg: nil, want: true},
+		{name: "field omitted defaults to on", cfg: &AgentConfig{}, want: true},
+		{name: "explicit true is on", cfg: &AgentConfig{RedactSecrets: &tru}, want: true},
+		{name: "explicit false opts out", cfg: &AgentConfig{RedactSecrets: &fls}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.cfg.RedactSecretsEnabled())
+		})
+	}
+}
+
+func TestRedactSecretsYAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		yaml    string
+		wantSet bool // whether the pointer should be non-nil
+		wantVal bool // value to expect when set
+		want    bool // expected effective value via RedactSecretsEnabled
+	}{
+		{name: "omitted", yaml: "model: openai/gpt-5", wantSet: false, want: true},
+		{name: "explicit true", yaml: "model: openai/gpt-5\nredact_secrets: true", wantSet: true, wantVal: true, want: true},
+		{name: "explicit false", yaml: "model: openai/gpt-5\nredact_secrets: false", wantSet: true, wantVal: false, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var cfg AgentConfig
+			require.NoError(t, yaml.Unmarshal([]byte(tt.yaml), &cfg))
+
+			if tt.wantSet {
+				require.NotNil(t, cfg.RedactSecrets, "field should be set")
+				assert.Equal(t, tt.wantVal, *cfg.RedactSecrets)
+			} else {
+				assert.Nil(t, cfg.RedactSecrets, "field should be nil when omitted")
+			}
+			assert.Equal(t, tt.want, cfg.RedactSecretsEnabled())
+		})
+	}
+}

--- a/pkg/config/v14/types.go
+++ b/pkg/config/v14/types.go
@@ -1,4 +1,4 @@
-package latest
+package v14
 
 import (
 	"cmp"
@@ -18,7 +18,7 @@ import (
 	"github.com/docker/docker-agent/pkg/effort"
 )
 
-const Version = "15"
+const Version = "14"
 
 // Config represents the entire configuration file
 type Config struct {

--- a/pkg/config/v14/unload_test.go
+++ b/pkg/config/v14/unload_test.go
@@ -1,0 +1,29 @@
+package v14
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModelConfigUnloadAPI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  *ModelConfig
+		want string
+	}{
+		{name: "no provider opts", cfg: &ModelConfig{}, want: ""},
+		{name: "key absent", cfg: &ModelConfig{ProviderOpts: map[string]any{"other": "/foo"}}},
+		{name: "valid path", cfg: &ModelConfig{ProviderOpts: map[string]any{"unload_api": "/api/unload"}}, want: "/api/unload"},
+		{name: "non-string ignored", cfg: &ModelConfig{ProviderOpts: map[string]any{"unload_api": 42}}, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.cfg.UnloadAPI())
+		})
+	}
+}

--- a/pkg/config/v14/validate.go
+++ b/pkg/config/v14/validate.go
@@ -1,0 +1,558 @@
+package v14
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+func (t *Config) UnmarshalYAML(unmarshal func(any) error) error {
+	type alias Config
+	var tmp alias
+	if err := unmarshal(&tmp); err != nil {
+		return err
+	}
+	*t = Config(tmp)
+	return t.Validate()
+}
+
+func (t *Config) Validate() error {
+	if err := t.Budget.validate(); err != nil {
+		return fmt.Errorf("budget: %w", err)
+	}
+	for name := range t.Budgets {
+		b := t.Budgets[name]
+		if err := b.validate(); err != nil {
+			return fmt.Errorf("budgets.%s: %w", name, err)
+		}
+	}
+	for name, p := range t.Providers {
+		if err := p.Auth.Validate(p.Provider); err != nil {
+			return fmt.Errorf("providers.%s: %w", name, err)
+		}
+	}
+	for name, m := range t.Models {
+		if err := m.validateFirstAvailable(); err != nil {
+			return fmt.Errorf("models.%s: %w", name, err)
+		}
+		if err := validateCompactionThreshold(m.CompactionThreshold); err != nil {
+			return fmt.Errorf("models.%s: %w", name, err)
+		}
+		if err := m.Cost.validate(); err != nil {
+			return fmt.Errorf("models.%s: %w", name, err)
+		}
+		if err := m.Auth.Validate(EffectiveProviderType(m, t.Providers)); err != nil {
+			return fmt.Errorf("models.%s: %w", name, err)
+		}
+	}
+
+	// Re-validate reusable, named toolset definitions here so they are
+	// checked even when no agent references them, and when a Config is
+	// constructed programmatically rather than parsed from YAML. (When
+	// parsed, each value is already validated by Toolset.UnmarshalYAML.)
+	// Mirrors the agent-toolset validation loop below.
+	for name := range t.Toolsets {
+		ts := t.Toolsets[name]
+		if err := ts.validate(); err != nil {
+			return fmt.Errorf("toolsets.%s: %w", name, err)
+		}
+	}
+
+	for i := range t.Agents {
+		agent := &t.Agents[i]
+
+		// Validate fallback config
+		if err := agent.validateFallback(); err != nil {
+			return err
+		}
+		if err := agent.validateHarness(); err != nil {
+			return err
+		}
+		if err := validateCompactionThreshold(agent.CompactionThreshold); err != nil {
+			return fmt.Errorf("agents.%s: %w", agent.Name, err)
+		}
+		for _, name := range agent.Budgets {
+			if _, ok := t.Budgets[name]; !ok {
+				return fmt.Errorf("agents.%s: budgets: unknown budget %q; define it under the top-level 'budgets'", agent.Name, name)
+			}
+		}
+
+		for j := range agent.Toolsets {
+			if err := agent.Toolsets[j].validate(); err != nil {
+				return err
+			}
+		}
+		if agent.Hooks != nil {
+			if err := agent.Hooks.Validate(); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateFirstAvailable validates a model's first_available selector. The
+// selector is mutually exclusive with other model configuration fields, and
+// every candidate reference must be non-empty.
+func (m *ModelConfig) validateFirstAvailable() error {
+	if m.FirstAvailable == nil {
+		return nil
+	}
+	if len(m.FirstAvailable) == 0 {
+		return errors.New("first_available must contain at least one candidate")
+	}
+	if m.Provider != "" || m.Model != "" {
+		return errors.New("first_available cannot be combined with provider/model")
+	}
+	if m.Temperature != nil {
+		return errors.New("first_available cannot be combined with temperature")
+	}
+	if m.MaxTokens != nil {
+		return errors.New("first_available cannot be combined with max_tokens")
+	}
+	if m.TopP != nil {
+		return errors.New("first_available cannot be combined with top_p")
+	}
+	if m.FrequencyPenalty != nil {
+		return errors.New("first_available cannot be combined with frequency_penalty")
+	}
+	if m.PresencePenalty != nil {
+		return errors.New("first_available cannot be combined with presence_penalty")
+	}
+	if m.BaseURL != "" {
+		return errors.New("first_available cannot be combined with base_url")
+	}
+	if m.TokenKey != "" {
+		return errors.New("first_available cannot be combined with token_key")
+	}
+	if m.BypassModelsGateway {
+		return errors.New("first_available cannot be combined with bypass_models_gateway (set it on the candidate models instead)")
+	}
+	if len(m.ProviderOpts) > 0 {
+		return errors.New("first_available cannot be combined with provider_opts")
+	}
+	if m.TrackUsage != nil {
+		return errors.New("first_available cannot be combined with track_usage")
+	}
+	if m.ThinkingBudget != nil {
+		return errors.New("first_available cannot be combined with thinking_budget")
+	}
+	if m.TaskBudget != nil {
+		return errors.New("first_available cannot be combined with task_budget")
+	}
+	if m.Auth != nil {
+		return errors.New("first_available cannot be combined with auth")
+	}
+	if len(m.Routing) > 0 {
+		return errors.New("first_available cannot be combined with routing")
+	}
+	if m.TitleModel != "" {
+		return errors.New("first_available cannot be combined with title_model")
+	}
+	if m.CompactionModel != "" {
+		return errors.New("first_available cannot be combined with compaction_model")
+	}
+	if m.CompactionThreshold != nil {
+		return errors.New("first_available cannot be combined with compaction_threshold")
+	}
+	if m.Cost != nil {
+		return errors.New("first_available cannot be combined with cost (set it on the candidate models instead)")
+	}
+	for i, ref := range m.FirstAvailable {
+		if strings.TrimSpace(ref) == "" {
+			return fmt.Errorf("first_available[%d] must not be empty", i)
+		}
+	}
+	return nil
+}
+
+// validateCompactionThreshold rejects a compaction_threshold outside (0, 1].
+// nil (unset) is valid and means "use the default".
+func validateCompactionThreshold(v *float64) error {
+	if v == nil {
+		return nil
+	}
+	if *v <= 0 || *v > 1 {
+		return fmt.Errorf("compaction_threshold must be greater than 0 and at most 1, got %v", *v)
+	}
+	return nil
+}
+
+// validateFallback validates the fallback configuration for an agent
+func (a *AgentConfig) validateFallback() error {
+	if a.Fallback == nil {
+		return nil
+	}
+
+	// -1 is allowed as a special value meaning "explicitly no retries"
+	if a.Fallback.Retries < -1 {
+		return errors.New("fallback.retries must be >= -1 (use -1 for no retries, 0 for default)")
+	}
+	if a.Fallback.Cooldown.Duration < 0 {
+		return errors.New("fallback.cooldown must be non-negative")
+	}
+
+	return nil
+}
+
+func (a *AgentConfig) validateHarness() error {
+	if a.Harness == nil {
+		return nil
+	}
+
+	// Harness agents skip docker-agent's model and compaction resolution: the
+	// harness manages its own context. Reject a setting that would silently be
+	// ignored.
+	if a.CompactionModel != "" {
+		return errors.New("compaction_model cannot be used with a harness; the harness manages its own context compaction")
+	}
+
+	h := a.Harness
+	switch h.Type {
+	case "claude-code", "codex", "pi", "opencode":
+	case "":
+		return errors.New("harness.type is required")
+	default:
+		return fmt.Errorf("unsupported harness.type %q (must be one of: claude-code, codex, pi, opencode)", h.Type)
+	}
+
+	if h.Effort != "" {
+		if h.Type != "claude-code" {
+			return errors.New("harness.effort can only be used with harness.type 'claude-code'")
+		}
+		switch h.Effort {
+		case "low", "medium", "high", "xhigh", "max":
+		default:
+			return errors.New("harness.effort must be one of: low, medium, high, xhigh, max")
+		}
+	}
+	if h.Agent != "" && h.Type != "opencode" {
+		return errors.New("harness.agent can only be used with harness.type 'opencode'")
+	}
+	if h.Thinking && h.Type != "opencode" {
+		return errors.New("harness.thinking can only be used with harness.type 'opencode'")
+	}
+
+	return nil
+}
+
+func (t *Toolset) validate() error {
+	// Attributes used on the wrong toolset type.
+	if len(t.Shell) > 0 && t.Type != "script" {
+		return errors.New("shell can only be used with type 'script'")
+	}
+	if t.Path != "" && t.Type != "memory" && t.Type != "tasks" {
+		return errors.New("path can only be used with type 'memory' or 'tasks'")
+	}
+	if len(t.PostEdit) > 0 && t.Type != "filesystem" {
+		return errors.New("post_edit can only be used with type 'filesystem'")
+	}
+	if t.IgnoreVCS != nil && t.Type != "filesystem" {
+		return errors.New("ignore_vcs can only be used with type 'filesystem'")
+	}
+	if len(t.AllowList) > 0 && t.Type != "filesystem" {
+		return errors.New("allow_list can only be used with type 'filesystem'")
+	}
+	if len(t.DenyList) > 0 && t.Type != "filesystem" {
+		return errors.New("deny_list can only be used with type 'filesystem'")
+	}
+	if err := validatePathRootEntries("allow_list", t.AllowList); err != nil {
+		return err
+	}
+	if err := validatePathRootEntries("deny_list", t.DenyList); err != nil {
+		return err
+	}
+	if len(t.Env) > 0 && (t.Type != "shell" && t.Type != "background_jobs" && t.Type != "script" && t.Type != "mcp" && t.Type != "lsp") {
+		return errors.New("env can only be used with type 'shell', 'background_jobs', 'script', 'mcp' or 'lsp'")
+	}
+	if len(t.FileTypes) > 0 && t.Type != "lsp" {
+		return errors.New("file_types can only be used with type 'lsp'")
+	}
+	if len(t.AllowedServers) > 0 && t.Type != "mcp_catalog" {
+		return errors.New("allowed_servers can only be used with type 'mcp_catalog'")
+	}
+	if len(t.BlockedServers) > 0 && t.Type != "mcp_catalog" {
+		return errors.New("blocked_servers can only be used with type 'mcp_catalog'")
+	}
+	if err := validateNonEmptyEntries("allowed_servers", t.AllowedServers); err != nil {
+		return err
+	}
+	if err := validateNonEmptyEntries("blocked_servers", t.BlockedServers); err != nil {
+		return err
+	}
+	if len(t.AllowedDomains) > 0 && t.Type != "fetch" {
+		return errors.New("allowed_domains can only be used with type 'fetch'")
+	}
+	if len(t.BlockedDomains) > 0 && t.Type != "fetch" {
+		return errors.New("blocked_domains can only be used with type 'fetch'")
+	}
+	if t.AllowPrivateIPsEnabled() && t.Type != "fetch" && t.Type != "mcp" && t.Type != "api" && t.Type != "openapi" && t.Type != "a2a" {
+		return errors.New("allow_private_ips can only be used with type 'fetch', 'api', 'openapi', 'a2a' or remote MCP toolsets")
+	}
+	if t.SudoAskpass != nil && t.Type != "shell" {
+		return errors.New("sudo_askpass can only be used with type 'shell'")
+	}
+	if t.Recall != nil && t.Type != "background_jobs" {
+		return errors.New("recall can only be used with type 'background_jobs'")
+	}
+	if t.Safer != nil && t.Type != "shell" {
+		return errors.New("safer can only be used with type 'shell'")
+	}
+	if len(t.AllowedDomains) > 0 && len(t.BlockedDomains) > 0 {
+		return errors.New("allowed_domains and blocked_domains are mutually exclusive")
+	}
+	if err := validateDomainPatterns("allowed_domains", t.AllowedDomains); err != nil {
+		return err
+	}
+	if err := validateDomainPatterns("blocked_domains", t.BlockedDomains); err != nil {
+		return err
+	}
+	if len(t.Models) > 0 && t.Type != "model_picker" {
+		return errors.New("models can only be used with type 'model_picker'")
+	}
+	if t.Shared && t.Type != "todo" {
+		return errors.New("shared can only be used with type 'todo'")
+	}
+	if t.Version != "" && t.Type != "mcp" && t.Type != "lsp" {
+		return errors.New("version can only be used with type 'mcp' or 'lsp'")
+	}
+	if t.Command != "" && t.Type != "mcp" && t.Type != "lsp" {
+		return errors.New("command can only be used with type 'mcp' or 'lsp'")
+	}
+	if len(t.Args) > 0 && t.Type != "mcp" && t.Type != "lsp" {
+		return errors.New("args can only be used with type 'mcp' or 'lsp'")
+	}
+	if t.Ref != "" && t.Type != "mcp" && t.Type != "rag" {
+		return errors.New("ref can only be used with type 'mcp' or 'rag'")
+	}
+	if (t.Remote.URL != "" || t.Remote.TransportType != "" || t.Remote.OAuth != nil) && t.Type != "mcp" {
+		return errors.New("remote can only be used with type 'mcp'")
+	}
+	if (len(t.Remote.Headers) > 0) && (t.Type != "mcp" && t.Type != "a2a") {
+		return errors.New("remote headers can only be used with type 'mcp' or 'a2a'")
+	}
+	if len(t.Headers) > 0 && t.Type != "openapi" && t.Type != "a2a" && t.Type != "fetch" {
+		return errors.New("headers can only be used with type 'openapi', 'a2a' or 'fetch'")
+	}
+	if t.Config != nil && t.Type != "mcp" {
+		return errors.New("config can only be used with type 'mcp'")
+	}
+	if t.URL != "" && t.Type != "a2a" && t.Type != "openapi" && t.Type != "open_url" {
+		return errors.New("url can only be used with type 'a2a', 'openapi' or 'open_url'")
+	}
+	if t.Name != "" && (t.Type != "mcp" && t.Type != "a2a" && t.Type != "rag" && t.Type != "open_url") {
+		return errors.New("name can only be used with type 'mcp', 'a2a', 'rag', or 'open_url'")
+	}
+	if t.RAGConfig != nil && t.Type != "rag" {
+		return errors.New("rag_config can only be used with type 'rag'")
+	}
+	if t.WorkingDir != "" && t.Type != "mcp" && t.Type != "lsp" {
+		return errors.New("working_dir can only be used with type 'mcp' or 'lsp'")
+	}
+	// working_dir requires a local subprocess; it is meaningless for remote MCP toolsets.
+	if t.WorkingDir != "" && t.Type == "mcp" && t.Remote.URL != "" {
+		return errors.New("working_dir is not valid for remote MCP toolsets (no local subprocess)")
+	}
+	if t.Lifecycle != nil && t.Type != "mcp" && t.Type != "lsp" {
+		return errors.New("lifecycle can only be used with type 'mcp' or 'lsp'")
+	}
+	if err := t.Lifecycle.validate(); err != nil {
+		return err
+	}
+
+	switch t.Type {
+	case "shell":
+		// no additional validation needed
+	case "background_jobs":
+		// no additional validation needed
+	case "memory":
+		// path is optional; defaults to ~/.cagent/memory/<agent-name>/memory.db
+	case "tasks":
+		// path defaults to ./tasks.json if not set
+	case "mcp":
+		count := 0
+		if t.Command != "" {
+			count++
+		}
+		if t.Remote.URL != "" {
+			count++
+		}
+		if t.Ref != "" {
+			count++
+		}
+		if count == 0 {
+			return errors.New("either command, remote or ref must be set")
+		}
+		if count > 1 {
+			return errors.New("either command, remote or ref must be set, but only one of those")
+		}
+		if t.AllowPrivateIPsEnabled() && t.Remote.URL == "" && t.Ref == "" {
+			return errors.New("allow_private_ips can only be used with type 'fetch', 'api', 'openapi', 'a2a' or remote MCP toolsets")
+		}
+		if t.Remote.OAuth != nil {
+			if t.Remote.URL == "" {
+				return errors.New("oauth requires remote url to be set")
+			}
+			if t.Remote.OAuth.ClientID == "" && t.Remote.OAuth.ClientSecret != "" {
+				return errors.New("oauth clientSecret requires clientId to be set")
+			}
+			if t.Remote.OAuth.CallbackPort != 0 && (t.Remote.OAuth.CallbackPort < 1 || t.Remote.OAuth.CallbackPort > 65535) {
+				return errors.New("oauth callbackPort must be between 1 and 65535")
+			}
+			if t.Remote.OAuth.CallbackRedirectURL != "" {
+				if err := validateCallbackRedirectURL(t.Remote.OAuth.CallbackRedirectURL); err != nil {
+					return err
+				}
+			}
+		}
+	case "a2a":
+		if t.URL == "" {
+			return errors.New("a2a toolset requires a url to be set")
+		}
+	case "lsp":
+		if t.Command == "" {
+			return errors.New("lsp toolset requires a command to be set")
+		}
+	case "openapi":
+		if t.URL == "" {
+			return errors.New("openapi toolset requires a url to be set")
+		}
+	case "open_url":
+		if t.URL == "" {
+			return errors.New("open_url toolset requires a url to be set")
+		}
+	case "model_picker":
+		if len(t.Models) == 0 {
+			return errors.New("model_picker toolset requires at least one model in the 'models' list")
+		}
+	case "rag":
+		// rag toolset requires either a ref or inline rag_config
+		if t.Ref == "" && t.RAGConfig == nil {
+			return errors.New("rag toolset requires either ref or rag_config")
+		}
+	case "background_agents":
+		// no additional validation needed
+	}
+
+	return nil
+}
+
+// validateNonEmptyEntries rejects empty / whitespace-only entries in a
+// generic string list (e.g. the mcp_catalog allow/block server lists). An
+// empty id would never match a catalog server but signals a config typo.
+func validateNonEmptyEntries(field string, entries []string) error {
+	for i, e := range entries {
+		if strings.TrimSpace(e) == "" {
+			return fmt.Errorf("%s[%d] must not be empty", field, i)
+		}
+	}
+	return nil
+}
+
+// validatePathRootEntries rejects empty / whitespace-only entries in a
+// filesystem allow- or deny-list. An empty entry would be a foot-gun: it
+// would resolve to the working directory and silently widen (or close) the
+// matched set in surprising ways.
+func validatePathRootEntries(field string, entries []string) error {
+	for i, e := range entries {
+		if strings.TrimSpace(e) == "" {
+			return fmt.Errorf("%s[%d] must not be empty", field, i)
+		}
+	}
+	return nil
+}
+
+// validateDomainPatterns rejects empty / whitespace-only entries and
+// malformed wildcard or CIDR patterns in a fetch allow- or block-list.
+//
+// Catching these at config-load time turns silent foot-guns (e.g.
+// `allowed_domains: [""]` rejecting every URL, `*.foo.*` matching nothing)
+// into actionable errors. Plain hostnames and the leading-dot subdomain form
+// are intentionally not validated for syntax — the matcher is purely
+// string-based and any non-conforming entry simply never matches.
+func validateDomainPatterns(field string, patterns []string) error {
+	for i, p := range patterns {
+		trimmed := strings.TrimSpace(p)
+		if trimmed == "" {
+			return fmt.Errorf("%s[%d] must not be empty", field, i)
+		}
+		if err := validateDomainPattern(trimmed); err != nil {
+			return fmt.Errorf("%s[%d] %q is invalid: %w", field, i, p, err)
+		}
+	}
+	return nil
+}
+
+// validateDomainPattern checks a single (already trimmed, non-empty) entry.
+func validateDomainPattern(p string) error {
+	// CIDR notation: must parse cleanly. We deliberately accept any /-bearing
+	// string as "intended to be a CIDR" so a typo like "10.0.0.0/33" is
+	// reported instead of being silently treated as a hostname.
+	if strings.Contains(p, "/") {
+		if _, _, err := net.ParseCIDR(p); err != nil {
+			return fmt.Errorf("not a valid CIDR: %w", err)
+		}
+		return nil
+	}
+	// Wildcards: only the leading "*." form is supported. Anything else
+	// ("foo.*", "*foo*", "**.example.com") would silently match nothing
+	// under the current matcher, which is almost never what the user wants.
+	if strings.Contains(p, "*") {
+		rest, ok := strings.CutPrefix(p, "*.")
+		if !ok || rest == "" || strings.Contains(rest, "*") {
+			return errors.New("'*' is only allowed as a leading '*.' wildcard, e.g. '*.example.com'")
+		}
+	}
+	return nil
+}
+
+// isLoopbackHost reports whether host is a loopback address (with or without
+// a port component). It accepts IPv4 loopback, IPv6 loopback, and the literal
+// "localhost".
+func isLoopbackHost(hostPort string) bool {
+	host := hostPort
+	if h, _, err := net.SplitHostPort(hostPort); err == nil {
+		host = h
+	}
+	host = strings.Trim(host, "[]") // strip IPv6 brackets
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+// validateCallbackRedirectURL ensures raw is a well-formed absolute URL
+// suitable for use as an OAuth redirect_uri.
+//
+// Rules:
+//   - Must parse as an absolute URL (scheme + host) once the ${callbackPort}
+//     placeholder has been substituted with a dummy value.
+//   - Scheme must be http or https. Other schemes (javascript:, file:, ftp:,
+//     …) are rejected: the browser will be navigated to this URL by the
+//     authorization server.
+//   - http is only permitted for loopback hosts (RFC 8252 §7.3); any other
+//     host must use https, since non-loopback http redirect URIs allow the
+//     authorization code to be exposed on the wire.
+func validateCallbackRedirectURL(raw string) error {
+	// Substitute the placeholder with a dummy port so url.Parse accepts the
+	// string (Go's parser validates that ports are numeric).
+	probe := strings.ReplaceAll(raw, "${callbackPort}", "1")
+	u, err := url.Parse(probe)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("oauth callbackRedirectURL must be an absolute URL: %q", raw)
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("oauth callbackRedirectURL scheme must be http or https, got %q", u.Scheme)
+	}
+	if scheme == "http" && !isLoopbackHost(u.Host) {
+		return fmt.Errorf("oauth callbackRedirectURL must use https for non-loopback hosts: %q", raw)
+	}
+	return nil
+}

--- a/pkg/config/v14/validate_test.go
+++ b/pkg/config/v14/validate_test.go
@@ -1,0 +1,622 @@
+package v14
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateCompactionThreshold(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   *float64
+		wantErr string
+	}{
+		{name: "nil is valid", value: nil},
+		{name: "just above zero", value: new(0.0001)},
+		{name: "mid range", value: new(0.5)},
+		{name: "exactly one", value: new(1.0)},
+		{name: "exactly zero", value: new(0.0), wantErr: "compaction_threshold must be greater than 0 and at most 1, got 0"},
+		{name: "negative", value: new(-0.5), wantErr: "compaction_threshold must be greater than 0 and at most 1, got -0.5"},
+		{name: "just above one", value: new(1.000001), wantErr: "compaction_threshold must be greater than 0 and at most 1"},
+		{name: "well above one", value: new(1.5), wantErr: "compaction_threshold must be greater than 0 and at most 1, got 1.5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateCompactionThreshold(tt.value)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestModelConfigValidateFirstAvailable(t *testing.T) {
+	t.Parallel()
+
+	candidates := []string{"openai/gpt-4o"}
+
+	tests := []struct {
+		name    string
+		model   ModelConfig
+		wantErr string
+	}{
+		{name: "nil selector", model: ModelConfig{Provider: "openai", Model: "gpt-4o"}},
+		{name: "single candidate", model: ModelConfig{FirstAvailable: candidates}},
+		{name: "multiple candidates", model: ModelConfig{FirstAvailable: []string{"anthropic/claude-sonnet-4-5", "dmr/local"}}},
+		{name: "empty selector", model: ModelConfig{FirstAvailable: []string{}}, wantErr: "first_available must contain at least one candidate"},
+		{name: "blank candidate", model: ModelConfig{FirstAvailable: []string{"openai/gpt-4o", "  "}}, wantErr: "first_available[1] must not be empty"},
+		{name: "with provider", model: ModelConfig{FirstAvailable: candidates, Provider: "openai"}, wantErr: "first_available cannot be combined with provider/model"},
+		{name: "with model", model: ModelConfig{FirstAvailable: candidates, Model: "gpt-4o"}, wantErr: "first_available cannot be combined with provider/model"},
+		{name: "with temperature", model: ModelConfig{FirstAvailable: candidates, Temperature: new(0.5)}, wantErr: "first_available cannot be combined with temperature"},
+		{name: "with max_tokens", model: ModelConfig{FirstAvailable: candidates, MaxTokens: new(int64(100))}, wantErr: "first_available cannot be combined with max_tokens"},
+		{name: "with top_p", model: ModelConfig{FirstAvailable: candidates, TopP: new(0.9)}, wantErr: "first_available cannot be combined with top_p"},
+		{name: "with frequency_penalty", model: ModelConfig{FirstAvailable: candidates, FrequencyPenalty: new(0.1)}, wantErr: "first_available cannot be combined with frequency_penalty"},
+		{name: "with presence_penalty", model: ModelConfig{FirstAvailable: candidates, PresencePenalty: new(0.1)}, wantErr: "first_available cannot be combined with presence_penalty"},
+		{name: "with base_url", model: ModelConfig{FirstAvailable: candidates, BaseURL: "https://example.invalid/v1"}, wantErr: "first_available cannot be combined with base_url"},
+		{name: "with token_key", model: ModelConfig{FirstAvailable: candidates, TokenKey: "MY_KEY"}, wantErr: "first_available cannot be combined with token_key"},
+		{name: "with bypass_models_gateway", model: ModelConfig{FirstAvailable: candidates, BypassModelsGateway: true}, wantErr: "first_available cannot be combined with bypass_models_gateway"},
+		{name: "with provider_opts", model: ModelConfig{FirstAvailable: candidates, ProviderOpts: map[string]any{"context_size": 4096}}, wantErr: "first_available cannot be combined with provider_opts"},
+		{name: "with track_usage", model: ModelConfig{FirstAvailable: candidates, TrackUsage: new(true)}, wantErr: "first_available cannot be combined with track_usage"},
+		{name: "with thinking_budget", model: ModelConfig{FirstAvailable: candidates, ThinkingBudget: &ThinkingBudget{Effort: "high"}}, wantErr: "first_available cannot be combined with thinking_budget"},
+		{name: "with task_budget", model: ModelConfig{FirstAvailable: candidates, TaskBudget: &TaskBudget{Type: "tokens", Total: 1000}}, wantErr: "first_available cannot be combined with task_budget"},
+		{name: "with auth", model: ModelConfig{FirstAvailable: candidates, Auth: &AuthConfig{Type: AuthTypeWorkloadIdentityFederation}}, wantErr: "first_available cannot be combined with auth"},
+		{name: "with routing", model: ModelConfig{FirstAvailable: candidates, Routing: []RoutingRule{{Model: "openai/gpt-4o-mini", Examples: []string{"hi"}}}}, wantErr: "first_available cannot be combined with routing"},
+		{name: "with title_model", model: ModelConfig{FirstAvailable: candidates, TitleModel: "small"}, wantErr: "first_available cannot be combined with title_model"},
+		{name: "with compaction_model", model: ModelConfig{FirstAvailable: candidates, CompactionModel: "small"}, wantErr: "first_available cannot be combined with compaction_model"},
+		{name: "with compaction_threshold", model: ModelConfig{FirstAvailable: candidates, CompactionThreshold: new(0.5)}, wantErr: "first_available cannot be combined with compaction_threshold"},
+		{name: "with cost", model: ModelConfig{FirstAvailable: candidates, Cost: &CostConfig{Input: 1}}, wantErr: "first_available cannot be combined with cost"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.model.validateFirstAvailable()
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestAgentConfigValidateFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		fallback *FallbackConfig
+		wantErr  string
+	}{
+		{name: "nil fallback", fallback: nil},
+		{name: "defaults", fallback: &FallbackConfig{Models: []string{"backup"}}},
+		{name: "explicit no retries", fallback: &FallbackConfig{Retries: -1}},
+		{name: "positive retries and cooldown", fallback: &FallbackConfig{Retries: 3, Cooldown: Duration{Duration: time.Minute}}},
+		{name: "retries below -1", fallback: &FallbackConfig{Retries: -2}, wantErr: "fallback.retries must be >= -1"},
+		{name: "negative cooldown", fallback: &FallbackConfig{Cooldown: Duration{Duration: -time.Second}}, wantErr: "fallback.cooldown must be non-negative"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			agent := AgentConfig{Name: "root", Fallback: tt.fallback}
+			err := agent.validateFallback()
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestAgentConfigValidateHarness(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		harness         *HarnessConfig
+		compactionModel string
+		wantErr         string
+	}{
+		{name: "nil harness", harness: nil},
+		{name: "nil harness with compaction model", harness: nil, compactionModel: "fast"},
+		{name: "claude-code", harness: &HarnessConfig{Type: "claude-code"}},
+		{name: "codex", harness: &HarnessConfig{Type: "codex"}},
+		{name: "pi", harness: &HarnessConfig{Type: "pi"}},
+		{name: "opencode", harness: &HarnessConfig{Type: "opencode"}},
+		{name: "missing type", harness: &HarnessConfig{}, wantErr: "harness.type is required"},
+		{name: "unsupported type", harness: &HarnessConfig{Type: "cursor"}, wantErr: `unsupported harness.type "cursor"`},
+		{name: "effort low", harness: &HarnessConfig{Type: "claude-code", Effort: "low"}},
+		{name: "effort medium", harness: &HarnessConfig{Type: "claude-code", Effort: "medium"}},
+		{name: "effort high", harness: &HarnessConfig{Type: "claude-code", Effort: "high"}},
+		{name: "effort xhigh", harness: &HarnessConfig{Type: "claude-code", Effort: "xhigh"}},
+		{name: "effort max", harness: &HarnessConfig{Type: "claude-code", Effort: "max"}},
+		{name: "effort on wrong type", harness: &HarnessConfig{Type: "codex", Effort: "high"}, wantErr: "harness.effort can only be used with harness.type 'claude-code'"},
+		{name: "invalid effort", harness: &HarnessConfig{Type: "claude-code", Effort: "extreme"}, wantErr: "harness.effort must be one of: low, medium, high, xhigh, max"},
+		{name: "agent on opencode", harness: &HarnessConfig{Type: "opencode", Agent: "build"}},
+		{name: "agent on wrong type", harness: &HarnessConfig{Type: "claude-code", Agent: "build"}, wantErr: "harness.agent can only be used with harness.type 'opencode'"},
+		{name: "thinking on opencode", harness: &HarnessConfig{Type: "opencode", Thinking: true}},
+		{name: "thinking on wrong type", harness: &HarnessConfig{Type: "codex", Thinking: true}, wantErr: "harness.thinking can only be used with harness.type 'opencode'"},
+		{name: "compaction model on harness", harness: &HarnessConfig{Type: "claude-code"}, compactionModel: "fast", wantErr: "compaction_model cannot be used with a harness"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			agent := AgentConfig{Name: "root", Harness: tt.harness, CompactionModel: tt.compactionModel}
+			err := agent.validateHarness()
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestToolsetValidateAttributeTypeMismatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		toolset Toolset
+		wantErr string
+	}{
+		{name: "shell map on non-script", toolset: Toolset{Type: "shell", Shell: map[string]ScriptShellToolConfig{"greet": {}}}, wantErr: "shell can only be used with type 'script'"},
+		{name: "path on non-memory/tasks", toolset: Toolset{Type: "shell", Path: "/tmp/db"}, wantErr: "path can only be used with type 'memory' or 'tasks'"},
+		{name: "post_edit on non-filesystem", toolset: Toolset{Type: "shell", PostEdit: []PostEditConfig{{}}}, wantErr: "post_edit can only be used with type 'filesystem'"},
+		{name: "ignore_vcs on non-filesystem", toolset: Toolset{Type: "shell", IgnoreVCS: new(true)}, wantErr: "ignore_vcs can only be used with type 'filesystem'"},
+		{name: "allow_list on non-filesystem", toolset: Toolset{Type: "shell", AllowList: []string{"."}}, wantErr: "allow_list can only be used with type 'filesystem'"},
+		{name: "deny_list on non-filesystem", toolset: Toolset{Type: "shell", DenyList: []string{"/etc"}}, wantErr: "deny_list can only be used with type 'filesystem'"},
+		{name: "blank allow_list entry", toolset: Toolset{Type: "filesystem", AllowList: []string{"  "}}, wantErr: "allow_list[0] must not be empty"},
+		{name: "blank deny_list entry", toolset: Toolset{Type: "filesystem", DenyList: []string{"/etc", ""}}, wantErr: "deny_list[1] must not be empty"},
+		{name: "env on wrong type", toolset: Toolset{Type: "filesystem", Env: map[string]string{"A": "b"}}, wantErr: "env can only be used with type 'shell', 'background_jobs', 'script', 'mcp' or 'lsp'"},
+		{name: "file_types on non-lsp", toolset: Toolset{Type: "shell", FileTypes: []string{"go"}}, wantErr: "file_types can only be used with type 'lsp'"},
+		{name: "allowed_servers on non-mcp_catalog", toolset: Toolset{Type: "shell", AllowedServers: []string{"github"}}, wantErr: "allowed_servers can only be used with type 'mcp_catalog'"},
+		{name: "blocked_servers on non-mcp_catalog", toolset: Toolset{Type: "shell", BlockedServers: []string{"github"}}, wantErr: "blocked_servers can only be used with type 'mcp_catalog'"},
+		{name: "blank allowed_servers entry", toolset: Toolset{Type: "mcp_catalog", AllowedServers: []string{""}}, wantErr: "allowed_servers[0] must not be empty"},
+		{name: "blank blocked_servers entry", toolset: Toolset{Type: "mcp_catalog", BlockedServers: []string{"github", " "}}, wantErr: "blocked_servers[1] must not be empty"},
+		{name: "allowed_domains on non-fetch", toolset: Toolset{Type: "shell", AllowedDomains: []string{"example.com"}}, wantErr: "allowed_domains can only be used with type 'fetch'"},
+		{name: "blocked_domains on non-fetch", toolset: Toolset{Type: "shell", BlockedDomains: []string{"example.com"}}, wantErr: "blocked_domains can only be used with type 'fetch'"},
+		{name: "allow_private_ips on wrong type", toolset: Toolset{Type: "shell", AllowPrivateIPs: new(true)}, wantErr: "allow_private_ips can only be used with type 'fetch', 'api', 'openapi', 'a2a' or remote MCP toolsets"},
+		{name: "sudo_askpass on non-shell", toolset: Toolset{Type: "fetch", SudoAskpass: new(true)}, wantErr: "sudo_askpass can only be used with type 'shell'"},
+		{name: "recall on non-background_jobs", toolset: Toolset{Type: "shell", Recall: new(true)}, wantErr: "recall can only be used with type 'background_jobs'"},
+		{name: "safer on non-shell", toolset: Toolset{Type: "fetch", Safer: new(true)}, wantErr: "safer can only be used with type 'shell'"},
+		{name: "allowed and blocked domains", toolset: Toolset{Type: "fetch", AllowedDomains: []string{"a.example.com"}, BlockedDomains: []string{"b.example.com"}}, wantErr: "allowed_domains and blocked_domains are mutually exclusive"},
+		{name: "invalid allowed_domains pattern", toolset: Toolset{Type: "fetch", AllowedDomains: []string{"foo.*"}}, wantErr: `allowed_domains[0] "foo.*" is invalid`},
+		{name: "invalid blocked_domains pattern", toolset: Toolset{Type: "fetch", BlockedDomains: []string{"10.0.0.0/33"}}, wantErr: `blocked_domains[0] "10.0.0.0/33" is invalid: not a valid CIDR`},
+		{name: "models on non-model_picker", toolset: Toolset{Type: "shell", Models: []string{"openai/gpt-4o"}}, wantErr: "models can only be used with type 'model_picker'"},
+		{name: "shared on non-todo", toolset: Toolset{Type: "shell", Shared: true}, wantErr: "shared can only be used with type 'todo'"},
+		{name: "version on wrong type", toolset: Toolset{Type: "shell", Version: "owner/repo"}, wantErr: "version can only be used with type 'mcp' or 'lsp'"},
+		{name: "command on wrong type", toolset: Toolset{Type: "shell", Command: "run"}, wantErr: "command can only be used with type 'mcp' or 'lsp'"},
+		{name: "args on wrong type", toolset: Toolset{Type: "shell", Args: []string{"-v"}}, wantErr: "args can only be used with type 'mcp' or 'lsp'"},
+		{name: "ref on wrong type", toolset: Toolset{Type: "shell", Ref: "docker/duckduckgo"}, wantErr: "ref can only be used with type 'mcp' or 'rag'"},
+		{name: "remote url on non-mcp", toolset: Toolset{Type: "shell", Remote: Remote{URL: "https://mcp.example.com"}}, wantErr: "remote can only be used with type 'mcp'"},
+		{name: "remote transport on non-mcp", toolset: Toolset{Type: "a2a", URL: "https://agent.example.com", Remote: Remote{TransportType: "sse"}}, wantErr: "remote can only be used with type 'mcp'"},
+		{name: "remote oauth on non-mcp", toolset: Toolset{Type: "shell", Remote: Remote{OAuth: &RemoteOAuthConfig{ClientID: "c"}}}, wantErr: "remote can only be used with type 'mcp'"},
+		{name: "remote headers on wrong type", toolset: Toolset{Type: "shell", Remote: Remote{Headers: map[string]string{"A": "b"}}}, wantErr: "remote headers can only be used with type 'mcp' or 'a2a'"},
+		{name: "headers on wrong type", toolset: Toolset{Type: "shell", Headers: map[string]string{"A": "b"}}, wantErr: "headers can only be used with type 'openapi', 'a2a' or 'fetch'"},
+		{name: "config on non-mcp", toolset: Toolset{Type: "shell", Config: map[string]any{"k": "v"}}, wantErr: "config can only be used with type 'mcp'"},
+		{name: "url on wrong type", toolset: Toolset{Type: "shell", URL: "https://example.com"}, wantErr: "url can only be used with type 'a2a', 'openapi' or 'open_url'"},
+		{name: "name on wrong type", toolset: Toolset{Type: "shell", Name: "custom"}, wantErr: "name can only be used with type 'mcp', 'a2a', 'rag', or 'open_url'"},
+		{name: "rag_config on non-rag", toolset: Toolset{Type: "shell", RAGConfig: &RAGConfig{}}, wantErr: "rag_config can only be used with type 'rag'"},
+		{name: "working_dir on wrong type", toolset: Toolset{Type: "shell", WorkingDir: "/tmp"}, wantErr: "working_dir can only be used with type 'mcp' or 'lsp'"},
+		{name: "working_dir on remote mcp", toolset: Toolset{Type: "mcp", WorkingDir: "/tmp", Remote: Remote{URL: "https://mcp.example.com"}}, wantErr: "working_dir is not valid for remote MCP toolsets"},
+		{name: "lifecycle on wrong type", toolset: Toolset{Type: "shell", Lifecycle: &LifecycleConfig{}}, wantErr: "lifecycle can only be used with type 'mcp' or 'lsp'"},
+		{name: "invalid lifecycle", toolset: Toolset{Type: "mcp", Command: "server", Lifecycle: &LifecycleConfig{Profile: "bogus"}}, wantErr: `lifecycle.profile "bogus" is not supported`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.ErrorContains(t, tt.toolset.validate(), tt.wantErr)
+		})
+	}
+}
+
+func TestToolsetValidateTypeRequirements(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		toolset Toolset
+		wantErr string
+	}{
+		{name: "mcp without source", toolset: Toolset{Type: "mcp"}, wantErr: "either command, remote or ref must be set"},
+		{name: "mcp command and remote", toolset: Toolset{Type: "mcp", Command: "server", Remote: Remote{URL: "https://mcp.example.com"}}, wantErr: "but only one of those"},
+		{name: "mcp command and ref", toolset: Toolset{Type: "mcp", Command: "server", Ref: "docker/duckduckgo"}, wantErr: "but only one of those"},
+		{name: "mcp remote and ref", toolset: Toolset{Type: "mcp", Remote: Remote{URL: "https://mcp.example.com"}, Ref: "docker/duckduckgo"}, wantErr: "but only one of those"},
+		{name: "local mcp with allow_private_ips", toolset: Toolset{Type: "mcp", Command: "server", AllowPrivateIPs: new(true)}, wantErr: "allow_private_ips can only be used with type 'fetch', 'api', 'openapi', 'a2a' or remote MCP toolsets"},
+		{name: "a2a without url", toolset: Toolset{Type: "a2a"}, wantErr: "a2a toolset requires a url to be set"},
+		{name: "lsp without command", toolset: Toolset{Type: "lsp"}, wantErr: "lsp toolset requires a command to be set"},
+		{name: "openapi without url", toolset: Toolset{Type: "openapi"}, wantErr: "openapi toolset requires a url to be set"},
+		{name: "open_url without url", toolset: Toolset{Type: "open_url"}, wantErr: "open_url toolset requires a url to be set"},
+		{name: "model_picker without models", toolset: Toolset{Type: "model_picker"}, wantErr: "model_picker toolset requires at least one model in the 'models' list"},
+		{name: "rag without ref or config", toolset: Toolset{Type: "rag"}, wantErr: "rag toolset requires either ref or rag_config"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.ErrorContains(t, tt.toolset.validate(), tt.wantErr)
+		})
+	}
+}
+
+func TestToolsetValidateOAuth(t *testing.T) {
+	t.Parallel()
+
+	remote := func(oauth *RemoteOAuthConfig) Toolset {
+		return Toolset{Type: "mcp", Remote: Remote{URL: "https://mcp.example.com", OAuth: oauth}}
+	}
+
+	tests := []struct {
+		name    string
+		toolset Toolset
+		wantErr string
+	}{
+		{name: "minimal oauth", toolset: remote(&RemoteOAuthConfig{ClientID: "client"})},
+		{name: "oauth without remote url", toolset: Toolset{Type: "mcp", Command: "server", Remote: Remote{OAuth: &RemoteOAuthConfig{ClientID: "client"}}}, wantErr: "oauth requires remote url to be set"},
+		{name: "missing clientId falls back to dynamic registration", toolset: remote(&RemoteOAuthConfig{})},
+		{name: "clientSecret without clientId", toolset: remote(&RemoteOAuthConfig{ClientSecret: "secret"}), wantErr: "oauth clientSecret requires clientId to be set"},
+		{name: "callback settings without clientId", toolset: remote(&RemoteOAuthConfig{CallbackPort: 8765, CallbackRedirectURL: "https://redirect.example.com/cb"})},
+		{name: "callback port unset", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackPort: 0})},
+		{name: "callback port lower bound", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackPort: 1})},
+		{name: "callback port upper bound", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackPort: 65535})},
+		{name: "callback port negative", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackPort: -1}), wantErr: "oauth callbackPort must be between 1 and 65535"},
+		{name: "callback port too large", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackPort: 65536}), wantErr: "oauth callbackPort must be between 1 and 65535"},
+		{name: "https redirect url", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackRedirectURL: "https://redirect.example.com/cb"})},
+		{name: "loopback redirect url with placeholder", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackRedirectURL: "http://127.0.0.1:${callbackPort}/callback"})},
+		{name: "http redirect to non-loopback", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackRedirectURL: "http://redirect.example.com/cb"}), wantErr: "oauth callbackRedirectURL must use https for non-loopback hosts"},
+		{name: "relative redirect url", toolset: remote(&RemoteOAuthConfig{ClientID: "client", CallbackRedirectURL: "/callback"}), wantErr: "oauth callbackRedirectURL must be an absolute URL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.toolset.validate()
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestToolsetValidateValidToolsets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		toolset Toolset
+	}{
+		{name: "shell", toolset: Toolset{Type: "shell", Env: map[string]string{"A": "b"}, SudoAskpass: new(true), Safer: new(true)}},
+		{name: "background_jobs", toolset: Toolset{Type: "background_jobs", Env: map[string]string{"A": "b"}, Recall: new(true)}},
+		{name: "memory with path", toolset: Toolset{Type: "memory", Path: "/tmp/memory.db"}},
+		{name: "memory without path", toolset: Toolset{Type: "memory"}},
+		{name: "tasks", toolset: Toolset{Type: "tasks", Path: "./tasks.json"}},
+		{name: "todo shared", toolset: Toolset{Type: "todo", Shared: true}},
+		{name: "script", toolset: Toolset{Type: "script", Shell: map[string]ScriptShellToolConfig{"greet": {}}, Env: map[string]string{"A": "b"}}},
+		{name: "filesystem", toolset: Toolset{Type: "filesystem", PostEdit: []PostEditConfig{{}}, IgnoreVCS: new(false), AllowList: []string{".", "~/src"}, DenyList: []string{"/etc"}}},
+		{name: "fetch with allowed domains", toolset: Toolset{Type: "fetch", AllowedDomains: []string{"example.com", "*.example.org", ".sub.example.net", "10.0.0.0/8"}, Headers: map[string]string{"Accept": "text/html"}, AllowPrivateIPs: new(true)}},
+		{name: "fetch with blocked domains", toolset: Toolset{Type: "fetch", BlockedDomains: []string{"internal.example.com"}}},
+		{name: "api with allow_private_ips", toolset: Toolset{Type: "api", AllowPrivateIPs: new(true)}},
+		{name: "mcp_catalog", toolset: Toolset{Type: "mcp_catalog", AllowedServers: []string{"github"}, BlockedServers: []string{"slack"}}},
+		{name: "mcp local command", toolset: Toolset{Type: "mcp", Command: "server", Args: []string{"--stdio"}, Env: map[string]string{"A": "b"}, Version: "owner/repo@v1", WorkingDir: ".", Config: map[string]any{"k": "v"}, Lifecycle: &LifecycleConfig{Profile: LifecycleProfileResilient}}},
+		{name: "mcp local allow_private_ips disabled", toolset: Toolset{Type: "mcp", Command: "server", AllowPrivateIPs: new(false)}},
+		{name: "mcp remote", toolset: Toolset{Type: "mcp", Remote: Remote{URL: "https://mcp.example.com", TransportType: "sse", Headers: map[string]string{"Authorization": "Bearer x"}}, AllowPrivateIPs: new(true)}},
+		{name: "mcp ref", toolset: Toolset{Type: "mcp", Ref: "docker/duckduckgo", Name: "search", AllowPrivateIPs: new(true)}},
+		{name: "a2a", toolset: Toolset{Type: "a2a", URL: "https://agent.example.com", Name: "helper", Headers: map[string]string{"A": "b"}, Remote: Remote{Headers: map[string]string{"C": "d"}}}},
+		{name: "lsp", toolset: Toolset{Type: "lsp", Command: "gopls", Args: []string{"serve"}, FileTypes: []string{"go"}, Version: "golang/tools", WorkingDir: ".", Env: map[string]string{"A": "b"}, Lifecycle: &LifecycleConfig{Profile: LifecycleProfileStrict}}},
+		{name: "openapi", toolset: Toolset{Type: "openapi", URL: "https://api.example.com/spec.yaml", Headers: map[string]string{"A": "b"}}},
+		{name: "open_url", toolset: Toolset{Type: "open_url", URL: "https://example.com", Name: "docs"}},
+		{name: "model_picker", toolset: Toolset{Type: "model_picker", Models: []string{"openai/gpt-4o", "anthropic/claude-sonnet-4-5"}}},
+		{name: "rag with ref", toolset: Toolset{Type: "rag", Ref: "docs", Name: "kb"}},
+		{name: "rag with inline config", toolset: Toolset{Type: "rag", RAGConfig: &RAGConfig{}}},
+		{name: "background_agents", toolset: Toolset{Type: "background_agents"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.NoError(t, tt.toolset.validate())
+		})
+	}
+}
+
+// TestToolsetValidateUnknownType documents current behavior: validate only
+// checks field/type pairings and per-type requirements, so an unknown type
+// with no extra fields passes because the trailing type switch has no
+// default case. Unknown types are still rejected elsewhere: agent-schema.json
+// constrains `type` to an enum, and toolset creation fails with "unknown
+// toolset type" in the teamloader registry (pkg/teamloader/registry.go).
+func TestToolsetValidateUnknownType(t *testing.T) {
+	t.Parallel()
+
+	toolset := Toolset{Type: "no-such-toolset"}
+	require.NoError(t, toolset.validate())
+}
+
+func TestValidateNonEmptyEntries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		entries []string
+		wantErr string
+	}{
+		{name: "nil list", entries: nil},
+		{name: "valid entries", entries: []string{"github", "slack"}},
+		{name: "empty entry", entries: []string{""}, wantErr: "field[0] must not be empty"},
+		{name: "whitespace entry", entries: []string{"github", " \t"}, wantErr: "field[1] must not be empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateNonEmptyEntries("field", tt.entries)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidatePathRootEntries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		entries []string
+		wantErr string
+	}{
+		{name: "nil list", entries: nil},
+		{name: "valid entries", entries: []string{".", "~", "/srv/data", "relative/dir"}},
+		{name: "empty entry", entries: []string{""}, wantErr: "allow_list[0] must not be empty"},
+		{name: "whitespace entry", entries: []string{".", "   "}, wantErr: "allow_list[1] must not be empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validatePathRootEntries("allow_list", tt.entries)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateDomainPatterns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		patterns []string
+		wantErr  string
+	}{
+		{name: "nil list", patterns: nil},
+		{name: "plain hostname", patterns: []string{"example.com"}},
+		{name: "leading dot subdomain form", patterns: []string{".example.com"}},
+		{name: "leading wildcard", patterns: []string{"*.example.com"}},
+		{name: "ipv4 cidr", patterns: []string{"10.0.0.0/8"}},
+		{name: "ipv6 cidr", patterns: []string{"fd00::/8"}},
+		{name: "untrimmed valid entry", patterns: []string{"  example.com  "}},
+		{name: "empty entry", patterns: []string{"example.com", " "}, wantErr: "allowed_domains[1] must not be empty"},
+		{name: "invalid cidr", patterns: []string{"10.0.0.0/33"}, wantErr: `allowed_domains[0] "10.0.0.0/33" is invalid: not a valid CIDR`},
+		{name: "trailing wildcard", patterns: []string{"foo.*"}, wantErr: "'*' is only allowed as a leading '*.' wildcard"},
+		{name: "surrounding wildcards", patterns: []string{"*foo*"}, wantErr: "'*' is only allowed as a leading '*.' wildcard"},
+		{name: "double wildcard", patterns: []string{"**.example.com"}, wantErr: "'*' is only allowed as a leading '*.' wildcard"},
+		{name: "bare wildcard prefix", patterns: []string{"*."}, wantErr: "'*' is only allowed as a leading '*.' wildcard"},
+		{name: "mid-label wildcard", patterns: []string{"sub.*.example.com"}, wantErr: "'*' is only allowed as a leading '*.' wildcard"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateDomainPatterns("allowed_domains", tt.patterns)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestIsLoopbackHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		host string
+		want bool
+	}{
+		{name: "localhost", host: "localhost", want: true},
+		{name: "localhost mixed case", host: "LocalHost", want: true},
+		{name: "localhost with port", host: "localhost:8080", want: true},
+		{name: "ipv4 loopback", host: "127.0.0.1", want: true},
+		{name: "ipv4 loopback with port", host: "127.0.0.1:9090", want: true},
+		{name: "ipv4 loopback range", host: "127.1.2.3", want: true},
+		{name: "ipv6 loopback", host: "::1", want: true},
+		{name: "bracketed ipv6 loopback", host: "[::1]", want: true},
+		{name: "bracketed ipv6 loopback with port", host: "[::1]:8080", want: true},
+		{name: "public hostname", host: "example.com", want: false},
+		{name: "public hostname with port", host: "example.com:443", want: false},
+		{name: "private non-loopback ip", host: "192.168.1.10", want: false},
+		{name: "unspecified address", host: "0.0.0.0", want: false},
+		{name: "empty string", host: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isLoopbackHost(tt.host))
+		})
+	}
+}
+
+func TestValidateCallbackRedirectURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr string
+	}{
+		{name: "https non-loopback", raw: "https://redirect.example.com/oauth?state=x"},
+		{name: "https with placeholder", raw: "https://redirect.example.com/cb/${callbackPort}"},
+		{name: "http ipv4 loopback", raw: "http://127.0.0.1:8080/callback"},
+		{name: "http localhost with placeholder", raw: "http://localhost:${callbackPort}/callback"},
+		{name: "http ipv6 loopback with placeholder", raw: "http://[::1]:${callbackPort}/callback"},
+		{name: "http non-loopback", raw: "http://redirect.example.com/callback", wantErr: "oauth callbackRedirectURL must use https for non-loopback hosts"},
+		{name: "unsupported scheme", raw: "ftp://example.com/cb", wantErr: `oauth callbackRedirectURL scheme must be http or https, got "ftp"`},
+		{name: "scheme without host", raw: "javascript:alert(1)", wantErr: "oauth callbackRedirectURL must be an absolute URL"},
+		{name: "relative url", raw: "/callback", wantErr: "oauth callbackRedirectURL must be an absolute URL"},
+		{name: "empty string", raw: "", wantErr: "oauth callbackRedirectURL must be an absolute URL"},
+		{name: "unparseable url", raw: "://bad", wantErr: "oauth callbackRedirectURL must be an absolute URL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateCallbackRedirectURL(tt.raw)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestConfigValidateErrorWrapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr string
+	}{
+		{
+			name:    "provider auth error",
+			config:  Config{Providers: map[string]ProviderConfig{"corp": {Provider: "openai", Auth: &AuthConfig{}}}},
+			wantErr: "providers.corp: auth.type is required",
+		},
+		{
+			name:    "model first_available error",
+			config:  Config{Models: map[string]ModelConfig{"pick": {FirstAvailable: []string{}}}},
+			wantErr: "models.pick: first_available must contain at least one candidate",
+		},
+		{
+			name:    "model compaction threshold error",
+			config:  Config{Models: map[string]ModelConfig{"main": {Provider: "openai", Model: "gpt-4o", CompactionThreshold: new(1.5)}}},
+			wantErr: "models.main: compaction_threshold must be greater than 0 and at most 1",
+		},
+		{
+			name:    "model auth provider mismatch",
+			config:  Config{Models: map[string]ModelConfig{"main": {Provider: "openai", Model: "gpt-4o", Auth: &AuthConfig{Type: AuthTypeWorkloadIdentityFederation}}}},
+			wantErr: "models.main: auth.type \"workload_identity_federation\" is only supported with the anthropic provider",
+		},
+		{
+			name:    "named toolset error",
+			config:  Config{Toolsets: map[string]Toolset{"web": {Type: "fetch", AllowedDomains: []string{""}}}},
+			wantErr: "toolsets.web: allowed_domains[0] must not be empty",
+		},
+		{
+			name:    "agent fallback error",
+			config:  Config{Agents: Agents{{Name: "root", Fallback: &FallbackConfig{Retries: -2}}}},
+			wantErr: "fallback.retries must be >= -1",
+		},
+		{
+			name:    "agent harness error",
+			config:  Config{Agents: Agents{{Name: "root", Harness: &HarnessConfig{}}}},
+			wantErr: "harness.type is required",
+		},
+		{
+			name:    "agent compaction threshold error",
+			config:  Config{Agents: Agents{{Name: "root", CompactionThreshold: new(0.0)}}},
+			wantErr: "agents.root: compaction_threshold must be greater than 0 and at most 1",
+		},
+		{
+			name:    "agent toolset error",
+			config:  Config{Agents: Agents{{Name: "root", Toolsets: []Toolset{{Type: "a2a"}}}}},
+			wantErr: "a2a toolset requires a url to be set",
+		},
+		{
+			name:    "agent hooks error",
+			config:  Config{Agents: Agents{{Name: "root", Hooks: &HooksConfig{Stop: HookDefinitions{{}}}}}},
+			wantErr: "hooks.stop[0]: type is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.ErrorContains(t, tt.config.Validate(), tt.wantErr)
+		})
+	}
+}
+
+func TestConfigValidateValidConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		Version: Version,
+		Providers: map[string]ProviderConfig{
+			"corp": {Provider: "anthropic", BaseURL: "https://llm.example.com/v1"},
+		},
+		Models: map[string]ModelConfig{
+			"main": {Provider: "openai", Model: "gpt-4o", CompactionThreshold: new(0.8)},
+			"pick": {FirstAvailable: []string{"anthropic/claude-sonnet-4-5", "dmr/local"}},
+			// Auth on a model routed through a custom provider exercises the
+			// EffectiveProviderType indirection in Config.Validate.
+			"wif": {
+				Provider: "corp",
+				Model:    "claude-sonnet-4-5",
+				Auth: &AuthConfig{
+					Type: AuthTypeWorkloadIdentityFederation,
+					Federation: &FederationAuthConfig{
+						FederationRuleID: "fdrl_123",
+						OrganizationID:   "org-id-for-tests",
+						IdentityToken:    &IdentityTokenSourceConfig{Env: "ANTHROPIC_OIDC_TOKEN"},
+					},
+				},
+			},
+		},
+		Toolsets: map[string]Toolset{
+			"web": {Type: "fetch", AllowedDomains: []string{"example.com", "*.example.org"}},
+		},
+		Agents: Agents{
+			{
+				Name:                "root",
+				Model:               "main",
+				Fallback:            &FallbackConfig{Models: []string{"pick"}, Retries: -1, Cooldown: Duration{Duration: time.Minute}},
+				Harness:             &HarnessConfig{Type: "claude-code", Effort: "high"},
+				CompactionThreshold: new(1.0),
+				Toolsets: []Toolset{
+					{Type: "shell"},
+					{Type: "mcp", Command: "server"},
+				},
+				Hooks: &HooksConfig{Stop: HookDefinitions{{Type: "command", Command: "echo done"}}},
+			},
+		},
+	}
+
+	require.NoError(t, cfg.Validate())
+}

--- a/pkg/config/versions.go
+++ b/pkg/config/versions.go
@@ -8,6 +8,7 @@ import (
 	v11 "github.com/docker/docker-agent/pkg/config/v11"
 	v12 "github.com/docker/docker-agent/pkg/config/v12"
 	v13 "github.com/docker/docker-agent/pkg/config/v13"
+	v14 "github.com/docker/docker-agent/pkg/config/v14"
 	v2 "github.com/docker/docker-agent/pkg/config/v2"
 	v3 "github.com/docker/docker-agent/pkg/config/v3"
 	v4 "github.com/docker/docker-agent/pkg/config/v4"
@@ -36,6 +37,7 @@ func versions() (map[string]func([]byte) (any, error), []func(any, []byte) (any,
 	v11.Register(parsers, &upgraders)
 	v12.Register(parsers, &upgraders)
 	v13.Register(parsers, &upgraders)
+	v14.Register(parsers, &upgraders)
 	latest.Register(parsers, &upgraders)
 
 	return parsers, upgraders


### PR DESCRIPTION
The config versioning scheme requires that each stable schema be frozen as an immutable numbered package before work-in-progress changes accumulate on `latest`. This PR performs that freeze step for version 14.

`pkg/config/latest` is copied verbatim into `pkg/config/v14` with the package name updated accordingly. The `latest` package then advances to version 15: its `Version` constant is bumped, its internal import of the previous version now points at `v14`, and `pkg/config/versions.go` registers the new package so the auto-loader can decode configs that declare `version: 14`. `agent-schema.json` is updated in parallel — the description string references v15, and `"14"` is added to the version enum and examples.

No behaviour changes for existing configs. Agents already on v14 will continue to load correctly via the frozen package; agents on any earlier version are unaffected.