### PR TITLE
fix(tui): open /context (not /cost) when clicking the ⚠ capped marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ## What's New
 
-- Splits the sidebar's Token Usage click target in two: clicking the token/context part (glyph, token count, context `%`, or the "compacting…" marker) opens the `/context` dialog, while clicking the cost part (`$` figure, `⚠ capped` marker, sub-session count) keeps opening `/cost`; the "Token Usage" section title is no longer clickable
+- Splits the sidebar's Token Usage click target in two: clicking the token/context part (glyph, token count, context `%`, the "compacting…" marker, or the `⚠ capped` marker) opens the `/context` dialog, while clicking the cost part (`$` figure, sub-session count) keeps opening `/cost`; the "Token Usage" section title is no longer clickable
 
 
 ## [v1.115.0] - 2026-07-22

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -195,7 +195,7 @@ While a compaction is running the percentage is replaced by a **"compacting…"*
 
 The thresholds are proportional to the agent's configured `compaction_threshold` (default `0.9`), so a custom value keeps a predictable visual runway. See [Compaction Threshold](../../configuration/models/index.md#delegating-session-compaction) for configuration details.
 
-Clicking the token/context part of the sidebar's usage reading (the glyph, token count, and context percentage — or the "compacting…" marker) opens the `/context` dialog with the full breakdown. Clicking the cost part (the `$` figure, the `⚠ capped` marker, and the sub-session count) opens the `/cost` dialog instead. The "Token Usage" section title itself is not clickable.
+Clicking the token/context part of the sidebar's usage reading (the glyph, token count, context percentage — or the "compacting…" marker — and the `⚠ capped` marker) opens the `/context` dialog with the full breakdown. Clicking the cost part (the `$` figure and the sub-session count) opens the `/cost` dialog instead. The "Token Usage" section title itself is not clickable.
 
 ### Thinking and Tool Details
 

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -353,9 +353,10 @@ type model struct {
 	usageReadingLine int
 	usageSectionEnd  int
 	// usageContextSegWidth is the lipgloss.Width of the reading line's context
-	// segment (glyph + token count + context %/compacting marker), recorded by
-	// tokenUsageLine while rendering. HandleClickType uses it to split a click
-	// on the reading line between the context dialog and the cost dialog.
+	// segment (glyph + token count + context %/compacting marker + ⚠ capped
+	// marker), recorded by tokenUsageLine while rendering. HandleClickType uses
+	// it to split a click on the reading line between the context dialog and
+	// the cost dialog.
 	usageContextSegWidth int
 	// agentLineOwners records, per rendered agent-section body line, which agent
 	// emitted it (empty for blank separators). It is produced during agentInfo
@@ -786,7 +787,7 @@ const (
 	ClickTitle        // Click on the title area (use double-click to edit)
 	ClickWorkingDir   // Click on the working directory line
 	ClickAgent        // Click on an agent name in the sidebar
-	ClickUsageContext // Click on the token/context part of the usage reading (glyph, tokens, context %/compacting)
+	ClickUsageContext // Click on the token/context part of the usage reading (glyph, tokens, context %/compacting, ⚠ capped)
 	ClickUsage        // Click on the cost part of the usage reading, or a budget line
 )
 
@@ -808,8 +809,8 @@ func (m *model) HandleClickType(x, y int) (ClickResult, string) {
 	}
 
 	// segmentClickResult splits a click at flat offset into the usage reading
-	// line between the context segment (glyph, tokens, context %/compacting —
-	// offset < usageContextSegWidth) and the cost segment (⚠ capped, cost,
+	// line between the context segment (glyph, tokens, context %/compacting,
+	// ⚠ capped — offset < usageContextSegWidth) and the cost segment (cost,
 	// sub-sessions — everything from there on).
 	segmentClickResult := func(offset int) ClickResult {
 		if offset < m.usageContextSegWidth {
@@ -1846,9 +1847,9 @@ func (m *model) tokenUsage(contentWidth int) string {
 // sub-session count, all with the same styling. The context reading warns as
 // it nears the compaction threshold and reads "compacting…" while a
 // compaction runs. It also records usageContextSegWidth, the rendered width
-// of the context segment (glyph through the %/compacting marker), so
-// HandleClickType can split a click on the reading line between the context
-// and cost dialogs.
+// of the context segment (glyph through the %/compacting marker and the ⚠
+// capped marker), so HandleClickType can split a click on the reading line
+// between the context and cost dialogs.
 func (m *model) tokenUsageLine() string {
 	s := m.computeUsageStats()
 
@@ -1859,11 +1860,12 @@ func (m *model) tokenUsageLine() string {
 	case s.contextPct != "":
 		line += " " + contextGaugeStyle(s.contextLevel, styles.NoStyle).Render("("+s.contextPct+")")
 	}
-	m.usageContextSegWidth = lipgloss.Width(line)
 
 	if m.agentCompactionModel != "" {
 		line += " " + styles.WarningStyle.Render("⚠ capped")
 	}
+	m.usageContextSegWidth = lipgloss.Width(line)
+
 	line += " " + styles.TabAccentStyle.Render(toolcommon.FormatCostUSD(s.totalCost))
 	if s.sessionCount > 1 {
 		line += " " + styles.MutedStyle.Render(fmt.Sprintf("(%d sub-sessions)", s.sessionCount-1))

--- a/pkg/tui/components/sidebar/usage_click_test.go
+++ b/pkg/tui/components/sidebar/usage_click_test.go
@@ -90,6 +90,41 @@ func TestSidebar_HandleClickType_Usage_Vertical_Compacting(t *testing.T) {
 	assert.Equal(t, ClickUsageContext, result, "a click on the compacting marker should report ClickUsageContext")
 }
 
+// TestSidebar_HandleClickType_Usage_Vertical_Capped verifies that a click on
+// the "⚠ capped" marker reports ClickUsageContext: a compaction-model cap
+// on the effective context window is context-related, not cost-related.
+func TestSidebar_HandleClickType_Usage_Vertical_Capped(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	sb := New(t.Context(), sessionState)
+
+	m := sb.(*model)
+	m.sessionHasContent = true
+	m.titleGenerated = true
+	m.sessionTitle = "Test"
+	m.width = 40
+	m.height = 50
+	m.agentCompactionModel = "some/model"
+
+	_ = sb.View()
+
+	require.GreaterOrEqual(t, m.usageReadingLine, 0)
+	line := ansi.Strip(m.cachedLines[m.usageReadingLine])
+	require.Contains(t, line, "⚠ capped")
+
+	paddingLeft := m.layoutCfg.PaddingLeft
+	cappedX := strings.Index(line, "⚠")
+	require.GreaterOrEqual(t, cappedX, 0)
+	result, _ := sb.HandleClickType(paddingLeft+cappedX, m.usageReadingLine)
+	assert.Equal(t, ClickUsageContext, result, "a click on the ⚠ capped marker should report ClickUsageContext")
+
+	dollarX := dollarOffset(t, m.cachedLines[m.usageReadingLine])
+	result, _ = sb.HandleClickType(paddingLeft+dollarX, m.usageReadingLine)
+	assert.Equal(t, ClickUsage, result, "a click on the cost segment should still report ClickUsage when capped")
+}
+
 // TestSidebar_HandleClickType_Usage_Vertical_Hidden verifies a hidden usage
 // section leaves no stale click zone behind.
 func TestSidebar_HandleClickType_Usage_Vertical_Hidden(t *testing.T) {
@@ -211,6 +246,42 @@ func TestSidebar_HandleClickType_Usage_Collapsed_OwnLine(t *testing.T) {
 	dollarX := dollarOffset(t, vm.UsageSummary)
 	result, _ = sb.HandleClickType(paddingLeft+dollarX, rowY)
 	assert.Equal(t, ClickUsage, result, "click on the cost segment should report ClickUsage")
+}
+
+// TestSidebar_HandleClickType_Usage_Collapsed_Capped verifies the collapsed
+// band's own-line usage reading also puts the "⚠ capped" marker on the
+// context side, inheriting the fix through the shared usageContextSegWidth.
+func TestSidebar_HandleClickType_Usage_Collapsed_Capped(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	sessionState := service.NewSessionState(sess)
+	sb := New(t.Context(), sessionState)
+
+	m := sb.(*model)
+	m.sessionHasContent = true
+	m.titleGenerated = true
+	m.mode = ModeCollapsed
+	m.width = 50
+	m.sessionTitle = "Hi"
+	m.workingDirectory = ""
+	m.agentCompactionModel = "some/model"
+
+	vm := m.computeCollapsedViewModel(m.contentWidth(false))
+	require.NotEmpty(t, vm.UsageSummary)
+	require.Contains(t, vm.UsageSummary, "⚠ capped")
+
+	paddingLeft := m.layoutCfg.PaddingLeft
+	rowY := vm.titleSectionLines()
+
+	cappedX := strings.Index(ansi.Strip(vm.UsageSummary), "⚠")
+	require.GreaterOrEqual(t, cappedX, 0)
+	result, _ := sb.HandleClickType(paddingLeft+cappedX, rowY)
+	assert.Equal(t, ClickUsageContext, result, "click on the ⚠ capped marker should report ClickUsageContext")
+
+	dollarX := dollarOffset(t, vm.UsageSummary)
+	result, _ = sb.HandleClickType(paddingLeft+dollarX, rowY)
+	assert.Equal(t, ClickUsage, result, "click on the cost segment should still report ClickUsage when capped")
 }
 
 // TestSidebar_HandleClickType_Usage_Collapsed_Hidden verifies a hidden usage


### PR DESCRIPTION
## What & why

Follow-up to #3813. On the sidebar **Token Usage** reading, clicking the **`⚠ capped`** marker opened the `/cost` dialog. The cap is a compaction-model context-window limit, not a cost matter, so it should open the **`/context`** dialog instead.

## How

In `tokenUsageLine()`, the context-segment width (`usageContextSegWidth`) was captured *before* the `⚠ capped` marker was appended, leaving the marker in the cost segment. Moving the capture to *after* the append brings `⚠ capped` into the context segment. The cost segment now starts at the `$…` figure. The click-offset boundary is otherwise unchanged, so both the vertical reading and the collapsed band are fixed through the shared width.

## Behavior

- `⚠ capped` → `/context`
- token count · `(NN%)` · `(compacting…)` → `/context`
- `$…` · sub-session count → `/cost`

## Tests
Added capped-marker cases (vertical + collapsed band) asserting `⚠` → context and `$` → cost.

## Docs
`docs/features/tui/index.md` and the Unreleased CHANGELOG entry updated to list `⚠ capped` under the context part (amends the still-unreleased #3813 wording).

Plan: `agent-card-context-cost-clicks`