### PR TITLE
docs: improve Ollama and local models discoverability

### DIFF
--- a/docs/concepts/models/index.md
+++ b/docs/concepts/models/index.md
@@ -97,7 +97,7 @@ for details.
 | Requesty            | `requesty`       | Multi-provider gateway               | `REQUESTY_API_KEY`                  |
 | OpenRouter          | `openrouter`     | Multi-provider gateway               | `OPENROUTER_API_KEY`                |
 | Azure OpenAI        | `azure`          | gpt-4o, gpt-5 on Azure               | `AZURE_API_KEY` + `base_url`        |
-| Ollama              | `ollama`         | Any local Ollama model               | None (local; optional `base_url`)   |
+| [Ollama](../../providers/local/index.md) | `ollama` | Any local Ollama model | None (local; optional `base_url`) |
 | GitHub Copilot      | `github-copilot` | Copilot-hosted OpenAI/Anthropic      | `GITHUB_TOKEN` (PAT with `copilot`) |
 | ChatGPT (OpenAI account) | `chatgpt`   | gpt-5 family via ChatGPT subscription | None (sign in via `docker agent setup`) |
 

--- a/docs/providers/local/index.md
+++ b/docs/providers/local/index.md
@@ -1,12 +1,13 @@
 ---
 title: "Local Models (Ollama, vLLM, LocalAI)"
 description: "Run Docker Agent with locally hosted models for privacy, offline use, or cost savings."
-keywords: docker agent, ai agents, model providers, llm, local models (ollama, vllm, localai)
+keywords: docker agent, ai agents, model providers, llm, local models, ollama, vllm, localai, offline models
 linkTitle: "Local Models"
 weight: 150
 canonical: https://docs.docker.com/ai/docker-agent/providers/local/
 aliases:
   - /ai/docker-agent/local-models/
+  - /ai/docker-agent/providers/ollama/
 ---
 
 _Run Docker Agent with locally hosted models for privacy, offline use, or cost savings._

--- a/docs/providers/overview/index.md
+++ b/docs/providers/overview/index.md
@@ -18,6 +18,7 @@ _Docker Agent supports multiple AI model providers. Choose the right one for you
 - [**Google Gemini**](../google/index.md) — Gemini 2.5 Flash, Gemini 3 Pro. Fast and cost-effective.
 - [**AWS Bedrock**](../bedrock/index.md) — access Claude, Nova, Llama, and more through AWS infrastructure.
 - [**Docker Model Runner**](../dmr/index.md) — run models locally with Docker. No API keys, no costs.
+- [**Local Models**](../local/index.md) — run Ollama, vLLM, or LocalAI locally. No API key required.
 - [**Provider Definitions**](../custom/index.md) — define reusable provider configurations with shared defaults for any provider type.
 
 ## Quick Comparison
@@ -29,6 +30,7 @@ _Docker Agent supports multiple AI model providers. Choose the right one for you
 | Google              | `google`         | No     | Fast inference, competitive pricing, multimodal       |
 | AWS Bedrock         | `amazon-bedrock` | No     | Enterprise features, multiple models, AWS integration |
 | Docker Model Runner | `dmr`            | Yes    | No API costs, data privacy, offline capable           |
+| Local Models (Ollama / vLLM) | `ollama` / custom | Yes | No API costs, full data privacy, any OpenAI-compatible server |
 
 ## Additional Built-in Providers
 
@@ -59,7 +61,7 @@ Docker Agent also includes built-in aliases for these providers:
 | Requesty       | `requesty`       | `REQUESTY_API_KEY`                  |
 | OpenRouter     | `openrouter`     | `OPENROUTER_API_KEY`                |
 | Azure OpenAI   | `azure`          | `AZURE_API_KEY` + `base_url`        |
-| Ollama         | `ollama`         | None (local; optional `base_url`)   |
+| [Ollama](../local/index.md) | `ollama` | None (local; optional `base_url`) |
 | GitHub Copilot | `github-copilot` | `GITHUB_TOKEN` (PAT with `copilot` scope) |
 
 ```bash


### PR DESCRIPTION
> 🤖 **Automated implementer agent** — *this comment was posted by the implementer bot from Docker Agentic Platform, not by a human developer*

Searching for "ollama" on the docs site returned no results because the local models page had no proper keywords for it and the overview/concepts pages had no links to the local models docs.

**Changes:**
- `docs/providers/local/index.md`: split keyword blob into proper comma-separated tokens; added `offline models`; added alias `/ai/docker-agent/providers/ollama/` so `/providers/ollama/` redirects here
- `docs/providers/overview/index.md`: added Local Models entry to Supported Providers bullet list; added Local Models row to Quick Comparison table; linked Ollama in the Additional Built-in Providers table
- `docs/concepts/models/index.md`: linked Ollama row in the Supported Providers table to the local models page