### PR TITLE
chore: remove dead TUI code

### DIFF
--- a/pkg/leantui/ui/transcript.go
+++ b/pkg/leantui/ui/transcript.go
@@ -165,13 +165,6 @@ func (t *Transcript) Lines(width, spinnerFrame int, busy bool, sessionState serv
 	return lines
 }
 
-// Clear drops all transcript content and active tool state.
-func (t *Transcript) Clear() {
-	t.blocks = nil
-	t.pending = nil
-	t.toolz.Reset()
-}
-
 // BlockCount reports the number of committed transcript blocks.
 func (t *Transcript) BlockCount() int { return len(t.blocks) }
 

--- a/pkg/tui/animation/coordinator.go
+++ b/pkg/tui/animation/coordinator.go
@@ -96,9 +96,6 @@ func (c *Coordinator) tickLocked() tea.Cmd {
 // animated components in the running TUI.
 var globalCoordinator = &Coordinator{}
 
-// Register increments the active animation count on the global coordinator.
-func Register() { globalCoordinator.Register() }
-
 // Unregister decrements the active animation count on the global coordinator.
 func Unregister() { globalCoordinator.Unregister() }
 

--- a/pkg/tui/styles/theme.go
+++ b/pkg/tui/styles/theme.go
@@ -456,35 +456,6 @@ func listUserThemeRefs() ([]string, error) {
 	return listThemeRefsFrom(ThemesDir())
 }
 
-// UserThemeExists returns true if a user theme file exists for the given ref
-// in the user themes directory (typically ~/.cagent/themes/).
-//
-// This handles the "user:" prefix - "user:nord" checks for ~/.cagent/themes/nord.yaml.
-func UserThemeExists(ref string) bool {
-	if ref == "" {
-		return false
-	}
-
-	// Strip user: prefix if present
-	baseRef := strings.TrimPrefix(ref, UserThemePrefix)
-
-	if err := validateThemeRef(baseRef); err != nil {
-		return false
-	}
-
-	dir := ThemesDir()
-
-	// Try .yaml first, then .yml
-	if _, err := os.Stat(filepath.Join(dir, baseRef+".yaml")); err == nil {
-		return true
-	}
-	if _, err := os.Stat(filepath.Join(dir, baseRef+".yml")); err == nil {
-		return true
-	}
-
-	return false
-}
-
 // SaveThemeToUserConfig persists the theme reference to the user config file.
 // If themeRef equals DefaultThemeRef, the setting is cleared (empty string).
 func SaveThemeToUserConfig(themeRef string) error {


### PR DESCRIPTION
## Summary

- remove the unused lean TUI transcript reset method
- remove the unused package-level animation registration shim
- remove the unused user-theme existence helper

## Validation

- `task build`
- `task lint`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy task test`
- dead-code analysis with tests across Darwin, Linux, and Windows
