### PR TITLE
feat: enforce lifecycle.call_timeout for MCP tool calls

### DIFF
--- a/agent-schema.json
+++ b/agent-schema.json
@@ -160,7 +160,7 @@
         },
         "call_timeout": {
           "type": "string",
-          "description": "Default per-call timeout. Informational today; the runtime currently uses the caller's context for cancellation."
+          "description": "Cap on an individual tool call, including one reconnect-retry. Enforced: on expiry the call is cancelled and surfaced to the model as a tool error; cancellation is propagated to the server. The budget includes any nested sampling/elicitation time. Go duration format (e.g. '30s', '2m'). 0/unset means no timeout (opt-in; no profile default)."
         },
         "restart": {
           "type": "string",

--- a/agent-schema.json
+++ b/agent-schema.json
@@ -156,7 +156,7 @@
         },
         "startup_timeout": {
           "type": "string",
-          "description": "Cap on the initial Connect+initialize duration. NOTE: not yet enforced; documented for forward compatibility. Go duration format (e.g. '30s', '2m'). 0 means no timeout."
+          "description": "Cap on the initial Connect+initialize duration. Enforced since v1.94.0: on expiry the toolset stays stopped and the runtime retries on the next turn. Go duration format (e.g. '30s', '2m'). 0 means no timeout."
         },
         "call_timeout": {
           "type": "string",

--- a/docs/configuration/tools/index.md
+++ b/docs/configuration/tools/index.md
@@ -277,13 +277,13 @@ toolsets:
 | `backoff.multiplier` | number | Multiplier applied each attempt. Default: `2`. |
 | `backoff.jitter` | number | Fraction (0..1) of the computed delay applied as a uniform random offset. `0` disables jitter (default). |
 | `required` | boolean | Marks the toolset as critical. Today this is informational; a future eager-startup phase will refuse to start the agent when a required toolset cannot reach Ready. Defaults to `true` under `strict`, `false` otherwise. |
-| `startup_timeout` | duration | Cap on the initial connect+initialize duration. Today this is informational; the eager-startup phase that enforces it ships in a follow-up. |
+| `startup_timeout` | duration | Cap on the initial connect+initialize duration. Enforced since v1.94.0: on expiry the toolset stays stopped and the runtime retries on the next turn. |
 | `call_timeout` | duration | Documented per-call timeout. Informational; the runtime currently uses the caller's context for cancellation. |
 
 > [!NOTE]
-> **`required` and `startup_timeout` are not yet enforced**
+> **`required` is not yet enforced**
 >
-> The schema validates these fields and the supervisor stores them, but no code path acts on them yet. They are documented now so config files written today keep working when the planned eager-startup phase lands. Picking the `strict` profile is forward-compatible — it will start enforcing `required=true` automatically.
+> The schema validates this field and the supervisor stores it, but no code path acts on it yet. It is documented now so config files written today keep working when the planned eager-startup phase lands. Picking the `strict` profile is forward-compatible — it will start enforcing `required=true` automatically.
 
 ### Inspecting and restarting toolsets at runtime
 

--- a/docs/configuration/tools/index.md
+++ b/docs/configuration/tools/index.md
@@ -278,7 +278,7 @@ toolsets:
 | `backoff.jitter` | number | Fraction (0..1) of the computed delay applied as a uniform random offset. `0` disables jitter (default). |
 | `required` | boolean | Marks the toolset as critical. Today this is informational; a future eager-startup phase will refuse to start the agent when a required toolset cannot reach Ready. Defaults to `true` under `strict`, `false` otherwise. |
 | `startup_timeout` | duration | Cap on the initial connect+initialize duration. Enforced since v1.94.0: on expiry the toolset stays stopped and the runtime retries on the next turn. |
-| `call_timeout` | duration | Documented per-call timeout. Informational; the runtime currently uses the caller's context for cancellation. |
+| `call_timeout` | duration | Cap on an individual tool call, including one reconnect-retry. Enforced: on expiry the call is cancelled and surfaced to the model as a tool error; cancellation is propagated to the server. `0`/unset means no timeout — opt-in only, no profile default. |
 
 > [!NOTE]
 > **`required` is not yet enforced**

--- a/pkg/config/latest/lifecycle.go
+++ b/pkg/config/latest/lifecycle.go
@@ -36,7 +36,7 @@ import (
 //	  profile: resilient        # strict | resilient | best-effort
 //	  required: false           # block agent startup if not Ready in startup_timeout
 //	  startup_timeout: 30s      # max wait for initial Connect+initialize
-//	  call_timeout: 60s         # default per-call timeout (informational)
+//	  call_timeout: 60s         # enforced per-call timeout; 0/unset = none
 //	  restart: on_failure       # never | on_failure | always
 //	  max_restarts: 5           # consecutive attempts; 0 = profile default; -1 = unlimited
 //	  backoff:
@@ -71,9 +71,15 @@ type LifecycleConfig struct {
 	// profiles default to 0.
 	StartupTimeout Duration `json:"startup_timeout,omitzero" yaml:"startup_timeout,omitempty"`
 
-	// CallTimeout is informational; it documents the user's expectation
-	// for individual tool calls. The runtime currently uses the caller's
-	// context for cancellation.
+	// CallTimeout caps the duration of an individual tool call, including
+	// the one reconnect-retry the toolset may perform on a dropped
+	// session. Enforced by the toolset: on expiry the call is cancelled
+	// and surfaced to the model as a tool error; the shared connection is
+	// not torn down.
+	//
+	// Zero means "no timeout" (use the caller's context, i.e. bounded
+	// only by the session/run deadline). There is no profile default —
+	// call_timeout is opt-in only.
 	CallTimeout Duration `json:"call_timeout,omitzero" yaml:"call_timeout,omitempty"`
 
 	// Restart controls how the supervisor reacts to an unexpected
@@ -172,6 +178,15 @@ func (l *LifecycleConfig) EffectiveStartupTimeout() time.Duration {
 		return l.StartupTimeout.Duration
 	}
 	return profileStartupTimeout(l.Profile)
+}
+
+// EffectiveCallTimeout returns CallTimeout. Zero means "no timeout" — there
+// is no profile default; call_timeout is opt-in only.
+func (l *LifecycleConfig) EffectiveCallTimeout() time.Duration {
+	if l == nil {
+		return 0
+	}
+	return l.CallTimeout.Duration
 }
 
 // profileRequired returns the Required default for the given profile.

--- a/pkg/config/latest/lifecycle_test.go
+++ b/pkg/config/latest/lifecycle_test.go
@@ -1,0 +1,24 @@
+package latest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEffectiveCallTimeout(t *testing.T) {
+	t.Parallel()
+
+	var nilConfig *LifecycleConfig
+	assert.Equal(t, time.Duration(0), nilConfig.EffectiveCallTimeout(), "nil config means no timeout")
+
+	assert.Equal(t, time.Duration(0), (&LifecycleConfig{}).EffectiveCallTimeout(), "zero value means no timeout")
+
+	assert.Equal(t, time.Duration(0), (&LifecycleConfig{Profile: LifecycleProfileStrict}).EffectiveCallTimeout(),
+		"call_timeout has no profile default, even under strict")
+
+	assert.Equal(t, 45*time.Second, (&LifecycleConfig{
+		CallTimeout: Duration{Duration: 45 * time.Second},
+	}).EffectiveCallTimeout(), "an explicit value is returned as-is")
+}

--- a/pkg/runtime/toolexec/dispatcher.go
+++ b/pkg/runtime/toolexec/dispatcher.go
@@ -1083,6 +1083,12 @@ func (c *call) translateError(ctx context.Context, span trace.Span, err error) *
 		span.SetStatus(codes.Ok, msg)
 		return tools.ResultError(msg)
 	}
+	if errors.Is(err, tools.ErrCallTimeout) {
+		// The call site (mcp.Toolset.callTool) already logged the WARN and
+		// span event for the timeout itself; avoid a duplicate RecordError.
+		span.SetStatus(codes.Error, "tool call timed out")
+		return tools.ResultError(err.Error())
+	}
 	span.RecordError(err)
 	span.SetStatus(codes.Error, "tool handler error")
 	slog.ErrorContext(ctx, "Error calling tool", "tool", c.tc.Function.Name, "error", err)

--- a/pkg/runtime/toolexec/translate_error_test.go
+++ b/pkg/runtime/toolexec/translate_error_test.go
@@ -1,0 +1,33 @@
+package toolexec
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/docker/docker-agent/pkg/tools"
+)
+
+// TestTranslateError_CallTimeout verifies the model-facing side of the
+// call_timeout feature: a tool error wrapping tools.ErrCallTimeout is
+// translated into an IsError tool result carrying the "timed out" message,
+// without the generic "Error calling tool: ..." wrapping applied to other
+// errors.
+func TestTranslateError_CallTimeout(t *testing.T) {
+	t.Parallel()
+
+	c := &call{}
+	_, span := noop.NewTracerProvider().Tracer("test").Start(t.Context(), "test")
+	defer span.End()
+
+	err := fmt.Errorf("%w after %s", tools.ErrCallTimeout, 60*time.Second)
+	result := c.translateError(t.Context(), span, err)
+
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+	assert.Equal(t, "tool call timed out after 1m0s", result.Output)
+}

--- a/pkg/tools/lifecycle/policy.go
+++ b/pkg/tools/lifecycle/policy.go
@@ -12,6 +12,7 @@ func PolicyFromConfig(name string, cfg *latest.LifecycleConfig) Policy {
 	policy := profilePolicy(profileName(cfg))
 	policy.Logger = slog.With("component", "supervisor", "toolset", name)
 	policy.StartupTimeout = cfg.EffectiveStartupTimeout()
+	policy.CallTimeout = cfg.EffectiveCallTimeout()
 
 	if cfg == nil {
 		return policy

--- a/pkg/tools/lifecycle/policy_test.go
+++ b/pkg/tools/lifecycle/policy_test.go
@@ -87,6 +87,42 @@ func TestPolicyFromConfig_StartupTimeout(t *testing.T) {
 	}).StartupTimeout)
 }
 
+func TestPolicyFromConfig_CallTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Nil config and an unset field both mean "no timeout" — call_timeout
+	// has no profile default, unlike startup_timeout.
+	assert.Equal(t, time.Duration(0), PolicyFromConfig("test", nil).CallTimeout)
+	assert.Equal(t, time.Duration(0), PolicyFromConfig("test", &latest.LifecycleConfig{
+		Profile: latest.LifecycleProfileStrict,
+	}).CallTimeout, "call_timeout has no profile default, even under strict")
+
+	assert.Equal(t, 45*time.Second, PolicyFromConfig("test", &latest.LifecycleConfig{
+		CallTimeout: latest.Duration{Duration: 45 * time.Second},
+	}).CallTimeout)
+}
+
+// TestPolicyFromConfig_NilEquivalentToZeroPolicy pins the equivalence that
+// NewGatewayToolset's lifecycle wiring relies on: callers that previously
+// passed no policy (zero value) must see the same supervisor behavior as
+// PolicyFromConfig(name, nil), so wiring lifecycle config through the
+// gateway path is not a behavior change for toolsets without a lifecycle
+// block. Logger is the only permitted difference.
+func TestPolicyFromConfig_NilEquivalentToZeroPolicy(t *testing.T) {
+	t.Parallel()
+
+	zero := Policy{}
+	fromNil := PolicyFromConfig("test", nil)
+
+	assert.Equal(t, zero.Restart, fromNil.Restart)
+	assert.Equal(t, zero.maxAttempts(), fromNil.maxAttempts())
+	assert.Equal(t, zero.Backoff, fromNil.Backoff)
+	assert.Equal(t, zero.StartupTimeout, fromNil.StartupTimeout)
+	assert.Equal(t, zero.CallTimeout, fromNil.CallTimeout)
+	assert.Nil(t, zero.Logger)
+	assert.NotNil(t, fromNil.Logger, "PolicyFromConfig always attaches a logger")
+}
+
 func TestParseRestart(t *testing.T) {
 	t.Parallel()
 	cases := map[string]Restart{

--- a/pkg/tools/lifecycle/supervisor.go
+++ b/pkg/tools/lifecycle/supervisor.go
@@ -116,6 +116,10 @@ type Policy struct {
 	// toolset stays in StateStopped so the caller can retry.
 	StartupTimeout time.Duration
 
+	// CallTimeout is carried through to the toolset for enforcement on
+	// individual tool calls; the Supervisor itself does not use it.
+	CallTimeout time.Duration
+
 	// OnDisconnect is called when the session ends, with Wait()'s result.
 	// Useful for cache invalidation.
 	OnDisconnect func(err error)

--- a/pkg/tools/mcp/gateway.go
+++ b/pkg/tools/mcp/gateway.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/gateway"
 	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/lifecycle"
 )
 
 const (
@@ -41,7 +42,14 @@ type GatewayToolset struct {
 
 var _ tools.ToolSet = (*GatewayToolset)(nil)
 
-func NewGatewayToolset(ctx context.Context, name, mcpServerName string, secrets []gateway.Secret, config any, envProvider environment.Provider, cwd string) (*GatewayToolset, error) {
+// NewGatewayToolset creates a new MCP toolset backed by the MCP gateway CLI
+// for a cataloged server (a `ref:`-based toolset).
+//
+// The optional policy lets callers tune restart/backoff/timeout behaviour;
+// see NewToolsetCommand for the semantics. When omitted, the zero value
+// is used, which is behaviorally equivalent to lifecycle.PolicyFromConfig
+// with a nil config (the resilient-profile default).
+func NewGatewayToolset(ctx context.Context, name, mcpServerName string, secrets []gateway.Secret, config any, envProvider environment.Provider, cwd string, policy ...lifecycle.Policy) (*GatewayToolset, error) {
 	slog.DebugContext(ctx, "Creating MCP Gateway toolset", "name", mcpServerName)
 
 	// A crash or SIGKILL skips Stop and leaves plaintext secrets behind;
@@ -75,7 +83,7 @@ func NewGatewayToolset(ctx context.Context, name, mcpServerName string, secrets 
 		"--config", fileConfig,
 	}
 
-	inner := NewToolsetCommand(name, "docker", args, nil, cwd)
+	inner := NewToolsetCommand(name, "docker", args, nil, cwd, policy...)
 	inner.description = "mcp(ref=" + mcpServerName + ")"
 
 	return &GatewayToolset{

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -90,7 +90,7 @@ func CreateToolSet(ctx context.Context, toolset latest.Toolset, runConfig *confi
 			envProvider,
 		)
 
-		return NewGatewayToolset(ctx, toolset.Name, mcpServerName, serverSpec.Secrets, toolset.Config, envProvider, cwd)
+		return NewGatewayToolset(ctx, toolset.Name, mcpServerName, serverSpec.Secrets, toolset.Config, envProvider, cwd, lifecycle.PolicyFromConfig(toolset.Name, toolset.Lifecycle))
 
 	case toolset.Command != "":
 		resolvedCommand, err := toolinstall.EnsureCommand(ctx, toolset.Command, toolset.Version)
@@ -173,6 +173,10 @@ type Toolset struct {
 
 	supervisor *lifecycle.Supervisor
 
+	// callTimeout bounds an individual callTool invocation, including its
+	// one reconnect-retry. Zero means no timeout (use the caller's ctx).
+	callTimeout time.Duration
+
 	mu sync.Mutex
 
 	// Cached tools and prompts, invalidated via MCP notifications and
@@ -232,6 +236,7 @@ func NewToolsetCommand(name, command string, args, env []string, cwd string, pol
 		mcpClient:   newStdioCmdClient(command, args, env, cwd),
 		logID:       command,
 		description: desc,
+		callTimeout: firstOrZero(policy).CallTimeout,
 	}
 	ts.supervisor = newSupervisor(ts, firstOrZero(policy))
 	return ts
@@ -282,6 +287,7 @@ func newRemoteToolset(
 		mcpClient:   newRemoteClient(urlString, transport, headers, NewKeyringTokenStore(), oauthConfig, allowPrivateIPs, env),
 		logID:       urlString,
 		description: desc,
+		callTimeout: firstOrZero(policy).CallTimeout,
 	}
 	ts.supervisor = newSupervisor(ts, remotePolicy(firstOrZero(policy)))
 	return ts
@@ -714,6 +720,8 @@ func (ts *Toolset) refreshPromptCache(ctx context.Context) {
 func (ts *Toolset) callTool(ctx context.Context, toolCall tools.ToolCall, _ tools.Runtime) (*tools.ToolCallResult, error) {
 	slog.DebugContext(ctx, "Calling MCP tool", "tool", toolCall.Function.Name, "arguments", toolCall.Function.Arguments)
 
+	start := time.Now()
+
 	toolCall.Function.Arguments = cmp.Or(toolCall.Function.Arguments, "{}")
 	var args map[string]any
 	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err != nil {
@@ -745,31 +753,67 @@ func (ts *Toolset) callTool(ctx context.Context, toolCall tools.ToolCall, _ tool
 	request.Name = serverToolName
 	request.Arguments = args
 
-	resp, err := ts.mcpClient.CallTool(ctx, request)
+	// callCtx scopes the whole call (including the reconnect-retry below)
+	// as one budget. It is a child of ctx, never a replacement for it: the
+	// connection/session context is detached separately (context.WithoutCancel
+	// in clientConnector.Connect) and must never be bounded here — a fired
+	// call_timeout must only cancel this call, not tear down the session.
+	callCtx := ctx
+	if ts.callTimeout > 0 {
+		var cancel context.CancelFunc
+		callCtx, cancel = context.WithTimeout(ctx, ts.callTimeout)
+		defer cancel()
+	}
+
+	resp, err := ts.mcpClient.CallTool(callCtx, request)
 
 	// If the call failed with a connection or session error (e.g. the
 	// server restarted), trigger or wait for a reconnection and retry
 	// the call once.
-	if err != nil && isConnectionError(err) && ctx.Err() == nil {
+	if err != nil && isConnectionError(err) && callCtx.Err() == nil {
 		slog.WarnContext(ctx, "MCP call failed, forcing reconnect and retrying", "tool", toolCall.Function.Name, "server", ts.logID, "error", err)
-		if waitErr := ts.supervisor.RestartAndWait(ctx, sessionMissingRetryTimeout); waitErr != nil {
-			return nil, fmt.Errorf("failed to reconnect after call failure: %w", waitErr)
+		if waitErr := ts.supervisor.RestartAndWait(callCtx, sessionMissingRetryTimeout); waitErr != nil {
+			return nil, ts.classifyCallToolError(ctx, callCtx, toolCall, start, fmt.Errorf("failed to reconnect after call failure: %w", waitErr))
 		}
-		resp, err = ts.mcpClient.CallTool(ctx, request)
+		resp, err = ts.mcpClient.CallTool(callCtx, request)
 	}
 	if err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
-			slog.DebugContext(ctx, "CallTool canceled by context", "tool", toolCall.Function.Name)
-			return nil, err
-		}
-		slog.ErrorContext(ctx, "Failed to call MCP tool", "tool", toolCall.Function.Name, "error", err)
-		return nil, fmt.Errorf("failed to call tool: %w", err)
+		return nil, ts.classifyCallToolError(ctx, callCtx, toolCall, start, err)
 	}
 
 	result := processMCPContent(resp)
 	slog.DebugContext(ctx, "MCP tool call completed", "tool", toolCall.Function.Name, "output_length", len(result.Output))
 	slog.DebugContext(ctx, result.Output)
 	return result, nil
+}
+
+// classifyCallToolError funnels every callTool failure path (the initial
+// call, the reconnect-retry wait, and the retried call) through one
+// classification, in order:
+//  1. Canceled — checked against the caller's ctx, which wins even though
+//     callCtx also reads Canceled once its parent is canceled.
+//  2. call_timeout expiry — ctx.Err() == nil attributes the deadline to
+//     our own timer rather than a parent/session deadline.
+//  3. Everything else — the existing generic wrap.
+func (ts *Toolset) classifyCallToolError(ctx, callCtx context.Context, toolCall tools.ToolCall, start time.Time, err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+		slog.DebugContext(ctx, "CallTool canceled by context", "tool", toolCall.Function.Name)
+		return err
+	}
+	if ts.callTimeout > 0 && ctx.Err() == nil && errors.Is(callCtx.Err(), context.DeadlineExceeded) {
+		elapsed := time.Since(start)
+		slog.WarnContext(ctx, "MCP tool call timed out", "tool", toolCall.Function.Name, "server", ts.logID, "call_timeout", ts.callTimeout, "elapsed", elapsed)
+		if span := trace.SpanFromContext(ctx); span.IsRecording() {
+			span.AddEvent("mcp.tool_call.timeout", trace.WithAttributes(
+				attribute.String("tool", toolCall.Function.Name),
+				attribute.String("call_timeout", ts.callTimeout.String()),
+				attribute.String("elapsed", elapsed.String()),
+			))
+		}
+		return fmt.Errorf("%w after %s", tools.ErrCallTimeout, ts.callTimeout)
+	}
+	slog.ErrorContext(ctx, "Failed to call MCP tool", "tool", toolCall.Function.Name, "error", err)
+	return fmt.Errorf("failed to call tool: %w", err)
 }
 
 func processMCPContent(toolResult *mcp.CallToolResult) *tools.ToolCallResult {

--- a/pkg/tools/mcp/mcp_test.go
+++ b/pkg/tools/mcp/mcp_test.go
@@ -614,6 +614,159 @@ func TestCallToolRecoversFromErrSessionMissing(t *testing.T) {
 	assert.Equal(t, int32(2), callCount.Load(), "expected exactly 2 CallTool invocations (1 failed + 1 retry)")
 }
 
+func TestCallToolTimeoutFires(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockMCPClient{
+		callToolFn: func(ctx context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	ts := newTestToolset("test-server", "test-server", mock)
+	ts.callTimeout = 50 * time.Millisecond
+	ts.markStartedForTesting()
+
+	start := time.Now()
+	_, err := ts.callTool(t.Context(), tools.ToolCall{
+		Function: tools.FunctionCall{Name: "test_tool", Arguments: `{}`},
+	}, tools.NopRuntime{})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, tools.ErrCallTimeout, "expected ErrCallTimeout, got: %v", err)
+	assert.Contains(t, err.Error(), "timed out")
+	assert.Less(t, elapsed, 5*time.Second, "the call_timeout should have fired promptly")
+	assert.Equal(t, lifecycle.StateReady, ts.State().State, "a fired call_timeout must not disturb the toolset's lifecycle state")
+}
+
+func TestCallToolNoTimeoutWhenCallTimeoutUnset(t *testing.T) {
+	t.Parallel()
+
+	var sawDeadline bool
+	mock := &mockMCPClient{
+		callToolFn: func(ctx context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+			_, sawDeadline = ctx.Deadline()
+			return callToolResult(&mcp.TextContent{Text: "ok"}), nil
+		},
+	}
+
+	ts := newTestToolset("test-server", "test-server", mock)
+	// ts.callTimeout is left at its zero value.
+	ts.markStartedForTesting()
+
+	result, err := ts.callTool(t.Context(), tools.ToolCall{
+		Function: tools.FunctionCall{Name: "test_tool", Arguments: `{}`},
+	}, tools.NopRuntime{})
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", result.Output)
+	assert.False(t, sawDeadline, "no call_timeout means the caller's context must be used unmodified")
+}
+
+func TestCallToolParentCancelWinsOverTimeout(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	mock := &mockMCPClient{
+		callToolFn: func(ctx context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+			close(started)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	ts := newTestToolset("test-server", "test-server", mock)
+	ts.callTimeout = time.Hour // large enough that only the parent cancel can fire first
+	ts.markStartedForTesting()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		<-started
+		cancel()
+	}()
+
+	_, err := ts.callTool(ctx, tools.ToolCall{
+		Function: tools.FunctionCall{Name: "test_tool", Arguments: `{}`},
+	}, tools.NopRuntime{})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled, "expected context.Canceled, got: %v", err)
+	assert.NotErrorIs(t, err, tools.ErrCallTimeout, "a parent cancel must not be misreported as a call_timeout")
+}
+
+func TestCallToolTimeoutCoversReconnectRetry(t *testing.T) {
+	t.Parallel()
+
+	var callCount, initCount atomic.Int32
+	mock := newReconnectableMock()
+	mock.callToolFn = func(_ context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+		callCount.Add(1)
+		// Always fail with a connection error, forcing a reconnect attempt.
+		return nil, fmt.Errorf("tools/call: %w", mcp.ErrSessionMissing)
+	}
+	slowInit := &slowReconnectClient{reconnectableMockClient: mock, reconnectDelay: 300 * time.Millisecond, initCount: &initCount}
+
+	ts := newTestToolset("test-server", "test-server", slowInit)
+	ts.callTimeout = 50 * time.Millisecond
+	require.NoError(t, ts.Start(t.Context()))
+	t.Cleanup(func() { _ = ts.Stop(t.Context()) })
+
+	start := time.Now()
+	_, err := ts.callTool(t.Context(), tools.ToolCall{
+		Function: tools.FunctionCall{Name: "test_tool", Arguments: `{}`},
+	}, tools.NopRuntime{})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, tools.ErrCallTimeout, "expected ErrCallTimeout, got: %v", err)
+	assert.Less(t, elapsed, sessionMissingRetryTimeout,
+		"the call_timeout must cover the reconnect-retry as one budget, not stack on top of the 35s retry wait")
+	assert.GreaterOrEqual(t, callCount.Load(), int32(1))
+}
+
+// slowReconnectClient blocks the second-and-later Initialize call for
+// reconnectDelay, simulating a reconnect that outlasts a short call_timeout.
+type slowReconnectClient struct {
+	*reconnectableMockClient
+
+	reconnectDelay time.Duration
+	initCount      *atomic.Int32
+}
+
+func (m *slowReconnectClient) Initialize(ctx context.Context, req *mcp.InitializeRequest) (*mcp.InitializeResult, error) {
+	if m.initCount.Add(1) > 1 {
+		select {
+		case <-time.After(m.reconnectDelay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return m.reconnectableMockClient.Initialize(ctx, req)
+}
+
+func TestNewToolsetCommandSetsCallTimeoutFromPolicy(t *testing.T) {
+	t.Parallel()
+
+	ts := NewToolsetCommand("test", "gopls", nil, nil, "", lifecycle.Policy{CallTimeout: 42 * time.Second})
+	assert.Equal(t, 42*time.Second, ts.callTimeout)
+}
+
+func TestNewRemoteToolsetSetsCallTimeoutFromPolicy(t *testing.T) {
+	t.Parallel()
+
+	ts := NewRemoteToolset("test", "https://example.com", "streamable", nil, nil, lifecycle.Policy{CallTimeout: 7 * time.Second})
+	assert.Equal(t, 7*time.Second, ts.callTimeout)
+}
+
+func TestNewToolsetCommandNoPolicyMeansNoCallTimeout(t *testing.T) {
+	t.Parallel()
+
+	ts := NewToolsetCommand("test", "gopls", nil, nil, "")
+	assert.Equal(t, time.Duration(0), ts.callTimeout)
+}
+
 func TestRemoteToolsetDefaultsRestartAlways(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tools/mcp/remote_test.go
+++ b/pkg/tools/mcp/remote_test.go
@@ -540,6 +540,49 @@ func TestRemoteClientUnixSocket(t *testing.T) {
 	assert.Equal(t, []string{"ping"}, names)
 }
 
+// TestRemoteClientCallToolAbortsOnContextDeadline verifies the transport-level
+// assumption the call_timeout design relies on: canceling the context passed
+// to a real remoteMCPClient.CallTool (streamable transport) aborts the
+// client's POST promptly, and the server observes that abort as its own
+// request context being canceled — rather than the tool call running to
+// completion in the background while the client just stops waiting.
+func TestRemoteClientCallToolAbortsOnContextDeadline(t *testing.T) {
+	t.Parallel()
+
+	serverSawCancel := make(chan struct{})
+	server := gomcp.NewServer(&gomcp.Implementation{Name: "test-server", Version: "1.0.0"}, nil)
+	gomcp.AddTool(server, &gomcp.Tool{Name: "hang", Description: "hangs until canceled"},
+		func(ctx context.Context, _ *gomcp.CallToolRequest, _ struct{}) (*gomcp.CallToolResult, struct{}, error) {
+			<-ctx.Done()
+			close(serverSawCancel)
+			return nil, struct{}{}, ctx.Err()
+		})
+
+	httpServer := httptest.NewServer(gomcp.NewStreamableHTTPHandler(func(*http.Request) *gomcp.Server { return server }, nil))
+	defer httpServer.Close()
+
+	client := newRemoteClient(httpServer.URL, "streamable", nil, NewInMemoryTokenStore(), nil, false, nil)
+	_, err := client.Initialize(t.Context(), nil)
+	require.NoError(t, err)
+	defer func() { _ = client.Close(context.WithoutCancel(t.Context())) }()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err = client.CallTool(ctx, &gomcp.CallToolParams{Name: "hang"})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Less(t, elapsed, 5*time.Second, "CallTool must abort promptly at the context deadline, not hang until the server responds")
+
+	select {
+	case <-serverSawCancel:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server-side tool handler never observed context cancellation; the client's POST was not aborted at the deadline")
+	}
+}
+
 // mutableEnvProvider is a context-aware, mutable environment.Provider for
 // tests that need to change a value between two requests on the same
 // connection.

--- a/pkg/tools/runtime.go
+++ b/pkg/tools/runtime.go
@@ -40,6 +40,11 @@ type Runtime interface {
 // cannot steer an agent loop.
 var ErrRecallNotSupported = errors.New("recall is not supported by this host")
 
+// ErrCallTimeout is returned when a tool call exceeds its configured
+// call_timeout. Wrapped with the elapsed duration via fmt.Errorf("%w after
+// %s", ErrCallTimeout, ...) — use errors.Is to detect it.
+var ErrCallTimeout = errors.New("tool call timed out")
+
 // NopRuntime is the [Runtime] for hosts without an agent loop (slash-command
 // expansion, prompt templates, tests). EmitOutput is a no-op, Recall fails
 // with [ErrRecallNotSupported], and no capability is supported.


### PR DESCRIPTION
## Summary

- Enforces the existing `lifecycle.call_timeout` toolset field, which was previously parsed but never acted on ("informational today" per its own doc comment). A Harbor Watch investigation stalled 178s on a single hung MCP tool call because docker-agent had no per-call deadline — a stuck call was bounded only by the session context (~600s).
- `Toolset.callTool` now wraps the call **and its one reconnect-retry** in a single `context.WithTimeout` budget derived from the toolset's configured `call_timeout`. A fired timeout is classified distinctly from cancellation/generic errors, logs a WARN + emits an `mcp.tool_call.timeout` span event (the original hang logged nothing), and surfaces a plain `tool call timed out after Ns` error to the model — the session continues normally (`Role=tool, IsError=true`, same mechanics as any other tool error).
- Also wires `lifecycle.Policy` through `NewGatewayToolset`, which previously dropped it entirely for `ref:`-based (MCP-catalog) toolsets — a pre-existing gap this change also closes since gateway toolsets share the same constructor plumbing. Verified behaviorally identical to the historical zero-policy default when no `lifecycle:` block is configured (`TestPolicyFromConfig_NilEquivalentToZeroPolicy`). **Let me know if this was intentional, please.**
- **Default (unset/zero, the vast majority of existing configs) is unchanged** — `if ts.callTimeout > 0` skips `context.WithTimeout` entirely, so `callCtx` is literally the caller's `ctx` and every code path (including the retry guard) behaves byte-for-byte as before. This is a strictly opt-in, per-toolset change, same precedent as `startup_timeout` enforcement in v1.94.0.
- Schema (`agent-schema.json`) and docs (`docs/configuration/tools/index.md`) updated to describe the enforced `call_timeout` semantics instead of "informational."
- Not touching `CHANGELOG.md` in this PR — every existing entry there is versioned/dated and appears to be added in batch at release-cut time (`docs: update CHANGELOG.md for vX` PRs), not accumulated per-feature-PR, so I'm leaving that to whoever cuts the next release.

Ref: [AIDT-619](https://docker.atlassian.net/browse/AIDT-619)

## Test plan

- [x] `go vet ./...`, `go build ./...`, `go mod tidy --diff` all clean
- [x] `golangci-lint run` (full repo) — 0 issues; `go run ./lint .` (custom repo lint) — no offenses
- [x] `go test ./...` — all packages pass; two failing tests are pre-existing/environment-specific (SSRF-probe tests behave differently under sandbox network policy), unrelated to this change
- [x] New tests: timeout fires and is classified correctly (`TestCallToolTimeoutFires`), no-op when unset (`TestCallToolNoTimeoutWhenCallTimeoutUnset`), parent cancel wins over timeout (`TestCallToolParentCancelWinsOverTimeout`), timeout covers the reconnect-retry as one budget rather than stacking on top of the 35s retry window (`TestCallToolTimeoutCoversReconnectRetry`), constructors (incl. gateway) wire `callTimeout` from policy, `translateError` model-facing message, and a real streamable-transport test (`TestRemoteClientCallToolAbortsOnContextDeadline`) confirming a canceled client context actually aborts the POST and the server observes the cancellation
- [x] Companion `docker/internal-agents` change (harbor-watch.yaml `lifecycle.call_timeout: 60s` + config version bump) validated end-to-end against this branch's config parser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AIDT-619]: https://docker.atlassian.net/browse/AIDT-619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ