### PR TITLE
fix: prevent concurrent LoadWithConfig calls from sharing working dir

### DIFF
--- a/pkg/teamloader/teamloader.go
+++ b/pkg/teamloader/teamloader.go
@@ -54,6 +54,11 @@ type loadOptions struct {
 
 type Opt func(*loadOptions) error
 
+// WithWorkingDir overrides the working directory toolsets are built with,
+// without touching the caller's RuntimeConfig. Callers that share one
+// RuntimeConfig across concurrent loads (the API server, one per session)
+// need this to keep each session's shell, filesystem and git tools rooted in
+// that session's directory.
 func WithWorkingDir(dir string) Opt {
 	return func(opts *loadOptions) error {
 		opts.workingDir = dir
@@ -176,6 +181,16 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 		}
 	}
 
+	// Toolsets read runConfig.WorkingDir, and the load below writes the
+	// resolved models, providers and provider registry back onto runConfig.
+	// Callers that load several agents from one RuntimeConfig (the API server
+	// shares a single one across concurrent sessions) must not see those
+	// writes, so take a copy when an explicit working directory is supplied.
+	if loadOpts.workingDir != "" && loadOpts.workingDir != runConfig.WorkingDir {
+		runConfig = runConfig.Clone()
+		runConfig.WorkingDir = loadOpts.workingDir
+	}
+
 	// Load the agent's configuration
 	cfg, err := config.Load(ctx, agentSource, config.WithFlavors(runConfig.Flavors...))
 	if err != nil {
@@ -258,12 +273,7 @@ func LoadWithConfig(ctx context.Context, agentSource config.Source, runConfig *c
 	runConfig.ProviderRegistry = loadOpts.providerRegistry
 
 	// Load agents
-	workingDir := cmp.Or(loadOpts.workingDir, runConfig.WorkingDir)
-	// Toolsets read runConfig.WorkingDir; propagate for this call and
-	// restore on return to avoid leaking across sessions that share rc.
-	originalWorkingDir := runConfig.WorkingDir
-	runConfig.WorkingDir = workingDir
-	defer func() { runConfig.WorkingDir = originalWorkingDir }()
+	workingDir := runConfig.WorkingDir
 	parentDir := cmp.Or(agentSource.ParentDir(), workingDir)
 	configName := configNameFromSource(agentSource.Name())
 	var agents []*agent.Agent

--- a/pkg/teamloader/teamloader_test.go
+++ b/pkg/teamloader/teamloader_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -1442,4 +1443,75 @@ agents:
 	}
 
 	assert.Positive(t, counter.calls.Load(), "transport wrapper supplied via WithModelOptions should have been invoked when the agent's model made a request")
+}
+
+// Concurrent loads that share one *RuntimeConfig — the shape the API server
+// uses, one config for every session — must each see their own working
+// directory. Toolsets read it off runConfig, so a load that mutates the
+// shared value hands the wrong directory to another session's shell,
+// filesystem and git tools.
+func TestLoadWithConfig_WithWorkingDirIsConcurrencySafe(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "dummy")
+
+	data := []byte(`agents:
+  root:
+    model: openai/gpt-4o
+    instruction: test
+    toolsets:
+      - type: recorder
+`)
+
+	var mu sync.Mutex
+	seen := map[string]string{}
+	recorder := NewToolsetRegistry(map[string]ToolsetCreator{
+		"recorder": func(_ context.Context, _ latest.Toolset, _ string, runConfig *config.RuntimeConfig, agentName string) (tools.ToolSet, error) {
+			// Hold the observed value across a scheduling point to widen
+			// the window in which a competing load could clobber it.
+			observed := runConfig.WorkingDir
+			runtime.Gosched()
+			mu.Lock()
+			defer mu.Unlock()
+			seen[observed] = agentName
+			return &mockToolSet{}, nil
+		},
+	})
+
+	callerDir := t.TempDir()
+	runConfig := &config.RuntimeConfig{}
+	runConfig.WorkingDir = callerDir
+
+	const loads = 8
+	sessionDirs := make([]string, loads)
+	for i := range sessionDirs {
+		sessionDirs[i] = t.TempDir()
+	}
+
+	var wg sync.WaitGroup
+	errs := make([]error, loads)
+	for i, dir := range sessionDirs {
+		wg.Go(func() {
+			_, errs[i] = Load(
+				t.Context(),
+				config.NewBytesSource("t.yaml", data),
+				runConfig,
+				WithProviderRegistry(providerdefaults.NewDefaultRegistry()),
+				WithToolsetRegistry(recorder),
+				WithWorkingDir(dir),
+			)
+		})
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "load %d", i)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, dir := range sessionDirs {
+		assert.Contains(t, seen, dir,
+			"each session's toolsets must be built with that session's working directory")
+	}
+	assert.Equal(t, callerDir, runConfig.WorkingDir,
+		"the shared RuntimeConfig must never be mutated")
 }


### PR DESCRIPTION
`pkg/teamloader.LoadWithConfig` previously mutated the caller's `*config.RuntimeConfig` directly — writing `runConfig.WorkingDir` to the value supplied by `WithWorkingDir`, then restoring the original in a `defer`. The API server holds a single shared `sm.runConfig` and passes it to `LoadWithConfig` for every session. Because sessions load concurrently, two simultaneous `RunSession` calls could observe each other's working directory inside that mutate-and-restore window. Toolsets (`shell`, `filesystem`, `git`, `backgroundjobs`, `mcp`, `lsp`) read `runConfig.WorkingDir` at creation time, so a session's tools could be rooted in another session's directory — a genuine isolation break, not just a cosmetic race.

When `WithWorkingDir` supplies a directory that differs from `runConfig.WorkingDir`, `LoadWithConfig` now clones the `RuntimeConfig` and works on the copy. The caller's config is never touched, so there is no window to race on. Callers that do not pass `WithWorkingDir` (CLI, MCP, A2A, ACP, and others) keep the existing behaviour, including the `Models`/`Providers`/`ProviderRegistry` write-back; `pkg/server` reads model info from `LoadResult` rather than from the config, so nothing depends on the write-back on that path.

`TestLoadWithConfig_WithWorkingDirIsConcurrencySafe` reproduces the bug: 8 concurrent loads share one `RuntimeConfig`, each with its own `WithWorkingDir`, and a recording toolset registry captures which directory each toolset was built with. Against the old code all 8 sessions got the same directory; the test passes cleanly with the fix, including under `-race -count=3`.