### PR TITLE
fix: prevent credential leaks in remote tool transports

### DIFF
--- a/pkg/tools/a2a/a2a.go
+++ b/pkg/tools/a2a/a2a.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	neturl "net/url"
 	"strings"
 	"sync"
 	"time"
@@ -96,6 +97,19 @@ func NewToolset(name, url string, headers map[string]string, opts ...Option) *To
 	return t
 }
 
+func sanitizeURLForLog(rawURL string) string {
+	u, err := neturl.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	u.User = nil
+	u.RawQuery = ""
+	u.ForceQuery = false
+	u.Fragment = ""
+	u.RawFragment = ""
+	return u.String()
+}
+
 // Instructions returns instructions for using the A2A toolset.
 func (t *Toolset) Instructions() string {
 	t.mu.RLock()
@@ -164,7 +178,7 @@ func (t *Toolset) Tools(_ context.Context) ([]tools.Tool, error) {
 
 // Start connects to the A2A agent and fetches the agent card.
 func (t *Toolset) Start(ctx context.Context) error {
-	slog.DebugContext(ctx, "Starting A2A toolset", "url", t.url, "timeout", t.timeout, "allow_private_ips", t.allowPrivateIPs)
+	slog.DebugContext(ctx, "Starting A2A toolset", "server", sanitizeURLForLog(t.url), "timeout", t.timeout, "allow_private_ips", t.allowPrivateIPs)
 
 	// Use the SSRF-safe client to fetch the agent card so a malicious or
 	// misconfigured `url:` cannot reach loopback / RFC1918 / link-local
@@ -183,8 +197,12 @@ func (t *Toolset) Start(ctx context.Context) error {
 		base = http.DefaultTransport
 	}
 
+	endpointOrigin := t.url
+	if card.URL != "" {
+		endpointOrigin = card.URL
+	}
 	headers := t.expander.ExpandMap(ctx, t.headers)
-	httpClient.Transport = upstream.NewHeaderTransport(base, headers)
+	httpClient.Transport = upstream.NewHeaderTransportForOrigin(base, endpointOrigin, headers)
 
 	client, err := a2aclient.NewFromCard(
 		ctx, card,

--- a/pkg/tools/builtin/agent/agent.go
+++ b/pkg/tools/builtin/agent/agent.go
@@ -511,7 +511,7 @@ func (t *ToolSet) Instructions() string {
 
 Use background agent tasks to dispatch work to sub-agents concurrently.
 
-- **run_background_agent**: Start a command, returns task ID. The sub-agent runs with all tools pre-approved — use only with trusted sub-agents and well-scoped tasks.
+- **run_background_agent**: Start a command and return its task ID. Native sub-agents inherit the current session's safety policy and permissions; calls requiring confirmation are denied because background tasks are non-interactive. External harnesses enforce their own permission model.
 - **list_background_agents**: Show all tasks with status and runtime
 - **view_background_agent**: Get output and status of a task by task_id
 - **stop_background_agent**: Terminate a task by task_id
@@ -525,8 +525,9 @@ func backgroundAgentTools() []tools.Tool {
 			Name:     ToolNameRunBackgroundAgent,
 			Category: "transfer",
 			Description: `Start a sub-agent task in the background and return immediately with a task ID.
-Use this to dispatch work to multiple sub-agents concurrently. The sub-agent runs with all tools
-pre-approved — use only with trusted sub-agents and well-scoped tasks. Check progress with
+Use this to dispatch work to multiple sub-agents concurrently. Native sub-agents inherit the current
+session's safety policy and permissions; calls requiring confirmation are denied because background
+tasks are non-interactive. External harnesses enforce their own permission model. Check progress with
 view_background_agent and collect results once the task is complete.`,
 			Parameters:  tools.MustSchemaFor[RunBackgroundAgentArgs](),
 			Annotations: tools.ToolAnnotations{Title: "Run Background Agent"},

--- a/pkg/tools/mcp/mcp.go
+++ b/pkg/tools/mcp/mcp.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -275,9 +276,9 @@ func newRemoteToolset(
 	policy ...lifecycle.Policy,
 ) *Toolset {
 	slog.Debug("Creating Remote MCP toolset",
-		"url", urlString,
+		"server", sanitizeRemoteAddress(urlString),
 		"transport", transport,
-		"headers", headers,
+		"header_names", headerNames(headers),
 		"allow_private_ips", allowPrivateIPs,
 	)
 
@@ -285,12 +286,21 @@ func newRemoteToolset(
 	ts := &Toolset{
 		name:        name,
 		mcpClient:   newRemoteClient(urlString, transport, headers, NewKeyringTokenStore(), oauthConfig, allowPrivateIPs, env),
-		logID:       urlString,
+		logID:       sanitizeRemoteAddress(urlString),
 		description: desc,
 		callTimeout: firstOrZero(policy).CallTimeout,
 	}
 	ts.supervisor = newSupervisor(ts, remotePolicy(firstOrZero(policy)))
 	return ts
+}
+
+func headerNames(headers map[string]string) []string {
+	names := make([]string, 0, len(headers))
+	for name := range headers {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
 }
 
 func remotePolicy(base lifecycle.Policy) lifecycle.Policy {

--- a/pkg/tools/mcp/mcp_test.go
+++ b/pkg/tools/mcp/mcp_test.go
@@ -1,9 +1,11 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"iter"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -16,6 +18,29 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/tools/lifecycle"
 )
+
+func TestRemoteToolsetLogsDoNotExposeCredentials(t *testing.T) {
+	var logs bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	const secret = "audit-secret-value"
+	ts := NewRemoteToolset(
+		"test",
+		"https://user:"+secret+"@example.com/mcp?api_key="+secret,
+		"streamable",
+		map[string]string{"Authorization": "Bearer " + secret, "X-API-Key": secret},
+		nil,
+	)
+
+	output := logs.String()
+	assert.NotContains(t, output, secret)
+	assert.NotContains(t, output, "user:")
+	assert.Contains(t, output, "Authorization")
+	assert.Contains(t, output, "X-API-Key")
+	assert.Equal(t, "example.com", ts.logID)
+}
 
 // mockMCPClient is a test double for the mcpClient interface.
 type mockMCPClient struct {

--- a/pkg/tools/mcp/oauth.go
+++ b/pkg/tools/mcp/oauth.go
@@ -28,6 +28,7 @@ import (
 	otelmcp "github.com/docker/docker-agent/pkg/telemetry/mcp"
 	"github.com/docker/docker-agent/pkg/tools"
 	"github.com/docker/docker-agent/pkg/tools/mcp/oauthflow"
+	"github.com/docker/docker-agent/pkg/upstream"
 )
 
 // resourceMetadataFromWWWAuth extracts resource metadata URL from WWW-Authenticate header.
@@ -107,13 +108,13 @@ func (o *oauth) getAuthorizationServerMetadata(ctx context.Context, authServerUR
 		switch {
 		case err != nil:
 			slog.DebugContext(ctx, "Metadata discovery candidate failed, trying next",
-				"url", u, "error", err)
+				"url", sanitizeURLForLog(u), "error", err)
 			if notableErr == nil && notableStatus == 0 {
 				notableErr, notableURL = err, u
 			}
 		case status != http.StatusNotFound:
 			slog.DebugContext(ctx, "Metadata discovery candidate returned unexpected status, trying next",
-				"url", u, "status", status)
+				"url", sanitizeURLForLog(u), "status", status)
 			if notableStatus == 0 {
 				notableStatus, notableURL = status, u
 				notableErr = nil
@@ -123,13 +124,13 @@ func (o *oauth) getAuthorizationServerMetadata(ctx context.Context, authServerUR
 
 	switch {
 	case notableErr != nil:
-		return nil, fmt.Errorf("failed to fetch authorization server metadata from %s: %w", notableURL, notableErr)
+		return nil, fmt.Errorf("failed to fetch authorization server metadata from %s: %w", sanitizeURLForLog(notableURL), notableErr)
 	case notableStatus != 0:
-		return nil, fmt.Errorf("unexpected status %d from %s", notableStatus, notableURL)
+		return nil, fmt.Errorf("unexpected status %d from %s", notableStatus, sanitizeURLForLog(notableURL))
 	}
 
 	slog.DebugContext(ctx, "All metadata discovery URLs returned 404, returning default metadata",
-		"authServerURL", authServerURL)
+		"authServerURL", sanitizeURLForLog(authServerURL))
 	return createDefaultMetadata(authServerURL), nil
 }
 
@@ -138,15 +139,16 @@ func (o *oauth) getAuthorizationServerMetadata(ctx context.Context, authServerUR
 // the caller should consider for fallback, or (nil, 0, err) on transport
 // or decode failure.
 func (o *oauth) fetchAuthorizationServerMetadata(ctx context.Context, metadataURL string) (*AuthorizationServerMetadata, int, error) {
+	safeURL := sanitizeURLForLog(metadataURL)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, http.NoBody)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("creating metadata request for %s: %w", safeURL, err)
 	}
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := o.metadataClient.Do(req)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("fetching metadata from %s: request failed", safeURL)
 	}
 	defer resp.Body.Close()
 
@@ -160,7 +162,7 @@ func (o *oauth) fetchAuthorizationServerMetadata(ctx context.Context, metadataUR
 
 	var metadata AuthorizationServerMetadata
 	if err := json.NewDecoder(resp.Body).Decode(&metadata); err != nil {
-		return nil, 0, fmt.Errorf("failed to decode metadata from %s: %w", metadataURL, err)
+		return nil, 0, fmt.Errorf("failed to decode metadata from %s: %w", safeURL, err)
 	}
 	return &metadata, resp.StatusCode, nil
 }
@@ -405,32 +407,32 @@ func (t *oauthTransport) handleServerRejectedToken(ctx context.Context, prev *OA
 	// Coalesce: if another goroutine already refreshed successfully, the
 	// stored token is now different. Return nil so the caller replays.
 	if current, err := t.tokenStore.GetToken(t.baseURL); err == nil && current.AccessToken != prev.AccessToken {
-		slog.DebugContext(ctx, "Token already refreshed by concurrent request; reusing", "url", t.baseURL)
+		slog.DebugContext(ctx, "Token already refreshed by concurrent request; reusing", "url", sanitizeURLForLog(t.baseURL))
 		return nil
 	}
 
 	// Evict the stale token; the refresh or interactive flow will store a
 	// fresh one.
 	if err := t.tokenStore.RemoveToken(t.baseURL); err != nil {
-		slog.DebugContext(ctx, "Failed to evict stale token", "url", t.baseURL, "error", err)
+		slog.DebugContext(ctx, "Failed to evict stale token", "url", sanitizeURLForLog(t.baseURL), "error", err)
 	}
 
 	// Attempt a silent refresh when we have a refresh token.
 	if prev.RefreshToken != "" {
 		_, err := t.refreshStoredToken(ctx, prev)
 		if err == nil {
-			slog.DebugContext(ctx, "Silently refreshed server-rejected token", "url", t.baseURL)
+			slog.DebugContext(ctx, "Silently refreshed server-rejected token", "url", sanitizeURLForLog(t.baseURL))
 			t.notifyOAuthSuccess()
 			return nil
 		}
 		slog.DebugContext(ctx, "Refresh failed after server-side token rejection; falling back to interactive auth",
-			"url", t.baseURL, "error", err)
+			"url", sanitizeURLForLog(t.baseURL), "error", err)
 	}
 
 	// Refresh not possible or failed: fall back to interactive OAuth if the
 	// context allows it.
 	if !InteractivePromptsAllowed(ctx) {
-		slog.DebugContext(ctx, "Non-interactive context: deferring re-auth after server-side token rejection", "url", t.baseURL)
+		slog.DebugContext(ctx, "Non-interactive context: deferring re-auth after server-side token rejection", "url", sanitizeURLForLog(t.baseURL))
 		t.mu.Lock()
 		t.lastAuthRequired = true
 		t.mu.Unlock()
@@ -465,7 +467,7 @@ func (t *oauthTransport) startInteractiveFlowLocked(ctx context.Context, authSer
 	declined := t.lastOAuthDeclined
 	t.mu.Unlock()
 	if declined {
-		slog.DebugContext(ctx, "OAuth flow short-circuited: user already declined on this transport", "url", t.baseURL)
+		slog.DebugContext(ctx, "OAuth flow short-circuited: user already declined on this transport", "url", sanitizeURLForLog(t.baseURL))
 		return &OAuthDeclinedError{URL: t.baseURL}
 	}
 
@@ -521,11 +523,14 @@ func (t *oauthTransport) roundTrip(req *http.Request, isRetry bool) (*http.Respo
 
 	reqClone := req.Clone(req.Context())
 
-	// Attach a valid token if available, silently refreshing if expired.
+	// Attach a valid token only to the configured MCP origin. Redirects to
+	// another origin must never receive bearer credentials.
 	var attachedToken *OAuthToken
-	if token := t.getValidToken(req.Context()); token != nil {
-		reqClone.Header.Set("Authorization", "Bearer "+token.AccessToken)
-		attachedToken = token
+	if upstream.SameOrigin(t.baseURL, reqClone.URL) {
+		if token := t.getValidToken(req.Context()); token != nil {
+			reqClone.Header.Set("Authorization", "Bearer "+token.AccessToken)
+			attachedToken = token
+		}
 	}
 
 	resp, err := t.base.RoundTrip(reqClone)
@@ -580,7 +585,7 @@ func (t *oauthTransport) roundTrip(req *http.Request, isRetry bool) (*http.Respo
 			// the agent and without making Ctrl-C wait for a user response
 			// that will never come.
 			if !InteractivePromptsAllowed(req.Context()) {
-				slog.Debug("Skipping OAuth elicitation in non-interactive context", "url", t.baseURL)
+				slog.Debug("Skipping OAuth elicitation in non-interactive context", "url", sanitizeURLForLog(t.baseURL))
 				resp.Body.Close()
 				t.mu.Lock()
 				t.lastAuthRequired = true
@@ -603,7 +608,7 @@ func (t *oauthTransport) roundTrip(req *http.Request, isRetry bool) (*http.Respo
 				// the next conversation turn with a properly-wired bridge.
 				var authErr *AuthorizationRequiredError
 				if errors.As(err, &authErr) {
-					slog.Debug("OAuth flow deferred: elicitation bridge not ready", "url", t.baseURL)
+					slog.Debug("OAuth flow deferred: elicitation bridge not ready", "url", sanitizeURLForLog(t.baseURL))
 					if authErr.URL == "" {
 						authErr.URL = t.baseURL
 					}
@@ -621,7 +626,7 @@ func (t *oauthTransport) roundTrip(req *http.Request, isRetry bool) (*http.Respo
 				// pattern this mirrors.
 				var declinedErr *OAuthDeclinedError
 				if errors.As(err, &declinedErr) {
-					slog.Debug("OAuth flow declined by user", "url", t.baseURL)
+					slog.Debug("OAuth flow declined by user", "url", sanitizeURLForLog(t.baseURL))
 					if declinedErr.URL == "" {
 						declinedErr.URL = t.baseURL
 					}
@@ -676,7 +681,7 @@ func (t *oauthTransport) logErrorResponse(req *http.Request, resp *http.Response
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBody))
 	if err != nil {
 		slog.Warn("Authenticated MCP request failed; could not read response body",
-			"url", req.URL.String(),
+			"url", sanitizeURLForLog(req.URL.String()),
 			"status", resp.StatusCode,
 			"error", err,
 		)
@@ -699,7 +704,7 @@ func (t *oauthTransport) logErrorResponse(req *http.Request, resp *http.Response
 	t.mu.Unlock()
 
 	slog.Warn("Authenticated MCP request was rejected by the server",
-		"url", req.URL.String(),
+		"url", sanitizeURLForLog(req.URL.String()),
 		"status", resp.StatusCode,
 		"www_authenticate", resp.Header.Get("WWW-Authenticate"),
 		"content_type", resp.Header.Get("Content-Type"),
@@ -811,12 +816,12 @@ func (t *oauthTransport) getValidToken(ctx context.Context) *OAuthToken {
 
 	if !t.tokenCoversConfiguredScopes(token) {
 		slog.DebugContext(ctx, "Stored token scopes no longer cover configured scopes; discarding to force re-auth",
-			"url", t.baseURL,
+			"url", sanitizeURLForLog(t.baseURL),
 			"stored", token.RequestedScopes,
 			"configured", configuredScopes(t.oauthConfig),
 		)
 		if err := t.tokenStore.RemoveToken(t.baseURL); err != nil {
-			slog.DebugContext(ctx, "Failed to remove stale token", "url", t.baseURL, "error", err)
+			slog.DebugContext(ctx, "Failed to remove stale token", "url", sanitizeURLForLog(t.baseURL), "error", err)
 		}
 		return nil
 	}
@@ -853,7 +858,7 @@ func (t *oauthTransport) refreshStoredToken(ctx context.Context, prev *OAuthToke
 		return nil, fmt.Errorf("skipping refresh: last attempt failed %s ago", time.Since(failedAt).Round(time.Second))
 	}
 
-	slog.DebugContext(ctx, "Attempting silent token refresh", "url", t.baseURL)
+	slog.DebugContext(ctx, "Attempting silent token refresh", "url", sanitizeURLForLog(t.baseURL))
 
 	// Wrap the refresh path in a span so the latency and failure
 	// rate of silent OAuth token refreshes are visible — the user
@@ -861,7 +866,7 @@ func (t *oauthTransport) refreshStoredToken(ctx context.Context, prev *OAuthToke
 	// cause. Pull conversation id from baggage so observability-svc
 	// can attribute the refresh to the spawning session.
 	refreshAttrs := []attribute.KeyValue{
-		attribute.String("cagent.oauth.base_url", t.baseURL),
+		attribute.String("cagent.oauth.base_url", sanitizeURLForLog(t.baseURL)),
 	}
 	if convID := otelmcp.ConversationIDFromBaggage(ctx); convID != "" {
 		refreshAttrs = append(refreshAttrs, attribute.String("gen_ai.conversation.id", convID))
@@ -878,7 +883,7 @@ func (t *oauthTransport) refreshStoredToken(ctx context.Context, prev *OAuthToke
 	authServer := cmp.Or(prev.AuthServer, t.baseURL)
 	metadata, err := o.getAuthorizationServerMetadata(ctx, authServer)
 	if err != nil {
-		slog.DebugContext(ctx, "Failed to fetch auth server metadata for refresh", "auth_server", authServer, "error", err)
+		slog.DebugContext(ctx, "Failed to fetch auth server metadata for refresh", "auth_server", sanitizeURLForLog(authServer), "error", err)
 		refreshSpan.RecordError(err)
 		refreshSpan.SetStatus(codes.Error, "metadata fetch failed")
 		refreshSpan.SetAttributes(attribute.String("error.type", "metadata"))
@@ -914,7 +919,7 @@ func (t *oauthTransport) refreshStoredToken(ctx context.Context, prev *OAuthToke
 		slog.WarnContext(ctx, "Failed to store refreshed token", "error", err)
 	}
 
-	slog.DebugContext(ctx, "Token refreshed successfully", "url", t.baseURL)
+	slog.DebugContext(ctx, "Token refreshed successfully", "url", sanitizeURLForLog(t.baseURL))
 	return newToken, nil
 }
 
@@ -968,7 +973,7 @@ func (t *oauthTransport) handleOAuthFlow(ctx context.Context, authServer, wwwAut
 	// back). The span makes that latency attributable and gives
 	// dashboards a way to count auth-failure rates by managed kind.
 	flowAttrs := []attribute.KeyValue{
-		attribute.String("cagent.oauth.base_url", t.baseURL),
+		attribute.String("cagent.oauth.base_url", sanitizeURLForLog(t.baseURL)),
 		attribute.String("cagent.oauth.kind", kind),
 	}
 	if convID := otelmcp.ConversationIDFromBaggage(ctx); convID != "" {
@@ -995,7 +1000,7 @@ func (t *oauthTransport) handleOAuthFlow(ctx context.Context, authServer, wwwAut
 }
 
 func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer, wwwAuth string) error {
-	slog.DebugContext(ctx, "Starting OAuth flow for server", "url", t.baseURL)
+	slog.DebugContext(ctx, "Starting OAuth flow for server", "url", sanitizeURLForLog(t.baseURL))
 	span := trace.SpanFromContext(ctx)
 
 	resourceURL := cmp.Or(resourceMetadataFromWWWAuth(wwwAuth), authServer+"/.well-known/oauth-protected-resource")
@@ -1102,7 +1107,7 @@ func (t *oauthTransport) handleManagedOAuthFlow(ctx context.Context, authServer,
 		return errors.New("user declined OAuth authorization")
 	}
 
-	slog.DebugContext(ctx, "Requesting authorization code", "url", authURL)
+	slog.DebugContext(ctx, "Requesting authorization code", "url", sanitizeURLForLog(authURL))
 	span.AddEvent("oauth.step", trace.WithAttributes(attribute.String("cagent.oauth.step", "request_authorization_code")))
 
 	code, receivedState, err := RequestAuthorizationCode(ctx, authURL, callbackServer, state)
@@ -1272,7 +1277,7 @@ func (t *oauthTransport) unmanagedRedirectURI() string {
 // receives an authorize_url but still wants to do the exchange itself is
 // free to return an access token.
 func (t *oauthTransport) handleUnmanagedOAuthFlow(ctx context.Context, authServer, wwwAuth string) error {
-	slog.DebugContext(ctx, "Starting unmanaged OAuth flow for server", "url", t.baseURL)
+	slog.DebugContext(ctx, "Starting unmanaged OAuth flow for server", "url", sanitizeURLForLog(t.baseURL))
 	span := trace.SpanFromContext(ctx)
 
 	// Extract resource URL from WWW-Authenticate header

--- a/pkg/tools/mcp/oauth_helpers.go
+++ b/pkg/tools/mcp/oauth_helpers.go
@@ -127,7 +127,7 @@ func oauthHTTPClientWithHeaders(rawURL string, headers map[string]string, allowP
 		CheckRedirect: base.CheckRedirect,
 		Transport: &hostScopedHeaderTransport{
 			host:        hostWithoutDefaultPort(u.Host, u.Scheme),
-			withHeaders: upstream.NewHeaderTransportWithResolver(inner, headers, resolve),
+			withHeaders: upstream.NewHeaderTransportWithResolverForOrigin(inner, rawURL, headers, resolve),
 			base:        inner,
 		},
 	}

--- a/pkg/tools/mcp/oauth_test.go
+++ b/pkg/tools/mcp/oauth_test.go
@@ -506,6 +506,41 @@ func TestExchangeCodeForToken_MissingAccessToken(t *testing.T) {
 	}
 }
 
+func TestOAuthTransport_DoesNotForwardBearerAcrossOrigins(t *testing.T) {
+	t.Parallel()
+
+	var redirectedAuthorization string
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedAuthorization = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer destination.Close()
+
+	sourceAuthorization := make(chan string, 1)
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sourceAuthorization <- r.Header.Get("Authorization")
+		http.Redirect(w, r, destination.URL, http.StatusFound)
+	}))
+	defer source.Close()
+
+	store := NewInMemoryTokenStore()
+	require.NoError(t, store.StoreToken(source.URL, &OAuthToken{AccessToken: "stored-at"}))
+	transport := &oauthTransport{
+		base:       http.DefaultTransport,
+		tokenStore: store,
+		baseURL:    source.URL,
+	}
+	client := &http.Client{Transport: transport}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, source.URL, http.NoBody)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, "Bearer stored-at", <-sourceAuthorization)
+	assert.Empty(t, redirectedAuthorization)
+}
+
 // TestOAuthTransport_RetryFailureExposesResponseBody verifies that when
 // the authenticated retry after a successful OAuth flow still fails with
 // a non-2xx status, the response body is logged and preserved for the

--- a/pkg/tools/mcp/remote.go
+++ b/pkg/tools/mcp/remote.go
@@ -50,9 +50,9 @@ func newRemoteClient(
 	env environment.Provider,
 ) *remoteMCPClient {
 	slog.Debug("Creating remote MCP client",
-		"url", url,
+		"server", sanitizeRemoteAddress(url),
 		"transport", transportType,
-		"headers", headers,
+		"header_names", headerNames(headers),
 		"allow_private_ips", allowPrivateIPs,
 	)
 
@@ -95,6 +95,19 @@ func sanitizeRemoteAddress(rawURL string) string {
 		return ""
 	}
 	return u.Host
+}
+
+func sanitizeURLForLog(rawURL string) string {
+	u, err := neturl.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	u.User = nil
+	u.RawQuery = ""
+	u.ForceQuery = false
+	u.Fragment = ""
+	u.RawFragment = ""
+	return u.String()
 }
 
 // unixSocketPath mirrors pkg/server.Listen: it strips the "unix://" prefix so
@@ -292,15 +305,17 @@ func (c *remoteMCPClient) expandHeaders(ctx context.Context, headers map[string]
 
 func (c *remoteMCPClient) headerTransport() http.RoundTripper {
 	base := http.DefaultTransport
+	origin := c.url
 	if path, ok := unixSocketPath(c.url); ok {
 		t := http.DefaultTransport.(*http.Transport).Clone()
 		t.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
 			return (&net.Dialer{}).DialContext(ctx, "unix", path)
 		}
 		base = t
+		origin = "http://localhost/"
 	}
 	if len(c.headers) > 0 {
-		return upstream.NewHeaderTransportWithResolver(base, c.headers, c.expandHeaders)
+		return upstream.NewHeaderTransportWithResolverForOrigin(base, origin, c.headers, c.expandHeaders)
 	}
 	return base
 }

--- a/pkg/tools/mcp/remote_test.go
+++ b/pkg/tools/mcp/remote_test.go
@@ -53,8 +53,16 @@ func TestSanitizeRemoteAddress(t *testing.T) {
 	}
 }
 
-// TestRemoteClientCustomHeaders verifies that custom headers passed to the remote
-// MCP client are actually applied to HTTP requests sent to the MCP server.
+func TestSanitizeURLForLog(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		"https://example.com:8443/mcp",
+		sanitizeURLForLog("https://alice:s3cret@example.com:8443/mcp?api_key=secret#fragment"),
+	)
+	assert.Empty(t, sanitizeURLForLog("not-a-url"))
+}
+
 func TestRemoteClientCustomHeaders(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/upstream/headers.go
+++ b/pkg/upstream/headers.go
@@ -4,9 +4,14 @@ package upstream
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"net/http"
+	"net/netip"
+	"net/url"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/docker/docker-agent/pkg/js"
 )
@@ -41,36 +46,106 @@ func Handler(next http.Handler) http.Handler {
 // by rotating credentials) without going stale on long-lived connections.
 type HeaderResolver func(ctx context.Context, headers map[string]string) map[string]string
 
-// NewHeaderTransport wraps an http.RoundTripper to set custom headers on
-// every outbound request. Header values may contain ${headers.NAME}
-// placeholders that are resolved at request time from upstream headers
-// stored in the request context.
+// NewHeaderTransport wraps an http.RoundTripper to set custom headers. The
+// first request pins the origin; redirects to another origin do not receive
+// the configured headers.
 func NewHeaderTransport(base http.RoundTripper, headers map[string]string) http.RoundTripper {
-	return NewHeaderTransportWithResolver(base, headers, nil)
+	return newHeaderTransport(base, "", headers, nil)
+}
+
+// NewHeaderTransportForOrigin is like NewHeaderTransport, but pins the origin
+// before the first request so a shared transport cannot be initialized by the
+// wrong caller.
+func NewHeaderTransportForOrigin(base http.RoundTripper, origin string, headers map[string]string) http.RoundTripper {
+	return newHeaderTransport(base, origin, headers, nil)
 }
 
 // NewHeaderTransportWithResolver is like NewHeaderTransport but resolves the
-// header values through resolve on every request. A nil resolve falls back
-// to ResolveHeaders (i.e. ${headers.NAME} placeholder resolution only).
+// header values through resolve on every request.
 func NewHeaderTransportWithResolver(base http.RoundTripper, headers map[string]string, resolve HeaderResolver) http.RoundTripper {
+	return newHeaderTransport(base, "", headers, resolve)
+}
+
+// NewHeaderTransportWithResolverForOrigin combines per-request resolution with
+// an explicitly pinned origin.
+func NewHeaderTransportWithResolverForOrigin(base http.RoundTripper, origin string, headers map[string]string, resolve HeaderResolver) http.RoundTripper {
+	return newHeaderTransport(base, origin, headers, resolve)
+}
+
+func newHeaderTransport(base http.RoundTripper, origin string, headers map[string]string, resolve HeaderResolver) http.RoundTripper {
 	if resolve == nil {
 		resolve = ResolveHeaders
 	}
-	return &headerTransport{base: base, headers: headers, resolve: resolve}
+	return &headerTransport{base: base, origin: parseOrigin(origin), headers: headers, resolve: resolve}
 }
 
 type headerTransport struct {
-	base    http.RoundTripper
-	headers map[string]string
-	resolve HeaderResolver
+	base       http.RoundTripper
+	originOnce sync.Once
+	origin     string
+	headers    map[string]string
+	resolve    HeaderResolver
 }
 
 func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Response != nil && req.Response.Request.URL.Scheme == "https" && req.URL.Scheme != "https" {
+		return nil, fmt.Errorf("refusing HTTPS downgrade redirect to %q", req.URL.Redacted())
+	}
+
+	t.originOnce.Do(func() {
+		if t.origin == "" {
+			t.origin = requestOrigin(req)
+		}
+	})
+
 	req = req.Clone(req.Context())
-	for key, value := range t.resolve(req.Context(), t.headers) {
-		req.Header.Set(key, value)
+	if requestOrigin(req) == t.origin {
+		for key, value := range t.resolve(req.Context(), t.headers) {
+			req.Header.Set(key, value)
+		}
 	}
 	return t.base.RoundTrip(req)
+}
+
+// SameOrigin reports whether target has the same scheme, host, and effective
+// port as rawURL.
+func SameOrigin(rawURL string, target *url.URL) bool {
+	return parseOrigin(rawURL) != "" && parseOrigin(rawURL) == origin(target)
+}
+
+func parseOrigin(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return origin(u)
+}
+
+func requestOrigin(req *http.Request) string {
+	if req == nil {
+		return ""
+	}
+	return origin(req.URL)
+}
+
+func origin(u *url.URL) string {
+	if u == nil || u.Scheme == "" || u.Host == "" {
+		return ""
+	}
+
+	scheme := strings.ToLower(u.Scheme)
+	host := strings.ToLower(u.Hostname())
+	if addr, err := netip.ParseAddr(host); err == nil {
+		host = addr.Unmap().String()
+	}
+
+	port := u.Port()
+	if port != "" && (scheme != "http" || port != "80") && (scheme != "https" || port != "443") {
+		host = net.JoinHostPort(host, port)
+	} else if strings.Contains(host, ":") {
+		host = "[" + host + "]"
+	}
+	return scheme + "://" + host
 }
 
 // ResolveHeaders resolves ${headers.NAME} placeholders in header values

--- a/pkg/upstream/headers_test.go
+++ b/pkg/upstream/headers_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,6 +50,33 @@ func TestHandler_InjectsHeaders(t *testing.T) {
 
 	require.NotNil(t, captured)
 	assert.Equal(t, "hello", captured.Get("X-Test"))
+}
+
+func TestSameOrigin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		origin string
+		target string
+		want   bool
+	}{
+		{name: "same", origin: "https://example.com/path", target: "https://example.com/other", want: true},
+		{name: "case insensitive", origin: "HTTPS://EXAMPLE.COM/path", target: "https://example.com/other", want: true},
+		{name: "default HTTPS port", origin: "https://example.com", target: "https://example.com:443/other", want: true},
+		{name: "different port", origin: "https://example.com", target: "https://example.com:8443/other", want: false},
+		{name: "different scheme", origin: "https://example.com", target: "http://example.com/other", want: false},
+		{name: "compressed IPv6", origin: "https://[2001:db8::1]", target: "https://[2001:0db8:0:0:0:0:0:1]:443/other", want: true},
+		{name: "IPv4 mapped", origin: "https://[::ffff:192.0.2.1]", target: "https://192.0.2.1/other", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			target, err := url.Parse(tt.target)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, SameOrigin(tt.origin, target))
+		})
+	}
 }
 
 func TestResolveHeaders(t *testing.T) {
@@ -200,4 +228,87 @@ func TestNewHeaderTransportWithResolver_InvokedPerRequest(t *testing.T) {
 	assert.Equal(t, "req-1", capture.seen[0].Get("X-Call"))
 	assert.Equal(t, "req-2", capture.seen[1].Get("X-Call"),
 		"the resolver must run on every request so dynamic values stay fresh")
+}
+
+func TestNewHeaderTransport_DoesNotForwardHeadersAcrossOrigins(t *testing.T) {
+	t.Parallel()
+
+	var redirectedHeader string
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer destination.Close()
+
+	var sourceHeader string
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sourceHeader = r.Header.Get("Authorization")
+		http.Redirect(w, r, destination.URL, http.StatusFound)
+	}))
+	defer source.Close()
+
+	client := &http.Client{
+		Transport: NewHeaderTransportForOrigin(
+			http.DefaultTransport,
+			source.URL,
+			map[string]string{"Authorization": "Bearer secret"},
+		),
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, source.URL, http.NoBody)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, "Bearer secret", sourceHeader)
+	assert.Empty(t, redirectedHeader)
+}
+
+func TestNewHeaderTransport_ForwardsHeadersOnSameOriginRedirect(t *testing.T) {
+	t.Parallel()
+
+	var redirectedHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/start" {
+			http.Redirect(w, r, "/final", http.StatusFound)
+			return
+		}
+		redirectedHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := &http.Client{
+		Transport: NewHeaderTransportForOrigin(
+			http.DefaultTransport,
+			server.URL,
+			map[string]string{"Authorization": "Bearer secret"},
+		),
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL+"/start", http.NoBody)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, "Bearer secret", redirectedHeader)
+}
+
+func TestNewHeaderTransport_RejectsHTTPSDowngradeRedirect(t *testing.T) {
+	t.Parallel()
+
+	capture := &captureTransport{}
+	transport := NewHeaderTransportForOrigin(capture, "https://example.test", map[string]string{
+		"Authorization": "Bearer secret",
+	})
+	original := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.test/start", http.NoBody)
+	redirected := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.test/final", http.NoBody)
+	redirected.Response = &http.Response{Request: original}
+
+	resp, err := transport.RoundTrip(redirected)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	require.ErrorContains(t, err, "refusing HTTPS downgrade redirect")
+	assert.Empty(t, capture.seen)
 }


### PR DESCRIPTION
Remote tool transports (MCP and A2A) previously attached bearer tokens and custom headers to every outgoing request unconditionally. If a server responded with a redirect to a different origin, those credentials would follow — a straightforward credential-leak vector that is especially acute for OAuth bearer tokens and operator-supplied authentication headers.

This change introduces origin-scoped credential attachment. Bearer tokens are only set when the request URL's origin matches the transport's configured base URL; the same guard applies to custom headers supplied in the agent config. Cross-origin redirects are additionally blocked when they would downgrade from HTTPS to HTTP, preventing a network-level attacker from stripping TLS to harvest tokens in transit. URL values that appear in log output are scrubbed of `userinfo` components and query strings before being written, so credentials embedded in URLs (e.g. `?token=...`) are not captured in debug logs.

The change also corrects the `background-agent` permission documentation, which described the wrong scope, and adds regression tests covering the origin-check logic, the redirect-downgrade rejection, and the log-sanitisation helpers.