### PR TITLE
fix(tui): keep wrapped URLs clickable

### DIFF
--- a/pkg/tui/components/messages/urldetect_test.go
+++ b/pkg/tui/components/messages/urldetect_test.go
@@ -6,6 +6,12 @@ import (
 
 	"github.com/charmbracelet/x/ansi"
 	"gotest.tools/v3/assert"
+
+	"github.com/docker/docker-agent/pkg/tools"
+	"github.com/docker/docker-agent/pkg/tools/builtin/fetch"
+	"github.com/docker/docker-agent/pkg/tui/components/tool"
+	"github.com/docker/docker-agent/pkg/tui/service"
+	"github.com/docker/docker-agent/pkg/tui/types"
 )
 
 func TestFindURLSpans(t *testing.T) {
@@ -272,6 +278,81 @@ func TestUnderlineLine(t *testing.T) {
 			} else {
 				// No change expected
 				assert.Equal(t, tt.line, result)
+			}
+		})
+	}
+}
+
+// TestFetchToolWrappedURLFragmentsResolveFullURL is a regression test for
+// issue #3821: the fetch/api tool renderer wraps a long URL argument like
+// "(<url> (+1 more))" across lines at a fixed width, and only the first
+// fragment (starting with "https://") was clickable — resolving to a
+// truncated URL. Every visible fragment on every rendered line must resolve
+// to the complete URL via OSC 8 detection.
+func TestFetchToolWrappedURLFragmentsResolveFullURL(t *testing.T) {
+	t.Parallel()
+	const longURL = "https://web.archive.org/web/2024/https://www.gnu.org/software/coreutils/manual/html_node/Directories-and-the-Set_002dUser_002dID-and-Set_002dGroup_002dID-Bits.html"
+
+	tests := []struct {
+		name       string
+		args       string
+		status     types.ToolStatus
+		wantLinked string
+	}{
+		{
+			name:       "multiple urls with +1 more suffix",
+			args:       `{"urls": ["` + longURL + `", "https://example.com/other"]}`,
+			status:     types.ToolStatusCompleted,
+			wantLinked: longURL,
+		},
+		{
+			name:       "single url",
+			args:       `{"urls": ["` + longURL + `"]}`,
+			status:     types.ToolStatusCompleted,
+			wantLinked: longURL,
+		},
+		{
+			// While running, the endpoint is shown twice: "(<url>): Calling <url>".
+			name:       "running endpoint",
+			args:       `{"url": "` + longURL + `"}`,
+			status:     types.ToolStatusRunning,
+			wantLinked: longURL + longURL,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			msg := types.ToolCallMessage("agent", tools.ToolCall{
+				ID:       "call-1",
+				Function: tools.FunctionCall{Name: fetch.ToolNameFetch, Arguments: tt.args},
+			}, tools.Tool{Name: fetch.ToolNameFetch}, tt.status)
+
+			view := tool.New(msg, service.StaticSessionState{})
+			_ = view.SetSize(80, 0)
+			lines := strings.Split(view.View(), "\n")
+			assert.Assert(t, len(lines) > 1, "long URL argument should wrap onto multiple lines")
+
+			// Concatenating every cell that resolves to the full URL must
+			// rebuild it exactly: each wrapped fragment is clickable with the
+			// complete destination, and nothing around it (parens, "(+1 more)",
+			// tool badge, result summary) links to it.
+			var linked strings.Builder
+			for _, line := range lines {
+				for col, r := range []rune(ansi.Strip(line)) {
+					if urlAtPosition(line, col) == longURL {
+						linked.WriteRune(r)
+					}
+				}
+			}
+			assert.Equal(t, tt.wantLinked, linked.String())
+
+			// The "(+1 more)" suffix must not be part of any link.
+			for _, line := range lines {
+				plain := ansi.Strip(line)
+				if idx := strings.Index(plain, "(+1 more)"); idx >= 0 {
+					assert.Equal(t, "", urlAtPosition(line, idx+1))
+				}
 			}
 		})
 	}

--- a/pkg/tui/components/toolcommon/hyperlink.go
+++ b/pkg/tui/components/toolcommon/hyperlink.go
@@ -1,0 +1,116 @@
+package toolcommon
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// urlRuneSpan is a URL detected in a line, with its rune-index range.
+type urlRuneSpan struct {
+	url   string
+	start int
+	end   int // exclusive
+}
+
+// findURLRuneSpans finds http(s):// URLs in a line and returns their rune
+// ranges. Matching mirrors the plain-text URL detection used for click
+// handling (pkg/tui/components/messages/urldetect.go), so emitted OSC 8
+// destinations agree with what detection finds on an unwrapped line.
+func findURLRuneSpans(runes []rune) []urlRuneSpan {
+	var spans []urlRuneSpan
+	n := len(runes)
+
+	for i := 0; i < n; {
+		if runes[i] != 'h' {
+			i++
+			continue
+		}
+		remaining := string(runes[i:])
+		var prefixLen int
+		switch {
+		case strings.HasPrefix(remaining, "https://"):
+			prefixLen = len("https://")
+		case strings.HasPrefix(remaining, "http://"):
+			prefixLen = len("http://")
+		default:
+			i++
+			continue
+		}
+
+		// Must not be preceded by a word character (avoid matching mid-word)
+		if i > 0 && isURLWordRune(runes[i-1]) {
+			i++
+			continue
+		}
+
+		j := i + prefixLen
+		for j < n && isURLRune(runes[j]) {
+			j++
+		}
+		// Strip common trailing punctuation that's unlikely part of the URL
+		for j > i+prefixLen && isTrailingURLPunct(runes[j-1]) {
+			j--
+		}
+		// Strip a trailing ')' only if unmatched, e.g. "(https://example.com)"
+		if hasUnbalancedCloseParen(runes[i:j]) {
+			j--
+		}
+
+		spans = append(spans, urlRuneSpan{url: string(runes[i:j]), start: i, end: j})
+		i = j
+	}
+	return spans
+}
+
+// writeChunkWithHyperlinks writes runes[start:end] to b, wrapping every part
+// that overlaps a URL span in an OSC 8 hyperlink to the span's full URL.
+// Wrapping can split a URL across lines; linking each visible fragment keeps
+// the complete destination clickable everywhere.
+func writeChunkWithHyperlinks(b *strings.Builder, runes []rune, start, end int, spans []urlRuneSpan) {
+	pos := start
+	for _, span := range spans {
+		if span.end <= pos || span.start >= end {
+			continue
+		}
+		from := max(span.start, pos)
+		to := min(span.end, end)
+		b.WriteString(string(runes[pos:from]))
+		b.WriteString(ansi.SetHyperlink(span.url))
+		b.WriteString(string(runes[from:to]))
+		b.WriteString(ansi.ResetHyperlink())
+		pos = to
+	}
+	b.WriteString(string(runes[pos:end]))
+}
+
+func hasUnbalancedCloseParen(url []rune) bool {
+	if len(url) == 0 || url[len(url)-1] != ')' {
+		return false
+	}
+	open, closed := 0, 0
+	for _, r := range url {
+		switch r {
+		case '(':
+			open++
+		case ')':
+			closed++
+		}
+	}
+	return closed > open
+}
+
+func isURLRune(r rune) bool {
+	if r <= ' ' || r == '"' || r == '<' || r == '>' || r == '{' || r == '}' || r == '|' || r == '\\' || r == '^' || r == '`' {
+		return false
+	}
+	return true
+}
+
+func isURLWordRune(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+}
+
+func isTrailingURLPunct(r rune) bool {
+	return r == '.' || r == ',' || r == ';' || r == ':' || r == '!' || r == '?'
+}

--- a/pkg/tui/components/toolcommon/hyperlink_test.go
+++ b/pkg/tui/components/toolcommon/hyperlink_test.go
@@ -1,0 +1,168 @@
+package toolcommon
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// archiveURL reproduces issue #3821: a fetch tool argument long enough to be
+// wrapped over several lines by wrapTextWithIndent.
+const archiveURL = "https://web.archive.org/web/2024/https://www.gnu.org/software/coreutils/manual/html_node/Directories-and-the-Set_002dUser_002dID-and-Set_002dGroup_002dID-Bits.html"
+
+var osc8LinkRe = regexp.MustCompile("\x1b\\]8;;([^\x07]*)\x07(.*?)\x1b\\]8;;\x07")
+
+type renderedLink struct {
+	url  string
+	text string
+}
+
+func osc8Links(line string) []renderedLink {
+	var links []renderedLink
+	for _, m := range osc8LinkRe.FindAllStringSubmatch(line, -1) {
+		links = append(links, renderedLink{url: m[1], text: m[2]})
+	}
+	return links
+}
+
+func TestFindURLRuneSpans(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		text      string
+		wantURLs  []string
+		wantSpans [][2]int // [start, end) rune ranges
+	}{
+		{
+			name:     "no URLs",
+			text:     "hello world",
+			wantURLs: nil,
+		},
+		{
+			name:      "fetch args with more suffix",
+			text:      "(" + archiveURL + " (+1 more))",
+			wantURLs:  []string{archiveURL},
+			wantSpans: [][2]int{{1, 1 + len(archiveURL)}},
+		},
+		{
+			name:      "single URL in parentheses",
+			text:      "(https://example.com)",
+			wantURLs:  []string{"https://example.com"},
+			wantSpans: [][2]int{{1, 20}},
+		},
+		{
+			name:      "URL with balanced parens in path",
+			text:      "(https://en.wikipedia.org/wiki/Go_(programming_language))",
+			wantURLs:  []string{"https://en.wikipedia.org/wiki/Go_(programming_language)"},
+			wantSpans: [][2]int{{1, 56}},
+		},
+		{
+			name:      "trailing punctuation stripped",
+			text:      "see https://example.com.",
+			wantURLs:  []string{"https://example.com"},
+			wantSpans: [][2]int{{4, 23}},
+		},
+		{
+			name:      "close paren then colon",
+			text:      "(https://example.com): Calling https://example.com",
+			wantURLs:  []string{"https://example.com", "https://example.com"},
+			wantSpans: [][2]int{{1, 20}, {31, 50}},
+		},
+		{
+			name:     "not preceded by word character",
+			text:     "xhttps://example.com",
+			wantURLs: nil,
+		},
+		{
+			name:      "multiple URLs",
+			text:      "https://a.com https://b.com",
+			wantURLs:  []string{"https://a.com", "https://b.com"},
+			wantSpans: [][2]int{{0, 13}, {14, 27}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := findURLRuneSpans([]rune(tt.text))
+			require.Len(t, got, len(tt.wantURLs))
+			for i, span := range got {
+				assert.Equal(t, tt.wantURLs[i], span.url)
+				assert.Equal(t, tt.wantSpans[i][0], span.start)
+				assert.Equal(t, tt.wantSpans[i][1], span.end)
+			}
+		})
+	}
+}
+
+func TestWrapTextWithIndentHyperlinksWrappedURL(t *testing.T) {
+	t.Parallel()
+
+	got := wrapTextWithIndent("(https://ex.com/abcdef)", 10, 12)
+
+	want := "(\x1b]8;;https://ex.com/abcdef\x07https://e\x1b]8;;\x07\n" +
+		"  \x1b]8;;https://ex.com/abcdef\x07x.com/abcdef\x1b]8;;\x07\n" +
+		"  )"
+	assert.Equal(t, want, got)
+}
+
+// TestWrapTextWithIndentWrappedFetchArgs is a regression test for issue #3821:
+// the fetch/api tool renders "(<url> (+1 more))" and wrapTextWithIndent splits
+// the URL over multiple lines. Every visible fragment must carry the full URL
+// as an OSC 8 hyperlink, while the surrounding parens and "(+1 more)" suffix
+// stay outside the link. The visible text and wrapping must be unchanged.
+func TestWrapTextWithIndentWrappedFetchArgs(t *testing.T) {
+	t.Parallel()
+
+	text := "(" + archiveURL + " (+1 more))"
+	const firstLineWidth, subsequentLineWidth = 66, 78
+
+	got := wrapTextWithIndent(text, firstLineWidth, subsequentLineWidth)
+	lines := strings.Split(got, "\n")
+	require.Greater(t, len(lines), 1, "URL should wrap over multiple lines")
+
+	var linked strings.Builder
+	for i, line := range lines {
+		width := firstLineWidth
+		if i > 0 {
+			width = subsequentLineWidth + 2 // subsequent lines carry the 2-cell indent
+		}
+		assert.LessOrEqual(t, lipgloss.Width(line), width)
+
+		for _, link := range osc8Links(line) {
+			assert.Equal(t, archiveURL, link.url, "every fragment must link to the full URL")
+			linked.WriteString(link.text)
+		}
+	}
+
+	// Fragments cover exactly the URL: nothing missing, parens and the
+	// "(+1 more)" suffix excluded from the hyperlink.
+	assert.Equal(t, archiveURL, linked.String())
+
+	// Visible rendering is unchanged: stripping OSC 8 and the "\n  " wraps
+	// reconstructs the original text.
+	assert.Equal(t, text, strings.ReplaceAll(ansi.Strip(got), "\n  ", ""))
+}
+
+func TestWrapTextWithIndentNoWrapNoHyperlinks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single line that fits is unchanged", func(t *testing.T) {
+		t.Parallel()
+		text := "(https://example.com)"
+		assert.Equal(t, text, wrapTextWithIndent(text, 40, 40))
+	})
+
+	t.Run("multi-line input with fitting lines is unchanged except indent", func(t *testing.T) {
+		t.Parallel()
+		got := wrapTextWithIndent("https://a.com\nhttps://b.com", 40, 40)
+		assert.Equal(t, "https://a.com\n  https://b.com", got)
+	})
+}

--- a/pkg/tui/components/toolcommon/truncate.go
+++ b/pkg/tui/components/toolcommon/truncate.go
@@ -95,6 +95,8 @@ func takeRunesThatFit(runes []rune, start, width int) int {
 // wrapTextWithIndent wraps text where the first line has a different available width.
 // Subsequent lines are indented to align with the tool name badge.
 // If text starts with a newline, it's considered pre-formatted and no indent is added.
+// On wrapped lines, each visible fragment of a URL is emitted inside an OSC 8
+// hyperlink to the full URL, so a URL split across lines stays clickable everywhere.
 func wrapTextWithIndent(text string, firstLineWidth, subsequentLineWidth int) string {
 	if firstLineWidth <= 0 || subsequentLineWidth <= 0 {
 		return text
@@ -145,6 +147,7 @@ func wrapTextWithIndent(text string, firstLineWidth, subsequentLineWidth int) st
 
 		// Need to wrap this line
 		runes := []rune(inputLine)
+		urlSpans := findURLRuneSpans(runes)
 		start := 0
 		for start < len(runes) {
 			// After first chunk, use subsequent width/indent
@@ -159,7 +162,7 @@ func wrapTextWithIndent(text string, firstLineWidth, subsequentLineWidth int) st
 				result.WriteByte('\n')
 			}
 			result.WriteString(prefix)
-			result.WriteString(string(runes[start:end]))
+			writeChunkWithHyperlinks(&result, runes, start, end, urlSpans)
 			start = end
 		}
 	}


### PR DESCRIPTION
## Summary

- detect complete URLs before tool argument wrapping
- emit each visible wrapped fragment as an OSC 8 hyperlink to the complete destination
- preserve existing visible text, wrapping, indentation, and non-link suffixes
- add an end-to-end regression test for the fetch tool renderer

## Issue expectations

| Expectation | Implementation |
|---|---|
| Detect URLs split across terminal lines | URL boundaries are captured before `wrapTextWithIndent` splits the text |
| Treat wrapped fragments as one link | Every fragment carries the same complete OSC 8 destination |
| Keep the entire URL clickable | Click detection is verified on every rendered URL cell |
| Exclude surrounding text | Parentheses, result summaries, and `(+1 more)` remain outside the link |

## Validation

- `task build`
- `task lint`
- `task test`
- `go test -race ./pkg/tui/components/toolcommon ./pkg/tui/components/messages`

Closes #3821
