### PR TITLE
fix: preserve safety modes across session flows

### DIFF
--- a/cmd/root/run.go
+++ b/cmd/root/run.go
@@ -901,16 +901,16 @@ func (f *runExecFlags) createLocalRuntimeAndSession(ctx context.Context, loadRes
 		sess, err = sessStore.GetSession(ctx, resolvedID)
 		switch {
 		case err == nil:
-			// Via the options, not raw field writes, so the legacy
-			// ToolsApproved flag and the mode stay in sync. Flags
-			// override whatever the stored session carried; --safety
+			// Flags override whatever the stored session carried, via
+			// the options (not raw field writes) so the legacy
+			// ToolsApproved flag and the mode stay in sync; --safety
 			// wins over --yolo when both are given, matching the
 			// option order buildSessionOpts applies to new sessions.
-			// The explicit escalation matters: WithToolsApproved only
-			// backfills autonomous onto an EMPTY stored policy, so
-			// --yolo on a session stored as balanced/strict would
-			// otherwise be silently discarded.
-			session.WithToolsApproved(req.ToolsApproved)(sess)
+			// The explicit autonomous escalation matters: --yolo must
+			// override even a session stored as balanced/strict.
+			// Without safety flags the stored state is left untouched —
+			// a plain resume must not reset ToolsApproved out from
+			// under a stored autonomous policy.
 			if req.SafetyPolicy != "" {
 				session.WithSafetyPolicy(req.SafetyPolicy)(sess)
 			} else if req.ToolsApproved {

--- a/cmd/root/run_session_test.go
+++ b/cmd/root/run_session_test.go
@@ -87,6 +87,54 @@ func TestCreateLocalRuntimeAndSession_ResumeKeepsExplicitSafetyPolicy(t *testing
 	assert.Equal(t, session.SafetyPolicyBalanced, sess.SafetyPolicy)
 }
 
+// A plain resume (no --yolo, no --safety) of a session stored as
+// autonomous must leave the stored state untouched: the policy stays
+// autonomous AND the legacy ToolsApproved flag stays true, so the two
+// fields remain in sync for legacy readers.
+func TestCreateLocalRuntimeAndSession_PlainResumeKeepsAutonomousInSync(t *testing.T) {
+	t.Parallel()
+
+	store := session.NewInMemorySessionStore()
+	require.NoError(t, store.AddSession(t.Context(), session.New(
+		session.WithID("existing"),
+		session.WithSafetyPolicy(session.SafetyPolicyAutonomous),
+	)))
+
+	f := &runExecFlags{}
+	req := runtime.CreateSessionRequest{AgentName: "root", ResumeSessionID: "existing"}
+
+	_, sess, err := f.createLocalRuntimeAndSession(t.Context(), newSessionTestLoadResult(), req, store)
+	require.NoError(t, err)
+	assert.Equal(t, session.SafetyPolicyAutonomous, sess.SafetyPolicy)
+	assert.True(t, sess.ToolsApproved, "plain resume must not reset the legacy flag out from under an autonomous policy")
+}
+
+// A plain resume of a legacy stored session — raw ToolsApproved=true with
+// no SafetyPolicy, the shape old stores deserialize to — must leave that
+// raw shape untouched: the blanket approval stays effective and no policy
+// is written onto the session behind the user's back.
+func TestCreateLocalRuntimeAndSession_PlainResumeKeepsLegacyToolsApprovedShape(t *testing.T) {
+	t.Parallel()
+
+	// WithToolsApproved(true) backfills SafetyPolicy=autonomous, so build
+	// the legacy deserialized shape via raw field writes instead.
+	legacy := session.New(session.WithID("existing"))
+	legacy.ToolsApproved = true
+	legacy.SafetyPolicy = ""
+
+	store := session.NewInMemorySessionStore()
+	require.NoError(t, store.AddSession(t.Context(), legacy))
+
+	f := &runExecFlags{}
+	req := runtime.CreateSessionRequest{AgentName: "root", ResumeSessionID: "existing"}
+
+	_, sess, err := f.createLocalRuntimeAndSession(t.Context(), newSessionTestLoadResult(), req, store)
+	require.NoError(t, err)
+	assert.True(t, sess.ToolsApproved, "plain resume must keep the legacy blanket approval")
+	assert.Equal(t, session.SafetyPolicy(""), sess.SafetyPolicy, "plain resume must not invent an explicit policy on a legacy session")
+	assert.Equal(t, session.SafetyPolicyAutonomous, sess.GetSafetyPolicy(), "the legacy flag alone must stay effective as autonomous")
+}
+
 // --yolo on resume escalates even a session stored with an explicit
 // non-autonomous mode: the flag is a direct user instruction for THIS
 // run, not a default that only fills a gap.

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1060,14 +1060,27 @@ func (a *App) NewSession() {
 	// Preserve user-controlled session flags
 	// so they don't reset to default on /new
 	var opts []session.Opt
+	var priorPolicy session.SafetyPolicy
 	if a.session != nil {
+		// WithSafetyPolicy("") is a no-op, so a legacy session (no explicit
+		// mode) keeps relying on the ToolsApproved flag alone; an explicit
+		// strict/balanced choice — which leaves ToolsApproved=false — must be
+		// carried over here or /new silently falls back to legacy behavior.
 		opts = append(opts,
 			session.WithToolsApproved(a.session.ToolsApproved),
+			session.WithSafetyPolicy(a.session.GetSafetyPolicy()),
 			session.WithHideToolResults(a.session.HideToolResults),
 			session.WithWorkingDir(a.session.WorkingDir),
 		)
+		priorPolicy = a.session.GetPriorSafetyPolicy()
 	}
-	a.session = session.New(opts...)
+	// There is no WithPriorSafetyPolicy option; writing the field before the
+	// session is published via a.session keeps the write on an unshared
+	// value, so it is safe. Preserving the toggle memory keeps an autonomous
+	// escalation able to toggle back to its prior mode.
+	sess := session.New(opts...)
+	sess.PriorSafetyPolicy = priorPolicy
+	a.session = sess
 	// Clear first message so it won't be re-sent on re-init
 	a.firstMessage = nil
 	a.firstMessageAttach = ""

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -442,6 +442,56 @@ func TestApp_NewSession_PreservesToolsApproved(t *testing.T) {
 	assert.True(t, app.Session().ToolsApproved, "NewSession should preserve ToolsApproved")
 }
 
+// Explicit strict/balanced modes leave ToolsApproved=false, so preserving
+// only that legacy flag silently dropped the mode on /new.
+func TestApp_NewSession_PreservesSafetyPolicy(t *testing.T) {
+	t.Parallel()
+
+	for _, policy := range []session.SafetyPolicy{session.SafetyPolicyStrict, session.SafetyPolicyBalanced} {
+		t.Run(string(policy), func(t *testing.T) {
+			t.Parallel()
+
+			rt := &mockRuntime{}
+
+			initialSess := session.New(session.WithSafetyPolicy(policy))
+			require.Equal(t, policy, initialSess.GetSafetyPolicy())
+
+			app := New(t.Context(), rt, initialSess)
+
+			app.NewSession()
+
+			assert.Equal(t, policy, app.Session().GetSafetyPolicy(), "NewSession should preserve the safety policy")
+			assert.False(t, app.Session().ToolsApproved, "non-autonomous modes must not grant blanket approval")
+		})
+	}
+}
+
+// An autonomous escalation must keep its toggle-back destination across
+// /new, or toggling yolo off afterwards drops to the legacy default
+// instead of the mode the user escalated from.
+func TestApp_NewSession_PreservesPriorSafetyPolicy(t *testing.T) {
+	t.Parallel()
+
+	rt := &mockRuntime{}
+
+	initialSess := session.New(session.WithSafetyPolicy(session.SafetyPolicyBalanced))
+	initialSess.ToggleYolo() // escalate: autonomous with prior=balanced
+	require.Equal(t, session.SafetyPolicyAutonomous, initialSess.GetSafetyPolicy())
+	require.Equal(t, session.SafetyPolicyBalanced, initialSess.GetPriorSafetyPolicy())
+
+	app := New(t.Context(), rt, initialSess)
+
+	app.NewSession()
+
+	sess := app.Session()
+	assert.Equal(t, session.SafetyPolicyAutonomous, sess.GetSafetyPolicy(), "NewSession should preserve the escalated mode")
+	assert.Equal(t, session.SafetyPolicyBalanced, sess.GetPriorSafetyPolicy(), "NewSession should preserve the toggle-back memory")
+
+	// The preserved memory must actually work: toggling off restores balanced.
+	sess.ToggleYolo()
+	assert.Equal(t, session.SafetyPolicyBalanced, sess.GetSafetyPolicy())
+}
+
 func TestApp_NewSession_PreservesHideToolResults(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/components/toolconfirm/toolconfirm.go
+++ b/pkg/tui/components/toolconfirm/toolconfirm.go
@@ -92,9 +92,10 @@ func BuildPermissionPattern(toolCall tools.ToolCall) string {
 // AlwaysAllowLabel is the descriptive label of the "always allow" option
 // for a pattern from BuildPermissionPattern: the command pattern for shell
 // ("always allow ls*"), the tool name otherwise. Whitespace runs are
-// collapsed: the label feeds a single-line help row whose click
-// hit-testing treats "  " as the segment separator, so an interior
-// double space (or newline) would corrupt the segment walk.
+// collapsed: a newline would split the label's help row across physical
+// lines, breaking the one-line-per-row contract click hit-testing relies
+// on, and an interior double space would read like the separator between
+// options.
 func AlwaysAllowLabel(pattern string) string {
 	if _, cmdPattern, ok := strings.Cut(pattern, ":cmd="); ok {
 		pattern = cmdPattern
@@ -103,12 +104,13 @@ func AlwaysAllowLabel(pattern string) string {
 }
 
 // ActionKeys are the uppercase action letters of the decision row, in
-// display order. Click hit-testing on the rendered options walks these
-// letters; map a hit back to its decision with DecisionForAction.
+// display order — one letter per OptionsHelp pair. UIs dispatch a clicked
+// option by its action key; map a key back to its decision with
+// DecisionForAction.
 const ActionKeys = "YNTBA"
 
-// DecisionForAction maps an action letter from ActionKeys ("Y", "N", "T",
-// "A") to its decision. ok is false for any other string.
+// DecisionForAction maps an action letter from ActionKeys to its
+// decision. ok is false for any other string.
 func DecisionForAction(action string) (decision Decision, ok bool) {
 	switch action {
 	case "Y":
@@ -127,9 +129,8 @@ func DecisionForAction(action string) (decision Decision, ok bool) {
 
 // OptionsHelp returns the key/label pairs of the decision row, in display
 // order, ready for a help-keys renderer (e.g. dialog.RenderHelpKeys). The
-// Balanced label is deliberately the short mode name: the confirmation
-// dialog is ~70% of the terminal wide and a longer label makes the row
-// wrap, which breaks row-based click hit-testing.
+// Balanced label is deliberately the short mode name: it keeps the
+// decision block compact, wrapping onto fewer rows at narrow widths.
 func OptionsHelp(pattern string) []string {
 	return []string{
 		"Y", "yes",

--- a/pkg/tui/dialog/tool_confirmation.go
+++ b/pkg/tui/dialog/tool_confirmation.go
@@ -28,6 +28,13 @@ const (
 	toolConfirmMinScrollHeight     = 5  // Minimum height for the scroll view
 	toolConfirmEmptyLinesBefore    = 2  // Empty lines before question
 	toolConfirmEmptyLinesAfter     = 1  // Empty lines after question
+
+	// toolConfirmMinOptionWidth is the narrowest width the option block
+	// can be laid out or rendered at: one action key, the key/label gap,
+	// and the "…" a fully truncated label collapses to. Anything narrower
+	// wraps a minimal segment across physical lines, breaking the
+	// one-line-per-row contract click hit-testing relies on.
+	toolConfirmMinOptionWidth = 3
 )
 
 type (
@@ -65,9 +72,16 @@ type toolConfirmationDialog struct {
 }
 
 // dialogDimensions returns computed dialog width and content width.
+// contentWidth never drops below toolConfirmMinOptionWidth: the outer
+// dialog style re-wraps its content at contentWidth, so shrinking
+// further would split even a minimal option row across physical lines
+// and misalign click hit-testing. An extremely narrow terminal clips
+// the dialog instead, which is the lesser evil. SetSize, View, Position
+// and handleMouseClick all derive from this one clamped layout.
 func (d *toolConfirmationDialog) dialogDimensions() (dialogWidth, contentWidth int) {
-	dialogWidth = d.Width() * toolConfirmDialogWidthPercent / 100
-	contentWidth = dialogWidth - styles.DialogStyle.GetHorizontalFrameSize()
+	frameWidth := styles.DialogStyle.GetHorizontalFrameSize()
+	dialogWidth = max(d.Width()*toolConfirmDialogWidthPercent/100, toolConfirmMinOptionWidth+frameWidth)
+	contentWidth = dialogWidth - frameWidth
 	return dialogWidth, contentWidth
 }
 
@@ -118,9 +132,88 @@ func (d *toolConfirmationDialog) renderSeparator(contentWidth int) string {
 	return RenderSeparator(contentWidth)
 }
 
-// renderOptions renders the Y/N/T/A decision row.
+// renderOptions renders the Y/N/T/B/A decision block: the option
+// segments laid out by optionRows, one centered help-keys line per row.
+// The width shares optionRows' clamp so a laid-out row never wraps
+// inside RenderHelpKeys.
 func (d *toolConfirmationDialog) renderOptions(contentWidth int) string {
-	return RenderHelpKeys(contentWidth, toolconfirm.OptionsHelp(d.permissionPattern)...)
+	contentWidth = max(contentWidth, toolConfirmMinOptionWidth)
+	rows := d.optionRows(contentWidth)
+	lines := make([]string, len(rows))
+	for i, row := range rows {
+		bindings := make([]string, 0, len(row)*2)
+		for _, seg := range row {
+			bindings = append(bindings, seg.action, seg.label)
+		}
+		lines[i] = RenderHelpKeys(contentWidth, bindings...)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// optionRows lays out the decision segments for the current permission
+// pattern. renderOptions and handleMouseClick both derive from this one
+// layout, so what the user sees and what a click hits cannot drift apart.
+// The width is clamped so a minimal "<key> …" segment always fits on one
+// row, no matter how narrow the caller's width is.
+func (d *toolConfirmationDialog) optionRows(contentWidth int) [][]optionSegment {
+	return layoutOptionRows(max(contentWidth, toolConfirmMinOptionWidth), toolconfirm.OptionsHelp(d.permissionPattern))
+}
+
+// optionSegment is one clickable "<key> <label>" unit of the decision
+// block. startX/endX are terminal cell offsets of the segment within its
+// row's visible text (centering padding excluded), endX exclusive.
+type optionSegment struct {
+	action string // action key, dispatched via toolconfirm.DecisionForAction
+	label  string // displayed label; truncated when the segment alone exceeds contentWidth
+	startX int
+	endX   int
+}
+
+// layoutOptionRows greedily packs "<key> <label>" segments into rows at
+// most contentWidth cells wide, breaking only at the two-space segment
+// separators so no segment ever splits across rows. A segment too wide
+// even for a row of its own gets its displayed label truncated with an
+// ellipsis — the action key stays visible and the underlying permission
+// pattern is unaffected. All widths are terminal cell widths, not byte
+// lengths (labels and the ellipsis can hold multi-byte runes). Callers
+// clamp contentWidth to toolConfirmMinOptionWidth or more, so even a
+// fully truncated "<key> …" segment fits its row.
+func layoutOptionRows(contentWidth int, bindings []string) [][]optionSegment {
+	if len(bindings) == 0 || len(bindings)%2 != 0 {
+		return nil
+	}
+	var rows [][]optionSegment
+	var row []optionSegment
+	rowWidth := 0
+	for i := 0; i < len(bindings); i += 2 {
+		action, label := bindings[i], bindings[i+1]
+		keyWidth := ansi.StringWidth(action)
+		if keyWidth+1+ansi.StringWidth(label) > contentWidth {
+			label = ansi.Truncate(label, max(contentWidth-keyWidth-1, 1), "…")
+		}
+		segWidth := keyWidth + 1 + ansi.StringWidth(label)
+		if len(row) > 0 && rowWidth+2+segWidth > contentWidth {
+			rows = append(rows, row)
+			row, rowWidth = nil, 0
+		}
+		startX := 0
+		if len(row) > 0 {
+			startX = rowWidth + 2
+		}
+		row = append(row, optionSegment{action: action, label: label, startX: startX, endX: startX + segWidth})
+		rowWidth = startX + segWidth
+	}
+	return append(rows, row)
+}
+
+// optionRowText is the plain text of one laid-out row — exactly what
+// helpKeysLine renders for its bindings, without styling.
+func optionRowText(row []optionSegment) string {
+	parts := make([]string, len(row))
+	for i, seg := range row {
+		parts[i] = seg.action + " " + seg.label
+	}
+	return strings.Join(parts, "  ")
 }
 
 // safetyConventionKeys are the metadata keys the safer_shell builtin
@@ -290,6 +383,12 @@ func (d *toolConfirmationDialog) executeAction(decision toolconfirm.Decision) (l
 			core.CmdHandler(RuntimeResumeMsg{Request: toolconfirm.ApproveTool.Resume(d.permissionPattern, "")}),
 		)
 	case toolconfirm.ApproveBalanced:
+		// A preempt/custom hook can raise a confirmation while the session
+		// is autonomous. Balanced moves the runtime session off autonomous,
+		// so the cached TUI flag must drop too — otherwise the sidebar keeps
+		// claiming YOLO and Ctrl+Y "toggles" it straight back to autonomous.
+		// Mirrors ApproveSession setting it true below.
+		d.sessionState.SetYoloMode(false)
 		return d, tea.Sequence(
 			core.CmdHandler(CloseDialogMsg{}),
 			core.CmdHandler(RuntimeResumeMsg{Request: toolconfirm.ApproveBalanced.Resume("", "")}),
@@ -342,72 +441,55 @@ func (d *toolConfirmationDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
 	return d, nil
 }
 
-// handleMouseClick handles mouse clicks on the action buttons (Y/N/T/A).
+// handleMouseClick handles mouse clicks on the action buttons (Y/N/T/B/A).
 func (d *toolConfirmationDialog) handleMouseClick(msg tea.MouseClickMsg) (layout.Model, tea.Cmd) {
 	dialogRow, dialogCol := d.Position()
 	renderedDialog := d.View()
 	dialogHeight := lipgloss.Height(renderedDialog)
 
-	// The options line is the last content line inside the dialog.
-	if msg.Y != ContentEndRow(dialogRow, dialogHeight) {
+	// The option rows are the last content lines inside the dialog: View
+	// appends renderOptions last, one physical line per laid-out row.
+	_, contentWidth := d.dialogDimensions()
+	rows := d.optionRows(contentWidth)
+	rowIdx := msg.Y - ContentEndRow(dialogRow, dialogHeight) + len(rows) - 1
+	if rowIdx < 0 || rowIdx >= len(rows) {
 		return d, nil
 	}
+	row := rows[rowIdx]
 
 	// Hit-test against the line the user actually saw: take the clicked
-	// row from the rendered dialog and locate the options text inside
-	// it. Reconstructing the left offset from frame sizes plus the
-	// centering padding is fragile — any extra inset between the frame
-	// and the help line shifts every click.
-	_, contentWidth := d.dialogDimensions()
-	optionsPlain := strings.TrimSpace(ansi.Strip(d.renderOptions(contentWidth)))
-	if optionsPlain == "" {
-		return d, nil
-	}
+	// row from the rendered dialog and locate the row's text inside it.
+	// Reconstructing the left offset from frame sizes plus the centering
+	// padding is fragile — any extra inset between the frame and the
+	// help line shifts every click. The matched byte position is turned
+	// into a cell offset (the border rune is multi-byte, and labels can
+	// be too), because mouse coordinates are terminal cells.
 	renderedLines := strings.Split(ansi.Strip(renderedDialog), "\n")
-	rowIdx := msg.Y - dialogRow
-	if rowIdx < 0 || rowIdx >= len(renderedLines) {
+	lineIdx := msg.Y - dialogRow
+	if lineIdx < 0 || lineIdx >= len(renderedLines) {
 		return d, nil
 	}
-	contentStart := strings.Index(renderedLines[rowIdx], optionsPlain)
-	if contentStart < 0 {
+	line := renderedLines[lineIdx]
+	byteStart := strings.Index(line, optionRowText(row))
+	if byteStart < 0 {
 		return d, nil
 	}
+	relX := msg.X - dialogCol - ansi.StringWidth(line[:byteStart])
 
-	plainLen := len(optionsPlain)
-	relX := msg.X - dialogCol - contentStart
-	if relX < 0 || relX >= plainLen {
-		return d, nil
-	}
-
-	// The help line is built by helpKeysLine as "<KEY> <label>" segments
-	// joined with two spaces, e.g.:
-	//
-	//	"Y yes  N no  T always allow rm*  B balanced  A all tools"
-	//
-	// Map the click onto its segment and dispatch on the segment's leading
-	// action key. Labels can contain uppercase letters (the always-allow
-	// label echoes the command pattern), so scanning the clicked character
-	// itself could fire the wrong action. Separator gaps are dead zones:
-	// attributing them to either neighbour would fire some action on a
-	// near-miss, and no attribution is uniformly the safer one (left
-	// makes the Y/N gap approve, right makes the B/A gap go autonomous).
-	start := 0
-	for start < plainLen {
-		textEnd := plainLen
-		if sep := strings.Index(optionsPlain[start:], "  "); sep >= 0 {
-			textEnd = start + sep
-		}
-		if relX < textEnd {
-			if decision, ok := toolconfirm.DecisionForAction(string(optionsPlain[start])); ok {
+	// Map the click onto its segment and dispatch the segment's action
+	// key — never a character parsed out of the label (labels can contain
+	// uppercase letters; the always-allow label echoes the command
+	// pattern). Separator gaps are dead zones: attributing them to either
+	// neighbour would fire some action on a near-miss, and no attribution
+	// is uniformly the safer one (left makes the Y/N gap approve, right
+	// makes the B/A gap go autonomous).
+	for _, seg := range row {
+		if relX >= seg.startX && relX < seg.endX {
+			if decision, ok := toolconfirm.DecisionForAction(seg.action); ok {
 				return d.executeAction(decision)
 			}
 			return d, nil
 		}
-		if relX < textEnd+2 {
-			// Inside the separator gap.
-			return d, nil
-		}
-		start = textEnd + 2
 	}
 
 	return d, nil

--- a/pkg/tui/dialog/tool_confirmation_test.go
+++ b/pkg/tui/dialog/tool_confirmation_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -212,14 +213,34 @@ func TestToolConfirmationDialog_EmbeddedSessionState(t *testing.T) {
 	assert.True(t, state.YoloMode(), "approving all tools must flip the embedder's session-wide approval")
 }
 
-// Clicking the leading action key must fire at every dialog width.
-// RenderHelpKeys bakes lipgloss centering spaces into the options line;
+// locateInView finds needle in the rendered dialog and returns the
+// absolute screen row and column (terminal cells) of its first cell.
+// The prefix before needle is measured in cells, not bytes, because
+// the dialog border rune is multi-byte and mouse coordinates are cells.
+func locateInView(d *toolConfirmationDialog, needle string) (y, x int, ok bool) {
+	dialogRow, dialogCol := d.Position()
+	for i, line := range strings.Split(ansi.Strip(d.View()), "\n") {
+		if before, _, found := strings.Cut(line, needle); found {
+			return dialogRow + i, dialogCol + ansi.StringWidth(before), true
+		}
+	}
+	return 0, 0, false
+}
+
+// clickCell dispatches a left click at the given absolute cell position.
+func clickCell(d *toolConfirmationDialog, y, x int) tea.Cmd {
+	_, cmd := d.handleMouseClick(tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft})
+	return cmd
+}
+
+// Clicking the leading action key must fire at every dialog width,
+// including widths where the options block wraps onto several rows.
+// RenderHelpKeys bakes lipgloss centering spaces into each line;
 // hit-testing must factor them out or 'Y' clicks dispatch on a padding
 // space and silently no-op whenever the centering padding is odd.
 func TestToolConfirmationDialog_ClickOnYFiresAtEveryWidth(t *testing.T) {
 	t.Parallel()
 
-	tested := 0
 	for width := 60; width <= 130; width++ {
 		dialog := NewToolConfirmationDialog(newConfirmationEvent(nil), &service.SessionState{})
 		_, _ = dialog.Update(tea.WindowSizeMsg{Width: width, Height: 30})
@@ -227,30 +248,209 @@ func TestToolConfirmationDialog_ClickOnYFiresAtEveryWidth(t *testing.T) {
 		d, ok := dialog.(*toolConfirmationDialog)
 		require.True(t, ok)
 
-		// Locate the rendered options line and the on-screen column of
-		// its 'Y' key, then click it.
-		dialogRow, dialogCol := d.Position()
-		view := ansi.Strip(d.View())
-		lines := strings.Split(view, "\n")
-		optionsRow := ContentEndRow(dialogRow, len(lines))
-		optionsLine := lines[optionsRow-dialogRow]
-		yIdx := strings.Index(optionsLine, "Y yes")
-		if yIdx < 0 {
-			// Narrow widths wrap the help line; hit-testing only
-			// targets the single-line layout.
-			continue
-		}
-		tested++
+		y, x, found := locateInView(d, "Y yes")
+		require.Truef(t, found, "width %d: 'Y yes' must be visible on some options row", width)
 
-		_, cmd := d.handleMouseClick(tea.MouseClickMsg{
-			X:      dialogCol + yIdx,
-			Y:      optionsRow,
-			Button: tea.MouseLeft,
-		})
-		assert.NotNilf(t, cmd, "width %d: click on 'Y' at col %d must fire", width, dialogCol+yIdx)
+		resume, ok := findMsg[RuntimeResumeMsg](collectMsgs(clickCell(d, y, x)))
+		require.Truef(t, ok, "width %d: click on 'Y' at col %d must fire", width, x)
+		assert.Equalf(t, runtime.ResumeApprove(), resume.Request, "width %d: 'Y' must approve the single call", width)
 	}
-	// The sweep must cover several widths (both centering parities).
-	assert.Greater(t, tested, 10)
+}
+
+// Adding the Balanced option makes the options block wrap at everyday
+// terminal sizes (80 columns → ~50 columns of dialog content). The
+// block must break only at segment separators, and every segment on
+// every wrapped row must stay clickable.
+func TestToolConfirmationDialog_WrappedLayoutClicksDispatch(t *testing.T) {
+	t.Parallel()
+
+	state := &service.EmbeddedSessionState{}
+	dialog := NewToolConfirmationDialog(newConfirmationEvent(nil), state)
+	_, _ = dialog.Update(tea.WindowSizeMsg{Width: 80, Height: 30})
+
+	d, ok := dialog.(*toolConfirmationDialog)
+	require.True(t, ok)
+
+	_, contentWidth := d.dialogDimensions()
+	rows := d.optionRows(contentWidth)
+	require.Greater(t, len(rows), 1, "width 80 must wrap the options block")
+	for _, row := range rows {
+		assert.LessOrEqual(t, ansi.StringWidth(optionRowText(row)), contentWidth,
+			"rows must break at segment separators, never overflow")
+	}
+	require.Equal(t, len(rows), lipgloss.Height(d.renderOptions(contentWidth)),
+		"each laid-out row must render as exactly one line")
+
+	bY, bX, found := locateInView(d, "B balanced")
+	require.True(t, found, "the Balanced segment must be visible")
+	aY, aX, found := locateInView(d, "A all tools")
+	require.True(t, found, "the all-tools segment must be visible")
+	require.NotEqual(t, bY, aY, "the wrapped layout must spread segments across rows")
+
+	resume, ok := findMsg[RuntimeResumeMsg](collectMsgs(clickCell(d, bY, bX)))
+	require.True(t, ok, "click on 'B balanced' must dispatch a resume")
+	assert.Equal(t, runtime.ResumeApproveBalanced(), resume.Request)
+
+	require.False(t, state.YoloMode())
+	resume, ok = findMsg[RuntimeResumeMsg](collectMsgs(clickCell(d, aY, aX)))
+	require.True(t, ok, "click on 'A all tools' on the wrapped row must dispatch a resume")
+	assert.Equal(t, runtime.ResumeApproveAutonomous(), resume.Request)
+	assert.True(t, state.YoloMode(), "the all-tools click must flip the session-wide approval")
+}
+
+// A realistic narrow split pane (45 columns → 25 columns of dialog
+// content) lays the options out on at least three rows, with the
+// always-allow segment on a middle row. Clicking there must dispatch
+// that segment's decision: the hit-map counts rows from the dialog's
+// bottom line, so an off-by-one shows up exactly on middle rows.
+func TestToolConfirmationDialog_MiddleRowClickInNarrowSplitPane(t *testing.T) {
+	t.Parallel()
+
+	dialog := NewToolConfirmationDialog(newConfirmationEvent(nil), &service.SessionState{})
+	_, _ = dialog.Update(tea.WindowSizeMsg{Width: 45, Height: 30})
+
+	d, ok := dialog.(*toolConfirmationDialog)
+	require.True(t, ok)
+
+	_, contentWidth := d.dialogDimensions()
+	rows := d.optionRows(contentWidth)
+	require.GreaterOrEqual(t, len(rows), 3, "width 45 must lay the options out on at least three rows")
+	middle := rows[1]
+	require.Equal(t, "T", middle[0].action, "the always-allow segment must sit on a middle row")
+
+	tY, tX, found := locateInView(d, optionRowText(middle))
+	require.True(t, found, "the middle row must be visible")
+
+	resume, ok := findMsg[RuntimeResumeMsg](collectMsgs(clickCell(d, tY, tX)))
+	require.True(t, ok, "click on the middle row's action key must dispatch a resume")
+	assert.Equal(t, runtime.ResumeApproveTool("shell"), resume.Request,
+		"the middle-row click must grant this tool, not a neighbouring row's decision")
+}
+
+// expectedOptionResume is the resume request each clickable action key
+// dispatches for the newConfirmationEvent fixture (pattern "shell").
+// "N" is absent: rejection opens the reason dialog instead of resuming.
+var expectedOptionResume = map[string]runtime.ResumeRequest{
+	"Y": runtime.ResumeApprove(),
+	"T": runtime.ResumeApproveTool("shell"),
+	"B": runtime.ResumeApproveBalanced(),
+	"A": runtime.ResumeApproveAutonomous(),
+}
+
+// assertOptionClick clicks the given cell and asserts it dispatches
+// exactly the clicked segment's decision — anything else is a misdispatch.
+func assertOptionClick(t *testing.T, d *toolConfirmationDialog, seg optionSegment, y, x, width int) {
+	t.Helper()
+	msgs := collectMsgs(clickCell(d, y, x))
+	if seg.action == "N" {
+		assert.Truef(t, hasMsg[OpenDialogMsg](msgs),
+			"width %d: click on %q must open the rejection-reason dialog", width, seg.action)
+		return
+	}
+	resume, ok := findMsg[RuntimeResumeMsg](msgs)
+	require.Truef(t, ok, "width %d: click on %q must dispatch a resume", width, seg.action)
+	assert.Equalf(t, expectedOptionResume[seg.action], resume.Request,
+		"width %d: click on %q dispatched another segment's decision", width, seg.action)
+}
+
+// Tiny terminals — all the way down to zero columns — must never wrap a
+// laid-out option row across physical lines: the layout width is clamped
+// so even a fully truncated "<key> …" segment fits its row, the extremely
+// narrow terminal clips the dialog instead. The sweep proves the
+// invariants the hit-map depends on: renderOptions' physical height
+// equals optionRows' logical row count, every row renders on the physical
+// line the hit-map expects, clicks dispatch exactly the segment they land
+// on, and near-misses stay dead. A wrapped or misaligned row wouldn't
+// panic — it would silently fire the wrong decision, the one failure mode
+// a confirmation dialog cannot have.
+func TestToolConfirmationDialog_TinyWidthsKeepRowsAlignedAndClickable(t *testing.T) {
+	t.Parallel()
+
+	for width := range 60 {
+		dialog := NewToolConfirmationDialog(newConfirmationEvent(nil), &service.SessionState{})
+		_, _ = dialog.Update(tea.WindowSizeMsg{Width: width, Height: 30})
+
+		d, ok := dialog.(*toolConfirmationDialog)
+		require.True(t, ok)
+
+		_, contentWidth := d.dialogDimensions()
+		require.GreaterOrEqualf(t, contentWidth, toolConfirmMinOptionWidth,
+			"width %d: the layout width must clamp to fit a minimal segment", width)
+		rows := d.optionRows(contentWidth)
+		require.NotEmptyf(t, rows, "width %d: the options must always lay out", width)
+		for _, row := range rows {
+			assert.LessOrEqualf(t, ansi.StringWidth(optionRowText(row)), contentWidth,
+				"width %d: no row may exceed the clamped layout width", width)
+		}
+		require.Equalf(t, len(rows), lipgloss.Height(d.renderOptions(contentWidth)),
+			"width %d: each logical row must render as exactly one physical line", width)
+
+		// Walk the rows bottom-anchored, exactly like handleMouseClick.
+		dialogRow, dialogCol := d.Position()
+		view := d.View()
+		renderedLines := strings.Split(ansi.Strip(view), "\n")
+		endY := ContentEndRow(dialogRow, lipgloss.Height(view))
+		for i, row := range rows {
+			y := endY - (len(rows) - 1) + i
+			line := renderedLines[y-dialogRow]
+			byteStart := strings.Index(line, optionRowText(row))
+			require.GreaterOrEqualf(t, byteStart, 0,
+				"width %d: row %d must render whole on the physical line the hit-map expects", width, i)
+			x := dialogCol + ansi.StringWidth(line[:byteStart])
+
+			for _, seg := range row {
+				assertOptionClick(t, d, seg, y, x+seg.startX, width)
+				assertOptionClick(t, d, seg, y, x+seg.endX-1, width)
+			}
+			last := row[len(row)-1]
+			assert.Nilf(t, clickCell(d, y, x-1), "width %d: the cell before row %d must be dead", width, i)
+			assert.Nilf(t, clickCell(d, y, x+last.endX), "width %d: the cell after row %d must be dead", width, i)
+			for s := 1; s < len(row); s++ {
+				assert.Nilf(t, clickCell(d, y, x+row[s].startX-1),
+					"width %d: the separator gap on row %d must be dead", width, i)
+			}
+		}
+	}
+}
+
+// A pathological permission pattern (very long first command word) must
+// not overflow the dialog: the lone oversize segment's displayed label
+// truncates, while the key stays visible and a click still grants the
+// full untruncated pattern.
+func TestToolConfirmationDialog_OversizeSegmentTruncatesLabel(t *testing.T) {
+	t.Parallel()
+
+	longWord := "very-long-binary-name-" + strings.Repeat("x", 100)
+	event := newConfirmationEvent(nil)
+	event.ToolCall.Function.Arguments = `{"cmd":"` + longWord + ` --flag"}`
+
+	dialog := NewToolConfirmationDialog(event, &service.SessionState{})
+	_, _ = dialog.Update(tea.WindowSizeMsg{Width: 80, Height: 30})
+
+	d, ok := dialog.(*toolConfirmationDialog)
+	require.True(t, ok)
+
+	wantPattern := "shell:cmd=" + longWord + "*"
+	require.Equal(t, wantPattern, d.permissionPattern)
+
+	_, contentWidth := d.dialogDimensions()
+	rows := d.optionRows(contentWidth)
+	for _, row := range rows {
+		assert.LessOrEqual(t, ansi.StringWidth(optionRowText(row)), contentWidth,
+			"the oversize label must truncate so no row exceeds the content width")
+	}
+	require.Equal(t, len(rows), lipgloss.Height(d.renderOptions(contentWidth)),
+		"each laid-out row must render as exactly one line")
+	assert.Contains(t, ansi.Strip(d.renderOptions(contentWidth)), "…",
+		"the truncated label must show an ellipsis")
+
+	tY, tX, found := locateInView(d, "T always allow")
+	require.True(t, found, "the truncated segment must keep its key and label prefix visible")
+
+	resume, ok := findMsg[RuntimeResumeMsg](collectMsgs(clickCell(d, tY, tX)))
+	require.True(t, ok, "click on the truncated segment must dispatch a resume")
+	assert.Equal(t, runtime.ResumeApproveTool(wantPattern), resume.Request,
+		"the granted pattern must be the full untruncated pattern")
 }
 
 // Separator gaps between the option segments are dead zones: a click
@@ -266,35 +466,47 @@ func TestToolConfirmationDialog_GapClicksAreDeadZones(t *testing.T) {
 	d, ok := dialog.(*toolConfirmationDialog)
 	require.True(t, ok)
 
-	dialogRow, dialogCol := d.Position()
-	view := ansi.Strip(d.View())
-	lines := strings.Split(view, "\n")
-	optionsRow := ContentEndRow(dialogRow, len(lines))
-	optionsLine := lines[optionsRow-dialogRow]
-
-	click := func(col int) tea.Cmd {
-		_, cmd := d.handleMouseClick(tea.MouseClickMsg{
-			X:      dialogCol + col,
-			Y:      optionsRow,
-			Button: tea.MouseLeft,
-		})
-		return cmd
-	}
+	// This width keeps the single-line layout: all segments on one row.
+	_, contentWidth := d.dialogDimensions()
+	require.Len(t, d.optionRows(contentWidth), 1)
 
 	// Clicking inside a segment's text fires.
-	nIdx := strings.Index(optionsLine, "N no")
-	require.GreaterOrEqual(t, nIdx, 0)
-	assert.NotNil(t, click(nIdx), "click on 'N' must fire")
-	assert.NotNil(t, click(nIdx+3), "click on N's label must fire")
+	nY, nX, found := locateInView(d, "N no")
+	require.True(t, found)
+	assert.NotNil(t, clickCell(d, nY, nX), "click on 'N' must fire")
+	assert.NotNil(t, clickCell(d, nY, nX+3), "click on N's label must fire")
 
 	// Clicking the two-space gap between "Y yes" and "N no" fires nothing.
-	assert.Nil(t, click(nIdx-1), "gap click must be a dead zone")
-	assert.Nil(t, click(nIdx-2), "gap click must be a dead zone")
+	assert.Nil(t, clickCell(d, nY, nX-1), "gap click must be a dead zone")
+	assert.Nil(t, clickCell(d, nY, nX-2), "gap click must be a dead zone")
 
-	// The trailing segment is clickable to its last character.
-	aIdx := strings.Index(optionsLine, "A all tools")
-	require.GreaterOrEqual(t, aIdx, 0)
-	assert.NotNil(t, click(aIdx), "click on 'A' must fire")
-	assert.NotNil(t, click(aIdx+len("A all tools")-1), "click on the last label char must fire")
-	assert.Nil(t, click(aIdx+len("A all tools")), "click past the line must be a no-op")
+	// The trailing segment is clickable to its last cell.
+	aY, aX, found := locateInView(d, "A all tools")
+	require.True(t, found)
+	require.Equal(t, nY, aY, "single-line layout keeps every segment on one row")
+	assert.NotNil(t, clickCell(d, aY, aX), "click on 'A' must fire")
+	assert.NotNil(t, clickCell(d, aY, aX+ansi.StringWidth("A all tools")-1), "click on the last label cell must fire")
+	assert.Nil(t, clickCell(d, aY, aX+ansi.StringWidth("A all tools")), "click past the line must be a no-op")
+}
+
+// A preempt/custom hook can force a confirmation while the session is
+// already autonomous. Choosing Balanced switches the runtime session off
+// autonomous, so it must also clear the cached TUI yolo flag — otherwise
+// the sidebar keeps saying YOLO and Ctrl+Y "toggles" the session straight
+// back to autonomous.
+func TestToolConfirmationDialog_BalancedClearsYoloMode(t *testing.T) {
+	t.Parallel()
+
+	state := &service.EmbeddedSessionState{}
+	state.SetYoloMode(true)
+	dialog := NewToolConfirmationDialog(newConfirmationEvent(nil), state)
+	_, _ = dialog.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+
+	_, cmd := dialog.Update(tea.KeyPressMsg{Code: 'b', Text: "b"})
+	require.NotNil(t, cmd)
+	assert.False(t, state.YoloMode(), "choosing Balanced must drop the session-wide yolo flag")
+
+	resume, ok := findMsg[RuntimeResumeMsg](collectMsgs(cmd))
+	require.True(t, ok, "Balanced must dispatch a resume request")
+	assert.Equal(t, runtime.ResumeApproveBalanced(), resume.Request)
 }


### PR DESCRIPTION
## Summary

- preserve stored autonomous and legacy approval state during plain session resume
- carry explicit safety policy and YOLO toggle-back state through `/new`
- keep wrapped tool-confirmation actions clickable across terminal widths
- synchronize the cached YOLO indicator when a confirmation switches the session to Balanced

## Context

Follow-up to #3835. The safety-mode implementation introduced session-state preservation gaps and two classic TUI regressions around wrapped confirmation actions and Balanced-mode state display.

## Changes

| Area | Fix |
| --- | --- |
| Session resume | Safety state changes only when `--safety` or `--yolo` is explicitly supplied. Plain resume preserves both explicit autonomous state and legacy `tools_approved` state. |
| `/new` | Preserves effective `SafetyPolicy` and `PriorSafetyPolicy`, including toggle-back behavior after an Autonomous escalation. |
| Confirmation TUI | Lays out complete action segments across rows, uses terminal-cell hit maps, truncates display-only labels when necessary, and preserves the full permission pattern. |
| YOLO indicator | Clears cached YOLO state when selecting Balanced from a hook-forced confirmation. |

## Validation

- `go build ./...`
- `go test ./pkg/tui/... ./pkg/leantui/... ./cmd/root/... ./pkg/app/...`
- `go test -race ./pkg/tui/dialog ./pkg/tui/components/toolconfirm ./cmd/root ./pkg/app`
- `go vet ./pkg/tui/... ./pkg/leantui/... ./cmd/root/... ./pkg/app/...`
- `golangci-lint run`
- `go run ./lint .`
- `go mod tidy --diff`

Full `go test ./...` was also run. Only environment-specific SSRF tests failed in `pkg/config`, `pkg/httpclient`, and `pkg/tools/builtin/{api,fetch,openapi}` because private-address traffic is intercepted by the sandbox network; all changed and related packages passed.
