### PR TITLE
refactor(board): simplify app and controller internals

### DIFF
--- a/pkg/board/app.go
+++ b/pkg/board/app.go
@@ -257,6 +257,15 @@ func (a *App) saveConfigLocked() error {
 	})
 }
 
+// projectsLocked returns the stored projects, nil when the board section
+// does not exist yet. Callers must hold a.mu.
+func (a *App) projectsLocked() []userconfig.BoardProject {
+	if a.config.Board == nil {
+		return nil
+	}
+	return a.config.Board.Projects
+}
+
 // Projects returns the configured projects.
 func (a *App) Projects() []Project {
 	a.mu.Lock()
@@ -264,8 +273,9 @@ func (a *App) Projects() []Project {
 	if a.config.Board == nil {
 		return nil
 	}
-	projects := make([]Project, 0, len(a.config.Board.Projects))
-	for _, p := range a.config.Board.Projects {
+	stored := a.projectsLocked()
+	projects := make([]Project, 0, len(stored))
+	for _, p := range stored {
 		projects = append(projects, Project{Name: p.Name, Path: expandHome(p.Path), Agent: p.Agent})
 	}
 	return projects
@@ -282,13 +292,13 @@ func (a *App) AddProject(p Project) error {
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if a.config.Board == nil {
-		a.config.Board = &userconfig.Board{}
-	}
-	for _, existing := range a.config.Board.Projects {
+	for _, existing := range a.projectsLocked() {
 		if existing.Name == stored.Name {
 			return fmt.Errorf("project %q already exists", stored.Name)
 		}
+	}
+	if a.config.Board == nil {
+		a.config.Board = &userconfig.Board{}
 	}
 	a.config.Board.Projects = append(a.config.Board.Projects, stored)
 	return a.saveConfigLocked()
@@ -306,10 +316,7 @@ func (a *App) UpdateProject(oldName string, p Project) error {
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	var projects []userconfig.BoardProject
-	if a.config.Board != nil {
-		projects = a.config.Board.Projects
-	}
+	projects := a.projectsLocked()
 	idx := slices.IndexFunc(projects, func(bp userconfig.BoardProject) bool { return bp.Name == oldName })
 	if idx < 0 {
 		return fmt.Errorf("unknown project %q", oldName)
@@ -377,10 +384,7 @@ func normalizeProjectPath(path string) (string, error) {
 func (a *App) MoveProject(name string, delta int) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	var projects []userconfig.BoardProject
-	if a.config.Board != nil {
-		projects = a.config.Board.Projects
-	}
+	projects := a.projectsLocked()
 	idx := slices.IndexFunc(projects, func(p userconfig.BoardProject) bool { return p.Name == name })
 	if idx < 0 {
 		return fmt.Errorf("unknown project %q", name)

--- a/pkg/board/app.go
+++ b/pkg/board/app.go
@@ -88,6 +88,12 @@ func NewApp(ctx context.Context, onChanged func()) (*App, error) {
 	return app, nil
 }
 
+// columnIndexLocked returns the position of the column with the given id,
+// or -1. Callers must hold a.mu.
+func (a *App) columnIndexLocked(id string) int {
+	return slices.IndexFunc(a.columns, func(c Column) bool { return c.ID == id })
+}
+
 // Columns returns the board's pipeline.
 func (a *App) Columns() []Column {
 	a.mu.Lock()
@@ -100,7 +106,7 @@ func (a *App) Columns() []Column {
 func (a *App) SetColumnPrompt(colID, prompt string) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	i := slices.IndexFunc(a.columns, func(c Column) bool { return c.ID == colID })
+	i := a.columnIndexLocked(colID)
 	if i < 0 {
 		return fmt.Errorf("unknown column %q", colID)
 	}
@@ -140,7 +146,7 @@ func (a *App) UpdateColumn(id string, col Column) (Column, error) {
 
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	idx := slices.IndexFunc(a.columns, func(c Column) bool { return c.ID == id })
+	idx := a.columnIndexLocked(id)
 	if idx < 0 {
 		return Column{}, fmt.Errorf("unknown column %q", id)
 	}
@@ -158,7 +164,7 @@ func (a *App) UpdateColumn(id string, col Column) (Column, error) {
 func (a *App) MoveColumn(id string, delta int) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	idx := slices.IndexFunc(a.columns, func(c Column) bool { return c.ID == id })
+	idx := a.columnIndexLocked(id)
 	if idx < 0 {
 		return fmt.Errorf("unknown column %q", id)
 	}
@@ -179,7 +185,7 @@ func (a *App) MoveColumn(id string, delta int) error {
 func (a *App) RemoveColumn(id string) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	idx := slices.IndexFunc(a.columns, func(c Column) bool { return c.ID == id })
+	idx := a.columnIndexLocked(id)
 	if idx < 0 {
 		return fmt.Errorf("unknown column %q", id)
 	}

--- a/pkg/board/controller.go
+++ b/pkg/board/controller.go
@@ -61,19 +61,10 @@ type controller struct {
 
 	mu       sync.Mutex
 	watchers map[string]*watcher
-	// expectTurn marks cards whose latest launch carried an initial prompt:
-	// a first turn is imminent, so the watcher keeps them "starting" until
-	// the event stream reports it instead of flashing "ready" first.
-	expectTurn map[string]bool
-	// launchFailures counts, per card, consecutive agent deaths before the
-	// control plane ever answered. It lives on the controller — not in the
-	// watcher loop — so a user-initiated relaunch can reset it and give the
-	// agent a fresh set of attempts after the cap tripped.
-	launchFailures map[string]int
-	// launchErrors keeps, per card, the last failed relaunch's error. When a
-	// session cannot even be recreated there is no dead pane to attach to and
-	// read, so this is the only record of why the card went red.
-	launchErrors map[string]error
+	// cards holds per-card recovery state. It lives on the controller — not
+	// in the watcher loop — so user-initiated relaunches (SendPrompt), which
+	// run outside the watcher, can read and update it too.
+	cards map[string]*cardState
 
 	// relaunchMu serializes session relaunches. A watcher's background
 	// resume and a prompt-bearing relaunch (SendPrompt) can otherwise race:
@@ -87,17 +78,31 @@ type watcher struct {
 	done   chan struct{}
 }
 
+// cardState is the controller's per-card recovery state, guarded by c.mu.
+type cardState struct {
+	// expectTurn marks a card whose latest launch carried an initial prompt:
+	// a first turn is imminent, so the watcher keeps it "starting" until the
+	// event stream reports it instead of flashing "ready" first.
+	expectTurn bool
+	// launchFailures counts consecutive agent deaths before the control
+	// plane ever answered. A user-initiated relaunch resets it to give the
+	// agent a fresh set of attempts after the cap tripped.
+	launchFailures int
+	// launchError keeps the last failed relaunch's error. When a session
+	// cannot even be recreated there is no dead pane to attach to and read,
+	// so this is the only record of why the card went red.
+	launchError error
+}
+
 func newController(ctx context.Context, store *Store, sessions sessionManager, onChanged func()) *controller {
 	return &controller{
-		ctx:            ctx,
-		store:          store,
-		sessions:       sessions,
-		onChanged:      onChanged,
-		clientFor:      func(socket, session string) sessionClient { return newClient(socket, session) },
-		watchers:       make(map[string]*watcher),
-		expectTurn:     make(map[string]bool),
-		launchFailures: make(map[string]int),
-		launchErrors:   make(map[string]error),
+		ctx:       ctx,
+		store:     store,
+		sessions:  sessions,
+		onChanged: onChanged,
+		clientFor: func(socket, session string) sessionClient { return newClient(socket, session) },
+		watchers:  make(map[string]*watcher),
+		cards:     make(map[string]*cardState),
 	}
 }
 
@@ -131,20 +136,28 @@ func (c *controller) ExpectTurn(cardID string) {
 	c.setExpectTurn(cardID, true)
 }
 
+// stateLocked returns the card's state, creating it on first use. Callers
+// must hold c.mu.
+func (c *controller) stateLocked(cardID string) *cardState {
+	s, ok := c.cards[cardID]
+	if !ok {
+		s = &cardState{}
+		c.cards[cardID] = s
+	}
+	return s
+}
+
 func (c *controller) setExpectTurn(cardID string, expect bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if expect {
-		c.expectTurn[cardID] = true
-	} else {
-		delete(c.expectTurn, cardID)
-	}
+	c.stateLocked(cardID).expectTurn = expect
 }
 
 func (c *controller) turnExpected(cardID string) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.expectTurn[cardID]
+	s := c.cards[cardID]
+	return s != nil && s.expectTurn
 }
 
 // launchFailed records one more agent death before the control plane ever
@@ -152,24 +165,23 @@ func (c *controller) turnExpected(cardID string) bool {
 func (c *controller) launchFailed(cardID string) int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.launchFailures[cardID]++
-	return c.launchFailures[cardID]
+	s := c.stateLocked(cardID)
+	s.launchFailures++
+	return s.launchFailures
 }
 
 func (c *controller) resetLaunchFailures(cardID string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	delete(c.launchFailures, cardID)
+	if s := c.cards[cardID]; s != nil {
+		s.launchFailures = 0
+	}
 }
 
 func (c *controller) setLaunchError(cardID string, err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if err == nil {
-		delete(c.launchErrors, cardID)
-	} else {
-		c.launchErrors[cardID] = err
-	}
+	c.stateLocked(cardID).launchError = err
 }
 
 // LaunchError returns the last failed relaunch's error for the card, or nil.
@@ -177,7 +189,10 @@ func (c *controller) setLaunchError(cardID string, err error) {
 func (c *controller) LaunchError(cardID string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.launchErrors[cardID]
+	if s := c.cards[cardID]; s != nil {
+		return s.launchError
+	}
+	return nil
 }
 
 // Stop cancels the card's watcher and waits for it to exit. Waiting matters:
@@ -202,9 +217,7 @@ func (c *controller) Stop(cardID string) {
 func (c *controller) forget(cardID string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	delete(c.expectTurn, cardID)
-	delete(c.launchFailures, cardID)
-	delete(c.launchErrors, cardID)
+	delete(c.cards, cardID)
 }
 
 // watch keeps one card mirrored to its control plane: snapshot to resync,


### PR DESCRIPTION
The `pkg/board` package had several repeated patterns that made the code harder to follow and introduced subtle maintenance hazards. Column lookup was duplicated across four methods using identical `slices.IndexFunc` calls, stored-project access was guarded by the same `if a.config.Board != nil` block in four places, and the per-card controller state was split across three parallel maps under the same mutex, which could drift out of sync.

This PR introduces two small private helpers in `app.go` — `columnIndexLocked` and `projectsLocked` — to centralize those repeated patterns, and consolidates the three per-card maps in `controller.go` (`expectTurn`, `launchFailures`, `launchErrors`) into a single `map[string]*cardState`. The `forget()` method now drops one entry instead of three, eliminating the map-drift risk entirely.

All changes are strictly behavior-preserving refactors with no functional modifications.