### PR TITLE
docs: auto-update for merged PRs (2026-07-23)

### DIFF
--- a/docs/configuration/overview/index.md
+++ b/docs/configuration/overview/index.md
@@ -19,7 +19,7 @@ A Docker Agent config has these main sections:
 
 ```bash
 # 1. Version — configuration schema version (optional but recommended)
-version: 14
+version: 15
 
 # 2. Metadata — optional agent metadata for distribution
 metadata:
@@ -295,10 +295,10 @@ For YAML editor autocompletion and validation, use the [Docker Agent JSON Schema
 
 ## Config Versioning
 
-Docker Agent configs are versioned. The current version is `14`. Add the version at the top of your config:
+Docker Agent configs are versioned. The current version is `15`. Add the version at the top of your config:
 
 ```yaml
-version: 14
+version: 15
 
 agents:
   root:


### PR DESCRIPTION
This PR updates documentation to reflect recent code changes merged into main.

## Documentation changes

### Config version update (v14 → v15)

Updated the configuration overview documentation to reflect that **v15** is now the current config schema version, following PR #3807 which froze config v14 and started v15 as the new latest version.

**Changed files:**
- `docs/configuration/overview/index.md` — Updated version references from 14 to 15

**Source PRs:**
- #3807 — feat(config): freeze config v14 and start v15 as latest

## Review notes

This is an automated documentation maintenance PR. All changes reflect merged code changes and keep the `/docs` directory in sync with the codebase.

The update is minimal and scoped: only version numbers in the configuration overview were updated to match the current schema version advertised in the codebase.