### PR TITLE
feat(tui): filter sidebar to active agents

### DIFF
--- a/docs/configuration/user-settings/index.md
+++ b/docs/configuration/user-settings/index.md
@@ -70,6 +70,7 @@ You rarely need to hand-edit this file. Most fields are managed from the TUI's `
 | `hide_session_path` | boolean | `false` | Hide the working-directory (session path) line, including its git branch. |
 | `hide_usage` | boolean | `false` | Hide the token-usage section. |
 | `hide_agents` | boolean | `false` | Hide the Agents section. |
+| `active_agents_only` | boolean | `false` | Show only agents active in the current session in the Agents section (and the top/bottom band), instead of the whole configured team. Ignored while the Agents section is hidden. |
 | `hide_tools` | boolean | `false` | Hide the Tools section. |
 | `hide_todos` | boolean | `false` | Hide the Todos section. |
 

--- a/docs/features/tui/index.md
+++ b/docs/features/tui/index.md
@@ -111,6 +111,8 @@ The sidebar's **Agents** section lists every agent in the team and has two displ
 
 Agents are separated by a blank line so rows stay visually distinct. The effort **gauge** is the only visual language for thinking; the focus card and the Agent Inspector spell out the exact level alongside it. Left-click any agent to switch to it.
 
+On large teams the roster can be trimmed to the agents that matter right now: enable **Active agents only** (nested under **Agents** in `/settings` → Appearance → Sidebar sections, off by default) to list only agents active in the current session — the selected or working agent, participants of an in-flight transfer, and any agent with recorded participation (usage or attributed cost, including agents restored with a reloaded session). The filter also applies to the top/bottom band, is purely presentational — <kbd>Ctrl</kbd>+<kbd>number</kbd> shortcuts keep their original team positions and agent cycling still walks the whole team — and is unavailable while the Agents section itself is hidden.
+
 #### Agent inspector
 
 Open a read-only **Agent Inspector** to inspect any agent's full configuration combined with its live state. The instruction/system prompt is deliberately omitted; everything else the agent declares is shown:
@@ -439,6 +441,7 @@ settings:
     hide_session_path: false
     hide_usage: true
     hide_agents: false
+    active_agents_only: false # true to filter to session-active agents
     hide_tools: false
     hide_todos: false
 ```

--- a/pkg/tui/components/sidebar/active_agents_test.go
+++ b/pkg/tui/components/sidebar/active_agents_test.go
@@ -1,0 +1,201 @@
+package sidebar
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/runtime"
+	"github.com/docker/docker-agent/pkg/session"
+)
+
+// activeAgentsRoster is a 3-agent team whose current agent is "root" (set by
+// the panel-sidebar constructors), used across the active-agents-only tests.
+func activeAgentsRoster() []runtime.AgentDetails {
+	return []runtime.AgentDetails{
+		{Name: "root", Provider: "anthropic", Model: "opus"},
+		{Name: "planner", Provider: "openai", Model: "gpt-5.4"},
+		{Name: "reviewer", Provider: "openai", Model: "gpt-4o"},
+	}
+}
+
+// rosterOwners renders the Agents panel and returns the deduped agent names
+// owning its body lines, in display order.
+func rosterOwners(m *model) []string {
+	renderAgentPanel(m)
+	var names []string
+	for _, owner := range m.agentLineOwners {
+		if owner == "" {
+			continue
+		}
+		if len(names) == 0 || names[len(names)-1] != owner {
+			names = append(names, owner)
+		}
+	}
+	return names
+}
+
+// TestActiveAgentsOnly_FiltersRosterToSessionParticipants verifies the filter
+// drops team agents without any session participation while keeping the
+// current agent and agents with recorded usage — and that the whole team
+// renders with the filter off (the default).
+func TestActiveAgentsOnly_FiltersRosterToSessionParticipants(t *testing.T) {
+	t.Parallel()
+
+	m := newCompactPanelSidebar(t, 40, activeAgentsRoster()...)
+	recordAgentUsageWithCost(m, "s-planner", "planner", 10_000, 100_000, 0.01)
+
+	assert.Equal(t, []string{"root", "planner", "reviewer"}, rosterOwners(m),
+		"the filter is off by default: the whole team renders")
+
+	m.SetActiveAgentsOnly(true)
+	assert.Equal(t, []string{"root", "planner"}, rosterOwners(m),
+		"only the current agent and session participants remain")
+
+	m.SetActiveAgentsOnly(false)
+	assert.Equal(t, []string{"root", "planner", "reviewer"}, rosterOwners(m),
+		"turning the filter off restores the whole team")
+}
+
+// TestActiveAgentsOnly_CurrentAgentFallback verifies the roster never goes
+// empty: with no participation recorded anywhere, the current agent still
+// renders, and the header reads the singular "Agent" for the filtered roster.
+func TestActiveAgentsOnly_CurrentAgentFallback(t *testing.T) {
+	t.Parallel()
+
+	m := newCompactPanelSidebar(t, 40, activeAgentsRoster()...)
+	m.SetActiveAgentsOnly(true)
+
+	assert.Equal(t, []string{"root"}, rosterOwners(m))
+
+	title := renderAgentPanel(m)[0]
+	assert.Contains(t, title, "Agent")
+	assert.NotContains(t, title, "Agents", "the header counts the filtered roster")
+}
+
+// TestActiveAgentsOnly_WorkingAgentVisible verifies an agent that is
+// currently working counts as active even before its first usage snapshot.
+func TestActiveAgentsOnly_WorkingAgentVisible(t *testing.T) {
+	t.Parallel()
+
+	m := newCompactPanelSidebar(t, 40, activeAgentsRoster()...)
+	m.SetActiveAgentsOnly(true)
+	m.workingAgent = "reviewer"
+
+	assert.Equal(t, []string{"root", "reviewer"}, rosterOwners(m))
+}
+
+// TestActiveAgentsOnly_RestoredCostCountsAsParticipation verifies an agent
+// whose participation only exists as restored per-message cost (a reloaded
+// session) stays on the filtered roster.
+func TestActiveAgentsOnly_RestoredCostCountsAsParticipation(t *testing.T) {
+	t.Parallel()
+
+	m := newCompactPanelSidebar(t, 40, activeAgentsRoster()...)
+	m.SetActiveAgentsOnly(true)
+
+	sess := session.New()
+	sess.Messages = append(sess.Messages, restoredItem("reviewer", 0.05))
+	m.LoadFromSession(sess)
+
+	assert.Equal(t, []string{"root", "reviewer"}, rosterOwners(m),
+		"restored attributed cost is participation evidence; planner stays hidden")
+}
+
+// TestActiveAgentsOnly_TransferParticipantsVisibleWhileRelevant verifies both
+// ends of an in-flight transfer stay on the filtered roster, through the
+// Return presentation, and drop off once the presentation clears (absent any
+// other participation evidence).
+func TestActiveAgentsOnly_TransferParticipantsVisibleWhileRelevant(t *testing.T) {
+	t.Parallel()
+
+	m := newAgentPanelSidebar(t, 40, activeAgentsRoster()...)
+	m.SetActiveAgentsOnly(true)
+	require.Equal(t, []string{"root"}, rosterOwners(m))
+
+	m.SetAgentSwitching(true, "root", "reviewer")
+	assert.Equal(t, []string{"root", "reviewer"}, rosterOwners(m),
+		"the destination of an in-flight hop is active")
+
+	m.SetAgentSwitching(false, "reviewer", "root")
+	assert.Equal(t, []string{"root", "reviewer"}, rosterOwners(m),
+		"the Return presentation keeps the participant visible")
+
+	expireReturn(t, m)
+	assert.Equal(t, []string{"root"}, rosterOwners(m),
+		"once the presentation clears, an evidence-less participant drops off")
+}
+
+// TestActiveAgentsOnly_PreservesShortcutIndices verifies a filtered roster
+// keeps each agent's original team index for the ^N switch shortcut, so the
+// shortcuts keep addressing the same team positions.
+func TestActiveAgentsOnly_PreservesShortcutIndices(t *testing.T) {
+	t.Parallel()
+
+	m := newCompactPanelSidebar(t, 40, activeAgentsRoster()...)
+	recordAgentUsageWithCost(m, "s-reviewer", "reviewer", 10_000, 100_000, 0.01)
+	m.SetActiveAgentsOnly(true)
+
+	require.Equal(t, []string{"root", "reviewer"}, rosterOwners(m))
+	line1, _ := agentLines(m, "reviewer")
+	assert.Contains(t, line1, "^3", "reviewer keeps its original team shortcut")
+	assert.NotContains(t, line1, "^2")
+}
+
+// TestActiveAgentsOnly_CollapsedBandFiltered verifies the top/bottom band's
+// agent summary honors the filter like the vertical panel.
+func TestActiveAgentsOnly_CollapsedBandFiltered(t *testing.T) {
+	t.Parallel()
+
+	m := newCompactPanelSidebar(t, 40, activeAgentsRoster()...)
+	recordAgentUsageWithCost(m, "s-planner", "planner", 10_000, 100_000, 0.01)
+
+	info := ansi.Strip(m.collapsedInfoLine(120))
+	require.Contains(t, info, "reviewer", "the filter is off by default")
+
+	m.SetActiveAgentsOnly(true)
+	info = ansi.Strip(m.collapsedInfoLine(120))
+	assert.Contains(t, info, "▶ root")
+	assert.Contains(t, info, "planner")
+	assert.NotContains(t, info, "reviewer")
+}
+
+// TestActiveAgentsOnly_DetailedSizingUsesFilteredRoster verifies the detailed
+// cards' roster-wide vocabulary choice scans only the filtered roster: a
+// hidden agent whose joined metric line would overflow no longer forces every
+// visible card into the compact vocabulary.
+func TestActiveAgentsOnly_DetailedSizingUsesFilteredRoster(t *testing.T) {
+	t.Parallel()
+
+	// At width 40 the joined wide metrics of a thinking agent overflow the
+	// metric column while a no-thinking agent's fit.
+	m := newAgentPanelSidebar(t, 40,
+		runtime.AgentDetails{Name: "root", Provider: "anthropic", Model: "opus"},
+		runtime.AgentDetails{Name: "verbose", Provider: "openai", Model: "gpt-5.4", Thinking: "high"},
+	)
+
+	assert.Contains(t, agentMetrics(m, "root"), "Ctx —",
+		"the overflowing teammate forces the compact vocabulary")
+
+	m.SetActiveAgentsOnly(true)
+	assert.Contains(t, agentMetrics(m, "root"), "Context —",
+		"with the teammate filtered out, the wide vocabulary fits again")
+}
+
+// TestSetActiveAgentsOnly_NoopWhenUnchanged mirrors the other section-setting
+// setters: reapplying the same value must not invalidate the render cache.
+func TestSetActiveAgentsOnly_NoopWhenUnchanged(t *testing.T) {
+	t.Parallel()
+
+	s := newTestSidebar(t)
+	s.renderSections(40)
+	s.cacheDirty = false
+
+	s.SetActiveAgentsOnly(false)
+	assert.False(t, s.cacheDirty, "identical value must not invalidate the cache")
+
+	s.SetActiveAgentsOnly(true)
+	assert.True(t, s.cacheDirty)
+}

--- a/pkg/tui/components/sidebar/sidebar.go
+++ b/pkg/tui/components/sidebar/sidebar.go
@@ -108,6 +108,10 @@ type Model interface {
 	// SetAgentInfoMode selects how the vertical Agents section renders each
 	// agent: the compact two-line roster (default) or detailed mini-cards.
 	SetAgentInfoMode(mode AgentInfoMode)
+	// SetActiveAgentsOnly filters the Agents roster (vertical panel and
+	// collapsed band) to agents active in the current session instead of the
+	// whole configured team.
+	SetActiveAgentsOnly(enabled bool)
 	GetSize() (width, height int)
 	LoadFromSession(sess *session.Session)
 	// ResetStreamTracking clears the active-stream stack so a new top-level run
@@ -328,6 +332,7 @@ type model struct {
 	sectionVisibility    SectionVisibility // which optional sections are rendered
 	sectionGap           int               // blank lines between sections in vertical mode
 	agentInfoMode        AgentInfoMode     // how the vertical Agents section renders each agent
+	activeAgentsOnly     bool              // filter the Agents roster to session-active agents
 
 	// Transfer-box animation: a single animation.Subscription drives the rail
 	// dot while any transfer_task hop is in flight. The frame counts shared
@@ -760,6 +765,16 @@ func (m *model) SetAgentInfoMode(mode AgentInfoMode) {
 		return
 	}
 	m.agentInfoMode = mode
+	m.invalidateCache()
+}
+
+// SetActiveAgentsOnly filters the Agents roster to agents active in the
+// current session (see rosterAgents).
+func (m *model) SetActiveAgentsOnly(enabled bool) {
+	if m.activeAgentsOnly == enabled {
+		return
+	}
+	m.activeAgentsOnly = enabled
 	m.invalidateCache()
 }
 
@@ -1522,7 +1537,8 @@ func (m *model) collapsedInfoLine(contentWidth int) string {
 // agentSummaryCollapsed renders the team roster for the band: the current
 // agent (in its accent color) with its model, then the other agents' names
 // in their own accent colors, so the whole team stays visible like in the
-// vertical Agents section.
+// vertical Agents section. The active-agents-only filter applies here too
+// (see rosterAgents).
 func (m *model) agentSummaryCollapsed() string {
 	name := m.sessionState.CurrentAgentName()
 	if name == "" {
@@ -1534,11 +1550,11 @@ func (m *model) agentSummaryCollapsed() string {
 	if m.agentModel != "" {
 		summary.WriteString(styles.MutedStyle.Render(" " + m.agentModel))
 	}
-	for _, agent := range m.availableAgents {
-		if agent.Name == name {
+	for _, entry := range m.rosterAgents() {
+		if entry.agent.Name == name {
 			continue
 		}
-		summary.WriteString(styles.MutedStyle.Render(" · ") + styles.AgentAccentStyleFor(agent.Name).Render(agent.Name))
+		summary.WriteString(styles.MutedStyle.Render(" · ") + styles.AgentAccentStyleFor(entry.agent.Name).Render(entry.agent.Name))
 	}
 	return summary.String()
 }
@@ -2052,7 +2068,9 @@ func (m *model) queueSection(contentWidth int) string {
 	return m.renderTab(title, strings.Join(lines, "\n"), contentWidth)
 }
 
-// agentInfo renders the Agents panel: every agent as a multi-line entry —
+// agentInfo renders the Agents panel: every roster agent (the whole team,
+// or only the session-active agents under the active-agents-only filter —
+// see rosterAgents) as a multi-line entry —
 // the compact two-line roster (see renderAgentLine) or a detailed mini-card
 // (see renderAgentCard), per the configured AgentInfoMode — with a blank
 // separator line between entries. The current agent is marked with ▶ (or the
@@ -2071,18 +2089,19 @@ func (m *model) agentInfo(contentWidth int) string {
 	if currentAgent == "" {
 		return ""
 	}
+	roster := m.rosterAgents()
 
 	agentTitle := "Agent"
-	if len(m.availableAgents) > 1 {
+	if len(roster) > 1 {
 		agentTitle = "Agents"
 	}
 	if m.delegationInFlight() {
 		agentTitle += " ↔"
 	}
 
-	renderAgent := m.compactAgentRenderer(contentWidth)
+	renderAgent := m.compactAgentRenderer(roster, contentWidth)
 	if m.agentInfoMode == AgentInfoDetailed {
-		renderAgent = m.detailedAgentRenderer(contentWidth)
+		renderAgent = m.detailedAgentRenderer(roster, contentWidth)
 	}
 
 	var bodyLines, owners []string
@@ -2090,15 +2109,15 @@ func (m *model) agentInfo(contentWidth int) string {
 		bodyLines = append(bodyLines, line)
 		owners = append(owners, owner)
 	}
-	for i, agent := range m.availableAgents {
+	for _, entry := range roster {
 		// Separate entries with a blank, unowned line so they stay visually
 		// distinct without being attributed to (or made clickable for) any agent.
 		if len(bodyLines) > 0 {
 			add("", "")
 		}
-		current := agent.Name == currentAgent
-		for _, line := range renderAgent(agent, i, current) {
-			add(line, agent.Name)
+		current := entry.agent.Name == currentAgent
+		for _, line := range renderAgent(entry.agent, entry.index, current) {
+			add(line, entry.agent.Name)
 		}
 	}
 	// The visible transfer presentation renders as a compact box below the
@@ -2119,12 +2138,60 @@ func (m *model) agentInfo(contentWidth int) string {
 // precomputed for the whole panel.
 type agentRenderer func(agent runtime.AgentDetails, index int, current bool) []string
 
+// rosterAgent is one Agents-roster entry: the agent's details plus its
+// original team index, preserved under filtering so the ^N switch shortcut
+// keeps addressing the same team position.
+type rosterAgent struct {
+	agent runtime.AgentDetails
+	index int
+}
+
+// rosterAgents returns the agents the Agents section presents, each with its
+// original team index. With the active-agents-only filter off this is the
+// whole team; with it on, only agents active in the current session (see
+// agentActiveInSession). Filtering is presentation-only: agent cycling and
+// switching still operate on the full team.
+func (m *model) rosterAgents() []rosterAgent {
+	roster := make([]rosterAgent, 0, len(m.availableAgents))
+	for i, agent := range m.availableAgents {
+		if m.activeAgentsOnly && !m.agentActiveInSession(agent.Name) {
+			continue
+		}
+		roster = append(roster, rosterAgent{agent: agent, index: i})
+	}
+	return roster
+}
+
+// agentActiveInSession reports whether the named agent counts as active for
+// the active-agents-only filter: the selected or working agent (so the
+// roster can never be empty), a participant of the in-flight transfer/return
+// presentation, or an agent with recorded participation in this session — a
+// usage snapshot or an attributed cost, live or restored.
+func (m *model) agentActiveInSession(name string) bool {
+	if name == m.sessionState.CurrentAgentName() || name == m.workingAgent {
+		return true
+	}
+	for _, hop := range m.agentTransfers {
+		if hop.from == name || hop.to == name {
+			return true
+		}
+	}
+	if r := m.agentReturn; r != nil && (r.from == name || r.to == name) {
+		return true
+	}
+	if _, ok := m.sessionState.AgentUsage(name); ok {
+		return true
+	}
+	_, ok := m.sessionState.AgentCost(name)
+	return ok
+}
+
 // compactAgentRenderer precomputes the compact roster's shared column widths
 // once — so every entry aligns and the badge width is not recomputed per
 // agent — and returns the per-agent two-line renderer (see renderAgentLine).
-func (m *model) compactAgentRenderer(contentWidth int) agentRenderer {
+func (m *model) compactAgentRenderer(roster []rosterAgent, contentWidth int) agentRenderer {
 	glyphOnly := contentWidth < rowGlyphOnlyMinWidth
-	badgeWidth := m.badgeColumnWidth(glyphOnly)
+	badgeWidth := badgeColumnWidth(roster, glyphOnly)
 	nameWidth := max(1, contentWidth-agentMarkerWidth-minGap-badgeWidth-1-agentShortcutWidth)
 	return func(agent runtime.AgentDetails, index int, current bool) []string {
 		return m.renderAgentLine(agent, index, contentWidth, nameWidth, badgeWidth, glyphOnly, current)
@@ -2141,11 +2208,11 @@ func (m *model) compactAgentRenderer(contentWidth int) agentRenderer {
 // If any agent's joined line would overflow, all cards use the compact
 // vocabulary (Eff/Ctx, no gauge) so the panel speaks one language and each
 // card stays as short as the width allows.
-func (m *model) detailedAgentRenderer(contentWidth int) agentRenderer {
+func (m *model) detailedAgentRenderer(roster []rosterAgent, contentWidth int) agentRenderer {
 	metricWidth := contentWidth - agentMarkerWidth
 	narrow := false
-	for _, agent := range m.availableAgents {
-		if lipgloss.Width(joinSegments(m.metricSegments(agent, false))) > metricWidth {
+	for _, entry := range roster {
+		if lipgloss.Width(joinSegments(m.metricSegments(entry.agent, false))) > metricWidth {
 			narrow = true
 			break
 		}
@@ -2233,10 +2300,10 @@ func thinkingBadge(label string) (badge, compact string) {
 // badgeColumnWidth returns the widest thinking badge across the roster so every
 // compact agent line reserves the same badge column and the badges stay
 // aligned. glyphOnly selects the single-cell compact form used near MinWidth.
-func (m *model) badgeColumnWidth(glyphOnly bool) int {
+func badgeColumnWidth(roster []rosterAgent, glyphOnly bool) int {
 	w := 0
-	for _, a := range m.availableAgents {
-		full, compact := thinkingBadge(a.Thinking)
+	for _, entry := range roster {
+		full, compact := thinkingBadge(entry.agent.Thinking)
 		b := full
 		if glyphOnly {
 			b = compact

--- a/pkg/tui/dialog/settings.go
+++ b/pkg/tui/dialog/settings.go
@@ -39,6 +39,7 @@ const (
 	rowSessionPath
 	rowUsage
 	rowAgents
+	rowActiveAgents
 	rowTools
 	rowTodos
 	rowSplitDiff
@@ -161,6 +162,9 @@ func (d *settingsDialog) selectable(tab, row int) bool {
 	if tab == tabAppearance && !d.showVisuals && row >= rowPosition && row <= rowTodos {
 		return false
 	}
+	if tab == tabAppearance && row == rowActiveAgents && d.current.Layout.HideAgents {
+		return false
+	}
 	if tab == tabNotifications && row == rowSoundThreshold && !d.current.Sound {
 		return false
 	}
@@ -235,6 +239,10 @@ func (d *settingsDialog) changeValue(delta int) tea.Cmd {
 			d.current.Layout.HideUsage = !d.current.Layout.HideUsage
 		case rowAgents:
 			d.current.Layout.HideAgents = !d.current.Layout.HideAgents
+		case rowActiveAgents:
+			if !d.current.Layout.HideAgents {
+				d.current.Layout.ActiveAgentsOnly = !d.current.Layout.ActiveAgentsOnly
+			}
 		case rowTools:
 			d.current.Layout.HideTools = !d.current.Layout.HideTools
 		case rowTodos:
@@ -371,6 +379,7 @@ func (d *settingsDialog) renderAppearanceTab(content *Content, inner int) {
 			AddContent(d.renderToggleRow(rowSessionPath, "Session path", !d.current.Layout.HideSessionPath)).
 			AddContent(d.renderToggleRow(rowUsage, "Token usage", !d.current.Layout.HideUsage)).
 			AddContent(d.renderToggleRow(rowAgents, "Agents", !d.current.Layout.HideAgents)).
+			AddContent(d.renderNestedToggleRow(rowActiveAgents, "Active agents only", d.current.Layout.ActiveAgentsOnly, d.current.Layout.HideAgents)).
 			AddContent(d.renderToggleRow(rowTools, "Tools", !d.current.Layout.HideTools)).
 			AddContent(d.renderToggleRow(rowTodos, "Todos", !d.current.Layout.HideTodos))
 	}
@@ -448,6 +457,20 @@ func (d *settingsDialog) renderToggleRow(row int, label string, enabled bool) st
 		checkStyle = checkStyle.Foreground(styles.Success)
 	}
 	return prefix + checkStyle.Render(check) + " " + labelStyle.Render(label)
+}
+
+// renderNestedToggleRow renders a toggle row indented under its parent row.
+// A disabled row (its parent section is off) renders fully muted and is
+// skipped by navigation (see selectable).
+func (d *settingsDialog) renderNestedToggleRow(row int, label string, enabled, disabled bool) string {
+	if disabled {
+		check := "[ ]"
+		if enabled {
+			check = "[x]"
+		}
+		return "    " + styles.MutedStyle.Render(check+" "+label)
+	}
+	return "  " + d.renderToggleRow(row, label, enabled)
 }
 
 // visibleSectionLabels returns the sidebar section labels that are visible

--- a/pkg/tui/dialog/settings_test.go
+++ b/pkg/tui/dialog/settings_test.go
@@ -100,10 +100,13 @@ func TestSettingsDialogWithoutVisualsTab(t *testing.T) {
 	assert.Contains(t, view, "Appearance")
 	assert.NotContains(t, view, "Sidebar position")
 	assert.NotContains(t, view, "Sidebar info mode")
+	assert.NotContains(t, view, "Active agents only")
 	assert.Contains(t, view, "Split diff view")
 
 	assert.False(t, d.selectable(tabAppearance, rowInfoMode),
 		"the info mode row is not selectable without a sidebar")
+	assert.False(t, d.selectable(tabAppearance, rowActiveAgents),
+		"the agent filter row is not selectable without a sidebar")
 }
 
 func TestSettingsDialogCyclesPositionAndPreviews(t *testing.T) {
@@ -226,6 +229,47 @@ func TestSettingsDialogTogglesSection(t *testing.T) {
 
 	d.Update(tea.KeyPressMsg{Code: tea.KeySpace})
 	assert.False(t, d.current.Layout.HideUsage, "space must toggle back")
+}
+
+func TestSettingsDialogTogglesActiveAgentsOnly(t *testing.T) {
+	t.Parallel()
+
+	d := newTestSettingsDialog(t, messages.LayoutSettings{})
+	d.selected[tabAppearance] = rowActiveAgents
+
+	_, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+	msgs := collectMsgs(cmd)
+	require.Len(t, msgs, 1)
+	preview, ok := msgs[0].(messages.PreviewLayoutMsg)
+	require.True(t, ok, "toggling the agent filter must emit a live preview")
+	assert.True(t, preview.Layout.ActiveAgentsOnly, "space must enable the filter")
+
+	d.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+	assert.False(t, d.current.Layout.ActiveAgentsOnly, "space must toggle back")
+
+	assert.Contains(t, ansi.Strip(d.View()), "Active agents only")
+}
+
+func TestSettingsDialogActiveAgentsRowDisabledWhenAgentsHidden(t *testing.T) {
+	t.Parallel()
+
+	d := newTestSettingsDialog(t, messages.LayoutSettings{HideAgents: true, ActiveAgentsOnly: true})
+	assert.False(t, d.selectable(tabAppearance, rowActiveAgents),
+		"the nested row is not selectable while Agents is hidden")
+
+	d.selected[tabAppearance] = rowAgents
+	d.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	assert.Equal(t, rowTools, d.selected[tabAppearance], "navigation skips the disabled nested row")
+
+	assert.Contains(t, ansi.Strip(d.View()), "Active agents only",
+		"the disabled row still renders (muted)")
+
+	// Re-showing Agents makes the nested row selectable again.
+	d.selected[tabAppearance] = rowAgents
+	d.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+	require.False(t, d.current.Layout.HideAgents)
+	d.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	assert.Equal(t, rowActiveAgents, d.selected[tabAppearance])
 }
 
 func TestSettingsDialogTogglesSessionPath(t *testing.T) {
@@ -372,6 +416,7 @@ func TestSettingsDialogViewShowsVisualsRows(t *testing.T) {
 	assert.Contains(t, view, "Session path")
 	assert.Contains(t, view, "Token usage")
 	assert.Contains(t, view, "Agents")
+	assert.Contains(t, view, "Active agents only")
 	assert.Contains(t, view, "Tools")
 	assert.Contains(t, view, "Todos")
 }

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -965,14 +965,15 @@ func (m *appModel) applyLayoutSettings(settings messages.LayoutSettings) (tea.Mo
 // layoutSettingsFromConfig converts persisted layout settings to their runtime form.
 func layoutSettingsFromConfig(l userconfig.LayoutSettings) messages.LayoutSettings {
 	return messages.LayoutSettings{
-		SidebarPosition: messages.ParseSidebarPosition(l.SidebarPosition),
-		SectionSpacing:  messages.ParseSectionSpacing(l.SectionSpacing),
-		SidebarInfoMode: messages.ParseSidebarInfoMode(l.SidebarInfoMode),
-		HideSessionPath: l.HideSessionPath,
-		HideUsage:       l.HideUsage,
-		HideAgents:      l.HideAgents,
-		HideTools:       l.HideTools,
-		HideTodos:       l.HideTodos,
+		SidebarPosition:  messages.ParseSidebarPosition(l.SidebarPosition),
+		SectionSpacing:   messages.ParseSectionSpacing(l.SectionSpacing),
+		SidebarInfoMode:  messages.ParseSidebarInfoMode(l.SidebarInfoMode),
+		ActiveAgentsOnly: l.ActiveAgentsOnly,
+		HideSessionPath:  l.HideSessionPath,
+		HideUsage:        l.HideUsage,
+		HideAgents:       l.HideAgents,
+		HideTools:        l.HideTools,
+		HideTodos:        l.HideTodos,
 	}
 }
 
@@ -1033,7 +1034,8 @@ func savePreferences(p messages.Preferences) error {
 		}
 		s.Layout = &userconfig.LayoutSettings{
 			SidebarPosition: position, SectionSpacing: spacing, SidebarInfoMode: infoMode,
-			HideSessionPath: layout.HideSessionPath, HideUsage: layout.HideUsage,
+			ActiveAgentsOnly: layout.ActiveAgentsOnly,
+			HideSessionPath:  layout.HideSessionPath, HideUsage: layout.HideUsage,
 			HideAgents: layout.HideAgents, HideTools: layout.HideTools, HideTodos: layout.HideTodos,
 		}
 		return nil

--- a/pkg/tui/messages/settings.go
+++ b/pkg/tui/messages/settings.go
@@ -91,16 +91,20 @@ func ParseSidebarInfoMode(raw string) SidebarInfoMode {
 // sidebar sits, which of its optional sections are rendered, how much
 // space separates them, and how the Agents section renders each agent.
 // The zero value is the default layout (sidebar on the right, everything
-// visible, normal spacing, compact agent info).
+// visible, normal spacing, compact agent info, full team roster).
 type LayoutSettings struct {
 	SidebarPosition SidebarPosition
 	SectionSpacing  SectionSpacing
 	SidebarInfoMode SidebarInfoMode
-	HideSessionPath bool
-	HideUsage       bool
-	HideAgents      bool
-	HideTools       bool
-	HideTodos       bool
+	// ActiveAgentsOnly filters the sidebar's Agents roster to agents active
+	// in the current session. Presentation-only: agent cycling and switching
+	// still address the full team.
+	ActiveAgentsOnly bool
+	HideSessionPath  bool
+	HideUsage        bool
+	HideAgents       bool
+	HideTools        bool
+	HideTodos        bool
 }
 
 // SendMode identifies what happens to a plain send while the agent is

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -404,13 +404,14 @@ func WithCommandParser(p *commands.Parser) PageOption {
 }
 
 // WithLayoutSettings applies initial layout customization (sidebar position,
-// section spacing, section visibility, and agent info mode).
+// section spacing, section visibility, agent info mode, and agent filtering).
 func WithLayoutSettings(settings msgtypes.LayoutSettings) PageOption {
 	return func(p *chatPage) {
 		p.layoutSettings = settings
 		p.sidebar.SetSectionVisibility(sectionVisibility(settings))
 		p.sidebar.SetSectionGap(settings.SectionSpacing.BlankLines())
 		p.sidebar.SetAgentInfoMode(agentInfoMode(settings.SidebarInfoMode))
+		p.sidebar.SetActiveAgentsOnly(settings.ActiveAgentsOnly)
 	}
 }
 
@@ -1281,6 +1282,7 @@ func (p *chatPage) SetLayoutSettings(settings msgtypes.LayoutSettings) tea.Cmd {
 	p.sidebar.SetSectionVisibility(sectionVisibility(settings))
 	p.sidebar.SetSectionGap(settings.SectionSpacing.BlankLines())
 	p.sidebar.SetAgentInfoMode(agentInfoMode(settings.SidebarInfoMode))
+	p.sidebar.SetActiveAgentsOnly(settings.ActiveAgentsOnly)
 	if p.width <= 0 || p.height <= 0 {
 		return nil
 	}

--- a/pkg/tui/page/chat/layout_position_test.go
+++ b/pkg/tui/page/chat/layout_position_test.go
@@ -234,6 +234,33 @@ func TestWithLayoutSettingsAppliesInfoMode(t *testing.T) {
 		"the initial layout option applies the detailed mode")
 }
 
+// TestSetLayoutSettingsForwardsActiveAgentsOnlyToSidebar verifies the agent
+// filter reaches the sidebar's roster and can be switched live: an agent
+// without session participation disappears while the filter is on and
+// returns when it is turned off.
+func TestSetLayoutSettingsForwardsActiveAgentsOnlyToSidebar(t *testing.T) {
+	t.Parallel()
+
+	p := newLayoutTestPage(t, msgtypes.SidebarRight)
+	p.sessionState.SetCurrentAgentName("root")
+	p.sidebar.SetTeamInfo([]runtime.AgentDetails{
+		{Name: "root", Provider: "openai", Model: "gpt-4"},
+		{Name: "idle", Provider: "openai", Model: "gpt-4o"},
+	})
+	p.SetSize(160, 40)
+
+	require.Contains(t, ansi.Strip(p.View()), "idle",
+		"the default layout renders the whole team")
+
+	p.SetLayoutSettings(msgtypes.LayoutSettings{ActiveAgentsOnly: true})
+	assert.NotContains(t, ansi.Strip(p.View()), "idle",
+		"the filter hides agents without session participation")
+
+	p.SetLayoutSettings(msgtypes.LayoutSettings{})
+	assert.Contains(t, ansi.Strip(p.View()), "idle",
+		"switching the filter off live restores the whole team")
+}
+
 func TestSetLayoutSettingsBeforeSizingReturnsNil(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/settings_persistence_test.go
+++ b/pkg/tui/settings_persistence_test.go
@@ -33,24 +33,26 @@ func TestLayoutSettingsFromConfig(t *testing.T) {
 		"unknown values fall back to the defaults")
 
 	got := layoutSettingsFromConfig(userconfig.LayoutSettings{
-		SidebarPosition: "bottom",
-		SectionSpacing:  "compact",
-		SidebarInfoMode: "detailed",
-		HideSessionPath: true,
-		HideUsage:       true,
-		HideAgents:      true,
-		HideTools:       true,
-		HideTodos:       true,
+		SidebarPosition:  "bottom",
+		SectionSpacing:   "compact",
+		SidebarInfoMode:  "detailed",
+		ActiveAgentsOnly: true,
+		HideSessionPath:  true,
+		HideUsage:        true,
+		HideAgents:       true,
+		HideTools:        true,
+		HideTodos:        true,
 	})
 	assert.Equal(t, messages.LayoutSettings{
-		SidebarPosition: messages.SidebarBottom,
-		SectionSpacing:  messages.SpacingCompact,
-		SidebarInfoMode: messages.InfoModeDetailed,
-		HideSessionPath: true,
-		HideUsage:       true,
-		HideAgents:      true,
-		HideTools:       true,
-		HideTodos:       true,
+		SidebarPosition:  messages.SidebarBottom,
+		SectionSpacing:   messages.SpacingCompact,
+		SidebarInfoMode:  messages.InfoModeDetailed,
+		ActiveAgentsOnly: true,
+		HideSessionPath:  true,
+		HideUsage:        true,
+		HideAgents:       true,
+		HideTools:        true,
+		HideTodos:        true,
 	}, got)
 }
 
@@ -115,10 +117,11 @@ func TestSavePreferences_RoundTripAndPreservesExtra(t *testing.T) {
 
 	preferences := messages.Preferences{
 		Layout: messages.LayoutSettings{
-			SidebarPosition: messages.SidebarBottom,
-			SectionSpacing:  messages.SpacingCompact,
-			SidebarInfoMode: messages.InfoModeDetailed,
-			HideAgents:      true,
+			SidebarPosition:  messages.SidebarBottom,
+			SectionSpacing:   messages.SpacingCompact,
+			SidebarInfoMode:  messages.InfoModeDetailed,
+			ActiveAgentsOnly: true,
+			HideAgents:       true,
 		},
 		SendMode:           messages.SendModeQueue,
 		SplitDiffView:      false,
@@ -250,4 +253,32 @@ func TestSavePreferences_CompactInfoModeClearsEntry(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, cfg.GetSettings().Layout,
 		"the default layout with an explicit compact info mode clears the config entry")
+}
+
+func TestSavePreferences_ActiveAgentsOnlyRoundTrip(t *testing.T) {
+	setupSettingsConfigTest(t)
+
+	saved := messages.LayoutSettings{
+		SidebarPosition:  messages.SidebarRight,
+		SectionSpacing:   messages.SpacingNormal,
+		SidebarInfoMode:  messages.InfoModeCompact,
+		ActiveAgentsOnly: true,
+	}
+	require.NoError(t, saveSettingsToUserConfig(saved, messages.SendModeSteer))
+
+	cfg, err := userconfig.Load()
+	require.NoError(t, err)
+	layout := cfg.GetSettings().Layout
+	require.NotNil(t, layout, "active_agents_only alone must keep the layout entry")
+	assert.True(t, layout.ActiveAgentsOnly)
+	assert.Empty(t, layout.SidebarPosition, "the default position is not written out")
+	assert.Equal(t, saved, layoutSettingsFromConfig(userconfig.Get().GetLayout()))
+
+	// Turning the filter back off restores the all-default layout and clears
+	// the entry entirely.
+	saved.ActiveAgentsOnly = false
+	require.NoError(t, saveSettingsToUserConfig(saved, messages.SendModeSteer))
+	cfg, err = userconfig.Load()
+	require.NoError(t, err)
+	assert.Nil(t, cfg.GetSettings().Layout, "the default (off) filter is not written out")
 }

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -152,6 +152,9 @@ type LayoutSettings struct {
 	// agent: "compact" (default, two lines per agent) or "detailed"
 	// (mini-cards with labeled effort/context/cost metrics).
 	SidebarInfoMode string `yaml:"sidebar_info_mode,omitempty"`
+	// ActiveAgentsOnly filters the sidebar's Agents section to agents active
+	// in the current session instead of the whole configured team.
+	ActiveAgentsOnly bool `yaml:"active_agents_only,omitempty"`
 	// HideSessionPath hides the working directory (session path) line in the sidebar.
 	HideSessionPath bool `yaml:"hide_session_path,omitempty"`
 	// HideUsage hides the token usage section in the sidebar.

--- a/pkg/userconfig/userconfig_test.go
+++ b/pkg/userconfig/userconfig_test.go
@@ -233,12 +233,13 @@ func TestSettings_LayoutRoundTrip(t *testing.T) {
 	config := &Config{
 		Settings: &Settings{
 			Layout: &LayoutSettings{
-				SidebarPosition: "left",
-				SectionSpacing:  "compact",
-				SidebarInfoMode: "detailed",
-				HideSessionPath: true,
-				HideUsage:       true,
-				HideTodos:       true,
+				SidebarPosition:  "left",
+				SectionSpacing:   "compact",
+				SidebarInfoMode:  "detailed",
+				ActiveAgentsOnly: true,
+				HideSessionPath:  true,
+				HideUsage:        true,
+				HideTodos:        true,
 			},
 		},
 	}
@@ -249,6 +250,7 @@ func TestSettings_LayoutRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(data), "hide_session_path: true")
 	assert.Contains(t, string(data), "sidebar_info_mode: detailed")
+	assert.Contains(t, string(data), "active_agents_only: true")
 
 	loaded, err := loadFrom(configFile, "")
 	require.NoError(t, err)
@@ -257,6 +259,7 @@ func TestSettings_LayoutRoundTrip(t *testing.T) {
 	assert.Equal(t, "left", layout.SidebarPosition)
 	assert.Equal(t, "compact", layout.SectionSpacing)
 	assert.Equal(t, "detailed", layout.SidebarInfoMode)
+	assert.True(t, layout.ActiveAgentsOnly)
 	assert.True(t, layout.HideSessionPath)
 	assert.True(t, layout.HideUsage)
 	assert.False(t, layout.HideAgents)


### PR DESCRIPTION
## Summary

- add an `Active agents only` option under `/settings` > Appearance > Sidebar sections
- filter vertical and horizontal agent rosters to agents participating in the current session
- persist the opt-in setting as `settings.layout.active_agents_only`
- preserve full-team agent cycling and original `Ctrl+number` shortcuts

## Behavior

An agent remains visible when it is:

- currently selected or working
- participating in an in-flight transfer or return
- represented by live usage or attributed cost
- represented by attributed cost restored from a reloaded session

The filter is disabled by default. Hiding the Agents section disables the nested option without clearing its saved value.

## Validation

- `task build`
- `task lint`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy task test`
- `go test ./pkg/tui/... ./pkg/userconfig/...`
- `npx --yes markdownlint-cli2@0.22.1 configuration/user-settings/index.md features/tui/index.md` from `docs/`
