### PR TITLE
fix: resolve data races in deferred tools and BM25 strategy, prevent TUI editor panic

### DIFF
--- a/pkg/rag/strategy/bm25.go
+++ b/pkg/rag/strategy/bm25.go
@@ -91,6 +91,7 @@ type BM25Strategy struct {
 	db           *bm25DB
 	docProcessor chunk.DocumentProcessor
 	fileHashes   map[string]string
+	fileHashesMu sync.Mutex
 	watcher      *fsnotify.Watcher
 	watcherMu    sync.Mutex
 	events       chan<- types.Event
@@ -525,6 +526,9 @@ func (s *BM25Strategy) loadExistingHashes(ctx context.Context) error {
 		return fmt.Errorf("failed to get file metadata: %w", err)
 	}
 
+	s.fileHashesMu.Lock()
+	defer s.fileHashesMu.Unlock()
+
 	for _, meta := range metadata {
 		s.fileHashes[meta.SourcePath] = meta.FileHash
 	}
@@ -538,7 +542,10 @@ func (s *BM25Strategy) needsIndexing(_ context.Context, filePath string) (bool, 
 		return false, fmt.Errorf("failed to hash file: %w", err)
 	}
 
+	s.fileHashesMu.Lock()
 	storedHash, exists := s.fileHashes[filePath]
+	s.fileHashesMu.Unlock()
+
 	if !exists {
 		return true, nil
 	}
@@ -598,7 +605,10 @@ func (s *BM25Strategy) indexFile(ctx context.Context, filePath string) error {
 		return fmt.Errorf("failed to update file metadata: %w", err)
 	}
 
+	s.fileHashesMu.Lock()
 	s.fileHashes[filePath] = fileHash
+	s.fileHashesMu.Unlock()
+
 	slog.DebugContext(ctx, "Indexed file with BM25", "path", filePath, "chunks", storedChunks)
 	return nil
 }
@@ -628,7 +638,9 @@ func (s *BM25Strategy) cleanupOrphanedDocuments(ctx context.Context, seenFiles m
 				continue
 			}
 
+			s.fileHashesMu.Lock()
 			delete(s.fileHashes, meta.SourcePath)
+			s.fileHashesMu.Unlock()
 		}
 	}
 

--- a/pkg/tools/builtin/deferred/deferred.go
+++ b/pkg/tools/builtin/deferred/deferred.go
@@ -252,8 +252,8 @@ func (d *ToolSet) Tools(context.Context) ([]tools.Tool, error) {
 
 func (d *ToolSet) Start(ctx context.Context) error {
 	// Note: we are not responsible for starting the underlying toolsets here
-	d.mu.RLock()
-	defer d.mu.RUnlock()
+	d.mu.Lock()
+	defer d.mu.Unlock()
 
 	for _, source := range d.sources {
 		allTools, err := source.toolset.Tools(ctx)

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -3027,18 +3027,16 @@ func (m *appModel) openExternalEditor() (tea.Model, tea.Cmd) {
 	}
 	_ = tmpFile.Close()
 
-	// Get the editor command (VISUAL, EDITOR, or platform default)
 	editorCmd := cmp.Or(os.Getenv("VISUAL"), os.Getenv("EDITOR"))
-	if editorCmd == "" {
+	parts := strings.Fields(editorCmd)
+	if len(parts) == 0 {
 		if goruntime.GOOS == "windows" {
-			editorCmd = "notepad"
+			parts = []string{"notepad"}
 		} else {
-			editorCmd = "vi"
+			parts = []string{"vi"}
 		}
 	}
 
-	// Parse editor command (may include arguments like "code --wait")
-	parts := strings.Fields(editorCmd)
 	args := append(parts[1:], tmpPath)
 	// External editor is owned by tea.ExecProcess, so exec.Command is intentional.
 	cmd := exec.Command(parts[0], args...) //nolint:noctx // owned by tea.ExecProcess


### PR DESCRIPTION
### Summary
This PR addresses two critical concurrency safety bugs and one runtime panic condition in the codebase.
### Changes Included
1. **Deferred Tools Mutex Fix**
   - File: pkg/tools/builtin/deferred/deferred.go
   - Fixed a memory safety bug where ToolSet.Start mutated the deferredTools map while holding only a read lock. Upgraded this to a write lock.
2. **RAG BM25 Strategy Concurrency Protection**
   - File: pkg/rag/strategy/bm25.go
   - Added fileHashesMu sync.Mutex to guard concurrent reads and writes to the fileHashes map from background watcher goroutines.
3. **External Editor Slice Panic Guard**
   - File: pkg/tui/tui.go
   - Guarded the parser against whitespace-only environment variables which caused index out of bounds panics.
### Validation
- All unit tests in the modified packages passed.
- Linting ran cleanly with zero issues.