### PR TITLE
docs: auto-update for merged PRs (2026-07-24)

### DIFF
--- a/docs/getting-started/installation/index.md
+++ b/docs/getting-started/installation/index.md
@@ -121,6 +121,7 @@ Docker Agent needs API keys for the model providers you want to use. Set them as
 export OPENAI_API_KEY="sk-..."           # OpenAI
 export ANTHROPIC_API_KEY="sk-ant-..."    # Anthropic
 export GOOGLE_API_KEY="AI..."            # Google Gemini (or GEMINI_API_KEY)
+export GITHUB_TOKEN="ghp-..."            # GitHub Copilot (PAT with copilot scope)
 export MISTRAL_API_KEY="..."             # Mistral
 export OPENROUTER_API_KEY="..."          # OpenRouter
 ```


### PR DESCRIPTION
## Summary

This PR updates documentation to reflect code changes merged into `main` in the last 36 hours.

## Documentation Changes

### PR #3793: Add GitHub Copilot to CLI setup and doctor

**Source:** https://github.com/docker/docker-agent/pull/3793

**Change:** Added `GITHUB_TOKEN` to the installation guide's API key examples section.

**Why:** PR #3793 added GitHub Copilot as a supported provider in the `docker agent setup` wizard and `doctor` command. While comprehensive GitHub Copilot documentation already exists in `docs/providers/github-copilot/` and the environment variables table in `docs/configuration/overview/`, the installation guide's quick-start API key examples did not include it. This change improves discoverability for users following the getting-started path.

## Analysis of Other Merged PRs

The following PRs were reviewed but did not require doc updates:

- **#3812, #3810, #3794**: Documentation-only PRs (no code changes requiring further doc updates)
- **#3809**: Internal codemode bug fix (no user-facing changes)
- **#3807**: Config schema version bump v14→v15 (docs already reflect v15)
- **#3796**: OAuth `clientId` made optional (docs already mark it as optional with ✗)
- **#3791**: Sandbox template and auth changes (docs already updated with new default template and login injection notes)
- **#3804**: Remove agent catalog traces (docs-only changes already merged in that PR)
- **#3801**: Dependency updates (no user-facing changes)
- **#3799, #3798, #3797**: TUI bug fixes (no doc impact)

---

_This PR was generated automatically by the docs maintenance workflow._