### PR TITLE
fix(codemode): forward capability handlers to inner toolsets

### DIFF
--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/docker/docker-agent/pkg/team"
 	"github.com/docker/docker-agent/pkg/tools"
 	agenttool "github.com/docker/docker-agent/pkg/tools/builtin/agent"
+	"github.com/docker/docker-agent/pkg/tools/codemode"
 	mcptools "github.com/docker/docker-agent/pkg/tools/mcp"
 )
 
@@ -1668,6 +1669,43 @@ func TestEmitStartupInfo_RecoveryAuthNoticeEmittedOnce(t *testing.T) {
 	rt.emitToolsProgressively(ctx, root, nopSend)
 	noticesPhase4 := root.DrainWarnings()
 	require.Len(t, noticesPhase4, 1, "fresh failure after streak reset must emit a new notice")
+}
+
+// TestConfigureToolsetHandlers_ReachesThroughCodeModeWrapper is the
+// regression test for the sigma MCP OAuth bug: an agent with
+// code_mode_tools:true wraps all its toolsets in a single codemode
+// meta-toolset that is neither Elicitable/OAuthCapable itself nor an
+// Unwrapper tools.As can walk through (it hides N inner toolsets, not one).
+// configureToolsetHandlers (called once per turn, before Tools()/Start())
+// must still reach the inner MCP-like toolset's elicitation handler through
+// that wrapper, otherwise its OAuth elicitation request finds no handler
+// wired up and defers forever — the toolset never surfaces its
+// authorization dialog and registers 0 tools.
+func TestConfigureToolsetHandlers_ReachesThroughCodeModeWrapper(t *testing.T) {
+	t.Parallel()
+
+	prov := &mockProvider{id: "test/codemode-model", stream: &mockStream{}}
+	inner := &elicitingToolSet{message: "authorize?"}
+
+	root := agent.New("root", "agent",
+		agent.WithModel(prov),
+		agent.WithToolSets(codemode.Wrap(inner)),
+	)
+	tm := team.New(team.WithAgents(root))
+	rt, err := NewLocalRuntime(t.Context(), tm, WithCurrentAgent("root"), WithModelStore(mockModelStore{}))
+	require.NoError(t, err)
+
+	events := make(chan Event, 8)
+	rt.configureToolsetHandlers(root, NewChannelSink(events))
+	close(events)
+	for range events {
+	}
+
+	inner.mu.Lock()
+	handler := inner.handler
+	inner.mu.Unlock()
+	require.NotNil(t, handler,
+		"configureToolsetHandlers must wire the elicitation handler through the code_mode_tools wrapper")
 }
 
 // TestEmitAgentWarnings_OnlyEmitsFailures verifies that emitAgentWarnings

--- a/pkg/tools/codemode/codemode.go
+++ b/pkg/tools/codemode/codemode.go
@@ -40,9 +40,14 @@ type codeModeTool struct {
 
 // Verify interface compliance
 var (
-	_ tools.ToolSet   = (*codeModeTool)(nil)
-	_ tools.Startable = (*codeModeTool)(nil)
-	_ tools.Named     = (*codeModeTool)(nil)
+	_ tools.ToolSet             = (*codeModeTool)(nil)
+	_ tools.Startable           = (*codeModeTool)(nil)
+	_ tools.Named               = (*codeModeTool)(nil)
+	_ tools.Elicitable          = (*codeModeTool)(nil)
+	_ tools.Sampleable          = (*codeModeTool)(nil)
+	_ tools.SampleableWithTools = (*codeModeTool)(nil)
+	_ tools.OAuthCapable        = (*codeModeTool)(nil)
+	_ tools.ChangeNotifier      = (*codeModeTool)(nil)
 )
 
 // Name implements tools.Named; loader-created, so no registry WithName wrapper.
@@ -141,4 +146,81 @@ func (c *codeModeTool) Stop(ctx context.Context) error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// SetElicitationHandler forwards the handler to every inner toolset that
+// supports elicitation (e.g. an MCP toolset driving an OAuth flow). Without
+// this, code_mode_tools wrapping hides the inner MCP toolset behind
+// codeModeTool, which As can't unwrap (it wraps N toolsets, not one), so the
+// handler would never reach it and any OAuth elicitation would find no
+// handler wired up and defer forever.
+func (c *codeModeTool) SetElicitationHandler(handler tools.ElicitationHandler) {
+	for _, t := range c.toolsets {
+		if e, ok := tools.As[tools.Elicitable](t); ok {
+			e.SetElicitationHandler(handler)
+		}
+	}
+}
+
+// SetSamplingHandler forwards the handler to every inner toolset that
+// supports sampling. See SetElicitationHandler for why forwarding is needed.
+func (c *codeModeTool) SetSamplingHandler(handler tools.SamplingHandler) {
+	for _, t := range c.toolsets {
+		if s, ok := tools.As[tools.Sampleable](t); ok {
+			s.SetSamplingHandler(handler)
+		}
+	}
+}
+
+// SetSamplingWithToolsHandler forwards the handler to every inner toolset
+// that supports sampling-with-tools. See SetElicitationHandler for why
+// forwarding is needed.
+func (c *codeModeTool) SetSamplingWithToolsHandler(handler tools.SamplingWithToolsHandler) {
+	for _, t := range c.toolsets {
+		if s, ok := tools.As[tools.SampleableWithTools](t); ok {
+			s.SetSamplingWithToolsHandler(handler)
+		}
+	}
+}
+
+// SetOAuthSuccessHandler forwards the handler to every inner toolset that
+// supports OAuth. See SetElicitationHandler for why forwarding is needed.
+func (c *codeModeTool) SetOAuthSuccessHandler(handler func()) {
+	for _, t := range c.toolsets {
+		if o, ok := tools.As[tools.OAuthCapable](t); ok {
+			o.SetOAuthSuccessHandler(handler)
+		}
+	}
+}
+
+// SetManagedOAuth forwards the managed-OAuth flag to every inner toolset
+// that supports OAuth. See SetElicitationHandler for why forwarding is needed.
+func (c *codeModeTool) SetManagedOAuth(managed bool) {
+	for _, t := range c.toolsets {
+		if o, ok := tools.As[tools.OAuthCapable](t); ok {
+			o.SetManagedOAuth(managed)
+		}
+	}
+}
+
+// SetUnmanagedOAuthRedirectURI forwards the unmanaged-OAuth redirect URI to
+// every inner toolset that supports OAuth. See SetElicitationHandler for why
+// forwarding is needed.
+func (c *codeModeTool) SetUnmanagedOAuthRedirectURI(uri string) {
+	for _, t := range c.toolsets {
+		if o, ok := tools.As[tools.OAuthCapable](t); ok {
+			o.SetUnmanagedOAuthRedirectURI(uri)
+		}
+	}
+}
+
+// SetToolsChangedHandler forwards the handler to every inner toolset that
+// can report a tool-list change (e.g. an MCP server sending
+// ToolListChanged). See SetElicitationHandler for why forwarding is needed.
+func (c *codeModeTool) SetToolsChangedHandler(handler func()) {
+	for _, t := range c.toolsets {
+		if n, ok := tools.As[tools.ChangeNotifier](t); ok {
+			n.SetToolsChangedHandler(handler)
+		}
+	}
 }

--- a/pkg/tools/codemode/codemode_test.go
+++ b/pkg/tools/codemode/codemode_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -251,6 +252,131 @@ func (t *testToolSet) Start(context.Context) error {
 func (t *testToolSet) Stop(context.Context) error {
 	t.stop++
 	return nil
+}
+
+// capableToolSet is a testToolSet that also implements the capability
+// interfaces codeModeTool must forward (Elicitable, Sampleable,
+// SampleableWithTools, OAuthCapable, ChangeNotifier) so tests can assert
+// that codeModeTool actually forwards to inner toolsets instead of
+// silently dropping them (the regression this file guards against: an
+// MCP toolset wrapped by code_mode_tools never got its OAuth elicitation
+// handler wired up, so its authorization dialog never surfaced).
+type capableToolSet struct {
+	testToolSet
+
+	elicitationHandler        tools.ElicitationHandler
+	samplingHandler           tools.SamplingHandler
+	samplingWithToolsHandler  tools.SamplingWithToolsHandler
+	oauthSuccessHandler       func()
+	managedOAuth              bool
+	unmanagedOAuthRedirectURI string
+	toolsChangedHandler       func()
+}
+
+var (
+	_ tools.Elicitable          = (*capableToolSet)(nil)
+	_ tools.Sampleable          = (*capableToolSet)(nil)
+	_ tools.SampleableWithTools = (*capableToolSet)(nil)
+	_ tools.OAuthCapable        = (*capableToolSet)(nil)
+	_ tools.ChangeNotifier      = (*capableToolSet)(nil)
+)
+
+func (c *capableToolSet) SetElicitationHandler(handler tools.ElicitationHandler) {
+	c.elicitationHandler = handler
+}
+
+func (c *capableToolSet) SetSamplingHandler(handler tools.SamplingHandler) {
+	c.samplingHandler = handler
+}
+
+func (c *capableToolSet) SetSamplingWithToolsHandler(handler tools.SamplingWithToolsHandler) {
+	c.samplingWithToolsHandler = handler
+}
+
+func (c *capableToolSet) SetOAuthSuccessHandler(handler func()) {
+	c.oauthSuccessHandler = handler
+}
+
+func (c *capableToolSet) SetManagedOAuth(managed bool) {
+	c.managedOAuth = managed
+}
+
+func (c *capableToolSet) SetUnmanagedOAuthRedirectURI(uri string) {
+	c.unmanagedOAuthRedirectURI = uri
+}
+
+func (c *capableToolSet) SetToolsChangedHandler(handler func()) {
+	c.toolsChangedHandler = handler
+}
+
+// TestCodeModeTool_ForwardsCapabilityHandlers verifies that codeModeTool
+// forwards elicitation, sampling, OAuth, and tool-list-changed handlers to
+// every inner toolset that supports them. Before this fix, codeModeTool
+// implemented none of these capability interfaces, so
+// tools.ConfigureHandlers (called by the runtime once per turn) could never
+// reach an MCP toolset hidden behind code_mode_tools — its OAuth
+// elicitation handler stayed nil forever and the authorization dialog
+// never surfaced.
+func TestCodeModeTool_ForwardsCapabilityHandlers(t *testing.T) {
+	t.Parallel()
+	capable := &capableToolSet{}
+	// A plain toolset without any capability must be tolerated (As returns
+	// ok=false) rather than panicking.
+	plain := &testToolSet{}
+
+	tool := Wrap(capable, plain)
+
+	elicitHandler := func(context.Context, *mcp.ElicitParams) (tools.ElicitationResult, error) {
+		return tools.ElicitationResult{}, nil
+	}
+	samplingHandler := func(context.Context, *mcp.CreateMessageParams) (*mcp.CreateMessageResult, error) {
+		return nil, nil
+	}
+	samplingWithToolsHandler := func(context.Context, *mcp.CreateMessageWithToolsParams) (*mcp.CreateMessageWithToolsResult, error) {
+		return nil, nil
+	}
+	oauthCalled := false
+
+	// tools.ConfigureHandlers is the exact call the runtime makes once per
+	// turn (see configureToolsetHandlers in pkg/runtime/loop.go); routing
+	// through it here instead of casting to each capability interface
+	// directly keeps this test aligned with the real call site.
+	tools.ConfigureHandlers(tool, elicitHandler, samplingHandler, samplingWithToolsHandler,
+		func() { oauthCalled = true }, true, "http://127.0.0.1:1234/callback")
+
+	require.NotNil(t, capable.elicitationHandler)
+	require.NotNil(t, capable.samplingHandler)
+	require.NotNil(t, capable.samplingWithToolsHandler)
+	require.NotNil(t, capable.oauthSuccessHandler)
+	capable.oauthSuccessHandler()
+	assert.True(t, oauthCalled)
+	assert.True(t, capable.managedOAuth)
+	assert.Equal(t, "http://127.0.0.1:1234/callback", capable.unmanagedOAuthRedirectURI)
+
+	changedCalled := false
+	tool.(tools.ChangeNotifier).SetToolsChangedHandler(func() { changedCalled = true })
+	require.NotNil(t, capable.toolsChangedHandler)
+	capable.toolsChangedHandler()
+	assert.True(t, changedCalled)
+}
+
+// TestCodeModeTool_ForwardsCapabilityHandlersThroughStartableWrapper verifies
+// that the capability forwarding also finds an inner toolset wrapped in a
+// tools.StartableToolSet, matching how real MCP toolsets are wired
+// (tools.NewStartable(mcpToolset)) before being handed to codemode.Wrap.
+func TestCodeModeTool_ForwardsCapabilityHandlersThroughStartableWrapper(t *testing.T) {
+	t.Parallel()
+	capable := &capableToolSet{}
+	wrapped := tools.NewStartable(capable)
+
+	tool := Wrap(wrapped)
+
+	handler := func(context.Context, *mcp.ElicitParams) (tools.ElicitationResult, error) {
+		return tools.ElicitationResult{}, nil
+	}
+	tool.(tools.Elicitable).SetElicitationHandler(handler)
+
+	assert.NotNil(t, capable.elicitationHandler)
 }
 
 // TestCodeModeTool_SuccessNoToolCalls verifies that successful execution does not include tool calls.


### PR DESCRIPTION
## Problem

With `code_mode_tools: true`, the code-mode wrapper prevents capability handlers from reaching wrapped remote MCP toolsets. OAuth elicitation is therefore never surfaced, and the toolset registers 0 tools.

## Fix

Forward the five capability interfaces (`Elicitable`, `Sampleable`, `SampleableWithTools`, `OAuthCapable`, and `ChangeNotifier`) from `codemode.codeModeTool` to every inner toolset that supports them.

Fixes #3808

## Testing

- Added unit tests in `pkg/tools/codemode/codemode_test.go` covering forwarding via `tools.ConfigureHandlers` and through a `tools.NewStartable` wrapper.
- Added runtime regression test `TestConfigureToolsetHandlers_ReachesThroughCodeModeWrapper` in `pkg/runtime/runtime_test.go` (fails pre-fix, passes post-fix).
- `task build`
- `task test`
- `task lint`

All pass.
