### PR TITLE
fix(setup): clarify model provider paths

### DIFF
--- a/cmd/root/setup.go
+++ b/cmd/root/setup.go
@@ -98,18 +98,21 @@ type setupWizard struct {
 func newSetupCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "setup",
-		Short: "Interactively set up a model (API key, local, custom endpoint, or Claude Code)",
+		Short: "Interactively set up a model (built-in provider, local, custom endpoint, or Claude Code)",
 		Long: `Set up a model for docker agent, interactively.
 
 Four paths:
-  - Cloud provider: pick a provider, paste its API key, and store it in the
-    docker agent env file (~/.config/cagent/.env). Picking chatgpt signs in
-    with your ChatGPT account in the browser instead of asking for an API key.
+  - Built-in cloud provider: pick a provider docker agent already knows
+    (Anthropic, OpenAI, Google, Groq, Hugging Face, ...) and connect it.
+    Credentials vary by provider: most paste an API key or token, stored in
+    the docker agent env file (~/.config/cagent/.env), while chatgpt signs
+    in with your ChatGPT account in the browser instead.
   - Local model: check Docker Model Runner and pull a model. No API key needed.
-  - OpenAI-compatible provider: register a custom endpoint (vLLM, LiteLLM,
-    a corporate gateway, ...) with its API format and API key variable. The
-    provider is saved to your user configuration and its models become
-    usable everywhere via --model <name>/<model>.
+  - Custom OpenAI-compatible endpoint: for endpoints that are not built in
+    (vLLM, LiteLLM, a corporate gateway, ...). Register the endpoint with
+    its base URL, API format, and API key variable; the provider is saved
+    to your user configuration and its models become usable everywhere via
+    --model <name>/<model>.
   - Claude Code harness: use your Claude subscription through the official
     'claude' CLI. Checks that the CLI is installed and logged in (offering
     'claude auth login --claudeai'), then writes a ready-to-run agent file.
@@ -159,7 +162,7 @@ func newTerminalSetupWizard(in io.Reader, out io.Writer) *setupWizard {
 			value, err := term.ReadPassword(int(os.Stdin.Fd()))
 			fmt.Fprintln(out)
 			if err != nil {
-				return "", fmt.Errorf("reading the API key: %w", err)
+				return "", fmt.Errorf("reading the credential: %w", err)
 			}
 			return string(value), nil
 		},
@@ -185,9 +188,9 @@ func (w *setupWizard) run(ctx context.Context) (*setupResult, error) {
 	fmt.Fprintln(w.out, "Let's set up a model for docker agent.")
 	fmt.Fprintln(w.out)
 	fmt.Fprintln(w.out, "How do you want to run models?")
-	fmt.Fprintln(w.out, "  1. Cloud provider (needs an API key)")
+	fmt.Fprintln(w.out, "  1. Built-in cloud provider (Anthropic, OpenAI, Groq, Hugging Face, ...)")
 	fmt.Fprintln(w.out, "  2. Local model via Docker Model Runner (no API key)")
-	fmt.Fprintln(w.out, "  3. OpenAI-compatible provider (custom endpoint, e.g. vLLM, LiteLLM)")
+	fmt.Fprintln(w.out, "  3. Custom OpenAI-compatible endpoint (your own base URL, e.g. vLLM, LiteLLM)")
 	fmt.Fprintln(w.out, "  4. Claude Code harness (Claude subscription via the official `claude` CLI)")
 
 	choice, err := w.promptChoice(ctx, 4, 1)
@@ -252,7 +255,7 @@ func (w *setupWizard) setupCloudProvider(ctx context.Context) (*setupResult, err
 		return &setupResult{Model: selected.Provider + "/" + config.DefaultModels[selected.Provider]}, nil
 	}
 
-	key, err := w.promptSecret(ctx, fmt.Sprintf("\nPaste your %s API key (%s, input hidden): ", selected.Provider, envVar))
+	key, err := w.promptSecret(ctx, fmt.Sprintf("\nPaste your %s credential (%s, input hidden): ", selected.Provider, envVar))
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +267,7 @@ func (w *setupWizard) setupCloudProvider(ctx context.Context) (*setupResult, err
 	return &setupResult{EnvVar: envVar, Value: key, Model: selected.Provider + "/" + config.DefaultModels[selected.Provider]}, nil
 }
 
-// promptSecret asks for the API key until a non-empty value is entered.
+// promptSecret asks for the secret until a non-empty value is entered.
 func (w *setupWizard) promptSecret(ctx context.Context, prompt string) (string, error) {
 	for {
 		if err := ctx.Err(); err != nil {

--- a/cmd/root/setup_test.go
+++ b/cmd/root/setup_test.go
@@ -57,7 +57,9 @@ func newTestWizard(answers string, keys []string, stores []environment.SecretSto
 	wizard := &setupWizard{
 		in:  bufio.NewReader(strings.NewReader(answers)),
 		out: &out,
-		readSecret: func(string) (string, error) {
+		readSecret: func(prompt string) (string, error) {
+			// Echo the prompt like the terminal readSecret so tests can assert on it.
+			fmt.Fprintln(&out, prompt)
 			if secretCalls >= len(keys) {
 				return "", errors.New("no scripted key left")
 			}
@@ -98,6 +100,8 @@ func TestSetupWizard_CloudPathStoresKey(t *testing.T) {
 
 	output := out.String()
 	assert.NotContains(t, output, "Where should", "a single store must not prompt for a location")
+	assert.Contains(t, output, "anthropic credential", "the built-in prompt asks for a credential")
+	assert.NotContains(t, output, "anthropic API key", "not every built-in credential is an API key (docker/docker-agent#3805)")
 	assert.Contains(t, output, "Stored ANTHROPIC_API_KEY in the config-env-file (fake).")
 	assert.Contains(t, output, "docker agent run")
 	assert.Contains(t, output, "--model anthropic/claude-sonnet-4-6")
@@ -293,6 +297,30 @@ func TestSetupWizard_InvalidChoiceReasks(t *testing.T) {
 
 	assert.Contains(t, out.String(), "Enter a number between 1 and 4.")
 	assert.Empty(t, *pulled)
+}
+
+// The top-level menu must make the built-in vs custom distinction obvious:
+// Groq and Hugging Face are built into option 1, and option 3 is only for a
+// custom endpoint reached through its base URL (docker/docker-agent#3805).
+func TestSetupWizard_MenuDistinguishesBuiltInFromCustomEndpoint(t *testing.T) {
+	t.Parallel()
+
+	wizard, out, _ := newTestWizard("2\n", nil, nil, []string{"ai/smollm2"}, nil)
+
+	_, err := wizard.run(t.Context())
+	require.NoError(t, err)
+
+	output := out.String()
+	assert.Contains(t, output, "1. Built-in cloud provider (Anthropic, OpenAI, Groq, Hugging Face, ...)")
+	assert.Contains(t, output, "3. Custom OpenAI-compatible endpoint (your own base URL, e.g. vLLM, LiteLLM)")
+	assert.NotContains(t, output, "needs an API key", "not every built-in provider uses a plain API key")
+
+	// The menu names Groq and Hugging Face as built-in; keep that honest.
+	providers := config.CloudProviderEnvVars()
+	for _, name := range []string{"groq", "huggingface"} {
+		contains := slices.ContainsFunc(providers, func(p config.ProviderEnvVars) bool { return p.Provider == name })
+		assert.True(t, contains, "%s must be a built-in cloud provider", name)
+	}
 }
 
 func TestSetupWizard_EOFCancels(t *testing.T) {

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -230,7 +230,14 @@ $ docker agent toolsets --format json | jq             # machine-readable (type,
 
 ### `docker agent setup`
 
-Set up a model interactively. Four paths: pick a cloud provider, paste its API key, and store it in the Docker Agent env file `~/.config/cagent/.env`; check Docker Model Runner and pull a local model (no API key needed); register a custom OpenAI-compatible provider (endpoint URL, API format, and API key variable) saved to your [user configuration](../../providers/custom/index.md#global-providers-user-configuration) so its models work everywhere via `--model <name>/<model>`; or set up the [Claude Code harness](../harnesses/index.md) to use a Claude subscription through the official `claude` CLI — the wizard checks that the CLI is installed and logged in, offers to run `claude auth login --claudeai` (only after you confirm), and writes a ready-to-run `claude-code-agent.yaml`. Ends with the exact command to start chatting. Secret values are never printed, and Docker Agent never reads or copies the Claude CLI's credentials.
+Set up a model interactively. Four paths:
+
+- **Built-in cloud provider**: pick a provider Docker Agent already knows (Anthropic, OpenAI, Google, Groq, Hugging Face, ...) and connect it. Credentials vary by provider: most take an API key or token, stored in the Docker Agent env file `~/.config/cagent/.env`, while `chatgpt` signs in with your ChatGPT account in the browser.
+- **Local model**: check Docker Model Runner and pull a model. No API key needed.
+- **Custom OpenAI-compatible endpoint**: register an endpoint that is not built in (vLLM, LiteLLM, a corporate gateway, ...) with its base URL, API format, and API key variable, saved to your [user configuration](../../providers/custom/index.md#global-providers-user-configuration) so its models work everywhere via `--model <name>/<model>`.
+- **Claude Code harness**: use a Claude subscription through the official `claude` CLI. The wizard checks that the CLI is installed and logged in, offers to run `claude auth login --claudeai` (only after you confirm), and writes a ready-to-run `claude-code-agent.yaml`. See [Coding Harnesses](../harnesses/index.md).
+
+Ends with the exact command to start chatting. Secret values are never printed, and Docker Agent never reads or copies the Claude CLI's credentials.
 
 The wizard is also offered automatically when an interactive run finds no usable model (decline-able; set `DOCKER_AGENT_NO_SETUP=1` to suppress the offer).
 

--- a/docs/getting-started/set-up-a-model/index.md
+++ b/docs/getting-started/set-up-a-model/index.md
@@ -1,32 +1,34 @@
 ---
 title: "Set Up a Model"
-description: "Make a model available to Docker Agent: bring a cloud provider API key or run a local model with Docker Model Runner."
-keywords: docker agent, ai agents, getting started, set up a model, api key, local model, docker model runner
+description: "Make a model available to Docker Agent: connect a cloud provider, run a local model with Docker Model Runner, or register a custom OpenAI-compatible endpoint."
+keywords: docker agent, ai agents, getting started, set up a model, api key, local model, docker model runner, custom endpoint
 weight: 25
 canonical: https://docs.docker.com/ai/docker-agent/getting-started/set-up-a-model/
 ---
 
-_Most agents need a model to think with: bring an API key for a cloud provider, or run a model locally with Docker Model Runner. This page walks through both paths end to end — plus the exception: agents that delegate to the Claude Code CLI on a Claude subscription, which need no model at all._
+_Most agents need a model to think with: connect a built-in cloud provider, run a model locally with Docker Model Runner, or register a custom OpenAI-compatible endpoint. This page walks through each path end to end — plus the exception: agents that delegate to the Claude Code CLI on a Claude subscription, which need no model at all._
 
 ## Pick a Path
 
-|              | Cloud provider (Path A)                 | Local model (Path B)                        |
-| ------------ | ---------------------------------------- | ------------------------------------------- |
-| You need     | An account and an API key                | Docker Desktop with Model Runner enabled    |
-| Cost         | Pay per token                            | Free once the model is downloaded           |
-| Your data    | Sent to the provider                     | Never leaves your machine                   |
-| Model quality| Frontier models (Claude, GPT-5, Gemini)  | Open models sized to your hardware          |
+|               | Built-in cloud provider (Path A)                 | Local model (Path B)                     |
+| ------------- | ------------------------------------------------ | ---------------------------------------- |
+| You need      | An account and a credential (usually an API key) | Docker Desktop with Model Runner enabled |
+| Cost          | Pay per token                                    | Free once the model is downloaded        |
+| Your data     | Sent to the provider                             | Never leaves your machine                |
+| Model quality | Frontier models (Claude, GPT-5, Gemini)          | Open models sized to your hardware       |
 
-You can set up both. When you don't name a model, Docker Agent's `auto` selection picks the first cloud provider with a configured key and falls back to a locally pulled Docker Model Runner model.
+You can set up both. When you don't name a model, Docker Agent's `auto` selection picks the first cloud provider with a configured credential and falls back to a locally pulled Docker Model Runner model.
 
-There is also a third path that is neither: if you have a **Claude subscription**, the [Claude Code harness](#path-c-claude-code-harness-claude-subscription) runs the official `claude` CLI as the agent — no API key and no local model required.
+Two more paths cover the remaining cases: if your models sit behind your own OpenAI-compatible endpoint (vLLM, LiteLLM, a corporate gateway), register it with its base URL as a [custom endpoint](#path-c-custom-openai-compatible-endpoint) (Path C); and if you have a **Claude subscription**, the [Claude Code harness](#path-d-claude-code-harness-claude-subscription) (Path D) runs the official `claude` CLI as the agent, with no API key and no local model required.
 
 > [!TIP]
 > **Prefer a wizard?**
 >
-> `docker agent setup` walks through the same choices interactively: pick a provider and store its key, check Docker Model Runner and pull a local model, or set up the Claude Code harness. This page is the manual version. See the [CLI reference](../../features/cli/index.md#docker-agent-setup).
+> `docker agent setup` walks through the same choices interactively: pick a built-in provider and store its credential, check Docker Model Runner and pull a local model, register a custom OpenAI-compatible endpoint, or set up the Claude Code harness. This page is the manual version. See the [CLI reference](../../features/cli/index.md#docker-agent-setup).
 
-## Path A: Cloud Provider (API Key)
+## Path A: Built-in Cloud Provider
+
+Docker Agent ships built-in support for many cloud providers: Anthropic, OpenAI, Google Gemini, Groq, Hugging Face, AWS Bedrock, GitHub Copilot, and more. You pick these by name instead of registering a custom provider. The providers `docker agent setup` lists — Groq and Hugging Face among them — come with a predefined endpoint, so setting the provider's credential is enough; some other built-in aliases need manual configuration, such as Azure OpenAI with your resource endpoint as `base_url`. The credential is usually an API key, but not always: Hugging Face uses the `HF_TOKEN` token, GitHub Copilot a `GITHUB_TOKEN`, AWS Bedrock your AWS credentials, and `chatgpt` signs in with your ChatGPT account in the browser via `docker agent setup`, with no key to paste. The steps below show the API-key flow that most providers follow.
 
 ### 1. Get an API key
 
@@ -38,7 +40,7 @@ Create a key in your provider's console:
 | OpenAI        | `OPENAI_API_KEY`     | [platform.openai.com](https://platform.openai.com/api-keys)          |
 | Google Gemini | `GOOGLE_API_KEY`     | [aistudio.google.com](https://aistudio.google.com/apikey)            |
 
-Every other provider works the same way. See [Model Providers](../../providers/overview/index.md) for the full list and each provider's environment variable.
+Every other provider with an API key works the same way. See [Model Providers](../../providers/overview/index.md) for the full list, each provider's credential variable, and the exceptions noted above.
 
 ### 2. Store the key
 
@@ -182,7 +184,36 @@ agents:
 
 When no cloud key is configured, bare `docker agent run` auto-selects a pulled local model, so after `docker model pull` you can run with no flags at all. The [Docker Model Runner provider page](../../providers/dmr/index.md) covers context size, runtime flags, and other tuning options.
 
-## Path C: Claude Code Harness (Claude Subscription)
+## Path C: Custom OpenAI-compatible Endpoint
+
+If your models are served from your own endpoint (vLLM, LiteLLM, a corporate gateway, an API proxy), register it as a custom provider: you supply its base URL, the API format, and the environment variable holding its API key, if it needs one. Built-in providers such as Groq or Hugging Face don't need this; use [Path A](#path-a-built-in-cloud-provider) and set their credential instead.
+
+The interactive wizard is the quickest way:
+
+```bash
+$ docker agent setup   # pick "Custom OpenAI-compatible endpoint"
+```
+
+Or define the provider once in your user configuration (`~/.config/cagent/config.yaml`):
+
+```yaml
+providers:
+  myprovider:
+    base_url: https://llm.corp.example.com/v1
+    api_type: openai_chatcompletions
+    token_key: MYPROVIDER_API_KEY
+```
+
+Its models then work with every command:
+
+```bash
+$ docker agent models --provider myprovider
+$ docker agent run --model myprovider/<model>
+```
+
+See [Provider Definitions](../../providers/custom/index.md#global-providers-user-configuration) for the full reference, including per-agent-file providers and gateway behavior.
+
+## Path D: Claude Code Harness (Claude Subscription)
 
 If you already pay for a Claude subscription, an agent can delegate its work to
 the official Claude Code CLI instead of calling a model API. This is an

--- a/docs/providers/custom/index.md
+++ b/docs/providers/custom/index.md
@@ -280,7 +280,7 @@ The easiest way to register one is the interactive wizard:
 
 ```bash
 docker agent setup
-# pick "3. OpenAI-compatible provider", then enter the endpoint,
+# pick "3. Custom OpenAI-compatible endpoint", then enter the base URL,
 # API format, and the environment variable holding the API key
 ```
 


### PR DESCRIPTION
## Summary

Clarifies the `docker agent setup` provider paths so built-in cloud providers are not confused with custom OpenAI-compatible endpoints.

- labels option 1 as the built-in provider path and names Groq and Hugging Face
- reserves option 3 for custom endpoints with their own base URL, such as vLLM and LiteLLM
- uses credential-neutral wording for built-in providers and documents ChatGPT, token, and AWS authentication cases
- aligns the CLI reference and model setup documentation with all four setup paths
- adds regression coverage for the menu distinction and built-in provider examples

## Issue expectations

| Expectation | Implementation |
| --- | --- |
| Option 1 clearly covers built-in providers | Menu and help label it as the built-in cloud provider path and include Groq and Hugging Face |
| Option 2 remains Docker Model Runner | Existing local-model wording and behavior are unchanged |
| Option 3 is only for custom OpenAI-compatible endpoints | Menu, help, and docs require the endpoint's own base URL and use vLLM/LiteLLM examples |
| Option 4 remains the Claude Code harness | Existing harness wording and behavior are unchanged |
| Authentication wording is not limited to API keys | Built-in flow uses “credential”; docs cover API keys, tokens, AWS credentials, and ChatGPT sign-in |

## Validation

- `task build`
- `task lint`
- `task test`
- `npx --yes markdownlint-cli2@0.22.1` from `docs/`
- `git diff --check`

Closes #3805
