### PR TITLE
fix(openai): recover final response tool arguments

### DIFF
--- a/pkg/model/provider/openai/response_stream.go
+++ b/pkg/model/provider/openai/response_stream.go
@@ -23,7 +23,15 @@ type ResponseStreamAdapter struct {
 	trackUsage     bool
 	itemCallIDMap  map[string]string
 	itemHasContent map[string]bool
+	itemHasArgs    map[string]bool
 	pendingArgs    map[string]string
+	// itemArgsFinal marks items whose complete final arguments were already
+	// received: emitted (function_call_arguments.done, output_item.done
+	// snapshot), buffered in pendingArgs, or streamed as deltas and confirmed
+	// by a non-empty function_call_arguments.done. Distinct from itemHasArgs,
+	// which only means some argument bytes were emitted: any later arguments
+	// delta for such an item is stale and must be dropped.
+	itemArgsFinal map[string]bool
 }
 
 func newResponseStreamAdapter(stream responseEventStream, trackUsage bool) *ResponseStreamAdapter {
@@ -32,7 +40,9 @@ func newResponseStreamAdapter(stream responseEventStream, trackUsage bool) *Resp
 		trackUsage:     trackUsage,
 		itemCallIDMap:  make(map[string]string),
 		itemHasContent: make(map[string]bool),
+		itemHasArgs:    make(map[string]bool),
 		pendingArgs:    make(map[string]string),
+		itemArgsFinal:  make(map[string]bool),
 	}
 }
 
@@ -119,8 +129,13 @@ func (a *ResponseStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 			// bytes with the first named tool-call delta so the runtime can still
 			// reconstruct the call.
 			if funcName != "" {
+				// itemArgsFinal is intentionally kept: if the flushed buffer
+				// held the final arguments, later deltas must stay ignored.
 				args := a.pendingArgs[itemID]
 				delete(a.pendingArgs, itemID)
+				if args != "" {
+					a.itemHasArgs[itemID] = true
+				}
 
 				slog.Debug("Emitting tool call with name", "item_id", event.ItemID, "call_id", callID, "name", funcName)
 				response.Choices = []chat.MessageStreamChoice{
@@ -144,12 +159,17 @@ func (a *ResponseStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 	case "response.function_call_arguments.delta":
 		// Handle function call arguments delta
 		slog.Debug("Function call arguments delta received", "item_id", event.ItemID)
-		if callID, ok := a.itemCallIDMap[event.ItemID]; ok {
+		if a.itemArgsFinal[event.ItemID] {
+			// The complete arguments were already emitted or buffered;
+			// appending a late delta would corrupt that JSON.
+			slog.Debug("Ignoring arguments delta after final arguments", "item_id", event.ItemID)
+		} else if callID, ok := a.itemCallIDMap[event.ItemID]; ok {
 			args := cmp.Or(event.Delta, event.Arguments)
 
 			slog.Debug("Emitting arguments delta", "item_id", event.ItemID, "call_id", callID, "delta_length", len(args), "delta_preview", args[:min(len(args), 20)])
 
 			if args != "" {
+				a.itemHasArgs[event.ItemID] = true
 				response.Choices = []chat.MessageStreamChoice{
 					{
 						Delta: chat.MessageDelta{
@@ -174,8 +194,44 @@ func (a *ResponseStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 			}
 		}
 	case "response.function_call_arguments.done":
-		// Function call arguments are complete - we already streamed them
+		// Arguments normally arrive via delta events, making this event
+		// redundant. Some Responses API implementations skip the deltas and
+		// only deliver the complete arguments here, so emit them once in that
+		// case.
 		slog.Debug("Function call arguments done", "item_id", event.ItemID, "call_id", a.itemCallIDMap[event.ItemID])
+		if args := event.Arguments; args != "" {
+			// A non-empty payload is by definition the complete final
+			// arguments, so any later delta for this item is stale and must
+			// be dropped, even when deltas already streamed the arguments.
+			a.itemArgsFinal[event.ItemID] = true
+			if !a.itemHasArgs[event.ItemID] {
+				if callID, ok := a.itemCallIDMap[event.ItemID]; ok {
+					slog.Debug("Emitting final arguments from arguments done event", "item_id", event.ItemID, "call_id", callID, "args_length", len(args))
+					a.itemHasArgs[event.ItemID] = true
+					response.Choices = []chat.MessageStreamChoice{
+						{
+							Delta: chat.MessageDelta{
+								ToolCalls: []tools.ToolCall{
+									{
+										ID:   callID,
+										Type: "function",
+										Function: tools.FunctionCall{
+											Arguments: args,
+										},
+									},
+								},
+							},
+						},
+					}
+				} else {
+					// The function item was not announced yet. This payload is
+					// the authoritative final snapshot: replace any partially
+					// buffered deltas with it.
+					a.pendingArgs[event.ItemID] = args
+					slog.Debug("Buffered final arguments before output item", "item_id", event.ItemID, "args_length", len(args))
+				}
+			}
+		}
 
 	case "response.reasoning_text.delta":
 		// Handle reasoning text deltas (thinking traces from reasoning models)
@@ -232,6 +288,30 @@ func (a *ResponseStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 					})
 					a.itemHasContent[itemID] = true
 				}
+			}
+		}
+		// Last-resort fallback for function calls whose arguments were neither
+		// streamed via deltas nor delivered by function_call_arguments.done:
+		// recover them from the completed item snapshot.
+		if event.Item.Type == "function_call" && !a.itemHasArgs[itemID] {
+			if args := event.Item.Arguments.OfString; args != "" {
+				callID := cmp.Or(a.itemCallIDMap[itemID], event.Item.CallID, itemID)
+				slog.Debug("Emitting final arguments from output item snapshot", "item_id", itemID, "call_id", callID, "args_length", len(args))
+				a.itemHasArgs[itemID] = true
+				a.itemArgsFinal[itemID] = true
+				response.Choices = append(response.Choices, chat.MessageStreamChoice{
+					Delta: chat.MessageDelta{
+						ToolCalls: []tools.ToolCall{
+							{
+								ID:   callID,
+								Type: "function",
+								Function: tools.FunctionCall{
+									Arguments: args,
+								},
+							},
+						},
+					},
+				})
 			}
 		}
 

--- a/pkg/model/provider/openai/response_stream_test.go
+++ b/pkg/model/provider/openai/response_stream_test.go
@@ -1,0 +1,640 @@
+package openai
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/openai/openai-go/v3/responses"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/chat"
+)
+
+// fakeEventStream replays pre-decoded Responses API events. It implements
+// responseEventStream so the adapter can be tested without a transport.
+type fakeEventStream struct {
+	events []responses.ResponseStreamEventUnion
+	pos    int
+}
+
+func (s *fakeEventStream) Next() bool {
+	if s.pos >= len(s.events) {
+		return false
+	}
+	s.pos++
+	return true
+}
+
+func (s *fakeEventStream) Current() responses.ResponseStreamEventUnion { return s.events[s.pos-1] }
+func (s *fakeEventStream) Err() error                                  { return nil }
+func (s *fakeEventStream) Close() error                                { return nil }
+
+// decodeEvents converts wire-format JSON events into SDK unions, exactly as
+// the SSE and WebSocket transports do.
+func decodeEvents(t *testing.T, raw []map[string]any) []responses.ResponseStreamEventUnion {
+	t.Helper()
+	events := make([]responses.ResponseStreamEventUnion, len(raw))
+	for i, m := range raw {
+		data, err := json.Marshal(m)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(data, &events[i]))
+	}
+	return events
+}
+
+func toolCallsCompletedEvent(id string) map[string]any {
+	return map[string]any{
+		"type": "response.completed",
+		"response": map[string]any{
+			"id": id,
+			"output": []any{
+				map[string]any{"type": "function_call"},
+			},
+			"usage": map[string]any{
+				"input_tokens":          8,
+				"output_tokens":         12,
+				"total_tokens":          20,
+				"input_tokens_details":  map[string]any{"cached_tokens": 0},
+				"output_tokens_details": map[string]any{"reasoning_tokens": 0},
+			},
+		},
+	}
+}
+
+// accumulatedToolCall mirrors how the runtime merges tool-call deltas: names
+// overwrite, argument bytes append. Duplicated argument emissions therefore
+// show up as doubled JSON.
+type accumulatedToolCall struct {
+	name string
+	args string
+}
+
+// drainToolCalls runs the adapter to EOF and accumulates tool-call deltas per
+// call ID. It returns the merged calls and the last finish reason seen.
+func drainToolCalls(t *testing.T, adapter *ResponseStreamAdapter) (map[string]accumulatedToolCall, chat.FinishReason) {
+	t.Helper()
+	calls := make(map[string]accumulatedToolCall)
+	var finishReason chat.FinishReason
+	for {
+		resp, err := adapter.Recv()
+		if errors.Is(err, io.EOF) {
+			return calls, finishReason
+		}
+		require.NoError(t, err)
+		for _, choice := range resp.Choices {
+			if choice.FinishReason != "" {
+				finishReason = choice.FinishReason
+			}
+			for _, tc := range choice.Delta.ToolCalls {
+				call := calls[tc.ID]
+				if tc.Function.Name != "" {
+					call.name = tc.Function.Name
+				}
+				call.args += tc.Function.Arguments
+				calls[tc.ID] = call
+			}
+		}
+	}
+}
+
+// TestResponseStream_ArgumentsOnlyInDoneEvent is a regression test for
+// https://github.com/docker/docker-agent/issues/3818.
+//
+// Some Responses API implementations (e.g. GitHub Copilot) announce the
+// function call in response.output_item.added, send no
+// response.function_call_arguments.delta events, and deliver the complete
+// JSON arguments only in response.function_call_arguments.done plus the
+// response.output_item.done snapshot. The adapter must emit those final
+// arguments exactly once.
+func TestResponseStream_ArgumentsOnlyInDoneEvent(t *testing.T) {
+	t.Parallel()
+
+	const args = `{"cmd":"ls -la"}`
+	events := decodeEvents(t, []map[string]any{
+		{
+			"type":    "response.output_item.added",
+			"item_id": "fc_1",
+			"item": map[string]any{
+				"type":    "function_call",
+				"id":      "fc_1",
+				"call_id": "call_1",
+				"name":    "shell",
+			},
+		},
+		{
+			"type":      "response.function_call_arguments.done",
+			"item_id":   "fc_1",
+			"name":      "shell",
+			"arguments": args,
+		},
+		{
+			"type":    "response.output_item.done",
+			"item_id": "fc_1",
+			"item": map[string]any{
+				"type":      "function_call",
+				"id":        "fc_1",
+				"call_id":   "call_1",
+				"name":      "shell",
+				"arguments": args,
+				"status":    "completed",
+			},
+		},
+		toolCallsCompletedEvent("resp_args_done_only"),
+	})
+
+	adapter := newResponseStreamAdapter(&fakeEventStream{events: events}, true)
+
+	// output_item.added → tool call announced with name, no arguments yet.
+	resp, err := adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	require.Len(t, resp.Choices[0].Delta.ToolCalls, 1)
+	assert.Equal(t, "call_1", resp.Choices[0].Delta.ToolCalls[0].ID)
+	assert.Equal(t, "shell", resp.Choices[0].Delta.ToolCalls[0].Function.Name)
+	assert.Empty(t, resp.Choices[0].Delta.ToolCalls[0].Function.Arguments)
+
+	// function_call_arguments.done → no deltas were streamed, so the
+	// complete arguments must be emitted here.
+	resp, err = adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	require.Len(t, resp.Choices[0].Delta.ToolCalls, 1)
+	assert.Equal(t, "call_1", resp.Choices[0].Delta.ToolCalls[0].ID)
+	assert.JSONEq(t, args, resp.Choices[0].Delta.ToolCalls[0].Function.Arguments)
+
+	// output_item.done → arguments already emitted, the snapshot must not
+	// duplicate them.
+	resp, err = adapter.Recv()
+	require.NoError(t, err)
+	assert.Empty(t, resp.Choices)
+
+	resp, err = adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	assert.Equal(t, chat.FinishReasonToolCalls, resp.Choices[0].FinishReason)
+
+	_, err = adapter.Recv()
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+// TestResponseStream_LateDeltaAfterArgumentsDoneIgnored is a regression test
+// for the sequence added -> arguments.done (complete args, no prior deltas)
+// -> late arguments.delta -> output_item.done snapshot. The final arguments
+// were already emitted by arguments.done, so the late delta must be dropped:
+// appending it would corrupt the JSON.
+func TestResponseStream_LateDeltaAfterArgumentsDoneIgnored(t *testing.T) {
+	t.Parallel()
+
+	const args = `{"cmd":"ls -la"}`
+	events := decodeEvents(t, []map[string]any{
+		{
+			"type":    "response.output_item.added",
+			"item_id": "fc_1",
+			"item": map[string]any{
+				"type":    "function_call",
+				"id":      "fc_1",
+				"call_id": "call_1",
+				"name":    "shell",
+			},
+		},
+		{
+			"type":      "response.function_call_arguments.done",
+			"item_id":   "fc_1",
+			"name":      "shell",
+			"arguments": args,
+		},
+		{
+			"type":    "response.function_call_arguments.delta",
+			"item_id": "fc_1",
+			"delta":   "EXTRA",
+		},
+		{
+			"type":    "response.output_item.done",
+			"item_id": "fc_1",
+			"item": map[string]any{
+				"type":      "function_call",
+				"id":        "fc_1",
+				"call_id":   "call_1",
+				"name":      "shell",
+				"arguments": args,
+				"status":    "completed",
+			},
+		},
+		toolCallsCompletedEvent("resp_late_delta_after_done"),
+	})
+
+	adapter := newResponseStreamAdapter(&fakeEventStream{events: events}, true)
+
+	// output_item.added → tool call announced with name, no arguments yet.
+	resp, err := adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	require.Len(t, resp.Choices[0].Delta.ToolCalls, 1)
+	assert.Equal(t, "shell", resp.Choices[0].Delta.ToolCalls[0].Function.Name)
+	assert.Empty(t, resp.Choices[0].Delta.ToolCalls[0].Function.Arguments)
+
+	// function_call_arguments.done → the complete arguments are emitted once.
+	resp, err = adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	require.Len(t, resp.Choices[0].Delta.ToolCalls, 1)
+	assert.Equal(t, "call_1", resp.Choices[0].Delta.ToolCalls[0].ID)
+	assert.JSONEq(t, args, resp.Choices[0].Delta.ToolCalls[0].Function.Arguments)
+
+	// Late arguments.delta → must be ignored, not appended.
+	resp, err = adapter.Recv()
+	require.NoError(t, err)
+	assert.Empty(t, resp.Choices)
+
+	// output_item.done → arguments already emitted, the snapshot must not
+	// duplicate them.
+	resp, err = adapter.Recv()
+	require.NoError(t, err)
+	assert.Empty(t, resp.Choices)
+
+	resp, err = adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	assert.Equal(t, chat.FinishReasonToolCalls, resp.Choices[0].FinishReason)
+
+	_, err = adapter.Recv()
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+// TestResponseStream_ArgumentsOnlyInOutputItemDoneSnapshot covers the
+// fallback where neither argument deltas nor an arguments.done payload were
+// received and only the output_item.done item snapshot carries the final
+// arguments.
+func TestResponseStream_ArgumentsOnlyInOutputItemDoneSnapshot(t *testing.T) {
+	t.Parallel()
+
+	const args = `{"path":"main.go"}`
+	events := decodeEvents(t, []map[string]any{
+		{
+			"type":    "response.output_item.added",
+			"item_id": "fc_1",
+			"item": map[string]any{
+				"type":    "function_call",
+				"id":      "fc_1",
+				"call_id": "call_1",
+				"name":    "read_file",
+			},
+		},
+		{
+			"type":    "response.function_call_arguments.done",
+			"item_id": "fc_1",
+		},
+		{
+			"type":    "response.output_item.done",
+			"item_id": "fc_1",
+			"item": map[string]any{
+				"type":      "function_call",
+				"id":        "fc_1",
+				"call_id":   "call_1",
+				"name":      "read_file",
+				"arguments": args,
+				"status":    "completed",
+			},
+		},
+		toolCallsCompletedEvent("resp_snapshot_only"),
+	})
+
+	adapter := newResponseStreamAdapter(&fakeEventStream{events: events}, true)
+
+	resp, err := adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	require.Len(t, resp.Choices[0].Delta.ToolCalls, 1)
+	assert.Equal(t, "read_file", resp.Choices[0].Delta.ToolCalls[0].Function.Name)
+	assert.Empty(t, resp.Choices[0].Delta.ToolCalls[0].Function.Arguments)
+
+	// arguments.done carries no arguments → nothing to emit.
+	resp, err = adapter.Recv()
+	require.NoError(t, err)
+	assert.Empty(t, resp.Choices)
+
+	// output_item.done → the snapshot is the only source of the arguments.
+	resp, err = adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	require.Len(t, resp.Choices[0].Delta.ToolCalls, 1)
+	assert.Equal(t, "call_1", resp.Choices[0].Delta.ToolCalls[0].ID)
+	assert.JSONEq(t, args, resp.Choices[0].Delta.ToolCalls[0].Function.Arguments)
+
+	resp, err = adapter.Recv()
+	require.NoError(t, err)
+	require.Len(t, resp.Choices, 1)
+	assert.Equal(t, chat.FinishReasonToolCalls, resp.Choices[0].FinishReason)
+
+	_, err = adapter.Recv()
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+// TestResponseStream_StreamedDeltasNotDuplicatedByDoneEvents pins down that
+// the done events stay redundant when arguments were streamed normally: the
+// OpenAI API repeats the full arguments in both function_call_arguments.done
+// and the output_item.done snapshot, and neither may be re-emitted.
+func TestResponseStream_StreamedDeltasNotDuplicatedByDoneEvents(t *testing.T) {
+	t.Parallel()
+
+	const args = `{"cmd":"go test ./..."}`
+	events := decodeEvents(t, []map[string]any{
+		{
+			"type":    "response.output_item.added",
+			"item_id": "fc_1",
+			"item": map[string]any{
+				"type":    "function_call",
+				"id":      "fc_1",
+				"call_id": "call_1",
+				"name":    "shell",
+			},
+		},
+		{
+			"type":    "response.function_call_arguments.delta",
+			"item_id": "fc_1",
+			"delta":   `{"cmd":"go test`,
+		},
+		{
+			"type":    "response.function_call_arguments.delta",
+			"item_id": "fc_1",
+			"delta":   ` ./..."}`,
+		},
+		{
+			"type":      "response.function_call_arguments.done",
+			"item_id":   "fc_1",
+			"name":      "shell",
+			"arguments": args,
+		},
+		{
+			"type":    "response.output_item.done",
+			"item_id": "fc_1",
+			"item": map[string]any{
+				"type":      "function_call",
+				"id":        "fc_1",
+				"call_id":   "call_1",
+				"name":      "shell",
+				"arguments": args,
+				"status":    "completed",
+			},
+		},
+		toolCallsCompletedEvent("resp_streamed_deltas"),
+	})
+
+	adapter := newResponseStreamAdapter(&fakeEventStream{events: events}, true)
+
+	calls, finishReason := drainToolCalls(t, adapter)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "shell", calls["call_1"].name)
+	assert.JSONEq(t, args, calls["call_1"].args)
+	assert.Equal(t, chat.FinishReasonToolCalls, finishReason)
+}
+
+// TestResponseStream_LateDeltaAfterStreamedDeltasAndDoneIgnored guards the
+// normal sequence added -> deltas -> arguments.done followed by a late
+// arguments.delta. The non-empty done payload is by definition the complete
+// final arguments, so the late delta must be dropped even though deltas were
+// already emitted: neither the done event may duplicate the arguments nor
+// the late delta corrupt them.
+func TestResponseStream_LateDeltaAfterStreamedDeltasAndDoneIgnored(t *testing.T) {
+	t.Parallel()
+
+	const args = `{"cmd":"go test ./..."}`
+	events := decodeEvents(t, []map[string]any{
+		{
+			"type":    "response.output_item.added",
+			"item_id": "fc_1",
+			"item": map[string]any{
+				"type":    "function_call",
+				"id":      "fc_1",
+				"call_id": "call_1",
+				"name":    "shell",
+			},
+		},
+		{
+			"type":    "response.function_call_arguments.delta",
+			"item_id": "fc_1",
+			"delta":   `{"cmd":"go test`,
+		},
+		{
+			"type":    "response.function_call_arguments.delta",
+			"item_id": "fc_1",
+			"delta":   ` ./..."}`,
+		},
+		{
+			"type":      "response.function_call_arguments.done",
+			"item_id":   "fc_1",
+			"name":      "shell",
+			"arguments": args,
+		},
+		{
+			"type":    "response.function_call_arguments.delta",
+			"item_id": "fc_1",
+			"delta":   "EXTRA",
+		},
+		{
+			"type":    "response.output_item.done",
+			"item_id": "fc_1",
+			"item": map[string]any{
+				"type":      "function_call",
+				"id":        "fc_1",
+				"call_id":   "call_1",
+				"name":      "shell",
+				"arguments": args,
+				"status":    "completed",
+			},
+		},
+		toolCallsCompletedEvent("resp_late_delta_after_streamed_done"),
+	})
+
+	adapter := newResponseStreamAdapter(&fakeEventStream{events: events}, true)
+
+	calls, finishReason := drainToolCalls(t, adapter)
+	require.Len(t, calls, 1)
+	assert.Equal(t, "shell", calls["call_1"].name)
+	assert.JSONEq(t, args, calls["call_1"].args)
+	assert.Equal(t, chat.FinishReasonToolCalls, finishReason)
+}
+
+// TestResponseStream_InterleavedCallsMixedArgumentDelivery verifies per-item
+// tracking with two interleaved calls: one streams argument deltas, the other
+// only delivers its arguments in the done event.
+func TestResponseStream_InterleavedCallsMixedArgumentDelivery(t *testing.T) {
+	t.Parallel()
+
+	const argsA = `{"cmd":"ls"}`
+	const argsB = `{"path":"go.mod"}`
+	events := decodeEvents(t, []map[string]any{
+		{
+			"type":    "response.output_item.added",
+			"item_id": "fc_a",
+			"item": map[string]any{
+				"type":    "function_call",
+				"id":      "fc_a",
+				"call_id": "call_a",
+				"name":    "shell",
+			},
+		},
+		{
+			"type":    "response.output_item.added",
+			"item_id": "fc_b",
+			"item": map[string]any{
+				"type":    "function_call",
+				"id":      "fc_b",
+				"call_id": "call_b",
+				"name":    "read_file",
+			},
+		},
+		{
+			"type":    "response.function_call_arguments.delta",
+			"item_id": "fc_a",
+			"delta":   argsA,
+		},
+		{
+			"type":      "response.function_call_arguments.done",
+			"item_id":   "fc_b",
+			"name":      "read_file",
+			"arguments": argsB,
+		},
+		{
+			"type":      "response.function_call_arguments.done",
+			"item_id":   "fc_a",
+			"name":      "shell",
+			"arguments": argsA,
+		},
+		{
+			"type":    "response.output_item.done",
+			"item_id": "fc_a",
+			"item": map[string]any{
+				"type":      "function_call",
+				"id":        "fc_a",
+				"call_id":   "call_a",
+				"name":      "shell",
+				"arguments": argsA,
+				"status":    "completed",
+			},
+		},
+		{
+			"type":    "response.output_item.done",
+			"item_id": "fc_b",
+			"item": map[string]any{
+				"type":      "function_call",
+				"id":        "fc_b",
+				"call_id":   "call_b",
+				"name":      "read_file",
+				"arguments": argsB,
+				"status":    "completed",
+			},
+		},
+		toolCallsCompletedEvent("resp_interleaved"),
+	})
+
+	adapter := newResponseStreamAdapter(&fakeEventStream{events: events}, true)
+
+	calls, finishReason := drainToolCalls(t, adapter)
+	require.Len(t, calls, 2)
+	assert.Equal(t, "shell", calls["call_a"].name)
+	assert.JSONEq(t, argsA, calls["call_a"].args)
+	assert.Equal(t, "read_file", calls["call_b"].name)
+	assert.JSONEq(t, argsB, calls["call_b"].args)
+	assert.Equal(t, chat.FinishReasonToolCalls, finishReason)
+}
+
+// TestResponseStream_FinalArgumentsBufferedBeforeOutputItemAdded covers
+// function_call_arguments.done arriving before output_item.added. The done
+// payload is the authoritative final snapshot: it must replace any partially
+// buffered deltas, be flushed exactly once when the item is announced, and
+// late deltas must not corrupt it.
+func TestResponseStream_FinalArgumentsBufferedBeforeOutputItemAdded(t *testing.T) {
+	t.Parallel()
+
+	const args = `{"cmd":"ls"}`
+
+	argumentsDone := map[string]any{
+		"type":      "response.function_call_arguments.done",
+		"item_id":   "fc_1",
+		"name":      "shell",
+		"arguments": args,
+	}
+	outputItemAdded := map[string]any{
+		"type":    "response.output_item.added",
+		"item_id": "fc_1",
+		"item": map[string]any{
+			"type":    "function_call",
+			"id":      "fc_1",
+			"call_id": "call_1",
+			"name":    "shell",
+		},
+	}
+	outputItemDone := map[string]any{
+		"type":    "response.output_item.done",
+		"item_id": "fc_1",
+		"item": map[string]any{
+			"type":      "function_call",
+			"id":        "fc_1",
+			"call_id":   "call_1",
+			"name":      "shell",
+			"arguments": args,
+			"status":    "completed",
+		},
+	}
+
+	tests := []struct {
+		name   string
+		events []map[string]any
+	}{
+		{
+			name: "arguments done then output item added",
+			events: []map[string]any{
+				argumentsDone,
+				outputItemAdded,
+				outputItemDone,
+				toolCallsCompletedEvent("resp_early_args_done"),
+			},
+		},
+		{
+			name: "late delta after arguments done is ignored",
+			events: []map[string]any{
+				argumentsDone,
+				{
+					"type":    "response.function_call_arguments.delta",
+					"item_id": "fc_1",
+					"delta":   "EXTRA",
+				},
+				outputItemAdded,
+				outputItemDone,
+				toolCallsCompletedEvent("resp_early_args_done_late_delta"),
+			},
+		},
+		{
+			name: "arguments done replaces partially buffered deltas",
+			events: []map[string]any{
+				{
+					"type":    "response.function_call_arguments.delta",
+					"item_id": "fc_1",
+					"delta":   `{"cmd":`,
+				},
+				argumentsDone,
+				outputItemAdded,
+				outputItemDone,
+				toolCallsCompletedEvent("resp_early_args_done_partial_deltas"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			adapter := newResponseStreamAdapter(&fakeEventStream{events: decodeEvents(t, tt.events)}, true)
+
+			calls, finishReason := drainToolCalls(t, adapter)
+			require.Len(t, calls, 1)
+			assert.Equal(t, "shell", calls["call_1"].name)
+			assert.JSONEq(t, args, calls["call_1"].args)
+			assert.Equal(t, chat.FinishReasonToolCalls, finishReason)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- recover Responses API function arguments when providers omit `response.function_call_arguments.delta`
- use `response.function_call_arguments.done` and the completed output-item snapshot as non-duplicating fallbacks
- buffer final arguments received before `response.output_item.added` and ignore stale late deltas
- add regression coverage for shell/read-file argument shapes, interleaved calls, reordered events, and duplicate prevention

## Issue expectations

| Expectation | Implementation |
|---|---|
| `shell` receives its `cmd` argument with GitHub Copilot OpenAI models | Final arguments are emitted from `response.function_call_arguments.done` when no deltas were delivered |
| `read_file` receives its `path` argument | The same provider-level recovery applies to every Responses API function tool |
| No tool-call doom loop | Empty arguments are no longer forwarded, and final snapshots are emitted only once |
| Preserve normal Responses API streaming | Existing argument deltas remain unchanged; final events only provide fallbacks and terminate stale deltas |

## Validation

- deterministic regression reproduced before the fix with empty arguments, then passed after the fix
- live GitHub Copilot checks passed with `gpt-5.5` and `gpt-5.6` variants for `shell` and `read_file`
- `go test ./pkg/model/provider/openai -run 'TestResponseStream_' -count=20`
- `go test -race ./pkg/model/provider/openai`
- `task test`
- `task lint`
- `task build`

## Residual uncertainty

GitHub Copilot may expose undocumented stream orderings beyond those observed. The implementation covers the standard ordering, missing argument deltas, final snapshots, early final events, interleaved calls, and stale late deltas.

Fixes #3818
