### PR TITLE
fix(models): unify gateway model discovery

### DIFF
--- a/cmd/root/models.go
+++ b/cmd/root/models.go
@@ -21,6 +21,8 @@ import (
 	"github.com/docker/docker-agent/pkg/environment"
 	"github.com/docker/docker-agent/pkg/httpclient"
 	"github.com/docker/docker-agent/pkg/model/provider"
+	"github.com/docker/docker-agent/pkg/modelsdev"
+	"github.com/docker/docker-agent/pkg/modelsgateway"
 	"github.com/docker/docker-agent/pkg/telemetry"
 	"github.com/docker/docker-agent/pkg/userconfig"
 )
@@ -128,28 +130,10 @@ func (f *modelsListFlags) runModelsListCommand(cmd *cobra.Command, args []string
 	env := f.runConfig.EnvProvider()
 
 	// Normalize the provider filter to lowercase so case-sensitive map lookups
-	// in AvailableProviders, db.Providers and IsCatalogProvider all match the
-	// same way strings.EqualFold does in the outer row filter below.
+	// in db.Providers and IsCatalogProvider all match the same way
+	// strings.EqualFold does in the outer row filter below.
 	if f.providerFilter != "" {
 		f.providerFilter = strings.ToLower(f.providerFilter)
-	}
-
-	// Determine which providers the user has credentials for.
-	availableProviders := make(map[string]bool)
-	for _, p := range config.AvailableProviders(ctx, f.runConfig.ModelsGateway, env) {
-		availableProviders[p] = true
-	}
-
-	// User-defined custom providers are available when they need no API key
-	// or their token variable is set.
-	for name, p := range f.runConfig.Providers {
-		if p.TokenKey == "" {
-			availableProviders[strings.ToLower(name)] = true
-			continue
-		}
-		if token, _ := env.Get(ctx, p.TokenKey); token != "" {
-			availableProviders[strings.ToLower(name)] = true
-		}
 	}
 
 	// Determine which model auto-selection would pick. DMR discovery is left
@@ -158,7 +142,21 @@ func (f *modelsListFlags) runModelsListCommand(cmd *cobra.Command, args []string
 	// default rather than a locally-pulled DMR model.
 	autoModel := config.AutoModelConfig(ctx, f.runConfig.ModelsGateway, env, f.runConfig.DefaultModel, nil)
 
-	rows := f.collectModels(ctx, env, availableProviders, autoModel)
+	// When a models gateway is configured, the models it actually serves are
+	// authoritative. Discovery failures (or an unusable list) fall back to
+	// the non-gateway sources below.
+	var rows []modelRow
+	if f.runConfig.ModelsGateway != "" {
+		rows = f.collectGatewayModels(ctx, env, autoModel)
+	}
+	if rows == nil {
+		availableProviders := config.DiscoveryAvailableProviders(ctx, env)
+		// DMR needs no credentials.
+		availableProviders["dmr"] = true
+		maps.Copy(availableProviders, f.customProviderAvailability(ctx, env))
+
+		rows = f.collectModels(ctx, env, availableProviders, autoModel)
+	}
 
 	// Apply provider filter
 	if f.providerFilter != "" {
@@ -195,6 +193,80 @@ func (f *modelsListFlags) runModelsListCommand(cmd *cobra.Command, args []string
 	}
 
 	return nil
+}
+
+// collectGatewayModels queries the configured models gateway for the models
+// it actually serves and returns them as rows, plus any usable user-defined
+// custom providers (which serve their models from their own endpoints, not
+// through the gateway). It returns nil when discovery fails (endpoint
+// unsupported, unreachable, invalid response, missing Docker token, …) or
+// when normalization leaves no usable model, so the caller falls back to the
+// non-gateway sources.
+//
+// The gateway list replaces the static per-provider defaults and the
+// models.dev catalog: it must neither hide providers the gateway really
+// exposes nor invent models the gateway does not serve. The default marker
+// is only set when the auto-selected model's ref is genuinely in the list.
+func (f *modelsListFlags) collectGatewayModels(ctx context.Context, env environment.Provider, autoModel latest.ModelConfig) []modelRow {
+	ids, err := modelsgateway.ListModels(ctx, f.runConfig.ModelsGateway, env)
+	if err != nil {
+		slog.WarnContext(ctx, "models gateway discovery failed, falling back to directly configured providers",
+			"gateway", f.runConfig.ModelsGateway, "error", err)
+		return nil
+	}
+
+	refs := modelsgateway.NormalizeIDs(ctx, ids, f.catalogMetadataLookup())
+	if len(refs) == 0 {
+		slog.WarnContext(ctx, "models gateway served no usable model, falling back to directly configured providers",
+			"gateway", f.runConfig.ModelsGateway)
+		return nil
+	}
+
+	seen := make(map[string]bool, len(refs))
+	rows := make([]modelRow, 0, len(refs))
+	for _, ref := range refs {
+		seen[ref.String()] = true
+		rows = append(rows, modelRow{
+			Provider: ref.Provider,
+			Model:    ref.Model,
+			Default:  ref.Provider == autoModel.Provider && ref.Model == autoModel.Model,
+		})
+	}
+
+	return append(rows, f.collectCustomProviderModels(ctx, env, f.customProviderAvailability(ctx, env), seen)...)
+}
+
+// catalogMetadataLookup adapts the models.dev store into the metadata
+// callback NormalizeIDs uses to filter embedding and non-text models. It
+// returns nil (no metadata filtering) when the store is unavailable.
+func (f *modelsListFlags) catalogMetadataLookup() modelsgateway.MetadataFunc {
+	store, err := f.runConfig.ModelsDevStore()
+	if err != nil {
+		return nil
+	}
+	return func(ctx context.Context, providerID, modelID string) (modelsgateway.Metadata, bool) {
+		m, err := store.GetModel(ctx, modelsdev.NewID(providerID, modelID))
+		if err != nil {
+			return modelsgateway.Metadata{}, false
+		}
+		return modelsgateway.Metadata{Family: m.Family, OutputModalities: m.Modalities.Output}, true
+	}
+}
+
+// customProviderAvailability reports which user-defined custom providers are
+// usable: those that need no API key or whose token variable is set.
+func (f *modelsListFlags) customProviderAvailability(ctx context.Context, env environment.Provider) map[string]bool {
+	available := make(map[string]bool, len(f.runConfig.Providers))
+	for name, p := range f.runConfig.Providers {
+		if p.TokenKey == "" {
+			available[strings.ToLower(name)] = true
+			continue
+		}
+		if token, _ := env.Get(ctx, p.TokenKey); token != "" {
+			available[strings.ToLower(name)] = true
+		}
+	}
+	return available
 }
 
 // collectModels returns all models from the catalog, filtered by credential

--- a/cmd/root/models_test.go
+++ b/cmd/root/models_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -446,4 +448,371 @@ func TestModelsListCommand_CustomProviderWithoutCredentials(t *testing.T) {
 
 	require.NoError(t, cmd.Execute())
 	assert.Contains(t, buf.String(), "corp-model-a")
+}
+
+// TestModelsListCommand_GatewayListsServedModels pins the models-gateway
+// regression: with --models-gateway set, `docker agent models` must query the
+// gateway's /v1/models endpoint and list the models it serves, instead of
+// showing only the static anthropic defaults.
+func TestModelsListCommand_GatewayListsServedModels(t *testing.T) {
+	t.Parallel()
+
+	var gatewayQueried atomic.Bool
+	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			http.NotFound(w, r)
+			return
+		}
+		gatewayQueried.Store(true)
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"object":"list","data":[
+			{"id":"anthropic/mock-claude"},
+			{"id":"google/mock-gemini"},
+			{"id":"openai/mock-gpt"}
+		]}`))
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(gateway.Close)
+
+	var buf bytes.Buffer
+	cmd := newModelsCmd(
+		// httptest binds to 127.0.0.1, which IsTrustedDockerURL treats as
+		// trusted, so gateway discovery authenticates with the Docker Desktop
+		// token; provide it through the hermetic env provider.
+		withTestConfig(map[string]string{environment.DockerDesktopTokenEnv: "test-docker-token"}),
+		// A non-nil empty providers map keeps the gateway pre-run from
+		// loading custom providers out of the developer's real user config.
+		withProviders(map[string]latest.ProviderConfig{}),
+	)
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--models-gateway", gateway.URL, "--format", "json"})
+
+	require.NoError(t, cmd.Execute())
+
+	var rows []modelRow
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &rows))
+
+	refs := make([]string, 0, len(rows))
+	for _, r := range rows {
+		refs = append(refs, r.Provider+"/"+r.Model)
+	}
+
+	assert.True(t, gatewayQueried.Load(), "the command must query the gateway's /v1/models endpoint")
+	assert.Contains(t, refs, "anthropic/mock-claude")
+	assert.Contains(t, refs, "google/mock-gemini")
+	assert.Contains(t, refs, "openai/mock-gpt")
+}
+
+// withCatalog overrides the in-memory models.dev catalog injected by
+// withTestConfig; it must come after withTestConfig in the options list.
+func withCatalog(db *modelsdev.Database) modelsCmdOption {
+	return func(rc *config.RuntimeConfig) {
+		rc.ModelsDevStoreOverride = modelsdev.NewDatabaseStore(db)
+	}
+}
+
+// newGatewayServer serves the given OpenAI-style body on /v1/models and
+// records the Authorization header of the last request.
+func newGatewayServer(t *testing.T, body string) (*httptest.Server, *atomic.Value) {
+	t.Helper()
+
+	var lastAuth atomic.Value
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			http.NotFound(w, r)
+			return
+		}
+		lastAuth.Store(r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(body))
+		assert.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+	return server, &lastAuth
+}
+
+// gatewayTestEnv is the hermetic env for gateway tests: httptest binds to
+// 127.0.0.1, which IsTrustedDockerURL treats as trusted, so discovery
+// requires the Docker Desktop token.
+func gatewayTestEnv(extra map[string]string) map[string]string {
+	env := map[string]string{environment.DockerDesktopTokenEnv: "test-docker-token"}
+	maps.Copy(env, extra)
+	return env
+}
+
+func TestModelsListCommand_GatewayProviderFilter(t *testing.T) {
+	t.Parallel()
+
+	gateway, lastAuth := newGatewayServer(t, `{"object":"list","data":[
+		{"id":"anthropic/mock-claude"},
+		{"id":"google/mock-gemini"},
+		{"id":"openai/mock-gpt"}
+	]}`)
+
+	var buf bytes.Buffer
+	cmd := newModelsCmd(
+		withTestConfig(gatewayTestEnv(nil)),
+		withProviders(map[string]latest.ProviderConfig{}),
+	)
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--models-gateway", gateway.URL, "--provider", "google", "--format", "json"})
+
+	require.NoError(t, cmd.Execute())
+
+	var rows []modelRow
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &rows))
+
+	require.Len(t, rows, 1, "--provider must filter the live gateway results")
+	assert.Equal(t, "google", rows[0].Provider)
+	assert.Equal(t, "mock-gemini", rows[0].Model)
+	assert.Equal(t, "Bearer test-docker-token", lastAuth.Load(), "a trusted Docker gateway must be queried with the Docker token")
+}
+
+// TestModelsListCommand_GatewayNormalizesAndSorts covers the full live
+// normalization matrix in one deterministic listing: dedup, bare-ID routing,
+// embedding filtering (by ID and by catalog family), non-text filtering by
+// catalog modalities, the default marker on a genuinely served ref, and the
+// deterministic JSON order.
+func TestModelsListCommand_GatewayNormalizesAndSorts(t *testing.T) {
+	t.Parallel()
+
+	gateway, _ := newGatewayServer(t, `{"object":"list","data":[
+		{"id":"openai/mock-b"},
+		{"id":"openai/mock-b"},
+		{"id":"anthropic/claude-sonnet-4-6"},
+		{"id":"openai/text-embedding-3"},
+		{"id":"google/vector-model"},
+		{"id":"openai/image-only"},
+		{"id":"bare-model"},
+		{"id":"openai/mock-a"}
+	]}`)
+
+	var buf bytes.Buffer
+	cmd := newModelsCmd(
+		withTestConfig(gatewayTestEnv(nil)),
+		withProviders(map[string]latest.ProviderConfig{}),
+		withCatalog(&modelsdev.Database{Providers: map[string]modelsdev.Provider{
+			// vector-model has no "embed" in its ID; only the catalog family
+			// identifies it. image-only is excluded by output modalities.
+			"google": {Models: map[string]modelsdev.Model{
+				"vector-model": {Name: "Vector", Family: "text-embedding"},
+			}},
+			"openai": {Models: map[string]modelsdev.Model{
+				"image-only": {Name: "Image Only", Modalities: modelsdev.Modalities{Output: []string{"image"}}},
+			}},
+		}}),
+	)
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--models-gateway", gateway.URL, "--format", "json"})
+
+	require.NoError(t, cmd.Execute())
+
+	var rows []modelRow
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &rows))
+
+	// anthropic/claude-sonnet-4-6 is the gateway auto-selection default and
+	// is genuinely served, so it is marked and sorted first.
+	assert.Equal(t, []modelRow{
+		{Provider: "anthropic", Model: "claude-sonnet-4-6", Default: true},
+		{Provider: "openai", Model: "bare-model"},
+		{Provider: "openai", Model: "mock-a"},
+		{Provider: "openai", Model: "mock-b"},
+	}, rows)
+}
+
+func TestModelsListCommand_GatewayNoFakeDefault(t *testing.T) {
+	t.Parallel()
+
+	gateway, _ := newGatewayServer(t, `{"object":"list","data":[{"id":"openai/mock-gpt"}]}`)
+
+	var buf bytes.Buffer
+	cmd := newModelsCmd(
+		withTestConfig(gatewayTestEnv(nil)),
+		withProviders(map[string]latest.ProviderConfig{}),
+	)
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--models-gateway", gateway.URL, "--format", "json"})
+
+	require.NoError(t, cmd.Execute())
+
+	var rows []modelRow
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &rows))
+
+	require.Equal(t, []modelRow{{Provider: "openai", Model: "mock-gpt"}}, rows,
+		"no fake gateway model may be added just to mark the default")
+}
+
+func TestModelsListCommand_GatewayKeepsCustomProviders(t *testing.T) {
+	t.Parallel()
+
+	gateway, _ := newGatewayServer(t, `{"object":"list","data":[{"id":"openai/mock-gpt"}]}`)
+	custom, _ := newCustomProviderServer(t, []string{"corp-model-a"})
+
+	var buf bytes.Buffer
+	cmd := newModelsCmd(
+		// The direct anthropic credential must not re-introduce the static
+		// defaults/catalog: the live gateway list replaces them.
+		withTestConfig(gatewayTestEnv(map[string]string{"ANTHROPIC_API_KEY": "test-key"})),
+		withProviders(map[string]latest.ProviderConfig{
+			"myprovider": {BaseURL: custom.URL},
+		}),
+	)
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--models-gateway", gateway.URL, "--format", "json"})
+
+	require.NoError(t, cmd.Execute())
+
+	var rows []modelRow
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &rows))
+
+	refs := make([]string, 0, len(rows))
+	for _, r := range rows {
+		refs = append(refs, r.Provider+"/"+r.Model)
+	}
+
+	assert.Contains(t, refs, "openai/mock-gpt")
+	assert.Contains(t, refs, "myprovider/corp-model-a", "custom providers serve their own endpoints and stay listed")
+	assert.NotContains(t, refs, "anthropic/claude-sonnet-4-6", "live gateway results replace the static defaults")
+	assert.NotContains(t, refs, "anthropic/"+catalogOnlyModel, "live gateway results replace the catalog")
+}
+
+// TestModelsListCommand_GatewayFallback verifies that every gateway discovery
+// failure mode falls back to the directly configured sources: the anthropic
+// default (direct API key), the injected catalog, and a usable custom
+// provider all remain listed, so one failing source never empties the others.
+func TestModelsListCommand_GatewayFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		handler        http.HandlerFunc
+		env            map[string]string
+		wantNotQueried bool
+	}{
+		{
+			name:    "endpoint not found",
+			handler: http.NotFound,
+			env:     gatewayTestEnv(map[string]string{"ANTHROPIC_API_KEY": "test-key"}),
+		},
+		{
+			name: "empty list",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+			},
+			env: gatewayTestEnv(map[string]string{"ANTHROPIC_API_KEY": "test-key"}),
+		},
+		{
+			name: "invalid JSON",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(`<html>not json</html>`))
+			},
+			env: gatewayTestEnv(map[string]string{"ANTHROPIC_API_KEY": "test-key"}),
+		},
+		{
+			// httptest is localhost, hence Docker-trusted: without the token
+			// the live request must not even be attempted, but the auth
+			// failure must not remove directly usable providers.
+			name: "missing Docker token",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"openai/mock-gpt"}]}`))
+			},
+			env:            map[string]string{"ANTHROPIC_API_KEY": "test-key"},
+			wantNotQueried: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var queried atomic.Bool
+			gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				queried.Store(true)
+				tt.handler(w, r)
+			}))
+			t.Cleanup(gateway.Close)
+
+			custom, _ := newCustomProviderServer(t, []string{"corp-model-a"})
+
+			var buf bytes.Buffer
+			cmd := newModelsCmd(
+				withTestConfig(tt.env),
+				withProviders(map[string]latest.ProviderConfig{
+					"myprovider": {BaseURL: custom.URL},
+				}),
+			)
+			cmd.SetOut(&buf)
+			cmd.SetErr(&buf)
+			cmd.SetArgs([]string{"--models-gateway", gateway.URL})
+
+			require.NoError(t, cmd.Execute())
+
+			output := buf.String()
+			assert.Contains(t, output, "claude-sonnet-4-6", "the direct anthropic provider must survive the gateway failure")
+			assert.Contains(t, output, catalogOnlyModel, "the catalog fallback must be read")
+			assert.Contains(t, output, "corp-model-a", "a usable custom provider must survive the gateway failure")
+			if tt.wantNotQueried {
+				assert.False(t, queried.Load(), "a trusted Docker gateway must not be queried without the Docker token")
+			}
+		})
+	}
+}
+
+func TestModelsListCommand_GatewayTimeoutFallsBack(t *testing.T) {
+	t.Parallel()
+
+	gateway := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		// Hold the response until the client gives up so the caller's short
+		// deadline, not the 5s discovery budget, decides the wait.
+		<-r.Context().Done()
+	}))
+	t.Cleanup(gateway.Close)
+
+	var buf bytes.Buffer
+	cmd := newModelsCmd(
+		withTestConfig(gatewayTestEnv(map[string]string{"ANTHROPIC_API_KEY": "test-key"})),
+		withProviders(map[string]latest.ProviderConfig{}),
+	)
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--models-gateway", gateway.URL})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+	cmd.SetContext(ctx)
+
+	start := time.Now()
+	require.NoError(t, cmd.Execute())
+
+	assert.Less(t, time.Since(start), 3*time.Second, "the caller deadline must win over the 5s discovery budget")
+	output := buf.String()
+	assert.Contains(t, output, "claude-sonnet-4-6", "the direct anthropic provider must survive the gateway timeout")
+	assert.Contains(t, output, catalogOnlyModel, "the in-memory catalog fallback must be read")
+}
+
+func TestModelsListCommand_AliasCredentialsListAliasModels(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	cmd := newModelsCmd(
+		withTestConfig(map[string]string{"XAI_API_KEY": "xai-test"}),
+		withProviders(map[string]latest.ProviderConfig{}),
+		withCatalog(&modelsdev.Database{Providers: map[string]modelsdev.Provider{
+			"xai": {Models: map[string]modelsdev.Model{
+				"grok-4": {Name: "Grok 4", Modalities: modelsdev.Modalities{Output: []string{"text"}}},
+			}},
+		}}),
+	)
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(nil)
+
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, buf.String(), "grok-4", "an alias credential must surface the alias's catalog models without --all")
 }

--- a/docs/features/cli/index.md
+++ b/docs/features/cli/index.md
@@ -210,6 +210,8 @@ $ docker agent models --provider openai
 $ docker agent models --format json | jq
 ```
 
+When a models gateway is configured (`--models-gateway`, `DOCKER_AGENT_MODELS_GATEWAY`, or the user config), the command first queries the gateway's `/v1/models` endpoint. A non-empty response is authoritative for the models routed through the gateway: the listing shows the models the gateway serves (`--provider` filters within it), alongside any custom providers you have configured, which serve their models from their own endpoints rather than through the gateway. If the gateway cannot be queried or serves no usable model (endpoint not implemented, empty list, invalid response, timeout, missing authentication), the command falls back to the providers you have configured directly — provider API keys, provider aliases, and custom providers — plus the model catalog; a failure of one source never prevents the others from being listed. The Docker Desktop token is only sent (and required) when the gateway targets a trusted Docker URL.
+
 ### `docker agent toolsets`
 
 List the built-in toolset types available for use in an agent configuration. Each type can be referenced under `toolsets:` in an agent YAML file. Use this to discover what's available without leaving the terminal.

--- a/pkg/config/discovery.go
+++ b/pkg/config/discovery.go
@@ -1,0 +1,137 @@
+package config
+
+import (
+	"context"
+	"sync"
+
+	"github.com/docker/docker-agent/pkg/concurrent"
+	"github.com/docker/docker-agent/pkg/environment"
+	"github.com/docker/docker-agent/pkg/model/provider"
+)
+
+// bedrockCredentialIndicators are quick heuristics for AWS credentials, which
+// can come from many sources:
+//   - AWS_ACCESS_KEY_ID: explicit access key
+//   - AWS_PROFILE / AWS_DEFAULT_PROFILE: named profile (credentials in ~/.aws/)
+//   - AWS_WEB_IDENTITY_TOKEN_FILE: EKS/IRSA web identity
+//   - AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: ECS task role
+//   - AWS_ROLE_ARN: assumed role
+//
+// This won't catch all cases (e.g. EC2 instance profiles, SSO) but those
+// require network calls which would block interactive listings.
+var bedrockCredentialIndicators = []string{
+	"AWS_ACCESS_KEY_ID",
+	"AWS_PROFILE",
+	"AWS_DEFAULT_PROFILE",
+	"AWS_WEB_IDENTITY_TOKEN_FILE",
+	"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+	"AWS_ROLE_ARN",
+}
+
+// DiscoveryAvailableProviders reports which providers are directly usable
+// from local credentials, for model discovery/listing purposes only. Unlike
+// [AvailableProviders] — which drives auto model selection and applies a
+// gateway-specific default — it deliberately ignores any configured models
+// gateway: it backs the fallback taken by `docker agent models` and the
+// runtime model picker when gateway discovery fails or none is configured,
+// so a gateway must neither suppress directly-configured providers nor
+// require a Docker token.
+//
+// A provider is available when one of its known credential env vars is set
+// (the same detection table auto-selection uses), or when it is a provider
+// alias whose token variable is set and whose (possibly templated) base URL
+// resolves from the environment. Local providers that need no credentials
+// (DMR, ollama) are left to the caller, as is any config-derived
+// availability (e.g. non-API-key auth schemes).
+func DiscoveryAvailableProviders(ctx context.Context, env environment.Provider) map[string]bool {
+	names := make([]string, 0, 64)
+	for _, p := range cloudProviders {
+		names = append(names, p.envVars...)
+	}
+	names = append(names, bedrockCredentialIndicators...)
+	for _, alias := range provider.EachAlias() {
+		if alias.TokenEnvVar != "" {
+			names = append(names, alias.TokenEnvVar)
+		}
+		// A templated base URL (e.g. Cloudflare's account/gateway-scoped
+		// endpoint) also needs the vars it references.
+		names = append(names, environment.Refs(alias.BaseURL)...)
+	}
+
+	values := lookupEnvironmentValues(ctx, env, names)
+
+	available := make(map[string]bool)
+	for _, p := range cloudProviders {
+		for _, envVar := range p.envVars {
+			if values[envVar] != "" {
+				available[p.name] = true
+				break
+			}
+		}
+	}
+
+	for name, alias := range provider.EachAlias() {
+		if alias.TokenEnvVar == "" || values[alias.TokenEnvVar] == "" {
+			continue
+		}
+		// Without the vars its base URL references the alias resolves to a
+		// broken URL, so don't advertise it (mirrors the preflight check in
+		// gather).
+		if !aliasBaseURLResolves(alias.BaseURL, values) {
+			continue
+		}
+		available[name] = true
+	}
+
+	for _, indicator := range bedrockCredentialIndicators {
+		if values[indicator] != "" {
+			available["amazon-bedrock"] = true
+			break
+		}
+	}
+
+	return available
+}
+
+// aliasBaseURLResolves reports whether every environment variable referenced
+// by a (possibly templated) alias base URL was resolved to a non-empty value.
+func aliasBaseURLResolves(baseURL string, values map[string]string) bool {
+	for _, name := range environment.Refs(baseURL) {
+		if values[name] == "" {
+			return false
+		}
+	}
+	return true
+}
+
+// lookupEnvironmentValues resolves the named variables concurrently: env
+// provider chains may consult slow sources (Docker Desktop, secret helpers),
+// so sequential lookups would make listings noticeably laggy. Unset or empty
+// variables are omitted from the result.
+func lookupEnvironmentValues(ctx context.Context, env environment.Provider, names []string) map[string]string {
+	values := concurrent.NewMap[string, string]()
+	unique := make(map[string]struct{}, len(names))
+	var wg sync.WaitGroup
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		if _, ok := unique[name]; ok {
+			continue
+		}
+		unique[name] = struct{}{}
+		wg.Go(func() {
+			if value, _ := env.Get(ctx, name); value != "" {
+				values.Store(name, value)
+			}
+		})
+	}
+	wg.Wait()
+
+	result := make(map[string]string, values.Length())
+	values.Range(func(name, value string) bool {
+		result[name] = value
+		return true
+	})
+	return result
+}

--- a/pkg/config/discovery_test.go
+++ b/pkg/config/discovery_test.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/docker/docker-agent/pkg/environment"
+)
+
+func TestDiscoveryAvailableProviders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		envVars     map[string]string
+		wantPresent []string
+		wantAbsent  []string
+	}{
+		{
+			name:       "no credentials",
+			envVars:    map[string]string{},
+			wantAbsent: []string{"openai", "anthropic", "xai", "dmr", "ollama"},
+		},
+		{
+			name:        "core provider keys",
+			envVars:     map[string]string{"OPENAI_API_KEY": "sk-test", "ANTHROPIC_API_KEY": "sk-ant"},
+			wantPresent: []string{"openai", "anthropic"},
+			wantAbsent:  []string{"google", "xai"},
+		},
+		{
+			name:        "google via GEMINI_API_KEY",
+			envVars:     map[string]string{"GEMINI_API_KEY": "gm-test"},
+			wantPresent: []string{"google"},
+		},
+		{
+			name:        "alias token surfaces the alias",
+			envVars:     map[string]string{"XAI_API_KEY": "xai-test"},
+			wantPresent: []string{"xai"},
+			wantAbsent:  []string{"openai"},
+		},
+		{
+			// A Docker token alone must not surface any provider: gateway
+			// availability is decided by live discovery, not by this helper.
+			name:       "docker token alone surfaces nothing",
+			envVars:    map[string]string{environment.DockerDesktopTokenEnv: "test-token"},
+			wantAbsent: []string{"openai", "anthropic", "google", "mistral", "xai"},
+		},
+		{
+			name:        "templated alias needs its URL vars",
+			envVars:     map[string]string{"CLOUDFLARE_API_TOKEN": "cf-test"},
+			wantAbsent:  []string{"cloudflare-workers-ai", "cloudflare-ai-gateway"},
+			wantPresent: []string{},
+		},
+		{
+			name: "templated alias with resolvable URL",
+			envVars: map[string]string{
+				"CLOUDFLARE_API_TOKEN":  "cf-test",
+				"CLOUDFLARE_ACCOUNT_ID": "acc-123",
+			},
+			wantPresent: []string{"cloudflare-workers-ai"},
+			wantAbsent:  []string{"cloudflare-ai-gateway"},
+		},
+		{
+			name:        "bedrock via AWS indicator",
+			envVars:     map[string]string{"AWS_WEB_IDENTITY_TOKEN_FILE": "/var/run/secrets/token"},
+			wantPresent: []string{"amazon-bedrock"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := DiscoveryAvailableProviders(t.Context(), environment.NewMapEnvProvider(tt.envVars))
+
+			for _, want := range tt.wantPresent {
+				assert.True(t, got[want], "expected provider %s to be available", want)
+			}
+			for _, absent := range tt.wantAbsent {
+				assert.False(t, got[absent], "expected provider %s to NOT be available", absent)
+			}
+		})
+	}
+}

--- a/pkg/modelsgateway/discovery.go
+++ b/pkg/modelsgateway/discovery.go
@@ -5,7 +5,6 @@ package modelsgateway
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -39,6 +38,13 @@ type listResponse struct {
 // that isn't a valid OpenAI-style model list. Callers are expected to fall
 // back to their non-discovery behavior in that case.
 func ListModels(ctx context.Context, gatewayURL string, env environment.Provider) ([]string, error) {
+	return listModelsWith(ctx, gatewayURL, env, nil)
+}
+
+// listModelsWith is ListModels with an injectable HTTP client. A nil client
+// uses the standard instrumented client; tests inject one to reach a
+// non-trusted hostname without touching the network.
+func listModelsWith(ctx context.Context, gatewayURL string, env environment.Provider, client *http.Client) ([]string, error) {
 	u, err := url.Parse(gatewayURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid gateway URL: %w", err)
@@ -57,15 +63,18 @@ func ListModels(ctx context.Context, gatewayURL string, env environment.Provider
 		return nil, err
 	}
 
-	if environment.IsTrustedDockerURL(gatewayURL) {
-		token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv)
-		if token == "" {
-			return nil, errors.New(base.NoDesktopTokenErrorMessage)
-		}
+	token, err := base.GatewayAuthToken(ctx, env, gatewayURL)
+	if err != nil {
+		return nil, err
+	}
+	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
-	resp, err := httpclient.NewHTTPClient(ctx).Do(req)
+	if client == nil {
+		client = httpclient.NewHTTPClient(ctx)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("querying gateway models: %w", err)
 	}

--- a/pkg/modelsgateway/discovery_test.go
+++ b/pkg/modelsgateway/discovery_test.go
@@ -1,9 +1,11 @@
 package modelsgateway
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -130,4 +132,57 @@ func TestListModels_InvalidURL(t *testing.T) {
 	_, err := ListModels(t.Context(), "http://[::1", tokenEnv())
 
 	require.Error(t, err)
+}
+
+// hostRewriteTransport redirects every request to a local test server,
+// letting tests exercise non-trusted hostnames without touching the network.
+type hostRewriteTransport struct {
+	host string
+}
+
+func (t hostRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	r2 := req.Clone(req.Context())
+	r2.URL.Scheme = "http"
+	r2.URL.Host = t.host
+	return http.DefaultTransport.RoundTrip(r2)
+}
+
+func TestListModels_GenericGatewayNeedsNoDockerToken(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"data":[{"id":"gpt-4o"}]}`))
+	}))
+	defer server.Close()
+
+	// models.example.com is not a trusted Docker URL, so discovery must
+	// neither require the Docker token nor send any Authorization header.
+	client := &http.Client{Transport: hostRewriteTransport{host: server.Listener.Addr().String()}}
+	ids, err := listModelsWith(t.Context(), "https://models.example.com", environment.NewMapEnvProvider(nil), client)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"gpt-4o"}, ids)
+	assert.Empty(t, gotAuth, "a generic gateway must not receive the Docker token")
+}
+
+func TestListModels_CallerContextDeadlineWins(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		// Hold the response until the client gives up, so the test measures
+		// which deadline fires without leaving a stuck handler behind.
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := ListModels(ctx, server.URL, tokenEnv())
+
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), listTimeout, "a caller deadline shorter than the internal timeout must win")
 }

--- a/pkg/modelsgateway/normalize.go
+++ b/pkg/modelsgateway/normalize.go
@@ -1,0 +1,99 @@
+package modelsgateway
+
+import (
+	"context"
+	"slices"
+	"strings"
+)
+
+// Ref is a normalized provider/model reference served by a models gateway.
+// It is deliberately a small neutral type so both the runtime (ModelChoice)
+// and the CLI (modelRow) can adapt it without depending on each other.
+type Ref struct {
+	Provider string
+	Model    string
+}
+
+// String renders the reference in the "provider/model" form used across
+// the codebase.
+func (r Ref) String() string { return r.Provider + "/" + r.Model }
+
+// Metadata is the subset of catalog information NormalizeIDs consults to
+// filter out models unsuitable for chat.
+type Metadata struct {
+	// Family is the model family from the catalog (e.g. "text-embedding").
+	Family string
+	// OutputModalities lists the output modalities the catalog declares.
+	OutputModalities []string
+}
+
+// MetadataFunc looks up catalog metadata for a provider/model pair. It
+// returns ok=false when the model is unknown to the catalog, in which case
+// NormalizeIDs keeps the model (no signal to exclude it). Callers typically
+// back it with a models.dev store; a nil MetadataFunc skips metadata-based
+// filtering entirely.
+type MetadataFunc func(ctx context.Context, provider, model string) (Metadata, bool)
+
+// NormalizeIDs transforms the raw model IDs returned by a gateway's
+// /v1/models endpoint into provider/model references:
+//
+//   - IDs already prefixed with a provider ("anthropic/claude-x") keep it;
+//     bare IDs are routed through the openai provider, matching how the
+//     gateway serves them over its OpenAI-compatible endpoint.
+//   - Providers are lowercased ("OpenAI/gpt-4o" → "openai/gpt-4o") so a
+//     gateway's casing matches the canonical provider IDs used for catalog
+//     lookups and deduplication; the model part keeps its case.
+//   - Malformed references (empty provider or model) are dropped.
+//   - Embedding models are excluded, identified by the model ID or by the
+//     catalog family when metadata is available.
+//   - Models whose catalog metadata declares output modalities without
+//     "text" are excluded (not suitable for chat); models without metadata
+//     or without declared modalities are kept.
+//   - Duplicates are removed; the first occurrence wins, so the result
+//     order deterministically follows the gateway's order.
+func NormalizeIDs(ctx context.Context, ids []string, lookup MetadataFunc) []Ref {
+	seen := make(map[string]bool, len(ids))
+	refs := make([]Ref, 0, len(ids))
+
+	for _, id := range ids {
+		prov, model, ok := strings.Cut(id, "/")
+		if !ok {
+			prov, model = "openai", id
+		}
+		prov = strings.ToLower(prov)
+		if prov == "" || model == "" {
+			continue
+		}
+
+		// Resolve catalog metadata before the embedding filter so the
+		// catalog family (e.g. "text-embedding") is consulted even when
+		// the model ID itself doesn't contain "embed".
+		var meta Metadata
+		var found bool
+		if lookup != nil {
+			meta, found = lookup(ctx, prov, model)
+		}
+		if isEmbeddingModel(meta.Family, model) {
+			continue
+		}
+		if found && len(meta.OutputModalities) > 0 && !slices.Contains(meta.OutputModalities, "text") {
+			continue
+		}
+
+		ref := prov + "/" + model
+		if seen[ref] {
+			continue
+		}
+		seen[ref] = true
+		refs = append(refs, Ref{Provider: prov, Model: model})
+	}
+
+	return refs
+}
+
+// isEmbeddingModel reports whether the family or model name identifies an
+// embedding model, which is never suitable for chat.
+func isEmbeddingModel(family, name string) bool {
+	return strings.Contains(strings.ToLower(family), "embed") ||
+		strings.Contains(strings.ToLower(name), "embed")
+}

--- a/pkg/modelsgateway/normalize_test.go
+++ b/pkg/modelsgateway/normalize_test.go
@@ -1,0 +1,80 @@
+package modelsgateway
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeIDs(t *testing.T) {
+	t.Parallel()
+
+	ids := []string{
+		"anthropic/claude-sonnet-4-6", // prefixed: preserved
+		"bare-model",                  // bare: routed through openai
+		"dmr/ai/qwen3:latest",         // model part may contain slashes
+		"anthropic/claude-sonnet-4-6", // duplicate: first wins
+		"openai/bare-model",           // duplicate of normalized bare ID
+		"openai/text-embedding-3",     // embedding by ID
+		"",                            // invalid
+		"foo/",                        // invalid: empty model
+		"/bar",                        // invalid: empty provider
+	}
+
+	got := NormalizeIDs(t.Context(), ids, nil)
+
+	assert.Equal(t, []Ref{
+		{Provider: "anthropic", Model: "claude-sonnet-4-6"},
+		{Provider: "openai", Model: "bare-model"},
+		{Provider: "dmr", Model: "ai/qwen3:latest"},
+	}, got, "order must deterministically follow the gateway's order")
+}
+
+func TestNormalizeIDs_ProviderCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	got := NormalizeIDs(t.Context(), []string{
+		"OpenAI/gpt-4o",      // mixed-case provider: lowercased
+		"openai/gpt-4o",      // duplicate of the lowercased form
+		"ANTHROPIC/Claude-X", // provider lowercased, model case preserved
+	}, nil)
+
+	assert.Equal(t, []Ref{
+		{Provider: "openai", Model: "gpt-4o"},
+		{Provider: "anthropic", Model: "Claude-X"},
+	}, got, "mixed-case providers must normalize to the canonical lowercase form and deduplicate against it")
+}
+
+func TestNormalizeIDs_MetadataFilters(t *testing.T) {
+	t.Parallel()
+
+	metadata := map[string]Metadata{
+		// The ID contains no "embed" substring; only the family says so.
+		"google/vector-model": {Family: "text-embedding"},
+		// Declared non-text output: not a chat model.
+		"openai/image-only": {OutputModalities: []string{"image"}},
+		// Declared text output: kept.
+		"openai/gpt-4o": {OutputModalities: []string{"text"}},
+		// No declared modalities: no signal, kept.
+		"openai/no-modalities": {},
+	}
+	lookup := func(_ context.Context, prov, model string) (Metadata, bool) {
+		m, ok := metadata[prov+"/"+model]
+		return m, ok
+	}
+
+	got := NormalizeIDs(t.Context(), []string{
+		"google/vector-model",
+		"openai/image-only",
+		"openai/gpt-4o",
+		"openai/no-modalities",
+		"openai/not-in-catalog",
+	}, lookup)
+
+	assert.Equal(t, []Ref{
+		{Provider: "openai", Model: "gpt-4o"},
+		{Provider: "openai", Model: "no-modalities"},
+		{Provider: "openai", Model: "not-in-catalog"},
+	}, got)
+}

--- a/pkg/runtime/gateway_models.go
+++ b/pkg/runtime/gateway_models.go
@@ -3,13 +3,11 @@ package runtime
 import (
 	"context"
 	"log/slog"
-	"strings"
 	"sync"
 	"time"
 
 	"golang.org/x/sync/singleflight"
 
-	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/modelsdev"
 	"github.com/docker/docker-agent/pkg/modelsgateway"
 )
@@ -111,50 +109,40 @@ func (r *LocalRuntime) buildGatewayChoices(ctx context.Context) ([]ModelChoice, 
 		}
 	}
 
-	choices := make([]ModelChoice, 0, len(ids))
-	for _, id := range ids {
-		prov, model, ok := strings.Cut(id, "/")
-		if !ok {
-			// Bare IDs (no provider prefix) are served through the
-			// gateway's OpenAI-compatible endpoint, so route them
-			// through the openai provider.
-			prov, model = "openai", id
+	// The metadata callback memoizes full catalog entries so the display
+	// name/pricing enrichment below reuses the lookup NormalizeIDs already
+	// performed for its embedding/modality filters.
+	metas := make(map[string]*modelsdev.Model)
+	lookup := func(ctx context.Context, prov, model string) (modelsgateway.Metadata, bool) {
+		if r.modelsStore == nil {
+			return modelsgateway.Metadata{}, false
 		}
-		if _, err := latest.ParseModelRef(prov + "/" + model); err != nil {
-			continue
+		m, err := r.modelsStore.GetModel(ctx, modelsdev.NewID(prov, model))
+		if err != nil {
+			return modelsgateway.Metadata{}, false
 		}
+		metas[prov+"/"+model] = m
+		return modelsgateway.Metadata{Family: m.Family, OutputModalities: m.Modalities.Output}, true
+	}
 
-		// Resolve catalog metadata before the embedding filter so the
-		// catalog Family (e.g. "text-embedding") is consulted even when
-		// the model ID itself doesn't contain "embed".
-		var meta *modelsdev.Model
-		if r.modelsStore != nil {
-			if m, err := r.modelsStore.GetModel(ctx, modelsdev.NewID(prov, model)); err == nil {
-				meta = m
-			}
-		}
-		family := ""
-		if meta != nil {
-			family = meta.Family
-		}
-		if isEmbeddingModel(family, model) {
-			continue
-		}
+	refs := modelsgateway.NormalizeIDs(ctx, ids, lookup)
 
-		ref := prov + "/" + model
+	choices := make([]ModelChoice, 0, len(refs))
+	for _, mr := range refs {
+		ref := mr.String()
 		if existingRefs[ref] {
 			continue
 		}
 		existingRefs[ref] = true
 
 		choice := ModelChoice{
-			Name:      model,
+			Name:      mr.Model,
 			Ref:       ref,
-			Provider:  prov,
-			Model:     model,
+			Provider:  mr.Provider,
+			Model:     mr.Model,
 			IsCatalog: true,
 		}
-		if meta != nil {
+		if meta := metas[ref]; meta != nil {
 			if meta.Name != "" {
 				choice.Name = meta.Name
 			}

--- a/pkg/runtime/gateway_models_test.go
+++ b/pkg/runtime/gateway_models_test.go
@@ -41,6 +41,8 @@ func (s stubModelStore) GetDatabase(context.Context) (*modelsdev.Database, error
 
 // gatewayRuntime builds a LocalRuntime wired to the given gateway URL with
 // a Docker token available (httptest servers are localhost, hence trusted).
+// A direct OpenAI credential is also set: the catalog fallback taken when
+// gateway discovery fails is credential-based, not gateway-based.
 func gatewayRuntime(gatewayURL string, store ModelStore) *LocalRuntime {
 	return &LocalRuntime{
 		modelsStore: store,
@@ -48,6 +50,7 @@ func gatewayRuntime(gatewayURL string, store ModelStore) *LocalRuntime {
 			ModelsGateway: gatewayURL,
 			EnvProvider: environment.NewMapEnvProvider(map[string]string{
 				environment.DockerDesktopTokenEnv: "test-token",
+				"OPENAI_API_KEY":                  "sk-test",
 			}),
 			Models: map[string]latest.ModelConfig{
 				"root_model": {Provider: "anthropic", Model: "claude-sonnet-4-0"},
@@ -360,5 +363,26 @@ func TestAvailableModels_GatewayEmbeddingFilteredByCatalogFamily(t *testing.T) {
 	got := refs(r.AvailableModels(t.Context()))
 
 	assert.NotContains(t, got, "openai/some-vector-model", "embedding models identified by catalog family must be filtered")
+	assert.Contains(t, got, "openai/gpt-4o")
+}
+
+func TestAvailableModels_GatewayNonTextFilteredByCatalogModalities(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"id":"openai/image-gen"},{"id":"openai/gpt-4o"}]}`))
+	}))
+	defer server.Close()
+
+	// The catalog declares image-only output for image-gen, so it is not a
+	// chat model. gpt-4o has no catalog entry and must be kept (no signal).
+	store := stubModelStore{models: map[string]*modelsdev.Model{
+		"openai/image-gen": {Name: "Image Gen", Modalities: modelsdev.Modalities{Output: []string{"image"}}},
+	}}
+	r := gatewayRuntime(server.URL, store)
+
+	got := refs(r.AvailableModels(t.Context()))
+
+	assert.NotContains(t, got, "openai/image-gen", "models whose catalog metadata declares non-text output must be filtered")
 	assert.Contains(t, got, "openai/gpt-4o")
 }

--- a/pkg/runtime/model_switcher.go
+++ b/pkg/runtime/model_switcher.go
@@ -7,11 +7,10 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/docker/docker-agent/pkg/agent"
-	"github.com/docker/docker-agent/pkg/concurrent"
+	"github.com/docker/docker-agent/pkg/config"
 	"github.com/docker/docker-agent/pkg/config/latest"
 	"github.com/docker/docker-agent/pkg/effort"
 	"github.com/docker/docker-agent/pkg/environment"
@@ -827,81 +826,18 @@ func isEmbeddingModel(family, name string) bool {
 	return strings.Contains(familyLower, "embed") || strings.Contains(nameLower, "embed")
 }
 
-// aliasBaseURLResolvable reports whether every environment variable referenced
-// by a (possibly templated) alias base URL is set. Aliases like Cloudflare's
-// account/gateway-scoped endpoints need extra vars beyond their token; without
-// them the alias would resolve to a broken URL, so it must not be advertised as
-// an available provider (mirrors the preflight check in config.gather).
-func aliasBaseURLResolvable(ctx context.Context, baseURL string, env environment.Provider) bool {
-	for _, name := range environment.Refs(baseURL) {
-		if v, _ := env.Get(ctx, name); v == "" {
-			return false
-		}
-	}
-	return true
-}
-
-// getAvailableProviders returns a map of provider names that the user has credentials for.
+// getAvailableProviders returns the providers that model discovery/listing
+// may surface for this runtime. Availability is credential-based (shared
+// with the CLI models-listing fallback via
+// [config.DiscoveryAvailableProviders]): a configured models gateway no
+// longer replaces it with a hardcoded provider list, so when gateway
+// discovery fails — or the gateway is a generic one without a Docker token —
+// the catalog fallback still reflects the providers the user can actually
+// reach directly.
 func (r *LocalRuntime) getAvailableProviders(ctx context.Context) map[string]bool {
-	available := make(map[string]bool)
 	env := r.modelSwitcherCfg.EnvProvider
 
-	// If using a models gateway, check for Docker token
-	if r.modelSwitcherCfg.ModelsGateway != "" {
-		if token, _ := env.Get(ctx, environment.DockerDesktopTokenEnv); token != "" {
-			// Gateway supports all providers
-			available["openai"] = true
-			available["anthropic"] = true
-			available["google"] = true
-			available["mistral"] = true
-			available["xai"] = true
-		}
-		return available
-	}
-
-	aliases := provider.EachAlias()
-	credentialNames := []string{
-		"OPENAI_API_KEY",
-		"ANTHROPIC_API_KEY",
-		"GOOGLE_API_KEY",
-		"AWS_ACCESS_KEY_ID",
-		"AWS_PROFILE",
-		"AWS_DEFAULT_PROFILE",
-		"AWS_WEB_IDENTITY_TOKEN_FILE",
-		"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
-		"AWS_ROLE_ARN",
-	}
-	for _, alias := range aliases {
-		if alias.TokenEnvVar != "" {
-			credentialNames = append(credentialNames, alias.TokenEnvVar)
-		}
-	}
-	credentials := lookupEnvironmentValues(ctx, env, credentialNames)
-
-	// Check credentials for each alias provider.
-	for name, alias := range aliases {
-		if credentials[alias.TokenEnvVar] == "" {
-			continue
-		}
-		// A templated base URL (e.g. Cloudflare's account/gateway-scoped
-		// endpoint) also needs the vars it references; without them the alias
-		// resolves to a broken URL, so don't advertise its catalog models.
-		if !aliasBaseURLResolvable(ctx, alias.BaseURL, env) {
-			continue
-		}
-		available[name] = true
-	}
-
-	// Check core providers with well-known env vars.
-	if credentials["OPENAI_API_KEY"] != "" {
-		available["openai"] = true
-	}
-	if credentials["ANTHROPIC_API_KEY"] != "" {
-		available["anthropic"] = true
-	}
-	if credentials["GOOGLE_API_KEY"] != "" {
-		available["google"] = true
-	}
+	available := config.DiscoveryAvailableProviders(ctx, env)
 
 	// Mark anthropic available when any model or referenced provider in the
 	// workspace has a non-API-key auth scheme configured (e.g. Workload
@@ -921,59 +857,7 @@ func (r *LocalRuntime) getAvailableProviders(ctx context.Context) map[string]boo
 	available["dmr"] = true
 	available["ollama"] = true
 
-	// Amazon Bedrock uses AWS credentials which can come from many sources.
-	// We do a quick heuristic check for common indicators without blocking:
-	// - AWS_ACCESS_KEY_ID: explicit access key
-	// - AWS_PROFILE / AWS_DEFAULT_PROFILE: named profile (credentials in ~/.aws/)
-	// - AWS_WEB_IDENTITY_TOKEN_FILE: EKS/IRSA web identity
-	// - AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: ECS task role
-	// - AWS_ROLE_ARN: assumed role
-	// Note: This won't catch all cases (e.g., EC2 instance profiles, SSO) but
-	// those require network calls which would block the UI.
-	awsCredentialIndicators := []string{
-		"AWS_ACCESS_KEY_ID",
-		"AWS_PROFILE",
-		"AWS_DEFAULT_PROFILE",
-		"AWS_WEB_IDENTITY_TOKEN_FILE",
-		"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
-		"AWS_ROLE_ARN",
-	}
-	for _, indicator := range awsCredentialIndicators {
-		if credentials[indicator] != "" {
-			available["amazon-bedrock"] = true
-			break
-		}
-	}
-
 	return available
-}
-
-func lookupEnvironmentValues(ctx context.Context, env environment.Provider, names []string) map[string]string {
-	values := concurrent.NewMap[string, string]()
-	unique := make(map[string]struct{}, len(names))
-	var wg sync.WaitGroup
-	for _, name := range names {
-		if name == "" {
-			continue
-		}
-		if _, ok := unique[name]; ok {
-			continue
-		}
-		unique[name] = struct{}{}
-		wg.Go(func() {
-			if value, _ := env.Get(ctx, name); value != "" {
-				values.Store(name, value)
-			}
-		})
-	}
-	wg.Wait()
-
-	result := make(map[string]string, values.Length())
-	values.Range(func(name, value string) bool {
-		result[name] = value
-		return true
-	})
-	return result
 }
 
 // modelHasAnthropicAuth reports whether the model (or its referenced

--- a/pkg/runtime/model_switcher_test.go
+++ b/pkg/runtime/model_switcher_test.go
@@ -800,20 +800,25 @@ func TestGetAvailableProviders(t *testing.T) {
 			wantProviders: []string{"openai", "anthropic", "dmr", "ollama"},
 		},
 		{
-			name: "with gateway - uses docker token",
+			// A gateway no longer replaces availability with a hardcoded
+			// provider list: direct credentials keep counting.
+			name: "with gateway - direct credentials still count",
 			envVars: map[string]string{
-				"DOCKER_TOKEN": "test-token",
+				"DOCKER_TOKEN":   "test-token",
+				"OPENAI_API_KEY": "sk-test",
 			},
 			modelsGateway: "https://gateway.example.com",
-			wantProviders: []string{"openai", "anthropic", "google", "mistral", "xai"},
+			wantProviders: []string{"openai", "dmr", "ollama"},
 		},
 		{
+			// A generic gateway must not require the Docker token for the
+			// credential-based fallback either.
 			name: "with gateway but no token",
 			envVars: map[string]string{
-				"OPENAI_API_KEY": "sk-test", // This is ignored when gateway is set
+				"OPENAI_API_KEY": "sk-test",
 			},
 			modelsGateway: "https://gateway.example.com",
-			wantProviders: []string{}, // No token means no providers via gateway
+			wantProviders: []string{"openai", "dmr", "ollama"},
 		},
 		{
 			name: "aws access key for bedrock",
@@ -864,6 +869,32 @@ func TestGetAvailableProviders(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGetAvailableProviders_GatewayDoesNotHardcodeProviders pins the removal
+// of the old gateway special case: a Docker token alone must not surface a
+// hardcoded provider list, since the fallback taken when gateway discovery
+// fails is purely credential-based.
+func TestGetAvailableProviders_GatewayDoesNotHardcodeProviders(t *testing.T) {
+	t.Parallel()
+
+	r := &LocalRuntime{
+		modelSwitcherCfg: &ModelSwitcherConfig{
+			ProviderRegistry: testProviderRegistry(),
+			EnvProvider: environment.NewMapEnvProvider(map[string]string{
+				"DOCKER_TOKEN": "test-token",
+			}),
+			ModelsGateway: "https://gateway.example.com",
+		},
+	}
+
+	got := r.getAvailableProviders(t.Context())
+
+	for _, name := range []string{"openai", "anthropic", "google", "mistral", "xai"} {
+		assert.False(t, got[name], "provider %s must not be available from the Docker token alone", name)
+	}
+	assert.True(t, got["dmr"], "local providers stay available")
+	assert.True(t, got["ollama"], "local providers stay available")
 }
 
 // TestGetAvailableProviders_TemplatedAlias verifies that an alias with a


### PR DESCRIPTION
## Summary

Unify models-gateway discovery semantics between `docker agent models` and the interactive `/model` picker.

A non-empty `/v1/models` response is now the source of truth for gateway-routed models. Discovery failures fall back independently to directly usable providers, aliases, custom providers, and the catalog without requiring a Docker Desktop token for generic gateways.

## Expected behavior

| Expectation | Implementation |
| --- | --- |
| Query gateway models from the CLI | `docker agent models` calls `<gateway>/v1/models` through `modelsgateway.ListModels` |
| Preserve arbitrary providers | Prefixed `provider/model` IDs are preserved; no provider allow-list is used |
| Apply live filtering | `--provider` filters normalized gateway results |
| Exclude unsuitable models | Shared normalization removes embeddings and catalog-declared non-text models |
| Deduplicate deterministically | Canonical references are deduplicated while retaining gateway response order; final CLI output remains deterministically sorted |
| Handle discovery failures | 404, empty or invalid responses, timeout, and authentication failures trigger the documented direct-provider/catalog fallback |
| Keep direct and custom providers usable | Credential-based discovery is shared by CLI fallback and runtime; custom endpoints remain independent sources |
| Support generic gateways | Docker Desktop authentication is requested only for trusted Docker URLs |
| Preserve Docker Model Runner behavior | Runtime DMR discovery/cache and intentional CLI DMR omission are unchanged |
| Preserve output behavior | Table/JSON output, `--all`, default marking, aliases, env credentials, env files, and user-config providers remain supported |

## Implementation

- Add a lightweight shared gateway normalization primitive in `pkg/modelsgateway`.
- Add a discovery-only provider availability helper in `pkg/config` without changing `config.AvailableProviders` or model auto-selection.
- Reuse the shared normalization in the CLI and runtime picker while keeping caller-specific cache policies.
- Document authoritative live discovery and fallback behavior in the CLI reference.

## Tests

Hermetic coverage includes:

- multi-provider live gateway discovery and `--provider` filtering;
- trusted Docker and generic gateway authentication;
- 404, empty response, invalid JSON, timeout, and missing authentication;
- direct providers, provider aliases, and authenticated/unauthenticated custom providers;
- embedding/non-text filtering, deduplication, provider casing, deterministic JSON/table output, and default marking;
- runtime gateway fallback and cache behavior.

Validation completed:

- `task build`
- `task lint`
- `task test`

No model generation or real provider API calls are used by the added tests.

## Scope

- No agent-file argument was added to `docker agent models`.
- Named models and `bypass_models_gateway` remain runtime-only concerns.
- Docker Model Runner live behavior is unchanged.
- Model routing and generation execution are unchanged.
