### PR TITLE
feat(run): expose spawned TUI tabs on the --listen control plane

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -29,6 +29,7 @@ import (
 	"github.com/docker/docker-agent/pkg/permissions"
 	"github.com/docker/docker-agent/pkg/profiling"
 	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/server"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/team"
 	"github.com/docker/docker-agent/pkg/teamloader"
@@ -111,6 +112,13 @@ type runExecFlags struct {
 	// session has independent snapshot state; that controller is local
 	// to the spawner closure and never reaches this field.
 	snapshotController builtins.SnapshotController
+
+	// listenSM is the SessionManager behind the --listen control plane, set
+	// by startSessionCoordinator. When present, sessions spawned later (TUI
+	// tabs) attach to it instead of a private manager, so control-plane
+	// clients can observe and drive every tab of the run — not just the
+	// initial session. Nil when --listen is off.
+	listenSM *server.SessionManager
 }
 
 func newRunCmd() *cobra.Command {

--- a/cmd/root/run_listen.go
+++ b/cmd/root/run_listen.go
@@ -26,13 +26,39 @@ import (
 // (Run/Retry/RunWithMessage) hold the same lock RunSession/AddMessage/
 // UpdateMessage use to detect an active stream, closing the gap where a
 // concurrent REST mutation could slip in during an attached/TUI stream (#3590).
+//
+// When the run serves a control plane (--listen), the session attaches to the
+// serving manager (f.listenSM) instead of a private one, and its events are
+// registered as a source. Sessions spawned after startup — TUI tabs — thereby
+// become first-class control-plane sessions: clients can snapshot them, tail
+// their events and send follow-ups, exactly like the initial session. Without
+// this, a board watching the run sees a green card while a tab is mid-turn.
 func (f *runExecFlags) recallCoordinatorOpt(ctx context.Context, rt runtime.Runtime, sess *session.Session) app.Opt {
-	sm := server.NewSessionManager(ctx, nil, rt.SessionStore(), 0, &f.runConfig)
+	sm := f.listenSM
+	exposed := sm != nil
+	if !exposed {
+		sm = server.NewSessionManager(ctx, nil, rt.SessionStore(), 0, &f.runConfig)
+	}
 	guard := sm.AttachRuntime(ctx, sess.ID, rt, sess)
 	return func(a *app.App) {
 		app.WithStreamGuard(guard)(a)
+		if exposed {
+			registerAppEventSource(sm, sess.ID, a)
+		}
 		sm.RegisterFollowUpInjector(sess.ID, a.InjectUserMessage)
 	}
+}
+
+// registerAppEventSource exposes an App's runtime events on the control
+// plane's per-session event log (GET /api/sessions/:id/events).
+func registerAppEventSource(sm *server.SessionManager, sessionID string, a *app.App) {
+	sm.RegisterEventSource(sessionID, func(ctx context.Context, send func(any)) {
+		a.SubscribeWith(ctx, func(msg tea.Msg) {
+			if ev, ok := msg.(runtime.Event); ok {
+				send(ev)
+			}
+		})
+	})
 }
 
 // startSessionCoordinator wires local recall delivery for the in-process
@@ -47,6 +73,10 @@ func (f *runExecFlags) startSessionCoordinator(ctx context.Context, out *cli.Pri
 
 	sm := server.NewSessionManager(ctx, nil, rt.SessionStore(), 0, &f.runConfig)
 	guard := sm.AttachRuntime(ctx, sess.ID, rt, sess)
+	// Publish the serving manager so sessions spawned later (TUI tabs) attach
+	// to it too (see recallCoordinatorOpt). Set before the TUI starts, so no
+	// spawn can race it.
+	f.listenSM = sm
 
 	ln, err := server.Listen(ctx, f.listenAddr)
 	if err != nil {
@@ -79,13 +109,7 @@ func (f *runExecFlags) startSessionCoordinator(ctx context.Context, out *cli.Pri
 
 	return func(a *app.App) {
 		app.WithStreamGuard(guard)(a)
-		sm.RegisterEventSource(sess.ID, func(ctx context.Context, send func(any)) {
-			a.SubscribeWith(ctx, func(msg tea.Msg) {
-				if ev, ok := msg.(runtime.Event); ok {
-					send(ev)
-				}
-			})
-		})
+		registerAppEventSource(sm, sess.ID, a)
 		// Route control-plane follow-ups and idle recalls into the TUI App so
 		// each starts a real turn and streams events to every subscriber.
 		sm.RegisterFollowUpInjector(sess.ID, a.InjectUserMessage)


### PR DESCRIPTION
When the agent runs with `--listen`, control-plane clients (such as the kanban board) watch session events over the control-plane socket. Sessions spawned *after* startup — TUI tabs opened with ctrl+t — were attached to a private `SessionManager` that was never published, so those sessions were invisible to any connected client. A board card would stay idle/green while a tab was actively mid-turn.

The fix publishes the serving `SessionManager` on the run flags before the TUI starts, so no tab can be spawned before the manager is wired up. `recallCoordinatorOpt` is updated to attach each new spawned session to that manager, registering its App event source and follow-up injector exactly as the initial session is registered. After this change, `GET /api/sessions/<tab-id>/events` streams the tab's `user_message`, `stream_started`, and `stream_stopped` events, each stamped with the correct `session_id`.

No breaking changes; the control-plane API surface is unchanged.