### PR TITLE
chore: update docker-agent-action to v2.0.3

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -18,7 +18,7 @@ jobs:
     if: |
       github.event_name == 'issue_comment' ||
       github.event.workflow_run.conclusion == 'success'
-    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@774b6e0e60d6c648b0f2dc43bd5221377a0a7420 # v2.0.2
+    uses: docker/docker-agent-action/.github/workflows/review-pr.yml@baf90543d81f5de59751dfd10e6cf45e21a5a982 # v2.0.3
     # Scoped to the job so other jobs in this workflow aren't over-permissioned
     permissions:
       contents: read # Read repository files and PR diffs


### PR DESCRIPTION
## Summary
Updates `docker-agent-action` reference in `.github/workflows/pr-review.yml` to [v2.0.3](https://github.com/docker/docker-agent-action/releases/tag/v2.0.3).
- **Commit**: `baf90543d81f5de59751dfd10e6cf45e21a5a982`
- **Version**: `v2.0.3`
> Auto-generated by the [release](https://github.com/docker/docker-agent-action/actions/runs/30279688033) workflow.