### PR TITLE
fix(openai): deduplicate Copilot response text

### DIFF
--- a/pkg/model/provider/openai/response_stream.go
+++ b/pkg/model/provider/openai/response_stream.go
@@ -23,8 +23,20 @@ type ResponseStreamAdapter struct {
 	trackUsage     bool
 	itemCallIDMap  map[string]string
 	itemHasContent map[string]bool
-	itemHasArgs    map[string]bool
-	pendingArgs    map[string]string
+	// outputIndexHasContent mirrors itemHasContent keyed by output_index.
+	// The key identifies an output slot of the response, not a specific item:
+	// all events sharing an output_index belong to the same output whatever
+	// item IDs they carry, and distinct slots are deduplicated independently.
+	// Some providers (GitHub Copilot) use inconsistent item IDs across the
+	// events of a single output while output_index stays stable, so an
+	// ID-only lookup misses the streamed deltas and would re-emit the
+	// output_item.done snapshot, doubling the text. Only events that actually
+	// carry an output_index participate (checked via JSON metadata, since the
+	// scalar field cannot distinguish absent from a legitimate 0), so streams
+	// omitting it cannot collide on the zero value.
+	outputIndexHasContent map[int64]bool
+	itemHasArgs           map[string]bool
+	pendingArgs           map[string]string
 	// itemArgsFinal marks items whose complete final arguments were already
 	// received: emitted (function_call_arguments.done, output_item.done
 	// snapshot), buffered in pendingArgs, or streamed as deltas and confirmed
@@ -36,18 +48,35 @@ type ResponseStreamAdapter struct {
 
 func newResponseStreamAdapter(stream responseEventStream, trackUsage bool) *ResponseStreamAdapter {
 	return &ResponseStreamAdapter{
-		stream:         stream,
-		trackUsage:     trackUsage,
-		itemCallIDMap:  make(map[string]string),
-		itemHasContent: make(map[string]bool),
-		itemHasArgs:    make(map[string]bool),
-		pendingArgs:    make(map[string]string),
-		itemArgsFinal:  make(map[string]bool),
+		stream:                stream,
+		trackUsage:            trackUsage,
+		itemCallIDMap:         make(map[string]string),
+		itemHasContent:        make(map[string]bool),
+		outputIndexHasContent: make(map[int64]bool),
+		itemHasArgs:           make(map[string]bool),
+		pendingArgs:           make(map[string]string),
+		itemArgsFinal:         make(map[string]bool),
 	}
 }
 
 func isTextContentPart(partType string) bool {
 	return partType == "text" || partType == "output_text"
+}
+
+// markContentEmitted records that text was emitted for this output, keyed by
+// item ID and, when the event carries one, by output_index.
+func (a *ResponseStreamAdapter) markContentEmitted(event responses.ResponseStreamEventUnion, itemID string) {
+	a.itemHasContent[itemID] = true
+	if event.JSON.OutputIndex.Valid() {
+		a.outputIndexHasContent[event.OutputIndex] = true
+	}
+}
+
+// hasEmittedContent reports whether text for this output was already emitted,
+// matching by item ID or by output_index when the event carries one.
+func (a *ResponseStreamAdapter) hasEmittedContent(event responses.ResponseStreamEventUnion, itemID string) bool {
+	return a.itemHasContent[itemID] ||
+		(event.JSON.OutputIndex.Valid() && a.outputIndexHasContent[event.OutputIndex])
 }
 
 // Recv gets the next completion chunk
@@ -67,7 +96,7 @@ func (a *ResponseStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 	case "response.output_text.delta":
 		content := cmp.Or(event.Delta, event.Text)
 		if content != "" {
-			a.itemHasContent[event.ItemID] = true
+			a.markContentEmitted(event, event.ItemID)
 			response.Choices = []chat.MessageStreamChoice{
 				{
 					Delta: chat.MessageDelta{
@@ -94,7 +123,7 @@ func (a *ResponseStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 	case "response.content_part.delta":
 		content := cmp.Or(event.Delta, event.Text, event.Code, event.Part.Text)
 		if content != "" {
-			a.itemHasContent[event.ItemID] = true
+			a.markContentEmitted(event, event.ItemID)
 			response.Choices = []chat.MessageStreamChoice{
 				{
 					Delta: chat.MessageDelta{
@@ -276,8 +305,10 @@ func (a *ResponseStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 		// Don't set finish reason here - wait for response.completed.
 		// Just handle any missed content. Some Responses API transports omit
 		// the top-level item_id on output_item.done while still providing
-		// item.id, so use the resolved itemID for deduplication.
-		if event.Item.Type == "message" && !a.itemHasContent[itemID] {
+		// item.id, so use the resolved itemID for deduplication. Others
+		// (GitHub Copilot) use different item IDs for the deltas and the done
+		// event of the same output, so also match on output_index.
+		if event.Item.Type == "message" && !a.hasEmittedContent(event, itemID) {
 			for _, content := range event.Item.Content {
 				if isTextContentPart(content.Type) && content.Text != "" {
 					response.Choices = append(response.Choices, chat.MessageStreamChoice{
@@ -286,7 +317,7 @@ func (a *ResponseStreamAdapter) Recv() (chat.MessageStreamResponse, error) {
 							Role:    "assistant",
 						},
 					})
-					a.itemHasContent[itemID] = true
+					a.markContentEmitted(event, itemID)
 				}
 			}
 		}

--- a/pkg/model/provider/openai/response_stream_test.go
+++ b/pkg/model/provider/openai/response_stream_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/openai/openai-go/v3/responses"
@@ -96,6 +97,28 @@ func drainToolCalls(t *testing.T, adapter *ResponseStreamAdapter) (map[string]ac
 				call.args += tc.Function.Arguments
 				calls[tc.ID] = call
 			}
+		}
+	}
+}
+
+// drainContent runs the adapter to EOF and concatenates text deltas, exactly
+// as the runtime accumulates assistant content. Duplicated emissions
+// therefore show up as doubled text.
+func drainContent(t *testing.T, adapter *ResponseStreamAdapter) (string, chat.FinishReason) {
+	t.Helper()
+	var content strings.Builder
+	var finishReason chat.FinishReason
+	for {
+		resp, err := adapter.Recv()
+		if errors.Is(err, io.EOF) {
+			return content.String(), finishReason
+		}
+		require.NoError(t, err)
+		for _, choice := range resp.Choices {
+			if choice.FinishReason != "" {
+				finishReason = choice.FinishReason
+			}
+			content.WriteString(choice.Delta.Content)
 		}
 	}
 }
@@ -635,6 +658,153 @@ func TestResponseStream_FinalArgumentsBufferedBeforeOutputItemAdded(t *testing.T
 			assert.Equal(t, "shell", calls["call_1"].name)
 			assert.JSONEq(t, args, calls["call_1"].args)
 			assert.Equal(t, chat.FinishReasonToolCalls, finishReason)
+		})
+	}
+}
+
+// TestResponseStream_CopilotUnstableItemIDsOutputTextNotDuplicated is a
+// regression test for https://github.com/docker/docker-agent/issues/3839.
+//
+// GitHub Copilot (api_type=openai_responses) assigns inconsistent item IDs
+// within a single output: output_item.added, content_part.added, each
+// output_text.delta and output_item.done can all carry distinct IDs, while
+// output_index stays stable. Deduplication keyed on item IDs alone then
+// misses the streamed deltas and re-emits the output_item.done snapshot,
+// doubling structured output. The snapshot must still be emitted when no
+// deltas arrived at all: content_part.added stays structural and must not
+// count as emitted content. Tracking is per output_index slot: content
+// streamed for one output must not suppress the snapshot fallback of a
+// sibling output at another index.
+func TestResponseStream_CopilotUnstableItemIDsOutputTextNotDuplicated(t *testing.T) {
+	t.Parallel()
+
+	const text = `{"answer":"structured","confidence":0.9}`
+	const secondText = "A second, distinct message."
+
+	outputItemAdded := map[string]any{
+		"type":         "response.output_item.added",
+		"output_index": 0,
+		"item": map[string]any{
+			"type": "message",
+			"id":   "msg_A",
+			"role": "assistant",
+		},
+	}
+	contentPartAdded := map[string]any{
+		"type":          "response.content_part.added",
+		"item_id":       "msg_B",
+		"output_index":  0,
+		"content_index": 0,
+		"part": map[string]any{
+			"type": "output_text",
+			"text": text,
+		},
+	}
+	outputItemDone := map[string]any{
+		"type":         "response.output_item.done",
+		"output_index": 0,
+		"item": map[string]any{
+			"type": "message",
+			"id":   "msg_A",
+			"role": "assistant",
+			"content": []any{
+				map[string]any{"type": "output_text", "text": text},
+			},
+			"status": "completed",
+		},
+	}
+	completed := map[string]any{
+		"type": "response.completed",
+		"response": map[string]any{
+			"id":     "resp_copilot_ids",
+			"output": []any{},
+			"usage": map[string]any{
+				"input_tokens":          4,
+				"output_tokens":         4,
+				"total_tokens":          8,
+				"input_tokens_details":  map[string]any{"cached_tokens": 0},
+				"output_tokens_details": map[string]any{"reasoning_tokens": 0},
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		events      []map[string]any
+		wantContent string
+	}{
+		{
+			name: "deltas under a different item id are not re-emitted by the done snapshot",
+			events: []map[string]any{
+				outputItemAdded,
+				contentPartAdded,
+				{
+					"type":         "response.output_text.delta",
+					"item_id":      "msg_C",
+					"output_index": 0,
+					"delta":        `{"answer":"structured",`,
+				},
+				{
+					"type":         "response.output_text.delta",
+					"item_id":      "msg_C",
+					"output_index": 0,
+					"delta":        `"confidence":0.9}`,
+				},
+				outputItemDone,
+				completed,
+			},
+			wantContent: text,
+		},
+		{
+			name: "without deltas the done snapshot is still emitted once",
+			events: []map[string]any{
+				outputItemAdded,
+				contentPartAdded,
+				outputItemDone,
+				completed,
+			},
+			wantContent: text,
+		},
+		{
+			name: "streamed content at index 0 does not suppress the snapshot of a second output",
+			events: []map[string]any{
+				outputItemAdded,
+				contentPartAdded,
+				{
+					"type":         "response.output_text.delta",
+					"item_id":      "msg_C",
+					"output_index": 0,
+					"delta":        text,
+				},
+				outputItemDone,
+				{
+					"type":         "response.output_item.done",
+					"output_index": 1,
+					"item": map[string]any{
+						"type": "message",
+						"id":   "msg_D",
+						"role": "assistant",
+						"content": []any{
+							map[string]any{"type": "output_text", "text": secondText},
+						},
+						"status": "completed",
+					},
+				},
+				completed,
+			},
+			wantContent: text + secondText,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			adapter := newResponseStreamAdapter(&fakeEventStream{events: decodeEvents(t, tt.events)}, true)
+
+			content, finishReason := drainContent(t, adapter)
+			assert.Equal(t, tt.wantContent, content)
+			assert.Equal(t, chat.FinishReasonStop, finishReason)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- deduplicate GitHub Copilot Responses API text by stable `output_index` when event `item_id` values differ
- preserve the completed-item snapshot fallback when no text delta was received
- add regression coverage for duplicated structured output, missing deltas, and multiple output slots

## Issue expectations

| Expectation | Implementation |
|---|---|
| Responses from `github-copilot` are emitted once | Streamed content is tracked by both item ID and `output_index` |
| Judge output remains valid JSON | The completed item snapshot is not appended after its text deltas |
| Providers that omit text deltas still return content | `response.output_item.done` remains a fallback when no content was emitted |
| Multiple outputs remain independent | Content state is tracked separately for each `output_index` |

## Reproduction

Before the fix, the regression stream produced:

```text
{"answer":"structured","confidence":0.9}{"answer":"structured","confidence":0.9}
```

After the fix, it produces:

```text
{"answer":"structured","confidence":0.9}
```

## Validation

- `go test ./pkg/model/provider/openai -run TestResponseStream_CopilotUnstableItemIDsOutputTextNotDuplicated -count=20`
- `go test -race ./pkg/model/provider/openai -run TestResponseStream_CopilotUnstableItemIDsOutputTextNotDuplicated -count=1`
- `go test ./pkg/model/provider/openai -count=1`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy task test`
- `task --force lint`
- `task build`

Live verification against the affected `gpt-5.6-*` models was unavailable because the models are disabled for the available Copilot token and return `model_not_supported`. The regression test replays the observed Copilot event shape deterministically.

Fixes #3839
