### PR TITLE
TUI - Program-scoped animation runtime

### DIFF
--- a/pkg/tui/animation/architecture_test.go
+++ b/pkg/tui/animation/architecture_test.go
@@ -1,0 +1,40 @@
+package animation
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestSingleGlobalTimingSourceArchitecture(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate animation package")
+	}
+	root := filepath.Dir(file)
+	forbidden := []string{"SubscribeEvery", "NewSubscriptionEvery", "startEvery", "registerEvery", "unregisterEvery", "ScheduledFor"}
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil || entry.IsDir() || filepath.Ext(path) != ".go" {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		text := string(data)
+		for _, symbol := range forbidden {
+			if strings.Contains(text, symbol) && path != file {
+				t.Errorf("%s contains forbidden alternate timing API %q", path, symbol)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if TickRate <= 0 {
+		t.Fatal("global TickRate must be positive")
+	}
+}

--- a/pkg/tui/animation/coordinator.go
+++ b/pkg/tui/animation/coordinator.go
@@ -8,6 +8,7 @@ package animation
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -16,95 +17,296 @@ import (
 // TickMsg is broadcast to all animated components on each animation frame.
 // Components should handle this message to update their animation state.
 type TickMsg struct {
+	// Frame is retained for compatibility with components that have not yet
+	// adopted elapsed-time animation. Program runtimes use their accepted tick
+	// count; legacy standalone ticks use the compatibility coordinator count.
 	Frame int
+
+	runtimeIdentity *runtimeIdentity
+	generation      int // identifies the current tick chain so stale or parallel chains are rejected
+
+	// deliveredAt is the timestamp tea.Tick supplies when this timer fires.
+	deliveredAt time.Time
+	// timerStartedAt records when the animation runtime created this tick's timer. It is
+	// the first tick's elapsed-time baseline; later ticks use lastDeliveredAt.
+	timerStartedAt    time.Time
+	dirty             *atomic.Bool
+	elapsedBeforeTick time.Duration
+	elapsedAfterTick  time.Duration
 }
 
-// Coordinator manages a single tick stream for all animations.
-// It tracks active animations and only generates ticks when at least one is active.
-type Coordinator struct {
-	// mu guards all fields. While Bubble Tea's Update loop is single-threaded,
-	// the mutex protects against accidental misuse from Cmd goroutines and
-	// ensures StartTickIfFirst is atomic (no race between check and register).
-	mu     sync.Mutex
-	frame  int
-	active int32
-}
-
-// Register increments the active animation count.
-// Call this when an animation starts.
-func (c *Coordinator) Register() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.active++
-}
-
-// Unregister decrements the active animation count.
-// Call this when an animation stops.
-func (c *Coordinator) Unregister() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.active > 0 {
-		c.active--
+// MarkDirty records that this accepted tick changed visible output. TickMsg
+// copies share the marker, so root can decide after complete fanout whether a
+// new view must be composed.
+func (m TickMsg) MarkDirty() {
+	if m.dirty != nil {
+		m.dirty.Store(true)
 	}
 }
 
-// HasActive returns true if any animations are currently active.
-func (c *Coordinator) HasActive() bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.active > 0
+// Dirty reports whether any visible component marked this accepted tick dirty.
+func (m TickMsg) Dirty() bool { return m.dirty != nil && m.dirty.Load() }
+
+// ElapsedBounds returns the animation clock immediately before and after this
+// accepted tick.
+func (m TickMsg) ElapsedBounds() (time.Duration, time.Duration) {
+	return m.elapsedBeforeTick, m.elapsedAfterTick
 }
 
-// StartTick starts the animation tick if any animations are active.
-// Call this after processing a TickMsg to continue the tick stream.
-func (c *Coordinator) StartTick() tea.Cmd {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.active <= 0 {
+// Runtime owns one program's animation clock, subscriptions, transitions, and
+// single outstanding tick lease. It must not be shared by concurrently running
+// Bubble Tea programs.
+type Runtime struct {
+	mu              sync.Mutex
+	runtimeIdentity *runtimeIdentity
+	elapsed         time.Duration
+	active          int32
+	generation      int
+
+	tickScheduled   bool
+	lastDeliveredAt time.Time
+	acceptedTicks   uint64
+}
+
+type runtimeIdentity struct{ _ byte }
+
+// NewRuntime creates an isolated program-scoped animation runtime.
+func NewRuntime() *Runtime { return &Runtime{runtimeIdentity: &runtimeIdentity{}} }
+
+// Register increments this animation runtime's active animation count.
+func (r *Runtime) Register() {
+	r.mustExist()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.active++
+}
+
+// Unregister decrements this animation runtime's active animation count.
+func (r *Runtime) Unregister() {
+	r.mustExist()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.active > 0 {
+		r.active--
+	}
+	if r.active == 0 {
+		r.abandonLeaseLocked()
+	}
+}
+
+// HasActive reports whether this animation runtime has active animations.
+func (r *Runtime) HasActive() bool { return r.ActiveCount() > 0 }
+
+// ActiveCount returns this animation runtime's active animation count.
+func (r *Runtime) ActiveCount() int32 {
+	r.mustExist()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.active
+}
+
+// Continue schedules the next tick when animations remain active. The root calls
+// it exactly once after fanout of an accepted TickMsg.
+func (r *Runtime) Continue() tea.Cmd {
+	r.mustExist()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.active == 0 {
+		r.abandonLeaseLocked()
+		r.lastDeliveredAt = time.Time{}
 		return nil
 	}
-	return c.tickLocked()
+	return r.tickLocked()
 }
 
-// StartTickIfFirst registers an animation and starts the tick if this is the first.
-// This is atomic: no race between checking and registering.
-// Returns the tick command if the tick stream was started, nil otherwise.
-func (c *Coordinator) StartTickIfFirst() tea.Cmd {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	wasEmpty := c.active == 0
-	c.active++
+// Accept consumes this animation runtime's current tick lease and advances its clock.
+func (r *Runtime) Accept(msg TickMsg) (TickMsg, bool) {
+	r.mustExist()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if msg.runtimeIdentity != r.runtimeIdentity || msg.generation != r.generation || !r.tickScheduled {
+		return msg, false
+	}
+	r.acceptedTicks++
+	// Frame is the legacy int representation of the monotonically increasing tick count.
+	msg.Frame = int(r.acceptedTicks) //nolint:gosec // Compatibility field is intentionally int.
+	r.tickScheduled = false
+	delta := msg.deliveredAt.Sub(r.lastDeliveredAt)
+	if r.lastDeliveredAt.IsZero() {
+		delta = msg.deliveredAt.Sub(msg.timerStartedAt)
+	}
+	if delta <= 0 {
+		delta = TickRate
+	}
+	r.lastDeliveredAt = msg.deliveredAt
+	msg.elapsedBeforeTick = r.elapsed
+	r.elapsed += delta
+	msg.elapsedAfterTick = r.elapsed
+	msg.dirty = &atomic.Bool{}
+	return msg, true
+}
+
+// Now returns elapsed time accepted by this animation runtime.
+func (r *Runtime) Now() time.Duration {
+	r.mustExist()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.elapsed
+}
+
+// EnsureRunning replaces a potentially lost outstanding tick command.
+func (r *Runtime) EnsureRunning() tea.Cmd {
+	r.mustExist()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.active == 0 {
+		r.abandonLeaseLocked()
+		r.lastDeliveredAt = time.Time{}
+		return nil
+	}
+	r.generation++
+	r.tickScheduled = false
+	return r.tickLocked()
+}
+
+// Stop invalidates all queued ticks and releases every registration owned by
+// this program. Program teardown calls it after component cleanup as a final
+// ownership boundary; a late queued TickMsg can then never revive the chain.
+func (r *Runtime) Stop() {
+	r.mustExist()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.active = 0
+	r.abandonLeaseLocked()
+	r.lastDeliveredAt = time.Time{}
+}
+
+// Subscribe creates an inactive subscription owned by this animation runtime.
+func (r *Runtime) Subscribe() Subscription { return NewSubscription(r) }
+
+// Transition creates an idle transition owned by this animation runtime.
+func (r *Runtime) Transition() Transition { return NewTransition(r) }
+
+func (r *Runtime) start() tea.Cmd {
+	r.mustExist()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	wasEmpty := r.active == 0
+	r.active++
 	if wasEmpty {
-		return c.tickLocked()
+		return r.tickLocked()
 	}
 	return nil
 }
 
-// tickLocked returns a tick command. Must be called with mu held.
-// 14 FPS - smooth enough for most animations without being too CPU-intensive.
-func (c *Coordinator) tickLocked() tea.Cmd {
-	return tea.Tick(time.Second/14, func(time.Time) tea.Msg {
-		c.mu.Lock()
-		defer c.mu.Unlock()
-		c.frame++
-		frame := c.frame
-		return TickMsg{Frame: frame}
+func (r *Runtime) mustExist() {
+	if r == nil || r.runtimeIdentity == nil {
+		panic("animation: nil or zero Runtime")
+	}
+}
+
+func (r *Runtime) abandonLeaseLocked() {
+	if r.tickScheduled {
+		r.generation++
+		r.tickScheduled = false
+	}
+}
+
+func (r *Runtime) tickLocked() tea.Cmd {
+	if r.tickScheduled {
+		return nil
+	}
+	r.tickScheduled = true
+	runtimeIdentity, generation, timerStartedAt := r.runtimeIdentity, r.generation, time.Now()
+	return tea.Tick(TickRate, func(t time.Time) tea.Msg {
+		return TickMsg{runtimeIdentity: runtimeIdentity, generation: generation, deliveredAt: t, timerStartedAt: timerStartedAt}
 	})
 }
 
-// globalCoordinator is the singleton coordinator instance shared by all
-// animated components in the running TUI.
-var globalCoordinator = &Coordinator{}
+// legacyContinue preserves the facade contract in which delivery itself
+// consumes the outstanding lease; legacy callers do not call Runtime.Accept.
+func (r *Runtime) legacyContinue() tea.Cmd {
+	r.mustExist()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.active == 0 {
+		r.abandonLeaseLocked()
+		return nil
+	}
+	return r.legacyTickLocked()
+}
 
-// Unregister decrements the active animation count on the global coordinator.
-func Unregister() { globalCoordinator.Unregister() }
+func (r *Runtime) legacyStart() tea.Cmd {
+	r.mustExist()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	wasEmpty := r.active == 0
+	r.active++
+	if wasEmpty {
+		return r.legacyTickLocked()
+	}
+	return nil
+}
 
-// HasActive reports whether any animations are active on the global coordinator.
-func HasActive() bool { return globalCoordinator.HasActive() }
+func (r *Runtime) legacyTickLocked() tea.Cmd {
+	if r.tickScheduled {
+		return nil
+	}
+	r.tickScheduled = true
+	runtimeIdentity, generation := r.runtimeIdentity, r.generation
+	return tea.Tick(TickRate, func(time.Time) tea.Msg {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		msg := TickMsg{runtimeIdentity: runtimeIdentity, generation: generation}
+		if runtimeIdentity == r.runtimeIdentity && generation == r.generation && r.tickScheduled {
+			r.acceptedTicks++
+			// Frame is the legacy int representation of the monotonically increasing tick count.
+			msg.Frame = int(r.acceptedTicks) //nolint:gosec // Compatibility field is intentionally int.
+			r.tickScheduled = false
+		}
+		return msg
+	})
+}
 
-// StartTick starts the global animation tick if any animations are active.
-func StartTick() tea.Cmd { return globalCoordinator.StartTick() }
+func (r *Runtime) isCurrent(msg TickMsg) bool {
+	r.mustExist()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return msg.runtimeIdentity == r.runtimeIdentity && msg.generation == r.generation
+}
 
-// StartTickIfFirst registers an animation on the global coordinator and starts
-// the tick if it is the first.
-func StartTickIfFirst() tea.Cmd { return globalCoordinator.StartTickIfFirst() }
+// legacyRuntime retains the pre-animation-runtime package API for incremental adoption.
+// New programs should own an animation Runtime and pass it to components explicitly.
+var legacyRuntime = NewRuntime()
+
+// Coordinator is retained as a compatibility facade for callers that own an
+// isolated coordinator. New code should use the animation Runtime.
+type Coordinator struct{ runtime *Runtime }
+
+func (c *Coordinator) boundRuntime() *Runtime {
+	if c.runtime == nil {
+		c.runtime = NewRuntime()
+	}
+	return c.runtime
+}
+func (c *Coordinator) Register()                 { c.boundRuntime().Register() }
+func (c *Coordinator) Unregister()               { c.boundRuntime().Unregister() }
+func (c *Coordinator) HasActive() bool           { return c.boundRuntime().HasActive() }
+func (c *Coordinator) StartTick() tea.Cmd        { return c.boundRuntime().legacyContinue() }
+func (c *Coordinator) StartTickIfFirst() tea.Cmd { return c.boundRuntime().legacyStart() }
+
+// Register, Unregister, HasActive, StartTick, and StartTickIfFirst preserve the
+// original package-level API while components migrate to program ownership.
+func Register()                 { legacyRuntime.Register() }
+func Unregister()               { legacyRuntime.Unregister() }
+func HasActive() bool           { return legacyRuntime.HasActive() }
+func StartTick() tea.Cmd        { return legacyRuntime.legacyContinue() }
+func StartTickIfFirst() tea.Cmd { return legacyRuntime.legacyStart() }
+
+// IsCurrentGen reports whether msg belongs to the package facade's current tick
+// chain. It is a side-effect-free compatibility check; facade tick delivery,
+// not this predicate, consumes the outstanding lease.
+func IsCurrentGen(msg TickMsg) bool { return legacyRuntime.isCurrent(msg) }
+
+// TickRate is the shared interval between animation ticks.
+const TickRate = time.Second / 14

--- a/pkg/tui/animation/coordinator_test.go
+++ b/pkg/tui/animation/coordinator_test.go
@@ -1,170 +1,216 @@
 package animation
 
 import (
-	"sync"
 	"testing"
 	"time"
 
-	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func getActiveCount(c *Coordinator) int32 {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.active
-}
-
-func runCmdWithTimeout(t *testing.T, cmd tea.Cmd) tea.Msg {
+func runTick(t *testing.T, cmd func() any) TickMsg {
 	t.Helper()
-	require.NotNil(t, cmd)
-
-	done := make(chan tea.Msg, 1)
-	go func() {
-		done <- cmd()
-	}()
-
-	timeout := time.NewTimer(250 * time.Millisecond)
-	defer timeout.Stop()
-
-	select {
-	case msg := <-done:
-		return msg
-	case <-timeout.C:
-		t.Fatal("timed out waiting for tick command")
-	}
-
-	return nil
-}
-
-func runTickCmd(t *testing.T, cmd tea.Cmd) TickMsg {
-	t.Helper()
-
-	msg := runCmdWithTimeout(t, cmd)
-	tickMsg, ok := msg.(TickMsg)
+	msg, ok := cmd().(TickMsg)
 	require.True(t, ok)
-
-	return tickMsg
+	return msg
 }
 
-func TestGlobalCoordinatorLifecycle(t *testing.T) {
-	t.Parallel()
-	c := &Coordinator{}
-
-	// No active animations = no tick
-	require.Nil(t, c.StartTick())
-
-	// First registration starts tick
-	firstTick := c.StartTickIfFirst()
-	tickMsg := runTickCmd(t, firstTick)
-	assert.Equal(t, 1, tickMsg.Frame)
-
-	// Subsequent tick continues
-	nextTick := c.StartTick()
-	tickMsg = runTickCmd(t, nextTick)
-	assert.Equal(t, 2, tickMsg.Frame)
-
-	// Second StartTickIfFirst registers but doesn't return tick (not first)
-	cmd := c.StartTickIfFirst()
-	require.Nil(t, cmd)
-	assert.Equal(t, int32(2), getActiveCount(c))
-
-	// Unregister one, still active
-	c.Unregister()
-	require.True(t, c.HasActive())
-	require.NotNil(t, c.StartTick())
-
-	// Unregister last one
-	c.Unregister()
-	require.False(t, c.HasActive())
-	require.Nil(t, c.StartTick())
+func resetLegacyRuntime(t *testing.T) {
+	t.Helper()
+	legacyRuntime = NewRuntime()
+	t.Cleanup(func() { legacyRuntime = NewRuntime() })
 }
 
-func TestUnregisterNeverGoesNegative(t *testing.T) {
-	t.Parallel()
-	c := &Coordinator{}
+func TestLegacyFacadeContinuesOnDeliveredTickWithoutAccept(t *testing.T) {
+	resetLegacyRuntime(t)
 
-	// Multiple unregisters when already at 0
-	c.Unregister()
-	c.Unregister()
-	c.Unregister()
+	first := StartTickIfFirst()
+	require.NotNil(t, first)
+	require.True(t, HasActive())
 
-	assert.Equal(t, int32(0), getActiveCount(c))
-	require.False(t, c.HasActive())
+	firstTick := runTick(t, func() any { return first() })
+	assert.Equal(t, 1, firstTick.Frame)
+	assert.True(t, IsCurrentGen(firstTick))
+
+	second := StartTick()
+	require.NotNil(t, second, "legacy delivery must release the lease without Runtime.Accept")
+	secondTick := runTick(t, func() any { return second() })
+	assert.Equal(t, 2, secondTick.Frame)
+	assert.True(t, IsCurrentGen(secondTick))
+
+	Unregister()
+	assert.False(t, HasActive())
+	assert.Nil(t, StartTick())
 }
 
-func TestConcurrentRegisterUnregister(t *testing.T) {
-	t.Parallel()
-	c := &Coordinator{}
+func TestLegacyIsCurrentGenIsPureAndRejectsStaleTicks(t *testing.T) {
+	resetLegacyRuntime(t)
 
-	const goroutines = 100
-	const opsPerGoroutine = 100
+	first := StartTickIfFirst()
+	require.NotNil(t, first)
+	firstTick := runTick(t, func() any { return first() })
+	assert.True(t, IsCurrentGen(firstTick))
+	assert.True(t, IsCurrentGen(firstTick), "generation checks are side-effect-free")
 
-	var wg sync.WaitGroup
-	wg.Add(goroutines * 2)
-
-	// Half goroutines do register
-	for range goroutines {
-		go func() {
-			defer wg.Done()
-			for range opsPerGoroutine {
-				c.Register()
-			}
-		}()
-	}
-
-	// Half goroutines do unregister
-	for range goroutines {
-		go func() {
-			defer wg.Done()
-			for range opsPerGoroutine {
-				c.Unregister()
-			}
-		}()
-	}
-
-	wg.Wait()
-
-	// Should have exactly goroutines * opsPerGoroutine registers
-	// minus whatever unregisters succeeded (capped at 0)
-	// Final count should be >= 0
-	count := getActiveCount(c)
-	assert.GreaterOrEqual(t, count, int32(0), "active count should never be negative")
+	second := StartTick()
+	require.NotNil(t, second, "generation checks must not interfere with re-arming")
+	Unregister()
+	assert.False(t, IsCurrentGen(runTick(t, func() any { return second() })), "stopped chain is stale")
 }
 
-func TestConcurrentStartTickIfFirst(t *testing.T) {
-	t.Parallel()
-	c := &Coordinator{}
+func TestAcceptedTickCopiesShareDirtyMarker(t *testing.T) {
+	runtime := NewRuntime()
+	sub := runtime.Subscribe()
+	tick := runTick(t, func() any { return sub.Start()() })
+	accepted, ok := runtime.Accept(tick)
+	require.True(t, ok)
+	acceptedCopy := accepted
+	assert.False(t, accepted.Dirty())
+	acceptedCopy.MarkDirty()
+	assert.True(t, accepted.Dirty())
+	elapsedBeforeTick, elapsedAfterTick := accepted.ElapsedBounds()
+	assert.Less(t, elapsedBeforeTick, elapsedAfterTick)
+	sub.Stop()
+}
 
-	const goroutines = 50
-	var wg sync.WaitGroup
-	wg.Add(goroutines)
+func TestRejectedTickCannotBecomeDirty(t *testing.T) {
+	first, second := NewRuntime(), NewRuntime()
+	sub := first.Subscribe()
+	tick := runTick(t, func() any { return sub.Start()() })
+	rejected, ok := second.Accept(tick)
+	assert.False(t, ok)
+	rejected.MarkDirty()
+	assert.False(t, rejected.Dirty())
+	sub.Stop()
+}
 
-	cmds := make(chan tea.Cmd, goroutines)
+func TestRuntimeIsolationAndOwnerToken(t *testing.T) {
+	first, second := NewRuntime(), NewRuntime()
+	firstSub, secondSub := first.Subscribe(), second.Subscribe()
+	firstCmd := firstSub.Start()
+	secondCmd := secondSub.Start()
+	require.NotNil(t, firstCmd)
+	require.NotNil(t, secondCmd)
 
-	// Many goroutines race to be "first"
-	for range goroutines {
-		go func() {
-			defer wg.Done()
-			cmd := c.StartTickIfFirst()
-			cmds <- cmd
-		}()
+	firstTick := runTick(t, func() any { return firstCmd() })
+	secondTick := runTick(t, func() any { return secondCmd() })
+	_, ok := second.Accept(firstTick)
+	assert.False(t, ok, "runtime identity rejects another runtime's tick")
+	assert.Zero(t, second.Now())
+	_, ok = first.Accept(firstTick)
+	require.True(t, ok)
+	assert.Positive(t, first.Now())
+	assert.Zero(t, second.Now())
+	_, ok = second.Accept(secondTick)
+	require.True(t, ok)
+}
+
+func TestRuntimeStopDoesNotAffectAnotherRuntime(t *testing.T) {
+	first, second := NewRuntime(), NewRuntime()
+	firstSub, secondSub := first.Subscribe(), second.Subscribe()
+	firstCmd, secondCmd := firstSub.Start(), secondSub.Start()
+	firstSub.Stop()
+	assert.False(t, first.HasActive())
+	assert.True(t, second.HasActive())
+	assert.Nil(t, first.Continue())
+	secondTick := runTick(t, func() any { return secondCmd() })
+	_, ok := second.Accept(secondTick)
+	require.True(t, ok)
+	assert.NotNil(t, second.Continue())
+	secondSub.Stop()
+	_ = firstCmd
+}
+
+func TestRuntimeAcceptOnlyOnce(t *testing.T) {
+	runtime := NewRuntime()
+	sub := runtime.Subscribe()
+	tick := runTick(t, func() any { return sub.Start()() })
+	_, ok := runtime.Accept(tick)
+	require.True(t, ok)
+	elapsed := runtime.Now()
+	_, ok = runtime.Accept(tick)
+	assert.False(t, ok)
+	assert.Equal(t, elapsed, runtime.Now())
+	sub.Stop()
+}
+
+func TestRuntimeTransitionUsesOwnedClock(t *testing.T) {
+	runtime := NewRuntime()
+	transition := runtime.Transition()
+	cmd := transition.Start(TickRate, Linear)
+	tick := runTick(t, func() any { return cmd() })
+	_, ok := runtime.Accept(tick)
+	require.True(t, ok)
+	transition.Tick()
+	assert.False(t, transition.Running())
+	assert.Equal(t, int32(0), runtime.ActiveCount())
+}
+
+func TestTickOwnerIsImmutableAcrossRecovery(t *testing.T) {
+	runtime := NewRuntime()
+	sub := runtime.Subscribe()
+	staleCmd := sub.Start()
+	freshCmd := runtime.EnsureRunning()
+	stale := runTick(t, func() any { return staleCmd() })
+	fresh := runTick(t, func() any { return freshCmd() })
+	_, ok := runtime.Accept(stale)
+	assert.False(t, ok)
+	_, ok = runtime.Accept(fresh)
+	assert.True(t, ok)
+	sub.Stop()
+}
+
+func TestRuntimeStopInvalidatesQueuedTickAndQuiesces(t *testing.T) {
+	runtime := NewRuntime()
+	sub := runtime.Subscribe()
+	queued := sub.Start()
+	require.NotNil(t, queued)
+
+	runtime.Stop()
+	assert.Equal(t, int32(0), runtime.ActiveCount())
+	assert.Nil(t, runtime.Continue(), "stopped animation runtime schedules no successor")
+
+	_, accepted := runtime.Accept(runTick(t, func() any { return queued() }))
+	assert.False(t, accepted, "queued generation is stale after teardown")
+	assert.Zero(t, runtime.Now(), "rejected queued tick does not advance the clock")
+}
+
+func TestExactlyOneContinuationPerAcceptedTick(t *testing.T) {
+	runtime := NewRuntime()
+	sub := runtime.Subscribe()
+	first := sub.Start()
+	_, accepted := runtime.Accept(runTick(t, func() any { return first() }))
+	require.True(t, accepted)
+
+	successor := runtime.Continue()
+	require.NotNil(t, successor)
+	assert.Nil(t, runtime.Continue(), "a live lease deduplicates parallel continuations")
+	sub.Stop()
+	_, accepted = runtime.Accept(runTick(t, func() any { return successor() }))
+	assert.False(t, accepted, "last unregister invalidates queued successor")
+	assert.Nil(t, runtime.Continue())
+}
+
+func TestTabBusySpinnerIsOneCellBraille(t *testing.T) {
+	for _, frame := range TabBusy.Frames() {
+		runes := []rune(frame)
+		require.Len(t, runes, 1)
+		assert.GreaterOrEqual(t, runes[0], rune(0x2800))
+		assert.LessOrEqual(t, runes[0], rune(0x28ff))
 	}
+}
 
-	wg.Wait()
-	close(cmds)
-
-	// Count non-nil commands (ticks started)
-	ticksStarted := 0
-	for cmd := range cmds {
-		if cmd != nil {
-			ticksStarted++
-		}
-	}
-
-	// Exactly one should have started the tick
-	assert.Equal(t, 1, ticksStarted, "exactly one goroutine should start the tick")
-	// All should have registered
-	assert.Equal(t, int32(goroutines), getActiveCount(c))
+func TestRuntimeNowAdvancesByDeliveredTime(t *testing.T) {
+	runtime := NewRuntime()
+	runtime.Register()
+	base := time.Now()
+	runtime.mu.Lock()
+	runtime.tickScheduled = true
+	runtime.generation = 2
+	runtime.lastDeliveredAt = base
+	runtime.mu.Unlock()
+	_, ok := runtime.Accept(TickMsg{runtimeIdentity: runtime.runtimeIdentity, generation: 2, deliveredAt: base.Add(125 * time.Millisecond)})
+	require.True(t, ok)
+	assert.Equal(t, 125*time.Millisecond, runtime.Now())
+	runtime.Unregister()
 }

--- a/pkg/tui/animation/durations.go
+++ b/pkg/tui/animation/durations.go
@@ -1,0 +1,47 @@
+package animation
+
+import "time"
+
+// Canonical animation durations shared across the TUI. Keeping them together
+// provides consistent pacing wherever content appears, expands, hides, or
+// collapses.
+//
+// Medium transitions remain visible without feeling sluggish, while short
+// transitions keep dismissals responsive.
+const (
+	// MediumDuration is the canonical medium transition duration.
+	MediumDuration = 500 * time.Millisecond
+
+	// ShortDuration is the canonical short transition duration.
+	ShortDuration = 350 * time.Millisecond
+
+	// LoadingMinDuration is the minimum on-screen time for a loading
+	// placeholder before it can be replaced with real content. Together with
+	// MediumDuration and ShortDuration this ensures fast network responses still
+	// produce a visually-pleasant transition rather than a jarring flash.
+	LoadingMinDuration = 250 * time.Millisecond
+
+	// DefaultSpinnerFrameDuration is the fallback cadence for catalog spinners
+	// that do not need a specialized speed.
+	DefaultSpinnerFrameDuration = 100 * time.Millisecond
+
+	// ChatSpinnerFrameDuration is the default cadence for chat/tool activity
+	// spinners.
+	ChatSpinnerFrameDuration = 100 * time.Millisecond
+
+	// CardSpinnerFrameDuration is the default cadence for compact activity
+	// indicators.
+	CardSpinnerFrameDuration = 125 * time.Millisecond
+
+	// WaitingSpinnerFrameDuration is the default cadence for attention/waiting
+	// indicators.
+	WaitingSpinnerFrameDuration = 100 * time.Millisecond
+
+	// SpinnerLightStepDuration is the default cadence for the loading text
+	// highlight sweep in the reusable spinner component.
+	SpinnerLightStepDuration = 100 * time.Millisecond
+
+	// SpinnerLightPauseDuration is the default dwell before the loading text
+	// highlight reverses direction.
+	SpinnerLightPauseDuration = 600 * time.Millisecond
+)

--- a/pkg/tui/animation/spinners.go
+++ b/pkg/tui/animation/spinners.go
@@ -1,0 +1,74 @@
+package animation
+
+import (
+	"slices"
+	"time"
+)
+
+// Spinner is an ordered animation with a default wall-clock cadence.
+type Spinner struct {
+	frames        Frames
+	frameDuration time.Duration
+}
+
+// NewSpinner creates a duration-aware spinner from raw frames.
+func NewSpinner(frames Frames, frameDuration time.Duration) Spinner {
+	if frameDuration <= 0 {
+		frameDuration = DefaultSpinnerFrameDuration
+	}
+	return Spinner{frames: slices.Clone(frames), frameDuration: frameDuration}
+}
+
+func (s Spinner) FrameAt(elapsed time.Duration) string {
+	return s.frames.TimedFrame(elapsed, s.frameDuration)
+}
+
+func (s Spinner) FrameEveryAt(elapsed, frameDuration time.Duration) string {
+	return s.frames.TimedFrame(elapsed, frameDuration)
+}
+
+func (s Spinner) FrameIndexAt(elapsed time.Duration) int {
+	return s.frames.TimedFrameIndex(elapsed, s.frameDuration)
+}
+
+func (s Spinner) FrameIndexEveryAt(elapsed, frameDuration time.Duration) int {
+	return s.frames.TimedFrameIndex(elapsed, frameDuration)
+}
+
+func (s Spinner) StepAt(elapsed time.Duration) int { return TimedStep(elapsed, s.frameDuration) }
+func (s Spinner) StepEveryAt(elapsed, frameDuration time.Duration) int {
+	return TimedStep(elapsed, frameDuration)
+}
+func (s Spinner) Frames() Frames                      { return slices.Clone(s.frames) }
+func (s Spinner) DefaultFrameDuration() time.Duration { return s.frameDuration }
+func (s Spinner) Len() int                            { return len(s.frames) }
+
+var (
+	Chat    = NewSpinner(Frames{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}, ChatSpinnerFrameDuration)
+	TabBusy = NewSpinner(Frames{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}, CardSpinnerFrameDuration)
+	Card    = NewSpinner(Frames{"◓", "◑", "◒", "◐"}, CardSpinnerFrameDuration)
+)
+
+// Frames is an ordered set of spinner characters.
+type Frames []string
+
+func (f Frames) TimedFrame(elapsed, frameDuration time.Duration) string {
+	if len(f) == 0 {
+		return ""
+	}
+	return f[f.TimedFrameIndex(elapsed, frameDuration)]
+}
+
+func (f Frames) TimedFrameIndex(elapsed, frameDuration time.Duration) int {
+	if len(f) == 0 {
+		return 0
+	}
+	return TimedStep(elapsed, frameDuration) % len(f)
+}
+
+func TimedStep(elapsed, frameDuration time.Duration) int {
+	if frameDuration <= 0 {
+		frameDuration = DefaultSpinnerFrameDuration
+	}
+	return int(elapsed / frameDuration)
+}

--- a/pkg/tui/animation/subscription.go
+++ b/pkg/tui/animation/subscription.go
@@ -20,7 +20,36 @@ import tea "charm.land/bubbletea/v2"
 //	    m.animSub.Stop()
 //	}
 type Subscription struct {
-	active bool
+	active  bool
+	runtime *Runtime
+}
+
+// NewSubscription returns an inactive subscription owned by an animation runtime.
+func NewSubscription(runtime *Runtime) Subscription {
+	if runtime == nil {
+		panic("animation: nil runtime")
+	}
+	return Subscription{runtime: runtime}
+}
+
+// SetRuntime binds an inactive subscription to a program's animation runtime.
+func (s *Subscription) SetRuntime(runtime *Runtime) {
+	if runtime == nil {
+		panic("animation: nil runtime")
+	}
+	if s.active {
+		panic("animation: cannot rebind active subscription")
+	}
+	s.runtime = runtime
+}
+
+func (s *Subscription) boundRuntime() *Runtime {
+	if s.runtime == nil {
+		// Preserve zero-value Subscription behavior for components that have not
+		// yet adopted explicit program ownership.
+		return legacyRuntime
+	}
+	return s.runtime
 }
 
 // Start activates the subscription if not already active.
@@ -31,7 +60,10 @@ func (s *Subscription) Start() tea.Cmd {
 		return nil
 	}
 	s.active = true
-	return StartTickIfFirst()
+	if s.runtime == nil {
+		return legacyRuntime.legacyStart()
+	}
+	return s.runtime.start()
 }
 
 // Stop deactivates the subscription if currently active.
@@ -41,7 +73,7 @@ func (s *Subscription) Stop() {
 		return
 	}
 	s.active = false
-	Unregister()
+	s.boundRuntime().Unregister()
 }
 
 // IsActive returns whether the subscription is currently active.
@@ -52,6 +84,7 @@ func (s *Subscription) IsActive() bool {
 // Reset returns a new inactive subscription.
 // Useful when recreating a component that needs fresh animation state.
 func (s *Subscription) Reset() Subscription {
+	runtime := s.runtime
 	s.Stop()
-	return Subscription{}
+	return Subscription{runtime: runtime}
 }

--- a/pkg/tui/animation/testing.go
+++ b/pkg/tui/animation/testing.go
@@ -1,0 +1,42 @@
+package animation
+
+import (
+	"sync/atomic"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// TickCmdForTest returns an immediate current-generation tick command whose
+// accepted clock delta is deterministic. It is intended for event-loop tests
+// that must exercise Runtime.Accept without sleeping.
+func TickCmdForTest(runtime *Runtime, delta time.Duration) tea.Cmd {
+	runtime.mustExist()
+	runtime.mu.Lock()
+	if delta <= 0 {
+		delta = TickRate
+	}
+	runtime.tickScheduled = true
+	runtimeIdentity, generation := runtime.runtimeIdentity, runtime.generation
+	deliveredAt := runtime.lastDeliveredAt.Add(delta)
+	if runtime.lastDeliveredAt.IsZero() {
+		deliveredAt = time.Unix(1, 0).Add(delta)
+	}
+	timerStartedAt := deliveredAt.Add(-delta)
+	runtime.mu.Unlock()
+	return func() tea.Msg {
+		return TickMsg{runtimeIdentity: runtimeIdentity, generation: generation, deliveredAt: deliveredAt, timerStartedAt: timerStartedAt}
+	}
+}
+
+// TickMsgForTest creates a current-generation tick and advances the animation runtime's
+// elapsed clock for component tests that fan out an already-accepted tick.
+func TickMsgForTest(runtime *Runtime, elapsed time.Duration) TickMsg {
+	runtime.mustExist()
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	elapsedBeforeTick := runtime.elapsed
+	runtime.elapsed = elapsed
+	msg := TickMsg{runtimeIdentity: runtime.runtimeIdentity, generation: runtime.generation, dirty: &atomic.Bool{}, elapsedBeforeTick: elapsedBeforeTick, elapsedAfterTick: elapsed}
+	return msg
+}

--- a/pkg/tui/animation/transition.go
+++ b/pkg/tui/animation/transition.go
@@ -1,0 +1,199 @@
+package animation
+
+import (
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// Transition animates a value from 0 to 1 over an animation-clock duration
+// using an easing function. It integrates with the owning animation Runtime: starting
+// a transition registers an active animation, and finishing or cancelling it
+// unregisters.
+//
+// Usage:
+//
+//	var t animation.Transition
+//	cmd := t.Start(140*time.Millisecond, animation.EaseOutCubic)
+//
+//	// On each TickMsg:
+//	if t.Running() {
+//	    t.Tick()
+//	    v := t.Value()           // 0.0 → 1.0, eased
+//	    current := from + (to-from) * v
+//	}
+
+type Transition struct {
+	runtime   *Runtime
+	running   bool
+	startedAt time.Duration
+	elapsed   time.Duration
+	duration  time.Duration
+	easingFn  EasingFunc
+}
+
+// NewTransition returns an idle transition owned by an animation runtime.
+func NewTransition(runtime *Runtime) Transition {
+	if runtime == nil {
+		panic("animation: nil runtime")
+	}
+	return Transition{runtime: runtime}
+}
+
+// SetRuntime binds an idle transition to a program's animation runtime.
+func (tr *Transition) SetRuntime(runtime *Runtime) {
+	if runtime == nil {
+		panic("animation: nil runtime")
+	}
+	if tr.running {
+		panic("animation: cannot rebind running transition")
+	}
+	tr.runtime = runtime
+}
+
+func (tr *Transition) boundRuntime() *Runtime {
+	if tr.runtime == nil {
+		panic("animation: unbound Transition")
+	}
+	return tr.runtime
+}
+
+// EasingFunc maps a linear progress value in [0,1] to an eased value in [0,1].
+type EasingFunc func(t float64) float64
+
+// EaseOutCubic decelerates toward the end — fast start, slow finish.
+func EaseOutCubic(t float64) float64 {
+	t = 1 - t
+	return 1 - t*t*t
+}
+
+// EaseOutQuint decelerates more aggressively than cubic.
+func EaseOutQuint(t float64) float64 {
+	t = 1 - t
+	return 1 - t*t*t*t*t
+}
+
+// EaseInOutCubic accelerates then decelerates symmetrically.
+func EaseInOutCubic(t float64) float64 {
+	if t < 0.5 {
+		return 4 * t * t * t
+	}
+	t = -2*t + 2
+	return 1 - t*t*t/2
+}
+
+// Linear performs no easing — constant speed.
+func Linear(t float64) float64 {
+	return t
+}
+
+// Start begins the transition over the given duration using the provided easing
+// function. If a transition is already running it is replaced without
+// re-registering. Returns a command to start the tick chain when this is the
+// first registration.
+func (tr *Transition) Start(duration time.Duration, fn EasingFunc) tea.Cmd {
+	if duration <= 0 {
+		duration = time.Nanosecond
+	}
+	if fn == nil {
+		fn = Linear
+	}
+	wasRunning := tr.running
+	tr.running = true
+	tr.startedAt = tr.boundRuntime().Now()
+	tr.elapsed = 0
+	tr.duration = duration
+	tr.easingFn = fn
+	if !wasRunning {
+		return tr.boundRuntime().start()
+	}
+	return nil
+}
+
+// Tick samples the animation-runtime-owned clock. When the transition completes
+// it stops automatically and unregisters from the coordinator.
+func (tr *Transition) Tick() {
+	if !tr.running {
+		return
+	}
+	tr.elapsed = tr.currentElapsed()
+	if tr.elapsed >= tr.duration {
+		tr.elapsed = tr.duration
+		tr.running = false
+		tr.boundRuntime().Unregister()
+	}
+}
+
+// Cancel stops the transition immediately and unregisters from the
+// coordinator. Safe to call when not running.
+func (tr *Transition) Cancel() {
+	if !tr.running {
+		return
+	}
+	tr.running = false
+	tr.boundRuntime().Unregister()
+}
+
+// Running reports whether the transition is in progress.
+func (tr *Transition) Running() bool { return tr.running }
+
+// Elapsed returns the elapsed time within the transition.
+func (tr *Transition) Elapsed() time.Duration {
+	if tr.running {
+		return tr.currentElapsed()
+	}
+	return tr.elapsed
+}
+
+// Duration returns the configured transition duration.
+func (tr *Transition) Duration() time.Duration { return tr.duration }
+
+// Progress returns the linear progress in [0, 1].
+func (tr *Transition) Progress() float64 {
+	if tr.duration <= 0 {
+		return 0
+	}
+	linear := float64(tr.Elapsed()) / float64(tr.duration)
+	if linear >= 1 {
+		return 1
+	}
+	if linear < 0 {
+		return 0
+	}
+	return linear
+}
+
+func (tr *Transition) currentElapsed() time.Duration {
+	elapsed := tr.boundRuntime().Now() - tr.startedAt
+	if elapsed < 0 {
+		return 0
+	}
+	if tr.duration > 0 && elapsed > tr.duration {
+		return tr.duration
+	}
+	return elapsed
+}
+
+// Value returns the eased progress in [0, 1]. Returns 0 before Start,
+// and 1 after the transition completes.
+func (tr *Transition) Value() float64 {
+	linear := tr.Progress()
+	if tr.easingFn != nil {
+		return tr.easingFn(linear)
+	}
+	return linear
+}
+
+// Lerp returns the linearly-interpolated value between from and to at
+// the current eased progress: from + (to-from) * Value().
+func (tr *Transition) Lerp(from, to int) int {
+	v := tr.Value()
+	return from + round(float64(to-from)*v)
+}
+
+func round(f float64) int {
+	if f >= 0 {
+		return int(f + 0.5)
+	}
+	return -int(-f + 0.5)
+}

--- a/pkg/tui/animation/transition_test.go
+++ b/pkg/tui/animation/transition_test.go
@@ -1,0 +1,223 @@
+package animation
+
+import (
+	"testing"
+	"testing/synctest"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runTransitionSynctest(t *testing.T, f func(t *testing.T)) {
+	t.Helper()
+	synctest.Test(t, func(t *testing.T) {
+		f(t)
+	})
+}
+
+func tickTransition(t *testing.T, cmd *tea.Cmd, tr *Transition) {
+	t.Helper()
+	tickAnimationClock(t, cmd, tr)
+	tr.Tick()
+	*cmd = transitionRuntime(tr).Continue()
+}
+
+func tickAnimationClock(t *testing.T, cmd *tea.Cmd, tr *Transition) {
+	t.Helper()
+	require.NotNil(t, *cmd)
+	tick := runTick(t, func() any { return (*cmd)() })
+	_, ok := transitionRuntime(tr).Accept(tick)
+	require.True(t, ok)
+}
+
+func TestTransition_BasicLifecycle(t *testing.T) {
+	runTransitionSynctest(t, func(t *testing.T) {
+		t.Helper()
+		runtime := NewRuntime()
+		tr := runtime.Transition()
+
+		assert.False(t, tr.Running())
+		assert.InDelta(t, 0.0, tr.Value(), 1e-9)
+
+		cmd := tr.Start(10*TickRate, Linear)
+		assert.True(t, tr.Running())
+		assert.Equal(t, int32(1), runtime.ActiveCount())
+
+		for range 10 {
+			tickTransition(t, &cmd, &tr)
+		}
+
+		assert.False(t, tr.Running(), "should stop after all ticks")
+		assert.InDelta(t, 1.0, tr.Value(), 1e-9)
+		assert.Equal(t, int32(0), runtime.ActiveCount(), "should unregister on completion")
+	})
+}
+
+func TestTransition_Cancel(t *testing.T) {
+	runTransitionSynctest(t, func(t *testing.T) {
+		t.Helper()
+		runtime := NewRuntime()
+		tr := runtime.Transition()
+		cmd := tr.Start(20*TickRate, Linear)
+		require.True(t, tr.Running())
+
+		for range 5 {
+			tickTransition(t, &cmd, &tr)
+		}
+		tr.Cancel()
+
+		assert.False(t, tr.Running())
+		assert.Equal(t, int32(0), runtime.ActiveCount())
+	})
+}
+
+func TestTransition_CancelWhenNotRunning(t *testing.T) {
+	runTransitionSynctest(t, func(t *testing.T) {
+		t.Helper()
+		runtime := NewRuntime()
+		tr := runtime.Transition()
+		tr.Cancel()
+		assert.Equal(t, int32(0), runtime.ActiveCount())
+	})
+}
+
+func TestTransition_Restart(t *testing.T) {
+	runTransitionSynctest(t, func(t *testing.T) {
+		t.Helper()
+		runtime := NewRuntime()
+		tr := runtime.Transition()
+		cmd := tr.Start(10*TickRate, Linear)
+		for range 5 {
+			tickTransition(t, &cmd, &tr)
+		}
+
+		// Restart while running; this should not double-register.
+		restartCmd := tr.Start(10*TickRate, Linear)
+		assert.Nil(t, restartCmd)
+		assert.True(t, tr.Running())
+		assert.Equal(t, int32(1), runtime.ActiveCount())
+		assert.InDelta(t, 0.0, tr.Value(), 1e-9, "should reset to 0")
+	})
+}
+
+func TestTransition_Lerp(t *testing.T) {
+	runTransitionSynctest(t, func(t *testing.T) {
+		t.Helper()
+		runtime := NewRuntime()
+		tr := runtime.Transition()
+		cmd := tr.Start(4*TickRate, Linear)
+
+		assert.Equal(t, 0, tr.Lerp(0, 100))
+
+		tickTransition(t, &cmd, &tr)
+		assert.Equal(t, 25, tr.Lerp(0, 100))
+
+		tickTransition(t, &cmd, &tr)
+		assert.Equal(t, 50, tr.Lerp(0, 100))
+
+		tickTransition(t, &cmd, &tr)
+		assert.Equal(t, 75, tr.Lerp(0, 100))
+
+		tickTransition(t, &cmd, &tr)
+		assert.Equal(t, 100, tr.Lerp(0, 100))
+	})
+}
+
+func TestTransition_LerpReverse(t *testing.T) {
+	runTransitionSynctest(t, func(t *testing.T) {
+		t.Helper()
+		runtime := NewRuntime()
+		tr := runtime.Transition()
+		cmd := tr.Start(2*TickRate, Linear)
+
+		assert.Equal(t, 200, tr.Lerp(200, 0))
+
+		tickTransition(t, &cmd, &tr)
+		assert.Equal(t, 100, tr.Lerp(200, 0))
+
+		tickTransition(t, &cmd, &tr)
+		assert.Equal(t, 0, tr.Lerp(200, 0))
+	})
+}
+
+func TestEaseOutCubic_BoundsAndMonotonicity(t *testing.T) {
+	assert.InDelta(t, 0.0, EaseOutCubic(0), 1e-9)
+	assert.InDelta(t, 1.0, EaseOutCubic(1), 1e-9)
+
+	prev := 0.0
+	for i := 1; i <= 100; i++ {
+		v := EaseOutCubic(float64(i) / 100)
+		assert.GreaterOrEqual(t, v, prev, "must be monotonically increasing")
+		prev = v
+	}
+}
+
+func TestEaseOutCubic_FastStartSlowEnd(t *testing.T) {
+	firstHalf := EaseOutCubic(0.5)
+	// Ease-out covers more than half the distance in the first half of time.
+	assert.Greater(t, firstHalf, 0.5, "ease-out should cover >50%% in the first half")
+}
+
+func TestEaseOutQuint_BoundsAndMonotonicity(t *testing.T) {
+	assert.InDelta(t, 0.0, EaseOutQuint(0), 1e-9)
+	assert.InDelta(t, 1.0, EaseOutQuint(1), 1e-9)
+
+	prev := 0.0
+	for i := 1; i <= 100; i++ {
+		v := EaseOutQuint(float64(i) / 100)
+		assert.GreaterOrEqual(t, v, prev)
+		prev = v
+	}
+}
+
+func TestEaseInOutCubic_BoundsAndSymmetry(t *testing.T) {
+	assert.InDelta(t, 0.0, EaseInOutCubic(0), 1e-9)
+	assert.InDelta(t, 0.5, EaseInOutCubic(0.5), 1e-9)
+	assert.InDelta(t, 1.0, EaseInOutCubic(1), 1e-9)
+}
+
+func TestTransition_EaseOutCubic_Integration(t *testing.T) {
+	runTransitionSynctest(t, func(t *testing.T) {
+		t.Helper()
+		runtime := NewRuntime()
+		tr := runtime.Transition()
+		cmd := tr.Start(10*TickRate, EaseOutCubic)
+
+		// Values should increase monotonically and ease out.
+		prev := 0.0
+		for range 10 {
+			tickTransition(t, &cmd, &tr)
+			v := tr.Value()
+			assert.GreaterOrEqual(t, v, prev)
+			prev = v
+		}
+		assert.InDelta(t, 1.0, prev, 1e-9)
+	})
+}
+
+func TestTransition_TickWhenNotRunning(t *testing.T) {
+	runTransitionSynctest(t, func(t *testing.T) {
+		t.Helper()
+		runtime := NewRuntime()
+		tr := runtime.Transition()
+		tr.Tick()
+		assert.Equal(t, int32(0), runtime.ActiveCount())
+	})
+}
+
+func TestTransition_ZeroTicks(t *testing.T) {
+	runTransitionSynctest(t, func(t *testing.T) {
+		t.Helper()
+		runtime := NewRuntime()
+		tr := runtime.Transition()
+		cmd := tr.Start(0*TickRate, Linear)
+		assert.True(t, tr.Running())
+
+		tickTransition(t, &cmd, &tr)
+		assert.False(t, tr.Running())
+		assert.InDelta(t, 1.0, tr.Value(), 1e-9)
+	})
+}
+
+func transitionRuntime(tr *Transition) *Runtime { return tr.runtime }


### PR DESCRIPTION
First of many TUI improvement proposals :) 

This PR sets some animation-related foundations for enabling a better overall TUI UX where we can:
- centralize spinners, durations, transitions, effects, etc for easier re-use
- make time based animations and effects, so frame rate changes or system load doesn't affect how long animations run
- start introducing more advanced effects more easily and robustly, e.g. fades, transitions, etc
- improve TUI re-rendering logic to reduce cpu usage
- facilitate integration of docker agent components into other pre-existing TUIs

### Why

The current global coordinator advances animations by frame count and does not own queued ticks. Under event-loop delays, animations slow down; stale or duplicate tick chains also cannot be rejected cleanly.

### What changed

- Adds one program-owned animation runtime with a single shared tick lease.
- Rejects stale, duplicate, and foreign ticks; stopping invalidates queued work.
- Drives transitions and spinners from elapsed duration, so missed frames do not change animation speed.
- Preserves the package facade during partial migration: delivered legacy ticks re-arm without `Runtime.Accept`, and `IsCurrentGen` remains a side-effect-free generation check. This matches some consumer's direct use of `TickMsg`, `StartTick*`, `HasActive`, and `IsCurrentGen`.


Component adoption of the new infra is for later PRs. The legacy facade can be removed after components and consumers have migrated.


```mermaid
flowchart LR
    Root["TUI root"] --> AnimationRuntime["Program animation runtime"]
    AnimationRuntime -->|shared tick| Components
    Components -->|subscribe while active| AnimationRuntime
```

```mermaid
flowchart LR
    Delivery["Tick delivery"] --> Clock["Elapsed time"]
    Clock --> Transition["progress = elapsed / duration"]
    Clock --> Spinner["frame = elapsed / cadence"]
```
