### PR TITLE
fix(backgroundjobs): resolve status race condition and subprocess pipe hang

### DIFF
--- a/pkg/tools/builtin/backgroundjobs/backgroundjobs.go
+++ b/pkg/tools/builtin/backgroundjobs/backgroundjobs.go
@@ -37,6 +37,18 @@ const (
 	ToolNameWaitBackgroundJob = "wait_background_job"
 
 	maxBackgroundJobOutputBytes = 10 * 1024 * 1024
+
+	// waitDelayAfterJobExit specifies how long cmd.Wait waits for I/O pipes to close
+	// after the main process exits. Like the shell tool, this prevents hangs when a
+	// background job daemonizes (e.g. `myserver &`) and the grandchild inherits
+	// stdout/stderr. If the delay expires, Wait() returns exec.ErrWaitDelay and the
+	// pipes are forcefully closed. This truncates captured output from the still-running
+	// grandchild and typically kills it with SIGPIPE on its next write. This trade-off
+	// is necessary: run_background_job is designed to exit its direct child quickly
+	// so the agent can continue its turn. If a user needs a permanently-running job
+	// that survives indefinitely while logging, they should redirect its output
+	// (e.g. `myserver > log.txt 2>&1 &`).
+	waitDelayAfterJobExit = 1 * time.Second
 )
 
 // ToolSet manages long-running shell commands.
@@ -224,6 +236,7 @@ func (h *backgroundJobsHandler) runBackgroundJob(ctx context.Context, rt tools.R
 	cmd.Env = h.env
 	cmd.Dir = h.resolveWorkDir(params.Cwd)
 	cmd.SysProcAttr = platformSpecificSysProcAttr()
+	cmd.WaitDelay = waitDelayAfterJobExit
 
 	job := &backgroundJob{
 		id:        jobID,
@@ -273,22 +286,29 @@ func (h *backgroundJobsHandler) monitorJob(ctx context.Context, job *backgroundJ
 	err := cmd.Wait()
 
 	job.outputMu.Lock()
-	if job.status.Load() == statusStopped {
-		job.outputMu.Unlock()
-		return
-	}
 
-	if err != nil {
+	var newStatus int32
+	if err != nil && !errors.Is(err, exec.ErrWaitDelay) {
 		if exitErr, ok := errors.AsType[*exec.ExitError](err); ok {
 			job.exitCode = exitErr.ExitCode()
 		} else {
 			job.exitCode = -1
 		}
-		job.status.Store(statusFailed)
+		newStatus = statusFailed
 		job.err = err
 	} else {
-		job.exitCode = 0
-		job.status.Store(statusCompleted)
+		// Either err == nil (clean exit) or err == exec.ErrWaitDelay (grandchild inherited pipes).
+		job.exitCode = cmd.ProcessState.ExitCode()
+		if job.exitCode == 0 {
+			newStatus = statusCompleted
+		} else {
+			newStatus = statusFailed
+		}
+	}
+
+	if !job.status.CompareAndSwap(statusRunning, newStatus) {
+		job.outputMu.Unlock()
+		return
 	}
 
 	status := job.status.Load()

--- a/pkg/tools/builtin/backgroundjobs/backgroundjobs_test.go
+++ b/pkg/tools/builtin/backgroundjobs/backgroundjobs_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -422,4 +423,49 @@ func TestResolveWorkDir(t *testing.T) {
 			assert.Equal(t, tt.expected, h.resolveWorkDir(tt.cwd))
 		})
 	}
+}
+
+// Regression test for a backgroundjobs hang caused by backgrounded grandchildren.
+//
+// A command like `sleep 10 &` makes the shell exit immediately, but the
+// backgrounded sleep inherits stdout/stderr. Without cmd.WaitDelay, Go's
+// exec.Cmd.Wait() blocks reading the pipe until the child dies.
+//
+// With the WaitDelay safeguard the monitor goroutine must finish within a small
+// fraction of the sleep timeout, and correctly interpret ErrWaitDelay as a
+// success if the direct child exited 0.
+func TestBackgroundJobsTool_BackgroundedChildDoesNotBlockReturn(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell backgrounding semantics; skipped on Windows")
+	}
+
+	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+
+	start := time.Now()
+	result, err := tool.handler.RunBackgroundJob(t.Context(), RunBackgroundJobArgs{
+		// sleep inherits stdout/stderr from the shell and holds the pipe
+		// open for 30s. The monitor must return as soon as the shell exits + waitDelay.
+		Cmd: "sleep 30 &",
+	}, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Wait for the monitor goroutine to mark the job as finished.
+	require.Eventually(t, func() bool {
+		listResult, err := tool.handler.ListBackgroundJobs(t.Context(), nil)
+		require.NoError(t, err)
+		return !strings.Contains(listResult.Output, "Status: running")
+	}, 10*time.Second, 100*time.Millisecond)
+
+	elapsed := time.Since(start)
+	assert.Less(t, elapsed, 5*time.Second,
+		"background job monitor must complete promptly when the command daemonizes a child; elapsed=%s", elapsed)
+
+	// Since the direct child (shell) exited 0, the job should be marked completed
+	// even though the pipes were forcefully closed (ErrWaitDelay).
+	listResult, err := tool.handler.ListBackgroundJobs(t.Context(), nil)
+	require.NoError(t, err)
+	assert.Contains(t, listResult.Output, "Status: completed")
+	assert.Contains(t, listResult.Output, "Exit Code: 0")
 }


### PR DESCRIPTION
## Summary

This pull request resolves a critical status race condition in background jobs and eliminates process hangs caused by inherited I/O pipes from background subprocesses. It also ensures cross-platform test reliability on Windows and silences platform-specific linter false-positives.

## Root Cause & Changes

### 1. Atomic Status Transitions (`CompareAndSwap`)
- **Issue:** Previously, `monitorJob` used blind status writes (`job.status.Store(...)`). If `StopBackgroundJob` or `ToolSet.Stop` terminated a job at the exact moment a process was exiting naturally, `monitorJob` could overwrite `statusStopped` with `statusCompleted` or `statusFailed`. This caused erroneous recall steering messages to be sent back to the AI model for manually aborted jobs.
- **Fix:** Replaced blind store assignments in `monitorJob` with atomic Compare-And-Swap (CAS) transitions (`job.status.CompareAndSwap(statusRunning, newStatus)`). Once a job transitions out of `statusRunning`, subsequent background monitoring completions cannot overwrite the terminated state.

### 2. Piped Subprocess Cleanup (`cmd.WaitDelay`)
- **Issue:** When background commands spawned child or grandchild processes that inherited open `stdout`/`stderr` file descriptors (such as backgrounded scripts or daemons), Go's `cmd.Wait()` would block indefinitely waiting for an `EOF` on the pipes even after the primary process terminated.
- **Fix:** Configured `cmd.WaitDelay = 1 * time.Second` on all executed background jobs to automatically force-close orphaned I/O pipes if child processes hold them open after the primary process exits.

### 3. Cross-Platform Compatibility & Linting
- **Test Reliability:** Updated `TestResolveWorkDir` in `backgroundjobs_test.go` to use `filepath.FromSlash` and conditional OS root prefixes (`C:\...` on Windows) to prevent false-positive path resolution failures on Windows.
- **Linting Harmony:** Updated `exec_windows.go` to use `exec.CommandContext` and wrapped secondary fallback errors with `%w`. Added `,nolintlint` to cross-platform silencing directives (`//nolint:gosec` in `snapshot.go` and `//nolint:bodyclose` in `transport_test.go`) so that running `golangci-lint` on Windows does not flag them as unused.

