### PR TITLE
docs: explain GITHUB_TOKEN forwarding for eval containers

### DIFF
--- a/docs/features/evaluation/index.md
+++ b/docs/features/evaluation/index.md
@@ -165,6 +165,38 @@ $ docker agent eval <agent-file>|<registry-ref> [<eval-dir>|./evals]
 | `-e, --env`         | (none)                      | Environment variables to pass to container (`KEY` or `KEY=VALUE`) |
 | `--repeat`          | `1`                         | Number of times to repeat each evaluation (useful for computing baselines) |
 
+### Provider Credentials
+
+Eval containers are isolated from your host environment. Dedicated model
+provider API keys (for example `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`) are
+forwarded into eval containers automatically, so most provider setups work
+without extra flags.
+
+> [!WARNING]
+> **`GITHUB_TOKEN` and `GH_TOKEN` are not forwarded automatically**
+>
+> GitHub tokens are broad credentials (git, `gh`, CI, packages), not dedicated
+> model API keys, so for security reasons Docker Agent does not forward them
+> into eval containers — even when they are set in your shell or in
+> `~/.config/cagent/.env`. If your agent uses the `github-copilot` provider,
+> pass the token explicitly by name:
+>
+> ```bash
+> docker agent eval agent.yaml ./evals -e GITHUB_TOKEN
+> ```
+>
+> When using a custom env file, both flags are required:
+>
+> ```bash
+> docker agent eval agent.yaml ./evals \
+>   --env-from-file /path/to/secrets.env \
+>   -e GITHUB_TOKEN
+> ```
+
+Note that the LLM judge runs on the host, not inside the eval container. If
+the token is not forwarded, judge validation can succeed while every
+evaluated agent run fails to authenticate.
+
 ### Custom Base Images
 
 When `--base-image` is set, the eval harness builds a derived image on top of your base image at evaluation time. Two things happen automatically:

--- a/docs/providers/github-copilot/index.md
+++ b/docs/providers/github-copilot/index.md
@@ -24,6 +24,20 @@ subscription can reuse their entitlement from Docker Agent.
 export GITHUB_TOKEN="ghp_..."
 ```
 
+## Running Evals
+
+Eval cases (`docker agent eval`) run in isolated containers. Unlike dedicated
+provider API keys, `GITHUB_TOKEN` and `GH_TOKEN` are **not** forwarded into
+eval containers automatically, because a GitHub token grants far broader
+access than a model API key. Pass the token explicitly:
+
+```bash
+docker agent eval agent.yaml ./evals -e GITHUB_TOKEN
+```
+
+See [Evaluation](../../features/evaluation/index.md#provider-credentials)
+for details, including behavior with `--env-from-file`.
+
 ## Configuration
 
 ### Inline


### PR DESCRIPTION
Fixes #3841

Eval containers deliberately do not receive GITHUB_TOKEN / GH_TOKEN, even though dedicated provider API keys are forwarded automatically (nonForwardableTokenEnvVars in pkg/config/auto.go excludes GITHUB_TOKEN). This is intentional but undocumented, and the asymmetry with other providers is confusing.

This PR adds a warning to the evaluation docs and the GitHub Copilot provider docs:
- How to pass the token explicitly with -e GITHUB_TOKEN
- That --env-from-file alone is not sufficient
- That the LLM judge runs on the host, so judge scoring can succeed while the evaluated agent fails to authenticate