### PR TITLE
fix(tui): compact detailed sidebar metrics

### DIFF
--- a/pkg/tui/components/sidebar/agent_click_test.go
+++ b/pkg/tui/components/sidebar/agent_click_test.go
@@ -95,9 +95,11 @@ func TestSidebar_AgentClickZones_EveryRenderedLineMapped(t *testing.T) {
 	assert.Positive(t, counts["agent1"], "agent1 should own rendered lines")
 	assert.Positive(t, counts["agent2"], "agent2 should own rendered lines")
 	// agent2 is a non-current roster agent: its mini-card spans the name line,
-	// the model line and two metric lines at this width, and ALL of them must
-	// map to it so a click on any card line switches to the agent.
-	assert.Equal(t, 4, counts["agent2"], "a roster agent owns every line of its card")
+	// the model line and one joined metric line at this width (the compact
+	// vocabulary renders, as agent1's preferred wide metric line would
+	// overflow), and ALL of them must map to it so a click on any card line
+	// switches to the agent.
+	assert.Equal(t, 3, counts["agent2"], "a roster agent owns every line of its card")
 
 	// The number of click zones equals the number of owned (non-blank) lines:
 	// every owned line is clickable.

--- a/pkg/tui/components/sidebar/agent_context_test.go
+++ b/pkg/tui/components/sidebar/agent_context_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"charm.land/lipgloss/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -27,7 +28,9 @@ func recordAgentUsage(m *model, sessionID, agentName string, contextLen, context
 
 // TestAgentRosterShowsPerAgentContextPercent verifies each card's metric line
 // carries the agent's own labeled context percentage once that agent has
-// emitted usage — and an explicit "—" for agents that have not run.
+// emitted usage — and an explicit "—" for agents that have not run. At the
+// default width this roster renders the compact vocabulary (root's preferred
+// wide joined metric line would overflow), so the label reads "Ctx".
 func TestAgentRosterShowsPerAgentContextPercent(t *testing.T) {
 	t.Parallel()
 
@@ -40,16 +43,16 @@ func TestAgentRosterShowsPerAgentContextPercent(t *testing.T) {
 	recordAgentUsage(m, "session-root", "root", 30_000, 100_000)
 	recordAgentUsage(m, "session-child", "developer", 42_000, 100_000)
 
-	assert.Contains(t, agentMetrics(m, "root"), "Context 30%",
+	assert.Contains(t, agentMetrics(m, "root"), "Ctx 30%",
 		"root's card shows its own labeled context percent")
 	_, rootLine2 := agentLines(m, "root")
 	assert.Contains(t, rootLine2, "anthropic/opus", "model text stays on line 2")
 
-	assert.Contains(t, agentMetrics(m, "developer"), "Context 42%",
+	assert.Contains(t, agentMetrics(m, "developer"), "Ctx 42%",
 		"developer's card shows its own labeled context percent")
 
 	idleMetrics := agentMetrics(m, "idle")
-	assert.Contains(t, idleMetrics, "Context —", "agents that never ran show an explicit —")
+	assert.Contains(t, idleMetrics, "Ctx —", "agents that never ran show an explicit —")
 	assert.NotContains(t, idleMetrics, "%", "agents that never ran show no percent")
 }
 
@@ -129,11 +132,12 @@ func TestAgentCardMetricLinesFitNarrowWidth(t *testing.T) {
 	card := agentCard(m, "root")
 	require.NotEmpty(t, card)
 	for _, line := range card {
-		assert.LessOrEqualf(t, len([]rune(line)), contentWidth,
+		assert.LessOrEqualf(t, lipgloss.Width(line), contentWidth,
 			"card line must fit the content width: %q", line)
 	}
 
 	metrics := strings.Join(card[2:], "\n")
-	assert.Contains(t, metrics, gaugePattern(4), "the full six-cell gauge survives the minimum width")
+	assert.Contains(t, metrics, "Eff high", "the compact effort label keeps its semantic value")
+	assert.NotContains(t, metrics, gaugePattern(4), "the decorative gauge is omitted at the minimum width")
 	assert.Contains(t, metrics, "Ctx 100%", "the compact context label keeps its percent")
 }

--- a/pkg/tui/components/sidebar/agent_cost_test.go
+++ b/pkg/tui/components/sidebar/agent_cost_test.go
@@ -266,8 +266,12 @@ func previewLines(m *model) []string {
 }
 
 // TestAgentCardPreview_DefaultWidth pins the exact ANSI-stripped Agents panel
-// at the default sidebar width (40 → 39 content columns). It doubles as the
-// visual reference for the mini-card design.
+// at the default sidebar width (40 → 39 content columns, 37 metric columns).
+// It doubles as the visual reference for the mini-card design at its most
+// common width: root's preferred wide joined metric line (45 columns) cannot
+// fit, so the roster adapts to the compact vocabulary and every card joins
+// its metrics on a single line — three lines per card, the issue #3856
+// vertical-space fix.
 func TestAgentCardPreview_DefaultWidth(t *testing.T) {
 	t.Parallel()
 
@@ -279,25 +283,25 @@ func TestAgentCardPreview_DefaultWidth(t *testing.T) {
 		"",
 		"▶ root                               ^1",
 		"  anthropic/claude-opus-4-8",
-		"  Effort ▰▰▰▰▱▱ high",
-		"  Context 30% · Cost $0.13",
+		"  Eff high · Ctx 30% · Cost $0.13",
 		"",
 		"  scout                              ^2",
 		"  openai/gpt-5.4-mini",
-		"  Effort ▱▱▱▱▱▱ off",
-		"  Context 6% · Cost $0.0042",
+		"  Eff off · Ctx 6% · Cost $0.0042",
 		"",
 		"  writer                             ^3",
 		"  google/gemini-flash",
-		"  Context — · Cost —",
+		"  Ctx — · Cost —",
 	}
 	require.Equal(t, want, got, "default-width preview changed:\n%s", strings.Join(got, "\n"))
 }
 
 // TestAgentCardPreview_MinWidth pins the exact ANSI-stripped Agents panel at
-// the minimum sidebar width (20 → 19 content columns): the full six-cell
-// effort gauge survives on its dedicated line (dropping only the value word
-// when it does not fit) and the context label compacts to "Ctx".
+// the minimum sidebar width (20 → 19 content columns, 17 metric columns):
+// the metric labels compact to Eff/Ctx, the effort value replaces the
+// decorative six-cell gauge while staying visible, and the compact segments
+// pack greedily — scout's "Eff off · Ctx 6%" (16 columns) shares a line
+// while root's "Eff high · Ctx 30%" (18 columns) would overflow and wraps.
 func TestAgentCardPreview_MinWidth(t *testing.T) {
 	t.Parallel()
 
@@ -309,14 +313,13 @@ func TestAgentCardPreview_MinWidth(t *testing.T) {
 		"",
 		"▶ root           ^1",
 		"  …/claude-opus-4-8",
-		"  Effort ▰▰▰▰▱▱",
+		"  Eff high",
 		"  Ctx 30%",
 		"  Cost $0.13",
 		"",
 		"  scout          ^2",
 		"  …nai/gpt-5.4-mini",
-		"  Effort ▱▱▱▱▱▱ off",
-		"  Ctx 6%",
+		"  Eff off · Ctx 6%",
 		"  Cost $0.0042",
 		"",
 		"  writer         ^3",

--- a/pkg/tui/components/sidebar/agent_info_mode_test.go
+++ b/pkg/tui/components/sidebar/agent_info_mode_test.go
@@ -67,7 +67,12 @@ func trimmedAgentBody(m *model) []string {
 // modes at the default (40) and minimum (20) sidebar widths. The compact
 // lines reproduce the pre-card roster: two lines per agent, the thinking
 // badge right-aligned on line 1 (single-cell glyph near MinWidth), the bare
-// context percent right-aligned on line 2, and no cost display.
+// context percent right-aligned on line 2, and no cost display. The detailed
+// cards adapt their metric vocabulary to the roster: root's preferred wide
+// joined line ("Effort <gauge> high · Context 30% · Cost $0.13", 45 columns)
+// overflows both widths, so every card compacts — at 40 each card joins its
+// metrics on a single line (a three-line card), at 20 the compact segments
+// pack greedily across lines.
 func TestAgentInfoModeExactOutputs(t *testing.T) {
 	t.Parallel()
 
@@ -114,21 +119,19 @@ func TestAgentInfoModeExactOutputs(t *testing.T) {
 			want: []string{
 				"▶ root                               ^1",
 				"  anthropic/claude-opus-4-8",
-				"  Effort ▰▰▰▰▱▱ high",
-				"  Context 30% · Cost $0.13",
+				"  Eff high · Ctx 30% · Cost $0.13",
 				"",
 				"  helper                             ^2",
 				"  openai/gpt-5.4-mini",
-				"  Effort ▱▱▱▱▱▱ off",
-				"  Context 91% · Cost $0.02",
+				"  Eff off · Ctx 91% · Cost $0.02",
 				"",
 				"  budget                             ^3",
 				"  openai/gpt-4o",
-				"  Effort ◉ 8.2K · Context — · Cost —",
+				"  Eff ◉ 8.2K · Ctx — · Cost —",
 				"",
 				"  plain                              ^4",
 				"  google/gemini-flash",
-				"  Context — · Cost —",
+				"  Ctx — · Cost —",
 			},
 		},
 		{
@@ -136,19 +139,18 @@ func TestAgentInfoModeExactOutputs(t *testing.T) {
 			want: []string{
 				"▶ root           ^1",
 				"  …/claude-opus-4-8",
-				"  Effort ▰▰▰▰▱▱",
+				"  Eff high",
 				"  Ctx 30%",
 				"  Cost $0.13",
 				"",
 				"  helper         ^2",
 				"  …nai/gpt-5.4-mini",
-				"  Effort ▱▱▱▱▱▱ off",
-				"  Ctx 91%",
+				"  Eff off · Ctx 91%",
 				"  Cost $0.02",
 				"",
 				"  budget         ^3",
 				"  openai/gpt-4o",
-				"  Effort ◉ 8.2K",
+				"  Eff ◉ 8.2K",
 				"  Ctx — · Cost —",
 				"",
 				"  plain          ^4",
@@ -308,7 +310,8 @@ func TestSetAgentInfoMode_LiveSwitch(t *testing.T) {
 			detailedOwned++
 		}
 	}
-	assert.Equal(t, 4, detailedOwned, "click-zone ownership follows the detailed card lines")
+	assert.Equal(t, 3, detailedOwned,
+		"click-zone ownership follows the detailed card lines: name, model, one joined metric line")
 
 	m.SetAgentInfoMode(AgentInfoCompact)
 	assert.NotContains(t, strings.Join(agentBody(m), "\n"), "Cost",

--- a/pkg/tui/components/sidebar/agent_panel_test.go
+++ b/pkg/tui/components/sidebar/agent_panel_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -116,11 +117,11 @@ func TestClassifyThinking(t *testing.T) {
 // TestAgentEntryLayout verifies an agent renders as a labeled mini-card:
 // line 1 carries the name and "^N" shortcut (no description), line 2 the
 // provider/model, and the metric lines the labeled effort gauge, context and
-// cost.
+// cost. Rendered wide enough (56) for the full metric vocabulary.
 func TestAgentEntryLayout(t *testing.T) {
 	t.Parallel()
 
-	m := newAgentPanelSidebar(t, 40,
+	m := newAgentPanelSidebar(t, 56,
 		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "claude-opus-4-8", Description: "Executive assistant", Thinking: "high"},
 	)
 
@@ -223,10 +224,11 @@ func TestShortcutColumnAlignment(t *testing.T) {
 // card's labeled metric line: effort levels keep the full six-cell gauge with
 // the level word, token budgets keep the token glyph with the budget,
 // adaptive reads "auto", and off shows an empty gauge with the word "off".
+// Rendered wide enough (56) for the full metric vocabulary.
 func TestEffortVocabularyOnCard(t *testing.T) {
 	t.Parallel()
 
-	m := newAgentPanelSidebar(t, 40,
+	m := newAgentPanelSidebar(t, 56,
 		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus", Thinking: "high"},
 		runtime.AgentDetails{Name: "alpha", Provider: "openai", Model: "gpt-5.4-mini", Thinking: "off"},
 		runtime.AgentDetails{Name: "beta", Provider: "openai", Model: "gpt-5.4", Thinking: "high"},
@@ -290,29 +292,179 @@ func TestMoreThanNineAgentsNoShortcutBeyond9(t *testing.T) {
 	assert.NotContains(t, body, "^10", "agents beyond the 9th have no shortcut")
 }
 
-// TestNarrowWidthKeepsFullGauge verifies that at a narrow width the effort
-// gauge keeps its full six cells on a dedicated metric line (dropping only
-// the value word when it does not fit), the context label compacts to "Ctx",
-// and the model still occupies line 2.
-func TestNarrowWidthKeepsFullGauge(t *testing.T) {
+// TestDetailedCardWidthThreshold pins the adaptive compact/wide boundary of
+// the detailed card: the wide vocabulary renders exactly when every agent's
+// preferred joined metric line fits the metric width (the content width
+// minus the two-column card indent). This roster's widest such line is
+// root's "Effort <gauge> high · Context 30% · Cost $0.13" at 45 display
+// columns, so with the one-column outer padding and the card indent, outer
+// width 48 (metric width 45) is the first wide width and outer width 47
+// (metric width 44) renders compact — the boundary is the roster's own
+// widest line, not a fixed layout constant. On both sides every card keeps
+// exactly one metric line: the transition trades vocabulary, never vertical
+// height.
+func TestDetailedCardWidthThreshold(t *testing.T) {
 	t.Parallel()
 
-	m := newAgentPanelSidebar(t, 21,
-		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus", Thinking: "high"},
-		runtime.AgentDetails{Name: "agent2", Provider: "anthropic", Model: "claude-sonnet-4-6", Thinking: "high"},
-	)
-
-	_, line2 := agentLines(m, "agent2")
-	metrics := agentMetrics(m, "agent2")
-	assert.Contains(t, metrics, gaugePattern(4), "narrow layout keeps the full six-cell gauge")
-	assert.Contains(t, metrics, "Ctx ", "narrow layout compacts the context label")
-	assert.NotContains(t, metrics, "Context", "narrow layout does not use the full context label")
-	assert.Contains(t, line2, "…", "narrow layout left-truncates the model on line 2")
-
-	contentWidth := m.contentWidth(false)
-	for _, line := range agentCard(m, "agent2") {
-		assert.LessOrEqual(t, len([]rune(line)), contentWidth, "no card line exceeds the content width: %q", line)
+	tests := []struct {
+		name  string
+		width int // outer width; one column of left padding
+		// metricCols is the width the metric lines get: the outer width minus
+		// the outer padding and the two-column card indent.
+		metricCols int
+		wide       bool
+		// wantMetrics are the exact indented metric lines of each card:
+		// grouping and line counts guard the vertical density.
+		wantMetrics map[string][]string
+		notWant     []string
+	}{
+		{
+			name:       "compact below the roster threshold",
+			width:      47,
+			metricCols: 44, // root's 45-column joined line no longer fits
+			wantMetrics: map[string][]string{
+				"root":  {"  Eff high · Ctx 30% · Cost $0.13"},
+				"scout": {"  Eff off · Ctx — · Cost —"},
+				"probe": {"  Eff minimal · Ctx — · Cost —"},
+			},
+			notWant: []string{"Effort", "Context", styles.GaugeFilled, styles.GaugeEmpty},
+		},
+		{
+			name:       "wide at the roster threshold",
+			width:      48,
+			metricCols: 45, // every agent's joined line fits
+			wide:       true,
+			wantMetrics: map[string][]string{
+				"root":  {"  Effort " + gaugePattern(4) + " high · Context 30% · Cost $0.13"},
+				"scout": {"  Effort " + gaugePattern(0) + " off · Context — · Cost —"},
+				"probe": {"  Effort " + gaugePattern(1) + " minimal · Context — · Cost —"},
+			},
+			notWant: []string{"Eff ", "Ctx"},
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := newAgentPanelSidebar(t, tt.width,
+				runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "claude-opus-4-8", Thinking: "high"},
+				runtime.AgentDetails{Name: "scout", Provider: "openai", Model: "gpt-5.4-mini", Thinking: "off"},
+				runtime.AgentDetails{Name: "probe", Provider: "openai", Model: "gpt-5.4", Thinking: "minimal"},
+			)
+			recordAgentUsageWithCost(m, "session-root", "root", 30_000, 100_000, 0.13)
+
+			// The roster's own threshold: its widest preferred joined line.
+			widest := 0
+			for _, agent := range m.availableAgents {
+				widest = max(widest, lipgloss.Width(joinSegments(m.metricSegments(agent, false))))
+			}
+			require.Equal(t, 45, widest, "root's full joined metric line sets this roster's threshold")
+
+			contentCols := m.contentWidth(false)
+			metricCols := contentCols - agentMarkerWidth
+			require.Equal(t, tt.metricCols, metricCols, "outer width must map to the intended metric columns")
+			if tt.wide {
+				require.GreaterOrEqual(t, metricCols, widest, "the wide side must fit the widest joined line")
+			} else {
+				require.Less(t, metricCols, widest, "the compact side must not fit the widest joined line")
+			}
+
+			for name, want := range tt.wantMetrics {
+				card := agentCard(m, name)
+				require.GreaterOrEqualf(t, len(card), 2, "card for %q renders its name and model lines", name)
+				got := make([]string, 0, len(card)-2)
+				for _, line := range card[2:] {
+					got = append(got, strings.TrimRight(line, " "))
+				}
+				assert.Equalf(t, want, got, "metric lines for %q at %d metric columns", name, metricCols)
+
+				metrics := strings.Join(got, "\n")
+				for _, notWant := range tt.notWant {
+					assert.NotContainsf(t, metrics, notWant, "metrics for %q at %d metric columns", name, metricCols)
+				}
+				for _, line := range card {
+					assert.LessOrEqualf(t, lipgloss.Width(line), contentCols,
+						"no card line for %q exceeds the content width: %q", name, line)
+				}
+			}
+
+			line1, line2 := agentLines(m, "root")
+			assert.Contains(t, line1, "root", "the name line stays readable")
+			assert.Contains(t, line2, "claude-opus-4-8", "the provider/model tail stays readable")
+		})
+	}
+}
+
+// TestDetailedCardResizeAcrossThreshold drives SetSize/View across the
+// roster's adaptive threshold through the realistic default width —
+// DefaultWidth (40, metric width 37: root's 45-column joined line overflows,
+// compact) → outer width 48 (metric width 45: every joined line fits, wide)
+// → DefaultWidth again — and verifies each rendering carries only its own
+// vocabulary at one joined metric line per three-line card, no line
+// overflows the sidebar width, and returning to the default width
+// reproduces the exact default rendering: nothing stale survives.
+func TestDetailedCardResizeAcrossThreshold(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, DefaultWidth,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "claude-opus-4-8", Thinking: "high"},
+		runtime.AgentDetails{Name: "scout", Provider: "openai", Model: "gpt-5.4-mini", Thinking: "off"},
+	)
+	recordAgentUsageWithCost(m, "session-root", "root", 30_000, 100_000, 0.13)
+	m.workingDirectory = "" // keep the full-view render environment-independent
+
+	render := func(width int) []string {
+		m.SetSize(width, 200)
+		lines := strings.Split(ansi.Strip(m.View()), "\n")
+		for i, line := range lines {
+			lines[i] = strings.TrimRight(line, " ")
+		}
+		return lines
+	}
+	assertFits := func(lines []string, width int) {
+		t.Helper()
+		for _, line := range lines {
+			assert.LessOrEqualf(t, lipgloss.Width(line), width, "line must fit the sidebar width: %q", line)
+		}
+	}
+	cardLines := func() map[string]int {
+		counts := map[string]int{}
+		for _, owner := range m.agentLineOwners {
+			if owner != "" {
+				counts[owner]++
+			}
+		}
+		return counts
+	}
+
+	defaultBefore := render(DefaultWidth)
+	compact := strings.Join(defaultBefore, "\n")
+	require.Contains(t, compact, "Eff high · Ctx 30% · Cost $0.13",
+		"the default width joins root's compact metrics on one line")
+	require.Contains(t, compact, "Eff off · Ctx — · Cost —",
+		"the default width joins scout's compact metrics on one line")
+	require.NotContains(t, compact, "Effort", "the default width drops the full effort label")
+	require.NotContains(t, compact, "Context", "the default width drops the full context label")
+	require.NotContains(t, compact, styles.GaugeFilled, "the default width omits the decorative gauge")
+	require.NotContains(t, compact, styles.GaugeEmpty, "the default width omits the decorative gauge")
+	require.Equal(t, map[string]int{"root": 3, "scout": 3}, cardLines(),
+		"compact cards are three lines: name, model, one joined metric line")
+	assertFits(defaultBefore, DefaultWidth)
+
+	wideLines := render(48) // metric width 45: this roster's widest joined line fits exactly
+	wide := strings.Join(wideLines, "\n")
+	assert.Contains(t, wide, "Effort "+gaugePattern(4)+" high · Context 30% · Cost $0.13",
+		"widening restores the full labels and gauge on one joined line")
+	assert.Contains(t, wide, "Effort "+gaugePattern(0)+" off · Context — · Cost —")
+	assert.NotContains(t, wide, "Eff ", "no compact effort label survives the widening")
+	assert.NotContains(t, wide, "Ctx", "no compact context label survives the widening")
+	assert.Equal(t, map[string]int{"root": 3, "scout": 3}, cardLines(),
+		"wide cards keep the same three-line height: the transition adds no lines")
+	assertFits(wideLines, 48)
+
+	defaultAfter := render(DefaultWidth)
+	assert.Equal(t, defaultBefore, defaultAfter,
+		"returning to the default width reproduces the exact default render — nothing stale survives")
 }
 
 // TestClickZonesEveryLine verifies that clicking any rendered agent line (either

--- a/pkg/tui/components/sidebar/agent_transfer_test.go
+++ b/pkg/tui/components/sidebar/agent_transfer_test.go
@@ -91,12 +91,12 @@ func TestTransferPanelContentAndPlacement(t *testing.T) {
 	// The roster stays uninterrupted: each agent keeps its card lines and the
 	// blank separators, then the breathing line and the three box lines follow.
 	assert.Equal(t, []string{
-		"root", "root", "root", "root", "",
-		"Scout", "Scout", "Scout", "Scout", "",
-		"Coder", "Coder", "Coder", "Coder",
+		"root", "root", "root", "",
+		"Scout", "Scout", "Scout", "",
+		"Coder", "Coder", "Coder",
 		"", "", "", "",
 	}, m.agentLineOwners)
-	require.Len(t, body, 18)
+	require.Len(t, body, 15)
 	assert.Equal(t, len(body)-2, idx, "the relation line is the box's middle line")
 	assert.Empty(t, strings.TrimSpace(body[len(body)-4]), "a blank breathing line precedes the box")
 
@@ -138,9 +138,9 @@ func TestTransferPanelBelowRosterAnyOrder(t *testing.T) {
 	require.GreaterOrEqual(t, idx, 0)
 
 	assert.Equal(t, []string{
-		"Coder", "Coder", "Coder", "Coder", "",
-		"middle", "middle", "middle", "middle", "",
-		"Scout", "Scout", "Scout", "Scout",
+		"Coder", "Coder", "Coder", "",
+		"middle", "middle", "middle", "",
+		"Scout", "Scout", "Scout",
 		"", "", "", "",
 	}, m.agentLineOwners, "nothing is inserted inside the roster")
 	assert.Equal(t, len(body)-2, idx, "the box stays at the bottom of the panel body")

--- a/pkg/tui/components/sidebar/effort_gauge_test.go
+++ b/pkg/tui/components/sidebar/effort_gauge_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,16 +23,17 @@ func gaugePattern(filled int) string {
 
 // TestEffortSegmentLevelUsesGauge verifies the level case of effortSegment
 // renders the labeled six-cell gauge with the level word (no ✻ glyph), and
-// that the minimal degradation drops only the word, never the gauge.
+// that the minimal degradation keeps the semantic value — the decorative
+// gauge goes, never the word.
 func TestEffortSegmentLevelUsesGauge(t *testing.T) {
 	t.Parallel()
 
-	seg := effortSegment("high")
+	seg := effortSegment("high", false)
 	assert.Equal(t, "Effort "+gaugePattern(4)+" high", ansi.Strip(seg.full),
 		"high renders the labeled 4/6-cell gauge with its value")
 	assert.NotContains(t, ansi.Strip(seg.full), styles.ThinkingGlyph, "gauge carries no ✻ glyph")
-	assert.Equal(t, "Effort "+gaugePattern(4), ansi.Strip(seg.minimal),
-		"the minimal form keeps the full six-cell gauge and drops only the word")
+	assert.Equal(t, "Eff high", ansi.Strip(seg.minimal),
+		"the minimal form is the compact segment: no gauge, the value stays")
 }
 
 // TestEffortSegmentUnknownLevelFallsBackToText verifies an unparseable level
@@ -40,15 +42,16 @@ func TestEffortSegmentLevelUsesGauge(t *testing.T) {
 func TestEffortSegmentUnknownLevelFallsBackToText(t *testing.T) {
 	t.Parallel()
 
-	seg := effortSegment("on")
+	seg := effortSegment("on", false)
 	assert.Equal(t, "Effort on", ansi.Strip(seg.full), "unknown label keeps a plain text value")
 	assert.NotContains(t, ansi.Strip(seg.full), styles.ThinkingGlyph, "no ✻ glyph")
-	assert.Equal(t, "Effort on", ansi.Strip(seg.minimal))
+	assert.Equal(t, "Eff on", ansi.Strip(seg.minimal), "the minimal form keeps the value under the compact label")
 }
 
 // TestEffortSegmentVocabulary verifies the full no-✻ segment vocabulary: none
 // renders nothing, off is an empty gauge with the word "off", adaptive is
-// "auto", and a token budget keeps its token glyph with the count.
+// "auto", a token budget keeps its token glyph with the count, and every
+// minimal fallback is the compact form that keeps the semantic value.
 func TestEffortSegmentVocabulary(t *testing.T) {
 	t.Parallel()
 
@@ -58,16 +61,66 @@ func TestEffortSegmentVocabulary(t *testing.T) {
 		minimal string
 	}{
 		{"", "", ""},
-		{"off", "Effort " + gaugePattern(0) + " off", "Effort " + gaugePattern(0)},
-		{"adaptive", "Effort auto", "Effort auto"},
-		{"8192", "Effort " + styles.TokenGlyph + " 8.2K", "Effort " + styles.TokenGlyph},
+		{"off", "Effort " + gaugePattern(0) + " off", "Eff off"},
+		{"adaptive", "Effort auto", "Eff auto"},
+		{"8192", "Effort " + styles.TokenGlyph + " 8.2K", "Eff " + styles.TokenGlyph + " 8.2K"},
+		{"minimal", "Effort " + gaugePattern(1) + " minimal", "Eff minimal"},
 	}
 	for _, c := range cases {
-		seg := effortSegment(c.label)
+		seg := effortSegment(c.label, false)
 		assert.Equalf(t, c.full, ansi.Strip(seg.full), "full segment for %q", c.label)
 		assert.Equalf(t, c.minimal, ansi.Strip(seg.minimal), "minimal segment for %q", c.label)
 		assert.NotContainsf(t, ansi.Strip(seg.full), styles.ThinkingGlyph, "segment for %q must carry no ✻", c.label)
 	}
+}
+
+// TestEffortSegmentNarrowVocabulary verifies the narrow-card effort
+// vocabulary: the label compacts to "Eff", the decorative six-cell gauge is
+// omitted while the semantic value stays visible, token budgets keep the
+// token glyph with their count, adaptive reads "auto", unknown level words
+// keep their text, and nothing degrades: full and minimal are identical.
+func TestEffortSegmentNarrowVocabulary(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		label string
+		want  string
+	}{
+		{"", ""},
+		{"off", "Eff off"},
+		{"adaptive", "Eff auto"},
+		{"8192", "Eff " + styles.TokenGlyph + " 8.2K"},
+		{"high", "Eff high"},
+		{"minimal", "Eff minimal"},
+		{"on", "Eff on"},
+	}
+	for _, c := range cases {
+		seg := effortSegment(c.label, true)
+		assert.Equalf(t, c.want, ansi.Strip(seg.full), "full narrow segment for %q", c.label)
+		assert.Equalf(t, c.want, ansi.Strip(seg.minimal),
+			"minimal narrow segment for %q — the semantic value never degrades away", c.label)
+		assert.NotContainsf(t, ansi.Strip(seg.full), styles.GaugeFilled, "narrow segment for %q carries no gauge", c.label)
+		assert.NotContainsf(t, ansi.Strip(seg.full), styles.GaugeEmpty, "narrow segment for %q carries no gauge", c.label)
+	}
+}
+
+// TestFlowMetricLinesWideEffortFallbackKeepsValue verifies the wide flow
+// never trades the semantic effort value for a bare gauge: an effort segment
+// that cannot fit a line even on its own — "Effort ▰▱▱▱▱▱ minimal" is 21
+// columns — degrades to the compact "Eff minimal" instead of "Effort
+// <gauge>", and the freed room lets the next segment share its line.
+func TestFlowMetricLinesWideEffortFallbackKeepsValue(t *testing.T) {
+	t.Parallel()
+
+	effortSeg := effortSegment("minimal", false)
+	require.Equal(t, 21, lipgloss.Width(effortSeg.full), "the full wide segment must overflow the 20-column line")
+	ctx := metricSegment{full: "Ctx 6%", minimal: "Ctx 6%"}
+
+	lines := flowMetricLines([]metricSegment{effortSeg, ctx}, 20, false)
+	require.Len(t, lines, 1, "the compact fallback frees enough room for the next segment")
+	assert.Equal(t, "Eff minimal · Ctx 6%", ansi.Strip(lines[0]),
+		"the semantic value survives; the decorative gauge goes")
+	assert.LessOrEqual(t, lipgloss.Width(lines[0]), 20, "the fallback line must not overflow")
 }
 
 // TestThinkingGaugeValueShowsGaugeAndWord verifies the shared thinking summary
@@ -91,10 +144,11 @@ func TestThinkingGaugeValueShowsGaugeAndWord(t *testing.T) {
 // TestCardGaugeColumnAlignment verifies a roster of effort-level agents renders
 // fixed-width six-cell gauges on their labeled effort line, and that the gauges
 // all start at the same column (right after the shared "Effort " label).
+// Rendered wide enough (56) for the full metric vocabulary.
 func TestCardGaugeColumnAlignment(t *testing.T) {
 	t.Parallel()
 
-	m := newAgentPanelSidebar(t, 40,
+	m := newAgentPanelSidebar(t, 56,
 		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus", Thinking: "high"},
 		runtime.AgentDetails{Name: "alpha", Provider: "openai", Model: "gpt-5.4-mini", Thinking: "minimal"},
 		runtime.AgentDetails{Name: "beta", Provider: "openai", Model: "gpt-5.4", Thinking: "medium"},

--- a/pkg/tui/components/sidebar/layout.go
+++ b/pkg/tui/components/sidebar/layout.go
@@ -22,12 +22,6 @@ const (
 	// the name column keeps usable room.
 	rowGlyphOnlyMinWidth = 22
 
-	// cardNarrowMinWidth is the content-column breakpoint (near MinWidth) below
-	// which a detailed agent card compacts its metric labels (Context → Ctx).
-	// The effort gauge keeps its full six cells at every width; only its value
-	// word may be dropped when the line cannot hold it.
-	cardNarrowMinWidth = 22
-
 	// starClickWidth is the clickable area width for the star indicator.
 	starClickWidth = 2
 

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -2132,9 +2132,24 @@ func (m *model) compactAgentRenderer(contentWidth int) agentRenderer {
 }
 
 // detailedAgentRenderer precomputes the detailed card layout's shared widths
-// and returns the per-agent mini-card renderer (see renderAgentCard).
+// and returns the per-agent mini-card renderer (see renderAgentCard). The
+// metric vocabulary adapts to the roster: cards render the wide forms — full
+// "Effort"/"Context" labels with the decorative six-cell gauge — only when
+// every agent's preferred joined metric line fits the width the metric lines
+// actually get (the content width minus the card's agentMarkerWidth indent),
+// i.e. exactly the widths where every wide card keeps a single metric line.
+// If any agent's joined line would overflow, all cards use the compact
+// vocabulary (Eff/Ctx, no gauge) so the panel speaks one language and each
+// card stays as short as the width allows.
 func (m *model) detailedAgentRenderer(contentWidth int) agentRenderer {
-	narrow := contentWidth < cardNarrowMinWidth
+	metricWidth := contentWidth - agentMarkerWidth
+	narrow := false
+	for _, agent := range m.availableAgents {
+		if lipgloss.Width(joinSegments(m.metricSegments(agent, false))) > metricWidth {
+			narrow = true
+			break
+		}
+	}
 	nameWidth := max(1, contentWidth-agentMarkerWidth-minGap-agentShortcutWidth)
 	return func(agent runtime.AgentDetails, index int, current bool) []string {
 		return m.renderAgentCard(agent, index, contentWidth, nameWidth, narrow, current)
@@ -2232,46 +2247,48 @@ func (m *model) badgeColumnWidth(glyphOnly bool) int {
 }
 
 // effortSegment builds the labeled effort metric for an agent's thinking
-// label: the full form ("Effort <gauge> <value>") and a minimal fallback
-// ("Effort <gauge>") for widths where the value word does not fit. Both are
-// empty when the agent has no thinking configuration. Effort levels and "off"
-// always carry the full six-cell gauge; adaptive reads "auto" and a token
-// budget keeps the token glyph with its count.
-func effortSegment(label string) metricSegment {
-	prefix := styles.MutedStyle.Render("Effort ")
+// label; both forms are empty when the agent has no thinking configuration.
+// The compact form ("Eff <value>") drops the decorative six-cell gauge but
+// always keeps the semantic value. Narrow cards use it outright, with no
+// minimal degradation; wide cards prefer the full form ("Effort <gauge>
+// <value>") and degrade to the compact form when even alone it overflows the
+// line — the decoration gives way, never the value. At every width adaptive
+// reads "auto" and a token budget keeps the token glyph with its count.
+func effortSegment(label string, narrow bool) metricSegment {
 	kind, tokens := classifyThinking(label)
+	var value, gauge string
 	switch kind {
 	case thinkingNone:
 		return metricSegment{}
 	case thinkingOff:
-		// Capable but disabled: a dim empty gauge, distinct from a non-capable
-		// model (which renders no effort segment at all).
-		gauge := toolcommon.EffortGaugeEmpty()
-		return metricSegment{
-			full:    prefix + gauge + " " + styles.MutedStyle.Faint(true).Render("off"),
-			minimal: prefix + gauge,
-		}
+		// Capable but disabled: dim, with an empty gauge on wide cards —
+		// distinct from a non-capable model (which renders no effort segment
+		// at all).
+		value = styles.MutedStyle.Faint(true).Render("off")
+		gauge = toolcommon.EffortGaugeEmpty()
 	case thinkingAdaptive:
-		auto := prefix + styles.ThinkingBadgeStyle.Render("auto")
-		return metricSegment{full: auto, minimal: auto}
+		value = styles.ThinkingBadgeStyle.Render("auto")
 	case thinkingTokens:
-		return metricSegment{
-			full:    prefix + styles.ThinkingBadgeStyle.Render(styles.TokenGlyph+" "+toolcommon.FormatTokenCount(tokens)),
-			minimal: prefix + styles.ThinkingBadgeStyle.Render(styles.TokenGlyph),
-		}
+		value = styles.ThinkingBadgeStyle.Render(styles.TokenGlyph + " " + toolcommon.FormatTokenCount(tokens))
 	default: // thinkingLevel
-		level, ok := effort.Parse(label)
-		if !ok {
+		if level, ok := effort.Parse(label); ok {
+			value = styles.MutedStyle.Render(label)
+			gauge = toolcommon.EffortGauge(level)
+		} else {
 			// Unknown/future level word: plain text so it still renders.
-			word := prefix + styles.ThinkingBadgeStyle.Render(label)
-			return metricSegment{full: word, minimal: word}
-		}
-		gauge := toolcommon.EffortGauge(level)
-		return metricSegment{
-			full:    prefix + gauge + " " + styles.MutedStyle.Render(label),
-			minimal: prefix + gauge,
+			value = styles.ThinkingBadgeStyle.Render(label)
 		}
 	}
+
+	compact := styles.MutedStyle.Render("Eff ") + value
+	if narrow {
+		return metricSegment{full: compact, minimal: compact}
+	}
+	wide := value
+	if gauge != "" {
+		wide = gauge + " " + value
+	}
+	return metricSegment{full: styles.MutedStyle.Render("Effort ") + wide, minimal: compact}
 }
 
 // contextSegment builds the labeled context metric for an agent: the latest
@@ -2390,10 +2407,12 @@ func (m *model) renderAgentLine(agent runtime.AgentDetails, index, contentWidth,
 // pad the marker column so the names stay aligned. Line 2: the indented
 // provider/model, left-truncated so its informative tail survives. The
 // remaining line(s) carry the labeled metrics, flowed to the width (see
-// flowMetricLines): effort keeps the full six-cell gauge at every width,
-// context keeps the warning/critical coloring, and cost is the agent's
-// cumulative attributed cost. The description is omitted. Agents past the 9th
-// have no shortcut.
+// flowMetricLines): wide cards label effort with the full six-cell gauge
+// while narrow cards compact the labels (Eff/Ctx) and keep the semantic
+// effort value in place of the gauge — a roster-wide adaptive choice (see
+// detailedAgentRenderer) — context keeps the warning/critical coloring, and
+// cost is the agent's cumulative attributed cost. The description is
+// omitted. Agents past the 9th have no shortcut.
 func (m *model) renderAgentCard(agent runtime.AgentDetails, index, contentWidth, nameWidth int, narrow, current bool) []string {
 	agentStyle := styles.AgentAccentStyleFor(agent.Name)
 
@@ -2442,47 +2461,63 @@ func metricSeparator() string {
 
 // metricSegment is one labeled metric of an agent card. full is the preferred
 // rendering; minimal is the degraded form used when full alone overflows the
-// line (only the effort segment degrades — it drops the value word but never
-// the six-cell gauge). Both empty means the segment is omitted entirely.
+// line (only the wide effort segment degrades — to its compact "Eff <value>"
+// form, which drops the decorative gauge but never the semantic value; narrow
+// segments never degrade). Both empty means the segment is omitted entirely.
 type metricSegment struct {
 	full    string
 	minimal string
 }
 
+// metricSegments builds the labeled metric segments of an agent's card in
+// display order: effort (omitted when the agent has no thinking
+// configuration), then context and cost.
+func (m *model) metricSegments(agent runtime.AgentDetails, narrow bool) []metricSegment {
+	segments := make([]metricSegment, 0, 3)
+	if s := effortSegment(agent.Thinking, narrow); s.full != "" {
+		segments = append(segments, s)
+	}
+	return append(segments, m.contextSegment(agent.Name, narrow), m.costSegment(agent.Name))
+}
+
 // metricLines builds the flowed metric lines of an agent card, fitted to
 // width columns.
 func (m *model) metricLines(agent runtime.AgentDetails, width int, narrow bool) []string {
-	segments := make([]metricSegment, 0, 3)
-	if s := effortSegment(agent.Thinking); s.full != "" {
-		segments = append(segments, s)
-	}
-	segments = append(segments, m.contextSegment(agent.Name, narrow), m.costSegment(agent.Name))
-	return flowMetricLines(segments, width)
+	return flowMetricLines(m.metricSegments(agent, narrow), width, narrow)
 }
 
 // flowMetricLines lays the metric segments out into lines of at most width
-// columns. All segments share one line when they fit — the ideal single
-// metrics line at wide sidebars. Otherwise the first segment (effort, when
-// present) takes a dedicated line, degrading to its minimal form if even
-// alone it overflows, and the remaining segments flow greedily. Segments are
-// never truncated: at the sidebar's minimum width every minimal form fits,
-// and narrower widths auto-collapse the sidebar before this matters.
-func flowMetricLines(segments []metricSegment, width int) []string {
+// columns. Narrow cards flow every segment greedily in order, sharing lines
+// wherever they fit, so the metrics take as few lines as possible. Wide
+// cards join all segments on one line — the adaptive vocabulary choice (see
+// detailedAgentRenderer) picks wide only when that line fits — with a
+// defensive degradation should it not: the first segment (effort, when
+// present) takes a dedicated line and the rest flow greedily, unless even
+// alone it overflows, in which case it degrades to its compact minimal form
+// and flows with the rest. Segments are never truncated: at the sidebar's
+// minimum width every minimal form fits, and narrower widths auto-collapse
+// the sidebar before this matters.
+func flowMetricLines(segments []metricSegment, width int, narrow bool) []string {
 	if len(segments) == 0 {
 		return nil
 	}
-	if all := joinSegments(segments); lipgloss.Width(all) <= width {
-		return []string{all}
-	}
-
-	first := segments[0].full
-	if lipgloss.Width(first) > width && segments[0].minimal != "" {
-		first = segments[0].minimal
-	}
-	lines := []string{first}
-
+	rest := segments
+	var lines []string
 	current := ""
-	for _, seg := range segments[1:] {
+	if !narrow {
+		if all := joinSegments(segments); lipgloss.Width(all) <= width {
+			return []string{all}
+		}
+		first := segments[0]
+		rest = segments[1:]
+		if lipgloss.Width(first.full) <= width || first.minimal == "" {
+			lines = append(lines, first.full)
+		} else {
+			current = first.minimal
+		}
+	}
+
+	for _, seg := range rest {
 		switch {
 		case current == "":
 			current = seg.full

--- a/pkg/tui/page/chat/layout_position_test.go
+++ b/pkg/tui/page/chat/layout_position_test.go
@@ -187,7 +187,9 @@ func TestAgentInfoModeMapsValues(t *testing.T) {
 
 // TestSetLayoutSettingsForwardsInfoModeToSidebar verifies the info mode
 // reaches the sidebar's roster renderer and can be switched live: the
-// detailed cards carry the "Effort" metric label, the compact roster does not.
+// detailed cards carry the labeled effort metric — "Eff high" in the compact
+// vocabulary the cards adapt to at the default sidebar width — while the
+// compact roster shows only the gauge badge, never the label.
 func TestSetLayoutSettingsForwardsInfoModeToSidebar(t *testing.T) {
 	t.Parallel()
 
@@ -198,15 +200,15 @@ func TestSetLayoutSettingsForwardsInfoModeToSidebar(t *testing.T) {
 	})
 	p.SetSize(160, 40)
 
-	require.NotContains(t, ansi.Strip(p.View()), "Effort",
+	require.NotContains(t, ansi.Strip(p.View()), "Eff high",
 		"the default layout renders the compact roster")
 
 	p.SetLayoutSettings(msgtypes.LayoutSettings{SidebarInfoMode: msgtypes.InfoModeDetailed})
-	assert.Contains(t, ansi.Strip(p.View()), "Effort",
+	assert.Contains(t, ansi.Strip(p.View()), "Eff high",
 		"detailed mode renders the labeled agent cards")
 
 	p.SetLayoutSettings(msgtypes.LayoutSettings{})
-	assert.NotContains(t, ansi.Strip(p.View()), "Effort",
+	assert.NotContains(t, ansi.Strip(p.View()), "Eff high",
 		"switching back live restores the compact roster")
 }
 
@@ -228,7 +230,7 @@ func TestWithLayoutSettingsAppliesInfoMode(t *testing.T) {
 	})
 	p.SetSize(160, 40)
 
-	assert.Contains(t, ansi.Strip(p.View()), "Effort",
+	assert.Contains(t, ansi.Strip(p.View()), "Eff high",
 		"the initial layout option applies the detailed mode")
 }
 


### PR DESCRIPTION
## Summary

- adapt Detailed sidebar metrics to the width required by the current agent roster
- use compact `Eff`, `Ctx`, and `Cost` forms without the decorative effort gauge at constrained and default widths
- preserve semantic effort values, agent names, and model rows while packing metrics onto the fewest lines that fit
- restore full labels and gauges when every agent's complete metric row fits

Fixes #3856

## Before and after

| Width | Before | After |
| --- | --- | --- |
| Default sidebar | `Effort ▰▰▰▰▱▱ high`<br>`Context 30% · Cost $0.13` | `Eff high · Ctx 30% · Cost $0.13` |
| Minimum sidebar | `Effort ▱▱▱▱▱▱ off`<br>`Ctx 6%`<br>`Cost $0.0042` | `Eff off · Ctx 6%`<br>`Cost $0.0042` |
| Sufficiently wide | Full labels and gauge | Full labels and gauge, unchanged |

The existing issue screenshot captures the visual before state. The table above shows the exact ANSI-stripped rendering pinned by the updated tests; no replacement screenshot is included because the result depends on the active roster and terminal width.

## Issue expectations

| Expectation | Implementation |
| --- | --- |
| Keep Detailed mode at narrow/default widths | The renderer stays in Detailed mode and changes only its metric vocabulary and flow |
| Use compact atomic labels | Constrained cards render `Eff`, `Ctx`, and `Cost` |
| Remove cramped gauge/value combinations | Compact effort rows omit the six-cell gauge and retain values such as `high`, `off`, `minimal`, `auto`, and token budgets |
| Keep names and models readable | Name and provider/model rows remain separate and preserve existing truncation behavior |
| Reduce vertical space | Compact metrics flow greedily; default-width cards use one joined metric row when it fits |
| Handle the width boundary | The roster switches to full labels and gauges only when every full joined metric row fits |
| Update correctly on resize | Tests cover default -> wide threshold -> default and verify exact restoration, line widths, and card ownership |

## Validation

- `task lint`
- `task build`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy task test`
- `go test ./pkg/tui/components/sidebar ./pkg/tui/page/chat -count=1 -race`
- `git diff --check`

The full test suite requires the workspace HTTP proxy variables to be unset because the injected localhost proxy intentionally intercepts private-address requests used by SSRF tests.
