### PR TITLE
feat(tui): open /context or /cost from the sidebar token-usage reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 
 
+## [Unreleased]
+
+## What's New
+
+- Splits the sidebar's Token Usage click target in two: clicking the token/context part (glyph, token count, context `%`, or the "compacting…" marker) opens the `/context` dialog, while clicking the cost part (`$` figure, `⚠ capped` marker, sub-session count) keeps opening `/cost`; the "Token Usage" section title is no longer clickable
+
+
 ## [v1.115.0] - 2026-07-22
 
 This release fixes permission pattern parsing for colon-containing values, adds provider-level compaction model defaults, resolves agent-switch slash commands over HTTP, and includes several bug fixes and refactors.

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -195,7 +195,7 @@ While a compaction is running the percentage is replaced by a **"compacting…"*
 
 The thresholds are proportional to the agent's configured `compaction_threshold` (default `0.9`), so a custom value keeps a predictable visual runway. See [Compaction Threshold](../../configuration/models/index.md#delegating-session-compaction) for configuration details.
 
-Clicking the token-usage / cost reading in the sidebar opens the `/cost` dialog directly, so you can see the full cost breakdown without typing the command.
+Clicking the token/context part of the sidebar's usage reading (the glyph, token count, and context percentage — or the "compacting…" marker) opens the `/context` dialog with the full breakdown. Clicking the cost part (the `$` figure, the `⚠ capped` marker, and the sub-session count) opens the `/cost` dialog instead. The "Token Usage" section title itself is not clickable.
 
 ### Thinking and Tool Details
 

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -783,10 +783,11 @@ type ClickResult int
 const (
 	ClickNone ClickResult = iota
 	ClickStar
-	ClickTitle      // Click on the title area (use double-click to edit)
-	ClickWorkingDir // Click on the working directory line
-	ClickAgent      // Click on an agent name in the sidebar
-	ClickUsage      // Click on the token usage / cost reading, or a budget line
+	ClickTitle        // Click on the title area (use double-click to edit)
+	ClickWorkingDir   // Click on the working directory line
+	ClickAgent        // Click on an agent name in the sidebar
+	ClickUsageContext // Click on the token/context part of the usage reading (glyph, tokens, context %/compacting)
+	ClickUsage        // Click on the cost part of the usage reading, or a budget line
 )
 
 // HandleClick checks if click is on the star or title and returns true if it was
@@ -804,6 +805,17 @@ func (m *model) HandleClickType(x, y int) (ClickResult, string) {
 	adjustedX := x - m.layoutCfg.PaddingLeft
 	if adjustedX < 0 {
 		return ClickNone, ""
+	}
+
+	// segmentClickResult splits a click at flat offset into the usage reading
+	// line between the context segment (glyph, tokens, context %/compacting —
+	// offset < usageContextSegWidth) and the cost segment (⚠ capped, cost,
+	// sub-sessions — everything from there on).
+	segmentClickResult := func(offset int) ClickResult {
+		if offset < m.usageContextSegWidth {
+			return ClickUsageContext
+		}
+		return ClickUsage
 	}
 
 	if m.mode == ModeCollapsed {
@@ -834,7 +846,7 @@ func (m *model) HandleClickType(x, y int) (ClickResult, string) {
 			usageWidth := lipgloss.Width(vm.UsageSummary)
 			if vm.WorkingDir != "" && vm.WdAndUsageOnOneLine {
 				if y == wdStartY && adjustedX >= vm.ContentWidth-usageWidth {
-					return ClickUsage, ""
+					return segmentClickResult(adjustedX - (vm.ContentWidth - usageWidth)), ""
 				}
 			} else {
 				usageStartY := wdStartY
@@ -842,7 +854,8 @@ func (m *model) HandleClickType(x, y int) (ClickResult, string) {
 					usageStartY += wdLines
 				}
 				if y >= usageStartY && y < usageStartY+linesNeeded(usageWidth, vm.ContentWidth) {
-					return ClickUsage, ""
+					offset := (y-usageStartY)*vm.ContentWidth + adjustedX
+					return segmentClickResult(offset), ""
 				}
 			}
 		}
@@ -885,7 +898,10 @@ func (m *model) HandleClickType(x, y int) (ClickResult, string) {
 
 	// Check if click is on the Token Usage reading line or a budget line
 	// below it. The section title line is not a click target.
-	if contentY == m.usageReadingLine || (m.usageReadingLine >= 0 && contentY > m.usageReadingLine && contentY < m.usageSectionEnd) {
+	if contentY == m.usageReadingLine {
+		return segmentClickResult(adjustedX), ""
+	}
+	if m.usageReadingLine >= 0 && contentY > m.usageReadingLine && contentY < m.usageSectionEnd {
 		return ClickUsage, ""
 	}
 

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -345,11 +345,18 @@ type model struct {
 
 	// Agent click zones: maps content line index to agent name for click detection
 	agentClickZones map[int]string // content line -> agent name
-	// Token Usage click zone: half-open content-line range [start, end) of the
-	// vertical Token Usage section, recorded while rendering. Empty when the
-	// section is hidden.
-	usageZoneStart int
-	usageZoneEnd   int
+	// Token Usage click zone: the content-line index of the reading line
+	// (glyph/tokens/context/cost/sub-sessions), and the half-open range of any
+	// budget lines below it, recorded while rendering. usageReadingLine is -1
+	// when the section is hidden. The section's "Token Usage" title line is
+	// deliberately excluded — it is not a click target.
+	usageReadingLine int
+	usageSectionEnd  int
+	// usageContextSegWidth is the lipgloss.Width of the reading line's context
+	// segment (glyph + token count + context %/compacting marker), recorded by
+	// tokenUsageLine while rendering. HandleClickType uses it to split a click
+	// on the reading line between the context dialog and the cost dialog.
+	usageContextSegWidth int
 	// agentLineOwners records, per rendered agent-section body line, which agent
 	// emitted it (empty for blank separators). It is produced during agentInfo
 	// rendering so click zones can be registered explicitly rather than inferred
@@ -388,6 +395,7 @@ func New(ctx context.Context, sessionState *service.SessionState) Model {
 		titleInput:       ti,
 		cacheDirty:       true, // Initial render needed
 		layoutDirty:      true, // First render must probe scrollbar visibility
+		usageReadingLine: -1,   // No usage zone recorded until the first render
 	}
 	return m
 }
@@ -778,7 +786,7 @@ const (
 	ClickTitle      // Click on the title area (use double-click to edit)
 	ClickWorkingDir // Click on the working directory line
 	ClickAgent      // Click on an agent name in the sidebar
-	ClickUsage      // Click on the token usage / cost reading
+	ClickUsage      // Click on the token usage / cost reading, or a budget line
 )
 
 // HandleClick checks if click is on the star or title and returns true if it was
@@ -875,8 +883,9 @@ func (m *model) HandleClickType(x, y int) (ClickResult, string) {
 		return ClickWorkingDir, ""
 	}
 
-	// Check if click is on the Token Usage section
-	if contentY >= m.usageZoneStart && contentY < m.usageZoneEnd {
+	// Check if click is on the Token Usage reading line or a budget line
+	// below it. The section title line is not a click target.
+	if contentY == m.usageReadingLine || (m.usageReadingLine >= 0 && contentY > m.usageReadingLine && contentY < m.usageSectionEnd) {
 		return ClickUsage, ""
 	}
 
@@ -1642,6 +1651,10 @@ func (m *model) renderFromCache() string {
 // returns the index of the section's first line so click zones can be anchored.
 func (m *model) renderSections(contentWidth int) []string {
 	var lines []string
+	// tabHeaderLines is the fixed number of lines a renderTab wrapper adds
+	// before a section's body: the tab title line plus the TabStyle top
+	// padding line (mirrored in buildAgentClickZones).
+	const tabHeaderLines = 2
 
 	appendSection := func(section string) int {
 		if section == "" {
@@ -1658,12 +1671,14 @@ func (m *model) renderSections(contentWidth int) []string {
 	}
 
 	appendSection(m.sessionInfo(contentWidth))
-	// Track the Token Usage section's line range (title included) so a click
-	// on it can open the cost dialog.
-	m.usageZoneStart, m.usageZoneEnd = 0, 0
+	// Track the Token Usage reading line (glyph/tokens/context/cost) and the
+	// end of the section (covering any budget lines below it) so a click can
+	// be routed to the context or cost dialog. The title line is excluded.
+	m.usageReadingLine, m.usageSectionEnd = -1, -1
 	if !m.sectionVisibility.HideUsage {
-		m.usageZoneStart = appendSection(m.tokenUsage(contentWidth))
-		m.usageZoneEnd = len(lines)
+		sectionStart := appendSection(m.tokenUsage(contentWidth))
+		m.usageReadingLine = sectionStart + tabHeaderLines
+		m.usageSectionEnd = len(lines)
 	}
 	appendSection(m.queueSection(contentWidth))
 
@@ -1814,7 +1829,10 @@ func (m *model) tokenUsage(contentWidth int) string {
 // tab and the collapsed band: token glyph, count, context %, cost, and the
 // sub-session count, all with the same styling. The context reading warns as
 // it nears the compaction threshold and reads "compacting…" while a
-// compaction runs.
+// compaction runs. It also records usageContextSegWidth, the rendered width
+// of the context segment (glyph through the %/compacting marker), so
+// HandleClickType can split a click on the reading line between the context
+// and cost dialogs.
 func (m *model) tokenUsageLine() string {
 	s := m.computeUsageStats()
 
@@ -1825,6 +1843,8 @@ func (m *model) tokenUsageLine() string {
 	case s.contextPct != "":
 		line += " " + contextGaugeStyle(s.contextLevel, styles.NoStyle).Render("("+s.contextPct+")")
 	}
+	m.usageContextSegWidth = lipgloss.Width(line)
+
 	if m.agentCompactionModel != "" {
 		line += " " + styles.WarningStyle.Render("⚠ capped")
 	}

--- a/pkg/tui/components/sidebar/title_edit_test.go
+++ b/pkg/tui/components/sidebar/title_edit_test.go
@@ -370,8 +370,8 @@ func TestSidebar_HandleClickType_HiddenPath_Collapsed(t *testing.T) {
 
 	// The row after the title must not keep a copyable hit target; with the
 	// path hidden the usage reading moves up into that row instead.
-	result, _ := sb.HandleClickType(paddingLeft+3, m.titleLineCount())
-	assert.Equal(t, ClickUsage, result, "a hidden path must not be clickable; the usage line takes the row")
+	result, _ := sb.HandleClickType(paddingLeft+1, m.titleLineCount())
+	assert.Equal(t, ClickUsageContext, result, "a hidden path must not be clickable; the usage line's context segment takes the row")
 
 	result, _ = sb.HandleClickType(paddingLeft+3, 0)
 	assert.Equal(t, ClickTitle, result, "the title stays clickable")

--- a/pkg/tui/components/sidebar/usage_click_test.go
+++ b/pkg/tui/components/sidebar/usage_click_test.go
@@ -1,6 +1,7 @@
 package sidebar
 
 import (
+	"strings"
 	"testing"
 
 	"charm.land/lipgloss/v2"
@@ -12,9 +13,19 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/service"
 )
 
+// dollarOffset returns the index of "$" within a rendered (ANSI-stripped)
+// usage reading line, i.e. the start of the cost segment.
+func dollarOffset(t *testing.T, renderedLine string) int {
+	t.Helper()
+	idx := strings.Index(ansi.Strip(renderedLine), "$")
+	require.GreaterOrEqual(t, idx, 0, "usage reading line must contain a cost figure")
+	return idx
+}
+
 // TestSidebar_HandleClickType_Usage_Vertical verifies that the vertical Token
-// Usage reading line (glyph, tokens, context %, cost) reports ClickUsage,
-// while the section's title line is no longer a click target.
+// Usage reading line splits between ClickUsageContext (glyph, tokens,
+// context %) and ClickUsage (cost, sub-sessions), while the section's title
+// line is no longer a click target.
 func TestSidebar_HandleClickType_Usage_Vertical(t *testing.T) {
 	t.Parallel()
 
@@ -44,7 +55,39 @@ func TestSidebar_HandleClickType_Usage_Vertical(t *testing.T) {
 	assert.Equal(t, ClickNone, result, "the Token Usage title line must not be a click target")
 
 	result, _ = sb.HandleClickType(paddingLeft+2, m.usageReadingLine)
-	assert.Equal(t, ClickUsage, result, "the reading line should report ClickUsage")
+	assert.Equal(t, ClickUsageContext, result, "a click on the token/context segment should report ClickUsageContext")
+
+	dollarX := dollarOffset(t, m.cachedLines[m.usageReadingLine])
+	result, _ = sb.HandleClickType(paddingLeft+dollarX, m.usageReadingLine)
+	assert.Equal(t, ClickUsage, result, "a click on the cost segment should report ClickUsage")
+}
+
+// TestSidebar_HandleClickType_Usage_Vertical_Compacting verifies that a click
+// on the "(compacting\u2026)" marker reports ClickUsageContext: compaction is
+// context-related, so it belongs on the context side, not the cost side.
+func TestSidebar_HandleClickType_Usage_Vertical_Compacting(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	sb := New(t.Context(), sessionState)
+
+	m := sb.(*model)
+	m.sessionHasContent = true
+	m.titleGenerated = true
+	m.sessionTitle = "Test"
+	m.width = 40
+	m.height = 50
+	m.compacting = true
+
+	_ = sb.View()
+
+	require.GreaterOrEqual(t, m.usageReadingLine, 0)
+	assert.Contains(t, ansi.Strip(m.cachedLines[m.usageReadingLine]), "compacting")
+
+	paddingLeft := m.layoutCfg.PaddingLeft
+	result, _ := sb.HandleClickType(paddingLeft+2, m.usageReadingLine)
+	assert.Equal(t, ClickUsageContext, result, "a click on the compacting marker should report ClickUsageContext")
 }
 
 // TestSidebar_HandleClickType_Usage_Vertical_Hidden verifies a hidden usage
@@ -101,8 +144,9 @@ func TestSidebar_HandleClickType_Usage_Vertical_ScrollbarNotUsage(t *testing.T) 
 }
 
 // TestSidebar_HandleClickType_Usage_Collapsed_SharedLine verifies the
-// right-aligned usage reading on the shared path/usage row reports
-// ClickUsage while the path part keeps reporting ClickWorkingDir.
+// right-aligned usage reading on the shared path/usage row splits between
+// ClickUsageContext and ClickUsage the same way the vertical reading does,
+// while the path part keeps reporting ClickWorkingDir.
 func TestSidebar_HandleClickType_Usage_Collapsed_SharedLine(t *testing.T) {
 	t.Parallel()
 
@@ -127,14 +171,19 @@ func TestSidebar_HandleClickType_Usage_Collapsed_SharedLine(t *testing.T) {
 	usageX := vm.ContentWidth - lipgloss.Width(vm.UsageSummary)
 
 	result, _ := sb.HandleClickType(paddingLeft+usageX+1, rowY)
-	assert.Equal(t, ClickUsage, result, "click on the usage reading should report ClickUsage")
+	assert.Equal(t, ClickUsageContext, result, "click on the token/context segment should report ClickUsageContext")
+
+	dollarX := dollarOffset(t, vm.UsageSummary)
+	result, _ = sb.HandleClickType(paddingLeft+usageX+dollarX, rowY)
+	assert.Equal(t, ClickUsage, result, "click on the cost segment should report ClickUsage")
 
 	result, _ = sb.HandleClickType(paddingLeft+3, rowY)
 	assert.Equal(t, ClickWorkingDir, result, "the path part of the row stays a working dir target")
 }
 
 // TestSidebar_HandleClickType_Usage_Collapsed_OwnLine verifies the usage
-// reading is clickable when it takes its own row (no session path).
+// reading splits between ClickUsageContext and ClickUsage when it takes its
+// own row (no session path).
 func TestSidebar_HandleClickType_Usage_Collapsed_OwnLine(t *testing.T) {
 	t.Parallel()
 
@@ -154,8 +203,14 @@ func TestSidebar_HandleClickType_Usage_Collapsed_OwnLine(t *testing.T) {
 	require.NotEmpty(t, vm.UsageSummary)
 
 	paddingLeft := m.layoutCfg.PaddingLeft
-	result, _ := sb.HandleClickType(paddingLeft+1, vm.titleSectionLines())
-	assert.Equal(t, ClickUsage, result, "click on the usage row should report ClickUsage")
+	rowY := vm.titleSectionLines()
+
+	result, _ := sb.HandleClickType(paddingLeft+1, rowY)
+	assert.Equal(t, ClickUsageContext, result, "click on the token/context segment should report ClickUsageContext")
+
+	dollarX := dollarOffset(t, vm.UsageSummary)
+	result, _ = sb.HandleClickType(paddingLeft+dollarX, rowY)
+	assert.Equal(t, ClickUsage, result, "click on the cost segment should report ClickUsage")
 }
 
 // TestSidebar_HandleClickType_Usage_Collapsed_Hidden verifies a hidden usage

--- a/pkg/tui/components/sidebar/usage_click_test.go
+++ b/pkg/tui/components/sidebar/usage_click_test.go
@@ -12,8 +12,9 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/service"
 )
 
-// TestSidebar_HandleClickType_Usage_Vertical verifies that a click anywhere
-// on the vertical Token Usage section (title included) reports ClickUsage.
+// TestSidebar_HandleClickType_Usage_Vertical verifies that the vertical Token
+// Usage reading line (glyph, tokens, context %, cost) reports ClickUsage,
+// while the section's title line is no longer a click target.
 func TestSidebar_HandleClickType_Usage_Vertical(t *testing.T) {
 	t.Parallel()
 
@@ -31,14 +32,19 @@ func TestSidebar_HandleClickType_Usage_Vertical(t *testing.T) {
 	// Force a render to record the usage click zone
 	_ = sb.View()
 
-	require.Less(t, m.usageZoneStart, m.usageZoneEnd, "the usage zone must be recorded")
-	assert.Contains(t, ansi.Strip(m.cachedLines[m.usageZoneStart]), "Token Usage")
+	require.GreaterOrEqual(t, m.usageReadingLine, 0, "the usage reading line must be recorded")
+	require.Less(t, m.usageReadingLine, m.usageSectionEnd)
+
+	titleLine := m.usageReadingLine - 2 // tab title line + TabStyle top padding line
+	assert.Contains(t, ansi.Strip(m.cachedLines[titleLine]), "Token Usage")
 
 	paddingLeft := m.layoutCfg.PaddingLeft
-	for y := m.usageZoneStart; y < m.usageZoneEnd; y++ {
-		result, _ := sb.HandleClickType(paddingLeft+2, y)
-		assert.Equalf(t, ClickUsage, result, "line %d of the usage section should report ClickUsage", y)
-	}
+
+	result, _ := sb.HandleClickType(paddingLeft+2, titleLine)
+	assert.Equal(t, ClickNone, result, "the Token Usage title line must not be a click target")
+
+	result, _ = sb.HandleClickType(paddingLeft+2, m.usageReadingLine)
+	assert.Equal(t, ClickUsage, result, "the reading line should report ClickUsage")
 }
 
 // TestSidebar_HandleClickType_Usage_Vertical_Hidden verifies a hidden usage
@@ -84,11 +90,11 @@ func TestSidebar_HandleClickType_Usage_Vertical_ScrollbarNotUsage(t *testing.T) 
 	_ = sb.View()
 
 	require.True(t, m.cachedNeedsScrollbar, "the sidebar must overflow for this test")
-	require.Less(t, m.usageZoneStart, m.usageZoneEnd)
+	require.GreaterOrEqual(t, m.usageReadingLine, 0)
 
 	paddingLeft := m.layoutCfg.PaddingLeft
 	scrollbarX := paddingLeft + m.contentWidth(true) // first non-content column
-	for y := m.usageZoneStart; y < m.usageZoneEnd; y++ {
+	for y := m.usageReadingLine; y < m.usageSectionEnd; y++ {
 		result, _ := sb.HandleClickType(scrollbarX, y)
 		assert.Equalf(t, ClickNone, result, "scrollbar column beside usage line %d must not be clickable content", y)
 	}
@@ -148,7 +154,7 @@ func TestSidebar_HandleClickType_Usage_Collapsed_OwnLine(t *testing.T) {
 	require.NotEmpty(t, vm.UsageSummary)
 
 	paddingLeft := m.layoutCfg.PaddingLeft
-	result, _ := sb.HandleClickType(paddingLeft+3, vm.titleSectionLines())
+	result, _ := sb.HandleClickType(paddingLeft+1, vm.titleSectionLines())
 	assert.Equal(t, ClickUsage, result, "click on the usage row should report ClickUsage")
 }
 

--- a/pkg/tui/page/chat/hittest.go
+++ b/pkg/tui/page/chat/hittest.go
@@ -16,6 +16,7 @@ const (
 	TargetSidebarTitle
 	TargetSidebarWorkingDir
 	TargetSidebarAgent
+	TargetSidebarUsageContext
 	TargetSidebarUsage
 	TargetSidebarContent
 	TargetMessages
@@ -115,6 +116,8 @@ func (h *HitTest) sidebarClickTarget(x, y int) MouseTarget {
 	case sidebar.ClickAgent:
 		h.AgentName = agentName
 		return TargetSidebarAgent
+	case sidebar.ClickUsageContext:
+		return TargetSidebarUsageContext
 	case sidebar.ClickUsage:
 		return TargetSidebarUsage
 	default:

--- a/pkg/tui/page/chat/hittest_test.go
+++ b/pkg/tui/page/chat/hittest_test.go
@@ -1,0 +1,65 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	msgtypes "github.com/docker/docker-agent/pkg/tui/messages"
+	"github.com/docker/docker-agent/pkg/tui/styles"
+)
+
+// TestHandleMouseClick_SidebarUsageContext_OpensContextDialog verifies that a
+// click on the token/context part of the sidebar's Token Usage reading opens
+// the context dialog rather than the cost dialog.
+func TestHandleMouseClick_SidebarUsageContext_OpensContextDialog(t *testing.T) {
+	t.Parallel()
+
+	p := newLayoutTestPage(t, msgtypes.SidebarRight)
+	sl := p.computeSidebarLayout()
+	require.Equal(t, sidebarVertical, sl.mode)
+
+	// Force a render so the sidebar records the usage click zone.
+	view := ansi.Strip(p.sidebar.View())
+	line, _ := findUsageReadingLine(t, view)
+
+	hit := NewHitTest(p)
+	// Offset 1 sits on the token glyph itself, safely within the context
+	// segment (glyph, token count, and any context %/compacting marker).
+	target := hit.At(styles.AppPadding+sl.sidebarStartX+1, line)
+	assert.Equal(t, TargetSidebarUsageContext, target, "a click on the context segment should target the context dialog")
+}
+
+// TestHandleMouseClick_SidebarUsage_OpensCostDialog mirrors the context-dialog
+// test for the cost segment ($ and onward), which keeps opening /cost.
+func TestHandleMouseClick_SidebarUsage_OpensCostDialog(t *testing.T) {
+	t.Parallel()
+
+	p := newLayoutTestPage(t, msgtypes.SidebarRight)
+	sl := p.computeSidebarLayout()
+	require.Equal(t, sidebarVertical, sl.mode)
+
+	view := ansi.Strip(p.sidebar.View())
+	line, dollarOffset := findUsageReadingLine(t, view)
+
+	hit := NewHitTest(p)
+	target := hit.At(styles.AppPadding+sl.sidebarStartX+dollarOffset, line)
+	assert.Equal(t, TargetSidebarUsage, target, "a click on the cost segment should keep targeting the cost dialog")
+}
+
+// findUsageReadingLine locates the Token Usage reading line ("◉ ... $...")
+// in the stripped sidebar view and returns its content-line index and the
+// offset of the "$" within it.
+func findUsageReadingLine(t *testing.T, strippedView string) (line, dollarOffset int) {
+	t.Helper()
+	for i, l := range strings.Split(strippedView, "\n") {
+		if idx := strings.Index(l, "$"); idx >= 0 && strings.Contains(l, "◉") {
+			return i, idx
+		}
+	}
+	t.Fatal("Token Usage reading line not found in sidebar view")
+	return 0, 0
+}

--- a/pkg/tui/page/chat/input_handlers.go
+++ b/pkg/tui/page/chat/input_handlers.go
@@ -152,6 +152,11 @@ func (p *chatPage) handleMouseClick(msg tea.MouseClickMsg) (layout.Model, tea.Cm
 			return p, cmd
 		}
 
+	case TargetSidebarUsageContext:
+		if msg.Button == tea.MouseLeft {
+			return p, core.CmdHandler(msgtypes.ShowContextDialogMsg{})
+		}
+
 	case TargetSidebarUsage:
 		if msg.Button == tea.MouseLeft {
 			return p, core.CmdHandler(msgtypes.ShowCostDialogMsg{})


### PR DESCRIPTION
## What & why

Clicking the sidebar **Token Usage** reading used to open the `/cost` dialog no matter where you clicked. This splits the click by segment so each part opens the dialog it describes:

- **Token count · `(NN%)` · `(compacting…)`** → `/context` dialog
- **`$…` · `⚠ capped` · sub-session count** → `/cost` dialog
- The **"Token Usage" title** is no longer clickable
- Budget lines keep opening `/cost`

Works in both the vertical sidebar and the collapsed top band.

## How

- New `ClickUsageContext` click result routed to a new `TargetSidebarUsageContext`, split from the existing cost path by the rendered X-width of the context segment (`usageContextSegWidth`, measured with `lipgloss.Width` so it's ANSI/terminal-cell aware).
- The usage click zone is narrowed to the reading line (the title line is excluded); the collapsed band splits by flat offset, handling both the right-aligned shared-line and the wrapped own-line cases.

## Commits
1. `feat(tui): make sidebar usage title non-clickable and track context-segment width`
2. `feat(tui): add ClickUsageContext and segment-aware usage click detection`
3. `feat(tui): route sidebar context clicks to the context dialog`
4. `docs(tui): document the context/cost click split`

## Stacked on #3811
Depends on `feat/context-compaction-limit-visibility` (#3811) for the `⚠ capped` / `agentCompactionModel` rendering the segment split keys off. This PR targets that branch and will retarget to `main` once #3811 merges.

## Validation
- `go build ./...` — clean
- `go test ./pkg/tui/components/sidebar/... ./pkg/tui/page/chat/...` — green
- `task lint` — 0 issues

## Note
The onboarding tour's cost step (matches `ShowCostDialogMsg`) no longer completes via a context-segment click — behavior-neutral for cost-segment clicks.

Plan: `usage-click-split-context-cost`
