### PR TITLE
fix(eval): preserve budget termination outcomes

### DIFF
--- a/docs/configuration/budget/index.md
+++ b/docs/configuration/budget/index.md
@@ -95,7 +95,7 @@ Starting a new session starts a fresh budget. It is a per-session ceiling, not a
 Crossing any limit — run-wide or named — stops the run and produces:
 
 - an assistant message in the transcript naming the limit and the amounts,
-- a `budget_exceeded` event carrying `budget`, `limit`, `used`, `max` and `config_path`,
+- a `budget_exceeded` event carrying `budget`, `limit`, `used`, `max`, `config_path` and, under `stop_message`, the assistant stop message itself (agent name, role, content and timestamp only),
 - a `notification` hook at `warning` level,
 - a stream end reason of `budget_exceeded`, so a stopped run is distinguishable from a completed one in telemetry.
 
@@ -107,6 +107,29 @@ limit (used $0.0312 of $0.0300).
 ```
 
 Unlike [`max_iterations`](../agents/index.md), a budget stop is **terminal** — there is no prompt offering to continue. A budget is a ceiling you set deliberately, so raising it means editing the config rather than answering a dialog.
+
+## Budget stops in evaluation output
+
+When a budgeted agent is exercised with `docker agent eval`, a budget stop is recorded as a structured termination. It is not an error, and it is distinct from an ordinary stream stop: the run output JSON exposes it as an optional `eval_result.termination` object on the affected session.
+
+```json
+"eval_result": {
+  "passed": true,
+  "termination": {
+    "reason": "budget_exceeded",
+    "budget": "run",
+    "limit": "max_cost",
+    "used": "$0.0312",
+    "max": "$0.0300",
+    "config_path": "budget.max_cost",
+    "message": "Execution stopped after reaching the configured budget.max_cost limit (used $0.0312 of $0.0300)."
+  }
+}
+```
+
+- `reason` is always `budget_exceeded`. The other fields are optional and are copied from the runtime's `budget_exceeded` event through an allow-list: only `budget`, `limit`, `used`, `max`, `config_path`, and `message` are ever taken, each sanitized (invalid UTF-8 and control characters stripped, bounded length) and omitted when missing or unusable.
+- The stored session (SQLite database and sessions JSON) keeps the stop marker at its chronological position, followed exactly once by the assistant stop message rebuilt from the event's embedded `stop_message` (again only agent name, role, content, and timestamp are taken, sanitized the same way). When the event carries no usable `stop_message`, the marker stands alone; nothing is invented from `termination.message`.
+- The termination is informational: it does not change `passed`, `failures`, or `error`. A run that completed normally or failed with an error simply has no `termination` field, and older outputs written before the field existed load unchanged.
 
 ## Tracking spend in the TUI
 

--- a/pkg/evaluation/eval.go
+++ b/pkg/evaluation/eval.go
@@ -576,6 +576,7 @@ func buildTranscript(events []map[string]any) string {
 	var transcript strings.Builder
 	var pendingText strings.Builder
 	var currentAgent string
+	terminations := &terminationTracker{}
 
 	flushText := func() {
 		if pendingText.Len() == 0 {
@@ -615,6 +616,22 @@ func buildTranscript(events []map[string]any) string {
 				response = response[:500] + "...(truncated)"
 			}
 			fmt.Fprintf(&transcript, "[Tool %q returns: %s]\n\n", name, response)
+
+		case "budget_exceeded":
+			// A budget stop is a structured termination, never an error. The
+			// marker lands at the event's chronological position, immediately
+			// followed by the assistant stop message the event embeds under
+			// stop_message. All message_added events are ignored: they carry
+			// no JSON payload, and regular assistant turns are already
+			// captured from agent_choice events.
+			flushText()
+			term, stop := terminations.observeBudgetExceeded(event)
+			if term != nil {
+				fmt.Fprintf(&transcript, "%s\n\n", terminationTranscriptMarker(term))
+			}
+			if stop != nil {
+				fmt.Fprintf(&transcript, "[Agent %s says]:\n%s\n\n", cmp.Or(stop.AgentName, currentAgent, "unknown"), stop.Message.Content)
+			}
 		}
 	}
 

--- a/pkg/evaluation/eval_test.go
+++ b/pkg/evaluation/eval_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1108,4 +1109,197 @@ func TestNeedsJudge(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestSanitizeEventText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		maxRunes int
+		want     string
+	}{
+		{"plain text unchanged", "used $0.03 of $0.03", 256, "used $0.03 of $0.03"},
+		{"surrounding whitespace trimmed", "  budget.max_cost \n", 256, "budget.max_cost"},
+		{"control characters removed", "bud\x00get\x1b[31m", 256, "budget[31m"},
+		{"newline and tab kept", "line one\n\tline two", 256, "line one\n\tline two"},
+		{"carriage return removed", "line one\r\nline two", 256, "line one\nline two"},
+		{"invalid utf-8 dropped", "bud\xffget", 256, "budget"},
+		{"rune bound applied", strings.Repeat("é", 10), 4, "éééé"},
+		{"trailing space after cut trimmed", "abc def", 4, "abc"},
+		{"empty stays empty", "", 256, ""},
+		{"whitespace only becomes empty", " \t\n ", 256, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := sanitizeEventText(tt.input, tt.maxRunes)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, got, sanitizeEventText(got, tt.maxRunes), "sanitization must be idempotent")
+			assert.LessOrEqual(t, utf8.RuneCountInString(got), tt.maxRunes)
+		})
+	}
+}
+
+func TestTerminationFromEvent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("native fields copied under the fixed reason", func(t *testing.T) {
+		t.Parallel()
+		term := terminationFromEvent(budgetExceededTestEvent())
+		assert.Equal(t, session.TerminationReasonBudgetExceeded, term.Reason)
+		assert.Equal(t, "run", term.Budget)
+		assert.Equal(t, "max_cost", term.Limit)
+		assert.Equal(t, "$0.03", term.Used)
+		assert.Equal(t, "$0.03", term.Max)
+		assert.Equal(t, "budget.max_cost", term.ConfigPath)
+		assert.Equal(t, budgetStopText, term.Message)
+	})
+
+	t.Run("missing and wrong-typed fields omitted", func(t *testing.T) {
+		t.Parallel()
+		term := terminationFromEvent(map[string]any{
+			"type":    "budget_exceeded",
+			"budget":  42,             // not a string
+			"limit":   true,           // not a string
+			"used":    []any{"$0.03"}, // not a string
+			"message": " \x00 ",       // empty after sanitization
+			// max and config_path absent
+		})
+		assert.Equal(t, session.TerminationReasonBudgetExceeded, term.Reason)
+		assert.Empty(t, term.Budget)
+		assert.Empty(t, term.Limit)
+		assert.Empty(t, term.Used)
+		assert.Empty(t, term.Max)
+		assert.Empty(t, term.ConfigPath)
+		assert.Empty(t, term.Message)
+	})
+
+	t.Run("only allow-listed keys are serialized", func(t *testing.T) {
+		t.Parallel()
+		event := budgetExceededTestEvent()
+		event["prompt"] = "secret instructions"
+		event["tool"] = "shell"
+
+		data, err := json.Marshal(terminationFromEvent(event))
+		require.NoError(t, err)
+
+		var keys map[string]any
+		require.NoError(t, json.Unmarshal(data, &keys))
+		allowed := []string{"reason", "budget", "limit", "used", "max", "config_path", "message"}
+		for key := range keys {
+			assert.Contains(t, allowed, key)
+		}
+		assert.NotContains(t, string(data), "sess-1", "session_id must never be copied")
+		assert.NotContains(t, string(data), "secret instructions")
+		assert.NotContains(t, string(data), "shell")
+	})
+
+	t.Run("oversized fields bounded deterministically", func(t *testing.T) {
+		t.Parallel()
+		event := map[string]any{
+			"type":    "budget_exceeded",
+			"budget":  strings.Repeat("b", 10_000),
+			"message": strings.Repeat("m", 10_000),
+		}
+		first := terminationFromEvent(event)
+		second := terminationFromEvent(event)
+		assert.Equal(t, first, second)
+		assert.Equal(t, maxTerminationFieldRunes, utf8.RuneCountInString(first.Budget))
+		assert.Equal(t, maxTerminationMessageRunes, utf8.RuneCountInString(first.Message))
+	})
+}
+
+func TestBuildTranscriptBudgetTermination(t *testing.T) {
+	t.Parallel()
+
+	t.Run("marker then one assistant stop in chronological order", func(t *testing.T) {
+		t.Parallel()
+		transcript := buildTranscript([]map[string]any{
+			{"type": "agent_choice", "content": "Working on it.", "agent_name": "root"},
+			{
+				"type":       "tool_call",
+				"agent_name": "root",
+				"tool_call": map[string]any{
+					"function": map[string]any{"name": "shell", "arguments": `{"cmd": "ls"}`},
+				},
+			},
+			budgetExceededTestEvent(),
+			messageAddedTestEvent("sess-1", "root", budgetStopText),
+			{"type": "stream_stopped"},
+		})
+
+		marker := "[Run terminated: budget_exceeded at budget.max_cost (used $0.03 of $0.03)]"
+		assert.Equal(t, 1, strings.Count(transcript, marker))
+		assert.Equal(t, 1, strings.Count(transcript, budgetStopText))
+
+		wantOrder := []string{"Working on it.", `calls tool "shell"`, marker, "[Agent root says]:\n" + budgetStopText}
+		lastIdx := -1
+		for _, substr := range wantOrder {
+			idx := strings.Index(transcript, substr)
+			assert.Greater(t, idx, lastIdx, "expected %q to appear after previous substring", substr)
+			lastIdx = idx
+		}
+	})
+
+	t.Run("repeated events do not duplicate marker or stop", func(t *testing.T) {
+		t.Parallel()
+		transcript := buildTranscript([]map[string]any{
+			budgetExceededTestEvent(),
+			budgetExceededTestEvent(),
+			{"type": "stream_stopped"},
+		})
+
+		assert.Equal(t, 1, strings.Count(transcript, "[Run terminated:"))
+		assert.Equal(t, 1, strings.Count(transcript, budgetStopText))
+	})
+
+	t.Run("malformed or missing stop_message keeps the marker alone", func(t *testing.T) {
+		t.Parallel()
+		wrongRole := budgetExceededTestEventWithoutStop()
+		payload := stopMessagePayload("root", "not the stop")
+		payload["message"].(map[string]any)["role"] = "user"
+		wrongRole["stop_message"] = payload
+
+		transcript := buildTranscript([]map[string]any{
+			wrongRole,
+			{"type": "stream_stopped"},
+		})
+
+		assert.Equal(t, 1, strings.Count(transcript, "[Run terminated:"))
+		assert.NotContains(t, transcript, "not the stop")
+		assert.NotContains(t, transcript, budgetStopText)
+	})
+
+	t.Run("ordinary streams get no marker and message_added is ignored", func(t *testing.T) {
+		t.Parallel()
+		transcript := buildTranscript([]map[string]any{
+			{"type": "agent_choice", "content": "All done.", "agent_name": "root"},
+			messageAddedTestEvent("sess-1", "helper", "an unrelated runtime message"),
+			{"type": "error", "error": "boom"},
+			{"type": "stream_stopped"},
+		})
+
+		assert.NotContains(t, transcript, "[Run terminated:")
+		assert.NotContains(t, transcript, "an unrelated runtime message")
+		assert.Contains(t, transcript, "All done.")
+	})
+
+	t.Run("foreign message_added and stream_stopped cannot disturb the stop", func(t *testing.T) {
+		t.Parallel()
+		transcript := buildTranscript([]map[string]any{
+			messageAddedTestEvent("other-session", "intruder", "fake stop"),
+			{"type": "stream_stopped", "session_id": "other-session"},
+			budgetExceededTestEvent(),
+			messageAddedTestEvent("other-session", "intruder", "another fake stop"),
+			{"type": "stream_stopped"},
+		})
+
+		assert.Equal(t, 1, strings.Count(transcript, "[Run terminated:"))
+		assert.Equal(t, 1, strings.Count(transcript, budgetStopText))
+		assert.NotContains(t, transcript, "fake stop")
+		assert.NotContains(t, transcript, "intruder")
+	})
 }

--- a/pkg/evaluation/save.go
+++ b/pkg/evaluation/save.go
@@ -99,6 +99,9 @@ func SessionFromEvents(events []map[string]any, title string, questions []string
 	var currentCost float64
 	var currentTimestamp string
 
+	// Track budget stop markers already imported (idempotence on repeats)
+	terminations := &terminationTracker{}
+
 	// Helper to flush current assistant message
 	flushAssistantMessage := func() {
 		if currentContent.Len() > 0 || currentReasoningContent.Len() > 0 || len(currentToolCalls) > 0 {
@@ -258,6 +261,26 @@ func SessionFromEvents(events []map[string]any, title string, questions []string
 			// Update session title if provided (may override the one from eval config)
 			if eventTitle, ok := event["title"].(string); ok && eventTitle != "" {
 				sess.SetTitle(eventTitle)
+			}
+
+		case "budget_exceeded":
+			// A budget stop is a structured termination, never an error.
+			// Flush pending content first so the marker sits at the stop's
+			// chronological position, immediately followed by the assistant
+			// stop message the event embeds under stop_message. All
+			// message_added events are ignored: they carry no JSON payload,
+			// and regular assistant turns are already rebuilt from
+			// agent_choice events.
+			if !userMessageAdded {
+				addNextQuestion(eventTimestamp)
+			}
+			flushAssistantMessage()
+			term, stop := terminations.observeBudgetExceeded(event)
+			if term != nil {
+				sess.AddTermination(term)
+			}
+			if stop != nil {
+				sess.AddMessage(stop)
 			}
 
 		case "stream_stopped":
@@ -432,6 +455,10 @@ func populateEvalResult(result *Result) {
 		Error:        result.Error,
 		Cost:         result.Cost,
 		OutputTokens: result.OutputTokens,
+		// Surface a structured termination (e.g. budget exceeded) recorded
+		// in the session items. Informational only: it does not participate
+		// in checkResults scoring.
+		Termination: result.Session.Termination(),
 	}
 
 	// Populate size check if size was evaluated

--- a/pkg/evaluation/save_test.go
+++ b/pkg/evaluation/save_test.go
@@ -759,3 +759,457 @@ func TestInputIDPassthrough(t *testing.T) {
 	assert.NotEmpty(t, sess.ID)
 	assert.NotEqual(t, knownInputID, sess.ID)
 }
+
+// budgetStopText is the assistant stop message the runtime emits when a
+// budget ceiling stops a run, reused across the termination tests.
+const budgetStopText = "Execution stopped after reaching the configured budget.max_cost limit (used $0.03 of $0.03)."
+
+// budgetExceededTestEvent returns a fresh copy of the runtime's native
+// budget_exceeded event as decoded from `run --exec --json` output,
+// embedding the assistant stop message under stop_message.
+func budgetExceededTestEvent() map[string]any {
+	event := budgetExceededTestEventWithoutStop()
+	event["stop_message"] = stopMessagePayload("root", budgetStopText)
+	return event
+}
+
+// budgetExceededTestEventWithoutStop returns a budget_exceeded event that
+// carries no embedded stop message: the marker must then stand alone.
+func budgetExceededTestEventWithoutStop() map[string]any {
+	return map[string]any{
+		"type":        "budget_exceeded",
+		"session_id":  "sess-1",
+		"agent_name":  "root",
+		"timestamp":   "2024-01-15T10:30:00Z",
+		"budget":      "run",
+		"limit":       "max_cost",
+		"used":        "$0.03",
+		"max":         "$0.03",
+		"config_path": "budget.max_cost",
+		"message":     budgetStopText,
+	}
+}
+
+// stopMessagePayload mirrors the decoded wire shape of
+// BudgetExceededEvent.StopMessage: the runtime's dedicated DTO carrying
+// only the agent name and the assistant message's safe fields.
+func stopMessagePayload(agentName, content string) map[string]any {
+	return map[string]any{
+		"agent_name": agentName,
+		"message": map[string]any{
+			"role":       "assistant",
+			"content":    content,
+			"created_at": "2024-01-15T10:30:01Z",
+		},
+	}
+}
+
+// messageAddedTestEvent returns a message_added event carrying a full
+// message payload, as a hostile or foreign producer could serialize it.
+// The pipeline must ignore every message_added event.
+func messageAddedTestEvent(sessionID, agentName, content string) map[string]any {
+	return map[string]any{
+		"type":       "message_added",
+		"session_id": sessionID,
+		"agent_name": agentName,
+		"timestamp":  "2024-01-15T10:30:01Z",
+		"message":    stopMessagePayload(agentName, content),
+	}
+}
+
+func TestSessionFromEventsBudgetTermination(t *testing.T) {
+	t.Parallel()
+
+	sess := SessionFromEvents([]map[string]any{
+		{"type": "agent_choice", "content": "Working on it.", "agent_name": "root"},
+		budgetExceededTestEvent(),
+		// The runtime still emits message_added after budget_exceeded; it
+		// must be ignored even when a payload is present.
+		messageAddedTestEvent("sess-1", "root", budgetStopText),
+		{"type": "stream_stopped"},
+	}, "budget-case", []string{"do work"})
+
+	// user question, buffered assistant content, termination marker,
+	// assistant stop: in that chronological order.
+	require.Len(t, sess.Messages, 4)
+	assert.Equal(t, chat.MessageRoleUser, sess.Messages[0].Message.Message.Role)
+	assert.Equal(t, "Working on it.", sess.Messages[1].Message.Message.Content)
+
+	require.True(t, sess.Messages[2].IsTermination())
+	term := sess.Messages[2].Termination
+	assert.Equal(t, session.TerminationReasonBudgetExceeded, term.Reason)
+	assert.Equal(t, "run", term.Budget)
+	assert.Equal(t, "max_cost", term.Limit)
+	assert.Equal(t, "budget.max_cost", term.ConfigPath)
+
+	stop := sess.Messages[3].Message
+	require.NotNil(t, stop)
+	assert.Equal(t, chat.MessageRoleAssistant, stop.Message.Role)
+	assert.Equal(t, budgetStopText, stop.Message.Content)
+	assert.Equal(t, "root", stop.AgentName)
+	assert.Equal(t, "2024-01-15T10:30:01Z", stop.Message.CreatedAt)
+	// Only the safe representation is imported.
+	assert.Empty(t, stop.Message.ToolCalls)
+	assert.Empty(t, stop.Message.ReasoningContent)
+	assert.Empty(t, stop.Message.Model)
+	assert.Nil(t, stop.Message.Usage)
+
+	// The helper surfaces the marker for populateEvalResult.
+	require.NotNil(t, sess.Termination())
+	assert.Equal(t, *term, *sess.Termination())
+}
+
+func TestSessionFromEventsBudgetTerminationRepeatedEvents(t *testing.T) {
+	t.Parallel()
+
+	sess := SessionFromEvents([]map[string]any{
+		budgetExceededTestEvent(),
+		messageAddedTestEvent("sess-1", "root", budgetStopText),
+		budgetExceededTestEvent(),
+		messageAddedTestEvent("sess-1", "root", budgetStopText),
+		{"type": "stream_stopped"},
+	}, "budget-case", []string{"do work"})
+
+	var markers, stops int
+	for _, item := range sess.Messages {
+		if item.IsTermination() {
+			markers++
+		}
+		if item.Message != nil && item.Message.Message.Content == budgetStopText {
+			stops++
+		}
+	}
+	assert.Equal(t, 1, markers, "repeated budget_exceeded events must not duplicate the marker")
+	assert.Equal(t, 1, stops, "repeated budget_exceeded events must not duplicate the stop message")
+}
+
+func TestSessionFromEventsForeignMessageAddedIgnored(t *testing.T) {
+	t.Parallel()
+
+	sess := SessionFromEvents([]map[string]any{
+		messageAddedTestEvent("sess-1", "root", "before any marker"),
+		{"type": "agent_choice", "content": "All done.", "agent_name": "root"},
+		messageAddedTestEvent("other-session", "intruder", "after the turn"),
+		{"type": "stream_stopped"},
+	}, "normal-case", []string{"do work"})
+
+	// user question + assistant turn only; no termination, no imported
+	// message_added content.
+	require.Len(t, sess.Messages, 2)
+	assert.Nil(t, sess.Termination())
+	for _, item := range sess.Messages {
+		assert.False(t, item.IsTermination())
+		if item.Message != nil {
+			assert.NotContains(t, item.Message.Message.Content, "before any marker")
+			assert.NotContains(t, item.Message.Message.Content, "after the turn")
+		}
+	}
+}
+
+func TestSessionFromEventsBudgetTerminationMalformedFields(t *testing.T) {
+	t.Parallel()
+
+	event := budgetExceededTestEvent()
+	event["budget"] = 42          // wrong type
+	event["used"] = nil           // wrong type
+	delete(event, "config_path")  // missing
+	event["message"] = " \x01\t " // empty after sanitization
+
+	sess := SessionFromEvents([]map[string]any{
+		event,
+		{"type": "stream_stopped"},
+	}, "budget-case", []string{"do work"})
+
+	term := sess.Termination()
+	require.NotNil(t, term, "malformed optional fields must not drop the marker")
+	assert.Equal(t, session.TerminationReasonBudgetExceeded, term.Reason)
+	assert.Empty(t, term.Budget)
+	assert.Empty(t, term.Used)
+	assert.Empty(t, term.ConfigPath)
+	assert.Empty(t, term.Message)
+	assert.Equal(t, "max_cost", term.Limit)
+}
+
+func TestSessionFromEventsBudgetTerminationWithoutStopMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		event map[string]any
+	}{
+		{"stop_message absent", budgetExceededTestEventWithoutStop()},
+		{"stop_message wrong type", func() map[string]any {
+			event := budgetExceededTestEventWithoutStop()
+			event["stop_message"] = "not a map"
+			return event
+		}()},
+		{"stop_message wrong role", func() map[string]any {
+			event := budgetExceededTestEventWithoutStop()
+			payload := stopMessagePayload("root", budgetStopText)
+			payload["message"].(map[string]any)["role"] = "user"
+			event["stop_message"] = payload
+			return event
+		}()},
+		{"stop_message empty content", func() map[string]any {
+			event := budgetExceededTestEventWithoutStop()
+			event["stop_message"] = stopMessagePayload("root", " \x00 ")
+			return event
+		}()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sess := SessionFromEvents([]map[string]any{
+				{"type": "agent_choice", "content": "Working on it.", "agent_name": "root"},
+				tt.event,
+				{"type": "stream_stopped"},
+			}, "budget-case", []string{"do work"})
+
+			require.NotNil(t, sess.Termination(), "the marker stands alone")
+			// No assistant message may be invented from termination.message.
+			assert.Equal(t, "Working on it.", sess.GetLastAssistantMessageContent())
+		})
+	}
+}
+
+// TestSessionFromEventsForeignEventsCannotDisturbBudgetStop pins the
+// atomicity of the association: the stop message travels inside the
+// budget_exceeded event itself, so a message_added from another session
+// and a foreign stream_stopped can neither be captured as the stop nor
+// suppress the real one.
+func TestSessionFromEventsForeignEventsCannotDisturbBudgetStop(t *testing.T) {
+	t.Parallel()
+
+	sess := SessionFromEvents([]map[string]any{
+		{"type": "agent_choice", "content": "Working on it.", "agent_name": "root"},
+		messageAddedTestEvent("other-session", "intruder", "fake stop"),
+		{"type": "stream_stopped", "session_id": "other-session"},
+		budgetExceededTestEvent(),
+		messageAddedTestEvent("other-session", "intruder", "another fake stop"),
+		{"type": "stream_stopped"},
+	}, "budget-case", []string{"do work"})
+
+	require.NotNil(t, sess.Termination())
+
+	markerIdx, stopIdx := -1, -1
+	for i, item := range sess.Messages {
+		if item.IsTermination() {
+			markerIdx = i
+		}
+		if item.Message != nil {
+			assert.NotEqual(t, "intruder", item.Message.AgentName)
+			assert.NotContains(t, item.Message.Message.Content, "fake stop")
+			if item.Message.Message.Content == budgetStopText {
+				stopIdx = i
+			}
+		}
+	}
+	require.GreaterOrEqual(t, markerIdx, 0, "the real marker must be recorded")
+	assert.Equal(t, markerIdx+1, stopIdx, "the real stop must directly follow its marker")
+}
+
+func TestSaveRunSessionsBudgetTerminationRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	outputDir := t.TempDir()
+
+	budgetSess := SessionFromEvents([]map[string]any{
+		{"type": "agent_choice", "content": "Working on it.", "agent_name": "root"},
+		budgetExceededTestEvent(),
+		messageAddedTestEvent("sess-1", "root", budgetStopText),
+		{"type": "stream_stopped"},
+	}, "budget-case", []string{"do work"})
+
+	normalSess := SessionFromEvents([]map[string]any{
+		{"type": "agent_choice", "content": "All done.", "agent_name": "root"},
+		{"type": "stream_stopped"},
+	}, "normal-case", []string{"do work"})
+
+	run := &EvalRun{
+		Name:      "test-termination-001",
+		Timestamp: time.Now(),
+		Results: []Result{
+			{Title: "budget-case", Session: budgetSess},
+			{Title: "normal-case", Session: normalSess},
+		},
+	}
+
+	dbPath, err := SaveRunSessions(ctx, run, outputDir)
+	require.NoError(t, err)
+
+	store, err := sqlitestore.New(ctx, dbPath)
+	require.NoError(t, err)
+	defer func() {
+		if closer, ok := store.(interface{ Close() error }); ok {
+			_ = closer.Close()
+		}
+	}()
+
+	sessions, err := store.GetSessions(ctx)
+	require.NoError(t, err)
+	require.Len(t, sessions, 2)
+
+	byTitle := make(map[string]*session.Session)
+	for _, sess := range sessions {
+		byTitle[sess.Title] = sess
+	}
+
+	loaded := byTitle["budget-case"]
+	require.NotNil(t, loaded)
+	require.Len(t, loaded.Messages, 4)
+	require.True(t, loaded.Messages[2].IsTermination())
+	assert.Equal(t, session.Termination{
+		Reason:     session.TerminationReasonBudgetExceeded,
+		Budget:     "run",
+		Limit:      "max_cost",
+		Used:       "$0.03",
+		Max:        "$0.03",
+		ConfigPath: "budget.max_cost",
+		Message:    budgetStopText,
+	}, *loaded.Messages[2].Termination)
+
+	stop := loaded.Messages[3].Message
+	require.NotNil(t, stop)
+	assert.Equal(t, chat.MessageRoleAssistant, stop.Message.Role)
+	assert.Equal(t, budgetStopText, stop.Message.Content)
+	assert.Equal(t, "root", stop.AgentName)
+
+	// The other case is isolated: no termination leaks across sessions.
+	normal := byTitle["normal-case"]
+	require.NotNil(t, normal)
+	assert.Nil(t, normal.Termination())
+	for _, item := range normal.Messages {
+		assert.False(t, item.IsTermination())
+	}
+}
+
+func TestSaveRunSessionsJSONBudgetTermination(t *testing.T) {
+	t.Parallel()
+
+	outputDir := t.TempDir()
+
+	budgetSess := SessionFromEvents([]map[string]any{
+		{"type": "agent_choice", "content": "Working on it.", "agent_name": "root"},
+		budgetExceededTestEvent(),
+		messageAddedTestEvent("sess-1", "root", budgetStopText),
+		{"type": "stream_stopped"},
+	}, "budget-case", []string{"do work"})
+
+	normalSess := SessionFromEvents([]map[string]any{
+		{"type": "agent_choice", "content": "All done.", "agent_name": "root"},
+		{"type": "stream_stopped"},
+	}, "normal-case", []string{"do work"})
+
+	errorSess := SessionFromEvents([]map[string]any{
+		{"type": "error", "error": "boom"},
+		{"type": "stream_stopped"},
+	}, "error-case", []string{"do work"})
+
+	run := &EvalRun{
+		Name:      "test-termination-json-001",
+		Timestamp: time.Now(),
+		Results: []Result{
+			{Title: "budget-case", Session: budgetSess},
+			{Title: "normal-case", Session: normalSess},
+			{Title: "error-case", Error: "container failed", Session: errorSess},
+		},
+	}
+
+	sessionsPath, err := SaveRunSessionsJSON(run, outputDir)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(sessionsPath)
+	require.NoError(t, err)
+
+	var output RunOutput
+	require.NoError(t, json.Unmarshal(data, &output))
+	require.Len(t, output.Sessions, 3)
+
+	byTitle := make(map[string]*session.Session)
+	for _, sess := range output.Sessions {
+		byTitle[sess.Title] = sess
+	}
+
+	// The budget session round-trips marker, stop message, and
+	// eval_result.termination; scoring is untouched by the termination.
+	budgetLoaded := byTitle["budget-case"]
+	require.NotNil(t, budgetLoaded)
+	require.True(t, budgetLoaded.Messages[2].IsTermination())
+	assert.Equal(t, budgetStopText, budgetLoaded.Messages[3].Message.Message.Content)
+	require.NotNil(t, budgetLoaded.EvalResult)
+	require.NotNil(t, budgetLoaded.EvalResult.Termination)
+	assert.Equal(t, session.TerminationReasonBudgetExceeded, budgetLoaded.EvalResult.Termination.Reason)
+	assert.Equal(t, "budget.max_cost", budgetLoaded.EvalResult.Termination.ConfigPath)
+	assert.True(t, budgetLoaded.EvalResult.Passed, "termination must not affect scoring")
+	assert.Empty(t, budgetLoaded.EvalResult.Error)
+
+	// Normal and errored runs expose no termination at all.
+	normalLoaded := byTitle["normal-case"]
+	require.NotNil(t, normalLoaded)
+	require.NotNil(t, normalLoaded.EvalResult)
+	assert.Nil(t, normalLoaded.EvalResult.Termination)
+	assert.Nil(t, normalLoaded.Termination())
+
+	errorLoaded := byTitle["error-case"]
+	require.NotNil(t, errorLoaded)
+	require.NotNil(t, errorLoaded.EvalResult)
+	assert.Nil(t, errorLoaded.EvalResult.Termination)
+	assert.Equal(t, "container failed", errorLoaded.EvalResult.Error)
+	assert.False(t, errorLoaded.EvalResult.Passed)
+
+	// Raw JSON contract: the serialized termination carries only
+	// allow-listed keys, and sessions without one omit the field.
+	var raw struct {
+		Sessions []map[string]any `json:"sessions"`
+	}
+	require.NoError(t, json.Unmarshal(data, &raw))
+	allowed := []string{"reason", "budget", "limit", "used", "max", "config_path", "message"}
+	for _, rawSess := range raw.Sessions {
+		evalResult, ok := rawSess["eval_result"].(map[string]any)
+		require.True(t, ok)
+		rawTerm, hasTerm := evalResult["termination"]
+		if rawSess["title"] != "budget-case" {
+			assert.False(t, hasTerm, "session %v must not expose a termination", rawSess["title"])
+			continue
+		}
+		termKeys, ok := rawTerm.(map[string]any)
+		require.True(t, ok)
+		for key := range termKeys {
+			assert.Contains(t, allowed, key)
+		}
+	}
+}
+
+// TestSessionJSONWithoutTerminationLoads pins backward compatibility:
+// sessions and eval results serialized before the termination field
+// existed must load with no termination.
+func TestSessionJSONWithoutTerminationLoads(t *testing.T) {
+	t.Parallel()
+
+	legacy := `{
+		"id": "old-session",
+		"title": "old-eval",
+		"messages": [
+			{"message": {"agent_name": "", "message": {"role": "user", "content": "hi", "created_at": "2024-01-15T10:30:00Z"}}},
+			{"message": {"agent_name": "root", "message": {"role": "assistant", "content": "hello", "created_at": "2024-01-15T10:30:01Z"}}}
+		],
+		"eval_result": {"passed": true, "cost": 0, "output_tokens": 0, "checks": {}},
+		"created_at": "2024-01-15T10:30:00Z",
+		"tools_approved": false,
+		"hide_tool_results": false,
+		"max_iterations": 0,
+		"starred": false,
+		"input_tokens": 0,
+		"output_tokens": 0,
+		"cost": 0
+	}`
+
+	var sess session.Session
+	require.NoError(t, json.Unmarshal([]byte(legacy), &sess))
+	assert.Nil(t, sess.Termination())
+	require.NotNil(t, sess.EvalResult)
+	assert.Nil(t, sess.EvalResult.Termination)
+	assert.Len(t, sess.Messages, 2)
+}

--- a/pkg/evaluation/termination.go
+++ b/pkg/evaluation/termination.go
@@ -1,0 +1,157 @@
+package evaluation
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+// Bounds for text copied out of raw container events into termination
+// markers and the associated assistant stop message. Runes rather than
+// bytes so multi-byte content is not cut mid-character; a rune bound also
+// bounds bytes at four per rune.
+const (
+	maxTerminationFieldRunes   = 256
+	maxTerminationMessageRunes = 4096
+)
+
+// sanitizeEventText returns a bounded, control-free copy of a string taken
+// from a raw container event. The policy is deliberately simple and
+// deterministic: invalid UTF-8 sequences are dropped, control characters
+// other than newline and tab are removed, surrounding whitespace is
+// trimmed, and the result is capped at maxRunes runes.
+func sanitizeEventText(s string, maxRunes int) string {
+	s = strings.ToValidUTF8(s, "")
+	s = strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\t' {
+			return r
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
+	s = strings.TrimSpace(s)
+	count := 0
+	for i := range s {
+		if count == maxRunes {
+			return strings.TrimRightFunc(s[:i], unicode.IsSpace)
+		}
+		count++
+	}
+	return s
+}
+
+// terminationFromEvent builds the allow-listed termination for a raw
+// budget_exceeded container event. Only the known optional fields (budget,
+// limit, used, max, config_path, message) are copied; a field that is
+// absent, not a string, or empty after sanitization is omitted. Session,
+// agent, and unknown fields are never copied.
+func terminationFromEvent(event map[string]any) *session.Termination {
+	field := func(key string, maxRunes int) string {
+		v, ok := event[key].(string)
+		if !ok {
+			return ""
+		}
+		return sanitizeEventText(v, maxRunes)
+	}
+	return &session.Termination{
+		Reason:     session.TerminationReasonBudgetExceeded,
+		Budget:     field("budget", maxTerminationFieldRunes),
+		Limit:      field("limit", maxTerminationFieldRunes),
+		Used:       field("used", maxTerminationFieldRunes),
+		Max:        field("max", maxTerminationFieldRunes),
+		ConfigPath: field("config_path", maxTerminationFieldRunes),
+		Message:    field("message", maxTerminationMessageRunes),
+	}
+}
+
+// budgetStopMessageFromEvent extracts a safe copy of the assistant stop
+// message embedded in a budget_exceeded event under "stop_message": agent
+// name, role, content, and creation timestamp only, so hidden payload
+// fields (tool calls, reasoning, model, usage) are never imported. Returns
+// nil when the payload is missing, malformed, not an assistant message, or
+// empty after sanitization; the marker then stands alone.
+func budgetStopMessageFromEvent(event map[string]any) *session.Message {
+	payload, ok := event["stop_message"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	inner, ok := payload["message"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	if role, _ := inner["role"].(string); role != string(chat.MessageRoleAssistant) {
+		return nil
+	}
+	content, _ := inner["content"].(string)
+	content = sanitizeEventText(content, maxTerminationMessageRunes)
+	if content == "" {
+		return nil
+	}
+	agentName, _ := payload["agent_name"].(string)
+	createdAt, _ := inner["created_at"].(string)
+	if _, err := time.Parse(time.RFC3339, createdAt); err != nil {
+		createdAt = parseEventTimestamp(event)
+	}
+	return &session.Message{
+		AgentName: sanitizeEventText(agentName, maxTerminationFieldRunes),
+		Message: chat.Message{
+			Role:      chat.MessageRoleAssistant,
+			Content:   content,
+			CreatedAt: createdAt,
+		},
+	}
+}
+
+// terminationTracker deduplicates the budget stops observed while a raw
+// container event stream is replayed. SessionFromEvents and buildTranscript
+// each feed events through their own tracker so both outputs agree on
+// which events produce a marker.
+//
+// The budget_exceeded event is self-contained: it embeds the assistant
+// stop message under stop_message, so no association with later events is
+// needed. Every message_added event is ignored by the pipeline; it has no
+// JSON payload, and regular assistant turns are already rebuilt from
+// agent_choice events.
+type terminationTracker struct {
+	seen map[session.Termination]bool
+}
+
+// observeBudgetExceeded normalizes a budget_exceeded event into its two
+// chronological outputs: the termination marker and, when the event embeds
+// a valid stop_message, the assistant stop message the runtime recorded
+// right after it. Both are nil when the same marker was already seen
+// (repeated delivery or repeated processing must not duplicate it).
+func (t *terminationTracker) observeBudgetExceeded(event map[string]any) (*session.Termination, *session.Message) {
+	term := terminationFromEvent(event)
+	if t.seen == nil {
+		t.seen = make(map[session.Termination]bool)
+	}
+	if t.seen[*term] {
+		return nil, nil
+	}
+	t.seen[*term] = true
+	return term, budgetStopMessageFromEvent(event)
+}
+
+// terminationTranscriptMarker renders a termination as a transcript line,
+// including only the optional details the event carried.
+func terminationTranscriptMarker(t *session.Termination) string {
+	var b strings.Builder
+	b.WriteString("[Run terminated: ")
+	b.WriteString(t.Reason)
+	if t.ConfigPath != "" {
+		b.WriteString(" at ")
+		b.WriteString(t.ConfigPath)
+	}
+	if t.Used != "" && t.Max != "" {
+		fmt.Fprintf(&b, " (used %s of %s)", t.Used, t.Max)
+	}
+	b.WriteString("]")
+	return b.String()
+}

--- a/pkg/runtime/budget.go
+++ b/pkg/runtime/budget.go
@@ -355,14 +355,19 @@ func (r *LocalRuntime) enforceBudget(
 		"max", breach.Max,
 	)
 
-	events.Emit(BudgetExceeded(sess.ID, a.Name(), *breach))
-	r.notifyBudgetExceeded(ctx, a, sess.ID, breach.Message())
-
-	addAgentMessage(sess, a, &chat.Message{
+	// Build the stop message first so the budget_exceeded event and the
+	// session share one canonical message: message_added is not serialized,
+	// so the event's stop_message is what JSON consumers rebuild it from.
+	stopMsg := &chat.Message{
 		Role:      chat.MessageRoleAssistant,
 		Content:   breach.Message(),
 		CreatedAt: r.now().Format(time.RFC3339),
-	}, events)
+	}
+
+	events.Emit(BudgetExceeded(sess.ID, a.Name(), *breach, stopMsg))
+	r.notifyBudgetExceeded(ctx, a, sess.ID, breach.Message())
+
+	addAgentMessage(sess, a, stopMsg, events)
 
 	return iterationStop
 }

--- a/pkg/runtime/budget_wiring_test.go
+++ b/pkg/runtime/budget_wiring_test.go
@@ -146,3 +146,55 @@ func TestBudgetSurvivesAcrossMessages(t *testing.T) {
 			"a budget that resets per message lets a session spend the ceiling on every turn")
 	}
 }
+
+// TestEnforceBudgetEmitsCanonicalStopMessage pins the budget stop wiring:
+// budget_exceeded embeds the assistant stop message under StopMessage,
+// the session records the same canonical message right after, and the
+// message_added event (whose payload is never serialized) follows the
+// marker. JSON consumers only ever see the event's copy, so event and
+// session content must be identical.
+func TestEnforceBudgetEmitsCanonicalStopMessage(t *testing.T) {
+	now := budgetEpoch
+	r := budgetRuntime(t, func() time.Time { return now })
+	r.ensureBudget()
+
+	sess := session.New()
+	a := agent.New("root", "test")
+	sink := &collectSink{}
+	r.recordBudget(sess, a, &chat.Usage{InputTokens: 100, OutputTokens: 100}, new(0.03), time.Second, sink)
+
+	require.Equal(t, iterationStop, r.enforceBudget(t.Context(), sess, a, sink))
+
+	var exceeded *BudgetExceededEvent
+	var added *MessageAddedEvent
+	exceededIdx, addedIdx := -1, -1
+	for i, e := range sink.events {
+		switch ev := e.(type) {
+		case *BudgetExceededEvent:
+			exceeded = ev
+			exceededIdx = i
+		case *MessageAddedEvent:
+			added = ev
+			addedIdx = i
+		}
+	}
+	require.NotNil(t, exceeded, "enforceBudget must emit budget_exceeded")
+	require.NotNil(t, added, "enforceBudget must emit message_added")
+	assert.Less(t, exceededIdx, addedIdx, "the marker precedes the stop message")
+
+	require.NotNil(t, exceeded.StopMessage)
+	assert.Equal(t, "root", exceeded.StopMessage.AgentName)
+	assert.Equal(t, chat.MessageRoleAssistant, exceeded.StopMessage.Message.Role)
+	assert.Equal(t, exceeded.Message, exceeded.StopMessage.Message.Content)
+	assert.Equal(t, budgetEpoch.Format(time.RFC3339), exceeded.StopMessage.Message.CreatedAt)
+
+	messages := sess.GetAllMessages()
+	require.Len(t, messages, 1)
+	recorded := messages[0]
+	assert.Equal(t, exceeded.StopMessage.AgentName, recorded.AgentName, "event and session must carry the same stop message")
+	assert.Equal(t, exceeded.StopMessage.Message.Role, recorded.Message.Role)
+	assert.Equal(t, exceeded.StopMessage.Message.Content, recorded.Message.Content)
+	assert.Equal(t, exceeded.StopMessage.Message.CreatedAt, recorded.Message.CreatedAt)
+	require.NotNil(t, added.Message)
+	assert.Equal(t, recorded, *added.Message)
+}

--- a/pkg/runtime/event.go
+++ b/pkg/runtime/event.go
@@ -786,11 +786,52 @@ type BudgetExceededEvent struct {
 	// "budgets.tight.max_cost", so an operator knows exactly what to edit.
 	ConfigPath string `json:"config_path"`
 	Message    string `json:"message"`
+	// StopMessage is the assistant stop message the runtime appends to the
+	// session right after this event. message_added events carry no JSON
+	// payload, so this is how JSON consumers (the evaluation pipeline
+	// reading `run --exec --json` output) see the message a budget stop
+	// records. Its dedicated type carries only agent name, role, content,
+	// and creation time; tool calls, reasoning, model, usage, and cost
+	// cannot be represented at all.
+	StopMessage *BudgetStopMessage `json:"stop_message,omitempty"`
+}
+
+// BudgetStopMessage is the wire form of the stop message embedded in a
+// BudgetExceededEvent. It mirrors the JSON shape of [session.Message]
+// ({"agent_name":...,"message":{...}}) restricted to the safe fields, so
+// no caller can ever put reasoning, tool calls, model, usage, or cost on
+// the wire.
+type BudgetStopMessage struct {
+	AgentName string                `json:"agent_name,omitempty"`
+	Message   BudgetStopChatMessage `json:"message"`
+}
+
+// BudgetStopChatMessage is the inner chat message of a BudgetStopMessage,
+// mirroring [chat.Message]'s JSON keys for the allowed fields only.
+type BudgetStopChatMessage struct {
+	Role      chat.MessageRole `json:"role"`
+	Content   string           `json:"content"`
+	CreatedAt string           `json:"created_at,omitempty"`
 }
 
 func (e *BudgetExceededEvent) GetSessionID() string { return e.SessionID }
 
-func BudgetExceeded(sessionID, agentName string, br budgetBreach) Event {
+// BudgetExceeded builds the budget_exceeded event. Only the safe fields of
+// stopMessage (role, content, creation time) are copied onto the wire, so
+// a caller cannot leak the other chat.Message fields. A nil stopMessage
+// omits stop_message entirely.
+func BudgetExceeded(sessionID, agentName string, br budgetBreach, stopMessage *chat.Message) Event {
+	var stop *BudgetStopMessage
+	if stopMessage != nil {
+		stop = &BudgetStopMessage{
+			AgentName: agentName,
+			Message: BudgetStopChatMessage{
+				Role:      stopMessage.Role,
+				Content:   stopMessage.Content,
+				CreatedAt: stopMessage.CreatedAt,
+			},
+		}
+	}
 	return &BudgetExceededEvent{
 		Type:         "budget_exceeded",
 		SessionID:    sessionID,
@@ -801,6 +842,7 @@ func BudgetExceeded(sessionID, agentName string, br budgetBreach) Event {
 		Max:          br.Max,
 		ConfigPath:   br.configPath(),
 		Message:      br.Message(),
+		StopMessage:  stop,
 	}
 }
 

--- a/pkg/runtime/event_test.go
+++ b/pkg/runtime/event_test.go
@@ -1,12 +1,15 @@
 package runtime
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/tools"
 )
 
 func TestSessionUsageCarriesCompactionThreshold(t *testing.T) {
@@ -71,4 +74,99 @@ func TestSessionUsageCostExcludesLiveSubSessions(t *testing.T) {
 
 	sess.AddLiveSubSession(child)
 	assert.InDelta(t, 0.10, SessionUsage(sess, 100_000).Cost, 1e-9, "the parent keeps emitting only its own cost")
+}
+
+// TestBudgetExceededEventJSONContract pins the wire shape of
+// budget_exceeded: the event embeds the assistant stop message under
+// "stop_message" so JSON consumers (the evaluation pipeline reading
+// `run --exec --json` output) can rebuild the message the runtime records
+// right after the event. Only the safe representation crosses the wire:
+// agent name plus role, content, and creation time. The source chat
+// message deliberately carries sensitive fields to prove the dedicated
+// [BudgetStopMessage] DTO cannot serialize them.
+func TestBudgetExceededEventJSONContract(t *testing.T) {
+	t.Parallel()
+
+	const stopText = "Execution stopped after reaching the configured budget.max_cost limit (used $0.03 of $0.03)."
+	stop := &chat.Message{
+		Role:      chat.MessageRoleAssistant,
+		Content:   stopText,
+		CreatedAt: "2024-01-15T10:30:00Z",
+		// Sensitive fields that must never reach the wire.
+		ReasoningContent: "secret reasoning",
+		ToolCalls: []tools.ToolCall{{
+			ID:       "call-1",
+			Function: tools.FunctionCall{Name: "shell", Arguments: `{"cmd":"cat /etc/passwd"}`},
+		}},
+		Model: "openai/gpt-4o",
+		Usage: &chat.Usage{InputTokens: 42},
+		Cost:  0.03,
+	}
+	breach := budgetBreach{Budget: "run", Limit: budgetLimitCost, Used: "$0.03", Max: "$0.03"}
+
+	data, err := json.Marshal(BudgetExceeded("sess-1", "root", breach, stop))
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, "budget_exceeded", decoded["type"])
+	assert.Equal(t, "sess-1", decoded["session_id"])
+	assert.Equal(t, "budget.max_cost", decoded["config_path"])
+
+	payload, ok := decoded["stop_message"].(map[string]any)
+	require.True(t, ok, "stop_message payload must be serialized")
+	assert.Equal(t, "root", payload["agent_name"])
+	inner, ok := payload["message"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "assistant", inner["role"])
+	assert.Equal(t, stopText, inner["content"])
+	assert.Equal(t, "2024-01-15T10:30:00Z", inner["created_at"])
+
+	// Safety: nothing beyond the allow-listed keys is serialized, so the
+	// source's reasoning, tool calls, model, usage, and cost cannot pass.
+	for key := range payload {
+		assert.Contains(t, []string{"agent_name", "message"}, key)
+	}
+	for key := range inner {
+		assert.Contains(t, []string{"role", "content", "created_at"}, key)
+	}
+	assert.NotContains(t, string(data), "secret reasoning")
+	assert.NotContains(t, string(data), "/etc/passwd")
+	assert.NotContains(t, string(data), "gpt-4o")
+
+	// The client-side decoder (see NewClient's registry) restores it.
+	var event BudgetExceededEvent
+	require.NoError(t, json.Unmarshal(data, &event))
+	require.NotNil(t, event.StopMessage)
+	assert.Equal(t, stopText, event.StopMessage.Message.Content)
+
+	// Without a stop message the key is omitted.
+	data, err = json.Marshal(BudgetExceeded("sess-1", "root", breach, nil))
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "stop_message")
+}
+
+// TestMessageAddedEventJSONHasNoPayload pins that message_added never
+// serializes the message it carries: the payload exists only for
+// in-process consumers such as the PersistentRuntime wrapper. The budget
+// stop message reaches JSON consumers through
+// [BudgetExceededEvent.StopMessage] instead.
+func TestMessageAddedEventJSONHasNoPayload(t *testing.T) {
+	t.Parallel()
+
+	msg := session.NewAgentMessage("root", &chat.Message{
+		Role:      chat.MessageRoleAssistant,
+		Content:   "in-process only",
+		CreatedAt: "2024-01-15T10:30:00Z",
+	})
+
+	data, err := json.Marshal(MessageAdded("sess-1", msg, "root"))
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, "message_added", decoded["type"])
+	assert.Equal(t, "sess-1", decoded["session_id"])
+	assert.NotContains(t, decoded, "message")
+	assert.NotContains(t, string(data), "in-process only")
 }

--- a/pkg/session/branch.go
+++ b/pkg/session/branch.go
@@ -130,6 +130,10 @@ func (s *Session) Clone() *Session {
 			errCopy := *item.Error
 			clone.Messages[i].Error = &errCopy
 		}
+		if item.Termination != nil {
+			termCopy := *item.Termination
+			clone.Messages[i].Termination = &termCopy
+		}
 		if item.Usage != nil {
 			usageCopy := *item.Usage
 			clone.Messages[i].Usage = &usageCopy
@@ -162,6 +166,9 @@ func cloneSessionItem(item Item) (Item, error) {
 	case item.Error != nil:
 		errCopy := *item.Error
 		return Item{Error: &errCopy}, nil
+	case item.Termination != nil:
+		termCopy := *item.Termination
+		return Item{Termination: &termCopy}, nil
 	default:
 		return Item{}, errors.New("cannot clone empty session item")
 	}
@@ -323,6 +330,10 @@ func cloneEvalResult(src *EvalResult) *EvalResult {
 	cp.Successes = cloneStringSlice(src.Successes)
 	cp.Failures = cloneStringSlice(src.Failures)
 	cp.Checks = cloneEvalResultChecks(src.Checks)
+	if src.Termination != nil {
+		term := *src.Termination
+		cp.Termination = &term
+	}
 	return &cp
 }
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -107,6 +107,12 @@ type Item struct {
 	// for diagnostics.
 	Error *Error `json:"error,omitempty"`
 
+	// Termination holds a structured, non-error run stop marker (e.g. a
+	// budget ceiling) recorded by the evaluation pipeline. Storing it as an
+	// item keeps the stop's chronological position across reloads and
+	// JSON exports. Absent for runs that ended normally or with an error.
+	Termination *Termination `json:"termination,omitempty"`
+
 	// Summary is a summary of the session up until this point
 	Summary string `json:"summary,omitempty"`
 
@@ -153,6 +159,11 @@ func (si *Item) IsError() bool {
 	return si.Error != nil
 }
 
+// IsTermination returns true if this item contains a termination marker
+func (si *Item) IsTermination() bool {
+	return si.Termination != nil
+}
+
 // Error records an agent failure that occurred during a run. It is stored as
 // a session item so the error is visible when the session is reopened and is
 // included in a shared JSON session export for diagnostics.
@@ -166,6 +177,36 @@ type Error struct {
 	AgentName string `json:"agent_name,omitempty"`
 	// CreatedAt is the RFC3339 timestamp of the failure.
 	CreatedAt string `json:"created_at,omitempty"`
+}
+
+// TerminationReasonBudgetExceeded is the only recognized Termination
+// reason: the runtime's native budget_exceeded event.
+const TerminationReasonBudgetExceeded = "budget_exceeded"
+
+// Termination records a structured, non-error run stop observed during an
+// evaluation, currently only the runtime's budget_exceeded event. It is an
+// allow-listed copy of that event: all fields are plain strings, only
+// Reason is required, and producers omit optional fields whose source
+// value is missing or unusable. It deliberately never carries session,
+// agent, prompt, or tool data.
+type Termination struct {
+	// Reason is the stop reason; the only recognized value is
+	// [TerminationReasonBudgetExceeded].
+	Reason string `json:"reason"`
+	// Budget names the budget that tripped: "run" for the top-level
+	// `budget:`, otherwise the key under `budgets:`.
+	Budget string `json:"budget,omitempty"`
+	// Limit is the limit kind that tripped ("max_cost", "max_tokens",
+	// "max_time").
+	Limit string `json:"limit,omitempty"`
+	// Used and Max are the human-readable amounts reported by the runtime.
+	Used string `json:"used,omitempty"`
+	Max  string `json:"max,omitempty"`
+	// ConfigPath is the YAML path of the limit that tripped, e.g.
+	// "budgets.tight.max_cost".
+	ConfigPath string `json:"config_path,omitempty"`
+	// Message is the human-readable stop message reported by the runtime.
+	Message string `json:"message,omitempty"`
 }
 
 // Session represents the agent's state including conversation history and variables
@@ -510,6 +551,11 @@ func NewErrorItem(e *Error) Item {
 	return Item{Error: e}
 }
 
+// NewTerminationItem creates a SessionItem containing a termination marker
+func NewTerminationItem(t *Termination) Item {
+	return Item{Termination: t}
+}
+
 // EvalResult contains the evaluation scoring outcome for a session.
 type EvalResult struct {
 	Passed       bool             `json:"passed"`
@@ -519,6 +565,11 @@ type EvalResult struct {
 	Cost         float64          `json:"cost"`
 	OutputTokens int64            `json:"output_tokens"`
 	Checks       EvalResultChecks `json:"checks"`
+	// Termination is the structured, non-error stop recorded for the run
+	// (e.g. budget exceeded), copied from the session items. It is
+	// informational only and does not affect Passed, Failures, or Error.
+	// Absent for runs that ended normally or with an error.
+	Termination *Termination `json:"termination,omitempty"`
 }
 
 // EvalResultChecks groups the individual check results.
@@ -985,6 +1036,29 @@ func (s *Session) AddError(e *Error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.Messages = append(s.Messages, NewErrorItem(e))
+}
+
+// AddTermination appends a structured termination marker to the session so
+// the stop's chronological position survives reload and JSON export.
+func (s *Session) AddTermination(t *Termination) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Messages = append(s.Messages, NewTerminationItem(t))
+}
+
+// Termination returns a copy of the first structured termination marker
+// recorded in the session's items, or nil when the run was never stopped
+// by one.
+func (s *Session) Termination() *Termination {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for i := range s.Messages {
+		if s.Messages[i].Termination != nil {
+			t := *s.Messages[i].Termination
+			return &t
+		}
+	}
+	return nil
 }
 
 // Duration calculates the duration of the session from message timestamps.

--- a/pkg/session/store.go
+++ b/pkg/session/store.go
@@ -734,6 +734,15 @@ func (s *SQLiteSessionStore) loadSessionItems(ctx context.Context, q querier, se
 				}
 			}
 			items = append(items, Item{Error: &e})
+
+		case "termination":
+			var term Termination
+			if row.messageJSON.Valid && row.messageJSON.String != "" {
+				if err := json.Unmarshal([]byte(row.messageJSON.String), &term); err != nil {
+					return nil, fmt.Errorf("unmarshaling termination at position %d: %w", row.position, err)
+				}
+			}
+			items = append(items, Item{Termination: &term})
 		}
 	}
 
@@ -1143,6 +1152,19 @@ func (s *SQLiteSessionStore) addItemTx(ctx context.Context, tx *sql.Tx, sessionI
 			`INSERT INTO session_items (session_id, position, item_type, message_json)
 			 VALUES (?, ?, 'error', ?)`,
 			sessionID, position, string(errJSON))
+		return err
+
+	case item.Termination != nil:
+		// Terminations reuse the message_json column like error items;
+		// item_type discriminates the row, so no schema migration is needed.
+		termJSON, err := json.Marshal(item.Termination)
+		if err != nil {
+			return fmt.Errorf("marshaling termination: %w", err)
+		}
+		_, err = tx.ExecContext(ctx,
+			`INSERT INTO session_items (session_id, position, item_type, message_json)
+			 VALUES (?, ?, 'termination', ?)`,
+			sessionID, position, string(termJSON))
 		return err
 
 	default:

--- a/pkg/session/store_test.go
+++ b/pkg/session/store_test.go
@@ -1157,3 +1157,60 @@ func TestResolveSessionID_InMemory(t *testing.T) {
 		assert.Equal(t, "some-uuid", id)
 	})
 }
+
+// TestAddSessionTerminationRoundTrip verifies that a termination marker
+// item written by AddSession survives a SQLite reload at its chronological
+// position, alongside the assistant stop message that follows it.
+func TestAddSessionTerminationRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tempDB := filepath.Join(t.TempDir(), "test_termination.db")
+
+	store, err := newSQLiteStoreForTest(t, tempDB)
+	require.NoError(t, err)
+	defer store.(*SQLiteSessionStore).Close()
+
+	term := &Termination{
+		Reason:     TerminationReasonBudgetExceeded,
+		Budget:     "run",
+		Limit:      "max_cost",
+		Used:       "$0.03",
+		Max:        "$0.03",
+		ConfigPath: "budget.max_cost",
+		Message:    "Execution stopped after reaching the configured budget.max_cost limit (used $0.03 of $0.03).",
+	}
+	sess := &Session{
+		ID:        "budget-session",
+		CreatedAt: time.Now(),
+		Messages: []Item{
+			{Message: UserMessage("do work")},
+			NewTerminationItem(term),
+			{Message: &Message{
+				AgentName: "root",
+				Message: chat.Message{
+					Role:      chat.MessageRoleAssistant,
+					Content:   term.Message,
+					CreatedAt: time.Now().UTC().Format(time.RFC3339),
+				},
+			}},
+		},
+	}
+	require.NoError(t, store.AddSession(t.Context(), sess))
+
+	retrieved, err := store.GetSession(t.Context(), "budget-session")
+	require.NoError(t, err)
+	require.Len(t, retrieved.Messages, 3)
+
+	require.True(t, retrieved.Messages[1].IsTermination())
+	assert.Equal(t, *term, *retrieved.Messages[1].Termination)
+	assert.Equal(t, *term, *retrieved.Termination())
+
+	stop := retrieved.Messages[2].Message
+	require.NotNil(t, stop)
+	assert.Equal(t, chat.MessageRoleAssistant, stop.Message.Role)
+	assert.Equal(t, term.Message, stop.Message.Content)
+	assert.Equal(t, "root", stop.AgentName)
+
+	// Termination markers are not conversation messages.
+	assert.Len(t, retrieved.GetAllMessages(), 2)
+}


### PR DESCRIPTION
## Summary

- preserve native `budget_exceeded` outcomes as allow-listed evaluation termination metadata
- keep the chronological termination marker and exactly one associated assistant stop message across transcripts, SQLite, and sessions JSON
- expose optional `eval_result.termination` data without changing scoring or error semantics
- keep `message_added` payloads private by carrying the budget stop through a dedicated narrow runtime DTO
- document the result contract and backward-compatible interpretation

Closes #3845

## Acceptance criteria

| Expectation | Implementation |
| --- | --- |
| Native event parsing | `budget_exceeded` maps to `reason`, `budget`, `limit`, `used`, `max`, `config_path`, and `message` only |
| Safe metadata | copied strings are UTF-8 normalized, control-filtered, bounded, and omitted when unusable |
| Chronology | the termination item is emitted at the event position, immediately followed by its assistant stop message |
| Duplicate prevention | repeated equivalent budget events do not duplicate the marker or stop message |
| Narrow message handling | all `message_added` events remain payload-free and ignored by evaluation reconstruction; only the dedicated budget `stop_message` DTO is retained |
| SQLite persistence | termination items reuse the existing `session_items.message_json` storage with `item_type = termination`, requiring no migration |
| Sessions JSON | termination marker, assistant stop message, and optional `eval_result.termination` survive serialization and reload |
| Result semantics | termination remains informational and does not alter `passed`, failures, errors, or scoring inputs |
| Compatibility | old sessions and results without termination data continue to load unchanged |
| Isolation | normal, error, ordinary stream-stop, and foreign-session events do not receive or disturb budget termination data |

## Validation

- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy go test ./...`
- `go build ./...`
- `go vet ./pkg/runtime ./pkg/evaluation ./pkg/session`
- `golangci-lint run ./pkg/runtime/... ./pkg/evaluation/... ./pkg/session/...`
- `go run ./lint .`
- `npx --yes markdownlint-cli2@0.22.1 configuration/budget/index.md` from `docs/`
- `./scripts/docs-check-canonical.sh`
- `git diff --check`

## Manual validation

Not run. A live budget-triggered evaluation would require a configured model/provider. Deterministic runtime, parser, chronology, persistence, compatibility, isolation, and security coverage is included in the automated tests.
