### PR TITLE
feat(desktop): log when Docker Desktop serves an expired token

### DIFF
--- a/pkg/desktop/login.go
+++ b/pkg/desktop/login.go
@@ -26,6 +26,8 @@ func GetToken(ctx context.Context) string {
 		return token
 	}
 
+	logExpiredToken(ctx, token)
+
 	if fresh := forceTokenRefresh(ctx); fresh != "" {
 		slog.InfoContext(ctx, "Recovered a fresh token from Docker Desktop",
 			"fingerprint", tokenFingerprint(fresh))
@@ -37,6 +39,17 @@ func GetToken(ctx context.Context) string {
 	return token
 }
 
+// logExpiredToken records evidence that Docker Desktop served an
+// already-expired token, so gateway 401s can be attributed to a stale Desktop
+// session rather than a rejection of a valid token.
+func logExpiredToken(ctx context.Context, token string) {
+	attrs := []any{"fingerprint", tokenFingerprint(token), "expired_for", expiredFor(token)}
+	if exp, ok := tokenExpiry(token); ok {
+		attrs = append(attrs, "expires_at", exp.UTC().Format(time.RFC3339))
+	}
+	slog.WarnContext(ctx, "Docker Desktop served an expired token", attrs...)
+}
+
 // tokenFingerprint returns a short non-reversible identifier, safe to log.
 func tokenFingerprint(token string) string {
 	sum := sha256.Sum256([]byte(token))
@@ -45,15 +58,25 @@ func tokenFingerprint(token string) string {
 
 // expiredFor returns how long ago the token's exp claim passed.
 func expiredFor(token string) string {
+	exp, ok := tokenExpiry(token)
+	if !ok {
+		return "unknown"
+	}
+	return time.Since(exp).Round(time.Second).String()
+}
+
+// tokenExpiry returns the token's exp claim, or false when the token doesn't
+// parse or carries no exp claim.
+func tokenExpiry(token string) (time.Time, bool) {
 	parsed, _, err := jwt.NewParser().ParseUnverified(token, jwt.MapClaims{})
 	if err != nil {
-		return "unknown"
+		return time.Time{}, false
 	}
 	exp, err := parsed.Claims.GetExpirationTime()
 	if err != nil || exp == nil {
-		return "unknown"
+		return time.Time{}, false
 	}
-	return time.Since(exp.Time).Round(time.Second).String()
+	return exp.Time, true
 }
 
 func GetUserInfo(ctx context.Context) DockerHubInfo {
@@ -72,12 +95,8 @@ func fetchToken(ctx context.Context) string {
 // leeway for clock skew between this machine and the token issuer.
 // Tokens that don't parse or carry no exp claim are treated as valid.
 func tokenExpired(token string) bool {
-	parsed, _, err := jwt.NewParser().ParseUnverified(token, jwt.MapClaims{})
-	if err != nil {
-		return false
-	}
-	exp, err := parsed.Claims.GetExpirationTime()
-	if err != nil || exp == nil {
+	exp, ok := tokenExpiry(token)
+	if !ok {
 		return false
 	}
 	return exp.Before(time.Now().Add(-expiryLeeway))
@@ -169,7 +188,7 @@ func awaitRefresh(ctx context.Context, done <-chan struct{}) string {
 }
 
 func runTokenRefresh(ctx context.Context) string {
-	slog.WarnContext(ctx, "Docker Desktop returned an expired token, forcing a refresh")
+	slog.WarnContext(ctx, "Forcing a Docker Desktop token refresh")
 	if err := postRefreshNudge(ctx); err != nil {
 		slog.WarnContext(ctx, "Failed to trigger Docker Desktop token refresh", "error", err)
 		return ""


### PR DESCRIPTION
### Why

When the models gateway rejects a request with a 401, the logs today can't answer the first triage question: was the token we forwarded already expired when Docker Desktop handed it to us, or was it locally valid and rejected upstream (e.g. revoked)? The only expiry-related warnings fire deep in the refresh path, so they are missing whenever a forced refresh is skipped (singleflight join, rate-limit window) or when it succeeds.

This adds a warning at the moment an expired token is received, before any recovery attempt:

```
WARN Docker Desktop served an expired token fingerprint=a1b2c3d4 expired_for=42m10s expires_at=2026-07-29T09:15:00Z
```

With it, log sequences become classifiable on their own:

```
stale session, stuck:      served an expired token -> Forcing a refresh -> did not deliver
                           a fresh token in time -> sending a token known to be expired
stale session, recovered:  served an expired token -> Forcing a refresh -> Recovered a fresh token
no such line before a 401: the token was locally valid; the rejection came from upstream
```

The `fingerprint` (non-reversible hash) distinguishes "same stale token served repeatedly" from "a different token each time"; `expires_at` is the raw `exp` claim, comparable against server-side request traces.