### PR TITLE
feat(tui): show compaction summary in context dialog

### DIFF
--- a/pkg/runtime/context_breakdown.go
+++ b/pkg/runtime/context_breakdown.go
@@ -74,6 +74,10 @@ type ContextBreakdown struct {
 	// the current on-disk content and are informational, not an extra
 	// bucket in TotalTokens.
 	AttachedFiles []ContextFile `json:"attached_files,omitempty"`
+	// LatestCompactionSummary is the verbatim text behind the
+	// CompactionSummary category: the most recent compaction summary
+	// stored on the session, or "" when it has never been compacted.
+	LatestCompactionSummary string `json:"latest_compaction_summary,omitempty"`
 
 	// ContextLimit is the resolved context window of the effective model,
 	// or 0 when it cannot be determined (harness-backed agents, models
@@ -112,8 +116,9 @@ func (b *ContextBreakdown) TotalTokens() int64 {
 }
 
 // ContextBreakdown computes the estimated context-window composition for
-// sess, categorizing the output of [session.Session.GetMessages] and adding
-// the tool definitions and prompt files that accompany every model call.
+// sess, categorizing the output of
+// [session.Session.GetMessagesAndLastSummary] and adding the tool
+// definitions and prompt files that accompany every model call.
 //
 // Tool listing failures and unreadable prompt files degrade gracefully: the
 // corresponding category is computed from whatever could be gathered and the
@@ -136,14 +141,15 @@ func (r *LocalRuntime) ContextBreakdown(ctx context.Context, sess *session.Sessi
 		}
 	}
 
-	messages := sess.GetMessages(a)
+	messages, summary := sess.GetMessagesAndLastSummary(a)
 	// Calibrate the heuristic against the provider-reported usage already
 	// recorded on this conversation, mirroring what the proactive
 	// compaction trigger does (see compactIfNeeded).
 	estimator := compaction.NewSliceEstimator(messages)
 
 	summaryContent := ""
-	if summary := sess.LastSummary(); summary != "" {
+	if summary != "" {
+		b.LatestCompactionSummary = summary
 		summaryContent = session.SummaryMessageContent(summary)
 	}
 

--- a/pkg/runtime/context_breakdown_test.go
+++ b/pkg/runtime/context_breakdown_test.go
@@ -95,6 +95,7 @@ func TestContextBreakdown_CategorizesMessages(t *testing.T) {
 	// No compaction happened.
 	assert.Zero(t, b.CompactionSummary.Items)
 	assert.Zero(t, b.CompactionSummary.Tokens)
+	assert.Empty(t, b.LatestCompactionSummary)
 
 	total := b.SystemPrompt.Tokens + b.ToolDefinitions.Tokens + b.PromptFiles.Tokens +
 		b.Messages.Tokens + b.ToolResults.Tokens + b.CompactionSummary.Tokens
@@ -122,6 +123,31 @@ func TestContextBreakdown_CompactionSummary(t *testing.T) {
 	assert.Equal(t, 1, b.CompactionSummary.Items)
 	assert.Positive(t, b.CompactionSummary.Tokens)
 	assert.Equal(t, 1, b.Messages.Items)
+
+	// The verbatim summary text is exposed for display.
+	assert.Equal(t, "We discussed old things.", b.LatestCompactionSummary)
+}
+
+// TestContextBreakdown_LatestCompactionSummaryWins verifies that after
+// multiple compactions the exposed text is the most recent summary.
+func TestContextBreakdown_LatestCompactionSummaryWins(t *testing.T) {
+	t.Parallel()
+
+	rt := newBreakdownRuntime(t)
+
+	items := []session.Item{
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "first question"}}),
+		{Summary: "First summary."},
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "second question"}}),
+		{Summary: "Second summary."},
+		session.NewMessageItem(&session.Message{Message: chat.Message{Role: chat.MessageRoleUser, Content: "third question"}}),
+	}
+	sess := session.New(session.WithMessages(items))
+
+	b, err := rt.ContextBreakdown(t.Context(), sess)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Second summary.", b.LatestCompactionSummary)
 }
 
 // TestContextBreakdown_UserMessageLooksLikeSummary pins the exact-match

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1824,7 +1824,10 @@ func (s *Session) LastSummary() string {
 // first kept message so that recent context is preserved after compaction.
 // Otherwise it is lastSummaryIndex+1 (i.e. right after the summary item), or
 // 0 when there is no summary.
-func (s *Session) buildSessionSummaryMessages(items []Item) ([]chat.Message, int) {
+//
+// summary is the raw text of the last summary item in items ("" when there
+// is none), i.e. exactly the text the synthetic message carries.
+func (s *Session) buildSessionSummaryMessages(items []Item) ([]chat.Message, int, string) {
 	var messages []chat.Message
 	// Find the last summary index to determine where conversation messages start
 	// and to include the summary in session summary messages
@@ -1836,10 +1839,12 @@ func (s *Session) buildSessionSummaryMessages(items []Item) ([]chat.Message, int
 		}
 	}
 
+	summary := ""
 	if lastSummaryIndex >= 0 && lastSummaryIndex < len(items) {
+		summary = items[lastSummaryIndex].Summary
 		messages = append(messages, chat.Message{
 			Role:      chat.MessageRoleUser,
-			Content:   SummaryMessageContent(items[lastSummaryIndex].Summary),
+			Content:   SummaryMessageContent(summary),
 			CreatedAt: s.now().Format(time.RFC3339),
 		})
 	}
@@ -1855,7 +1860,7 @@ func (s *Session) buildSessionSummaryMessages(items []Item) ([]chat.Message, int
 		}
 	}
 
-	return messages, startIndex
+	return messages, startIndex, summary
 }
 
 // CompactionInput returns the chat messages that the compactor should
@@ -1983,16 +1988,30 @@ func (s *Session) instructionMessages() ([]chat.Message, []InstructionUpdate) {
 }
 
 func (s *Session) GetMessages(a *agent.Agent, extraSystemMessages ...chat.Message) []chat.Message {
-	return s.getMessages(a, true, extraSystemMessages...)
+	messages, _ := s.getMessages(a, true, extraSystemMessages...)
+	return messages
 }
 
 // GetMessagesWithoutInstructionContext assembles the legacy prompt where
 // dynamic context is supplied directly as extra system messages.
 func (s *Session) GetMessagesWithoutInstructionContext(a *agent.Agent, extraSystemMessages ...chat.Message) []chat.Message {
-	return s.getMessages(a, false, extraSystemMessages...)
+	messages, _ := s.getMessages(a, false, extraSystemMessages...)
+	return messages
 }
 
-func (s *Session) getMessages(a *agent.Agent, includeInstructionContext bool, extraSystemMessages ...chat.Message) []chat.Message {
+// GetMessagesAndLastSummary is GetMessages plus the most recent compaction
+// summary that assembly used, both derived from the same snapshot of
+// s.Messages: the returned summary is exactly the text behind the synthetic
+// "Session Summary: ..." user message in the returned prompt ("" when the
+// snapshot holds no summary), even if a compaction lands concurrently.
+// Separate GetMessages and LastSummary calls cannot promise that. The
+// guarantee covers only the session-history snapshot, not the other state
+// read during assembly (instruction context, agent configuration).
+func (s *Session) GetMessagesAndLastSummary(a *agent.Agent, extraSystemMessages ...chat.Message) ([]chat.Message, string) {
+	return s.getMessages(a, true, extraSystemMessages...)
+}
+
+func (s *Session) getMessages(a *agent.Agent, includeInstructionContext bool, extraSystemMessages ...chat.Message) ([]chat.Message, string) {
 	slog.Debug("Getting messages for agent", "agent", a.Name(), "session_id", s.ID)
 
 	// Build invariant system messages (cacheable across sessions/users/projects)
@@ -2009,7 +2028,7 @@ func (s *Session) getMessages(a *agent.Agent, includeInstructionContext bool, ex
 	}
 
 	// Build session summary messages (vary per session)
-	summaryMessages, startIndex := s.buildSessionSummaryMessages(items)
+	summaryMessages, startIndex, summary := s.buildSessionSummaryMessages(items)
 
 	var messages []chat.Message
 	messages = append(messages, invariantMessages...)
@@ -2092,7 +2111,7 @@ func (s *Session) getMessages(a *agent.Agent, includeInstructionContext bool, ex
 		"conversation_messages", conversationCount,
 		"max_history_items", maxItems)
 
-	return messages
+	return messages, summary
 }
 
 // trimMessages ensures we don't exceed the maximum number of messages while maintaining

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -211,6 +211,36 @@ func TestSummaryMessageContentMatchesGetMessages(t *testing.T) {
 	assert.True(t, found, "GetMessages output must contain the exact SummaryMessageContent string")
 }
 
+// TestGetMessagesAndLastSummary pins the accessor's contract: messages and
+// summary come from the same history snapshot, the summary is exactly the
+// text behind the synthetic "Session Summary: ..." user message, and the
+// most recent summary item wins.
+func TestGetMessagesAndLastSummary(t *testing.T) {
+	t.Parallel()
+
+	s := New()
+	messages, summary := s.GetMessagesAndLastSummary(&agent.Agent{})
+	assert.Empty(t, messages)
+	assert.Empty(t, summary, "fresh session has no summary")
+
+	s.AddMessage(NewAgentMessage("", &chat.Message{Role: chat.MessageRoleUser, Content: "hi"}))
+	s.Messages = append(s.Messages, Item{Summary: "first summary"})
+	s.AddMessage(NewAgentMessage("", &chat.Message{Role: chat.MessageRoleUser, Content: "more"}))
+	s.Messages = append(s.Messages, Item{Summary: "second summary"})
+
+	messages, summary = s.GetMessagesAndLastSummary(&agent.Agent{})
+	assert.Equal(t, "second summary", summary, "most recent summary wins")
+
+	want := SummaryMessageContent(summary)
+	found := false
+	for _, msg := range messages {
+		if msg.Role == chat.MessageRoleUser && msg.Content == want {
+			found = true
+		}
+	}
+	assert.True(t, found, "returned summary must be exactly the synthetic summary message's text")
+}
+
 func TestGetMessages_Instructions(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tui/dialog/context.go
+++ b/pkg/tui/dialog/context.go
@@ -312,6 +312,10 @@ const contextDropNote = "Dropping a file removes it from the session's attachmen
 // at a safe point, so it never interrupts an in-flight model turn.
 const contextCompactNote = "Press Enter to compact the selected live session; sub-agent compactions run at the session's next safe point."
 
+// contextSummarySection titles the verbatim latest-compaction-summary text
+// in both the styled view and the plain-text copy.
+const contextSummarySection = "Latest compaction summary"
+
 // categoryColors returns the per-category accent colors, aligned with the
 // order of contextRows. Hues are used categorically (Error's rose tint
 // carries no alarm semantics here); each maps to a distinct color in the
@@ -358,6 +362,7 @@ func (d *contextDialog) renderContent(contentWidth, maxHeight int) string {
 	d.rowLines = d.rowLines[:0]
 	lines = d.appendLiveSessions(lines)
 	lines = d.appendInventory(lines, scale, contentWidth)
+	lines = d.appendCompactionSummary(lines, contentWidth)
 
 	lines = append(lines, "")
 	lines = append(lines, wrapMutedLines(contextEstimateNote, contentWidth)...)
@@ -459,6 +464,20 @@ func (d *contextDialog) appendInventory(lines []string, scale int64, contentWidt
 	return lines
 }
 
+// appendCompactionSummary renders the verbatim text of the latest
+// compaction summary, wrapped to the content width. Placed after the
+// selectable sections so the rowLines mapping built by appendLiveSessions/
+// appendInventory stays aligned with the selection indexes. Omitted
+// entirely (no ghost title) when the session has never been compacted.
+func (d *contextDialog) appendCompactionSummary(lines []string, contentWidth int) []string {
+	summary := d.breakdown.LatestCompactionSummary
+	if summary == "" {
+		return lines
+	}
+	lines = append(lines, "", sectionStyle().Render(contextSummarySection))
+	return append(lines, wrapTextLines(summary, contentWidth)...)
+}
+
 // fileLabelWidth returns the display width of the inventory file-name
 // column, sized to the longest base name across both sections and clamped
 // so one long name cannot push the token columns off screen.
@@ -540,6 +559,13 @@ func filePathSuffix(file *runtime.ContextFile, available int) string {
 // individual lines, so the scrollview's line accounting stays exact.
 func wrapMutedLines(text string, width int) []string {
 	return strings.Split(styles.MutedStyle.Width(width).Render(text), "\n")
+}
+
+// wrapTextLines wraps text to width in the default style, preserving hard
+// newlines, and returns the individual lines so the scrollview's line
+// accounting stays exact.
+func wrapTextLines(text string, width int) []string {
+	return strings.Split(lipgloss.NewStyle().Width(width).Render(text), "\n")
 }
 
 // markerColor picks the row's accent color: its category color, or muted
@@ -749,6 +775,10 @@ func (d *contextDialog) renderPlainText() string {
 		for i := range b.PromptFileItems {
 			lines = append(lines, plainFileLine(&b.PromptFileItems[i], scale))
 		}
+	}
+
+	if b.LatestCompactionSummary != "" {
+		lines = append(lines, "", contextSummarySection, b.LatestCompactionSummary)
 	}
 
 	lines = append(lines, "", contextEstimateNote)

--- a/pkg/tui/dialog/context_test.go
+++ b/pkg/tui/dialog/context_test.go
@@ -621,3 +621,130 @@ func TestContextDialogViewScalesWithCappedHeader(t *testing.T) {
 	}
 	assert.Equal(t, 5, d.selected)
 }
+
+// ---------------------------------------------------------------------------
+// Latest compaction summary
+// ---------------------------------------------------------------------------
+
+func TestContextDialogViewCompactionSummaryText(t *testing.T) {
+	t.Parallel()
+
+	b := testBreakdown()
+	b.LatestCompactionSummary = "We refactored the parser and fixed the tokenizer bug."
+
+	dialog := NewContextDialog(b)
+	dialog.SetSize(100, 50)
+	view := dialog.View()
+
+	assert.Contains(t, view, "Latest compaction summary")
+	assert.Contains(t, view, "We refactored the parser")
+}
+
+// TestContextDialogCompactionSummaryWrapping pins the wrapping contract of
+// the summary section at a deliberately small width: the text soft-wraps
+// into more lines than its hard newlines alone produce, every line fits the
+// width, hard newlines survive verbatim, and no content is lost. It fails
+// if wrapTextLines stops wrapping (e.g. returns the text as one line).
+func TestContextDialogCompactionSummaryWrapping(t *testing.T) {
+	t.Parallel()
+
+	const width = 24
+	summary := "Goal: ship it.\n\nDecisions:\n" +
+		strings.TrimSpace(strings.Repeat("keep the line math exact ", 4))
+
+	b := testBreakdown()
+	b.LatestCompactionSummary = summary
+	d := &contextDialog{breakdown: b}
+
+	lines := d.appendCompactionSummary(nil, width)
+	require.Greater(t, len(lines), 2, "expected a spacer, the section title and the wrapped body")
+	assert.Empty(t, lines[0])
+	assert.Contains(t, lines[1], contextSummarySection)
+
+	body := lines[2:]
+	require.Greater(t, len(body), strings.Count(summary, "\n")+1,
+		"the long paragraph must soft-wrap into more lines than hard newlines alone produce")
+
+	trimmed := make([]string, len(body))
+	for i, line := range body {
+		assert.LessOrEqual(t, lipgloss.Width(line), width, "body line %d exceeds the wrap width", i)
+		// Wrapped lines are padded to the full width; drop the padding so
+		// the reassembly below only re-adds the spaces the wraps consumed.
+		trimmed[i] = strings.TrimRight(line, " ")
+	}
+
+	// Hard newlines survive: the short first paragraph, the blank separator
+	// and the "Decisions:" heading each keep their own line.
+	assert.Equal(t, []string{"Goal: ship it.", "", "Decisions:"}, trimmed[:3])
+
+	// No content is lost or reordered: undoing only the line breaks (each
+	// soft wrap consumed one space) restores the original text.
+	assert.Equal(t, strings.ReplaceAll(summary, "\n", " "), strings.Join(trimmed, " "))
+}
+
+func TestContextDialogViewNoCompactionSummaryText(t *testing.T) {
+	t.Parallel()
+
+	dialog := NewContextDialog(testBreakdown())
+	dialog.SetSize(100, 50)
+	view := dialog.View()
+
+	assert.NotContains(t, view, "Latest compaction summary")
+}
+
+// TestContextDialogCompactionSummaryKeepsRowLines pins the layout contract
+// behind #3870: the summary renders after the selectable sections, so with
+// identical live sessions and files the rowLines mapping stays exactly the
+// same with and without a long summary, covers every selectable row, and
+// still scrolls off-screen rows into a low viewport.
+func TestContextDialogCompactionSummaryKeepsRowLines(t *testing.T) {
+	t.Parallel()
+
+	render := func(summary string) *contextDialog {
+		b := testBreakdownWithFiles()
+		b.LatestCompactionSummary = summary
+		d := NewContextDialog(b, testLiveSessions()...).(*contextDialog)
+		d.SetSize(100, 16) // low window: the selectable rows start off screen
+		d.View()
+		return d
+	}
+
+	without := render("")
+	with := render(strings.Repeat("a long compaction summary ", 20))
+
+	require.Len(t, with.rowLines, with.selectableCount(),
+		"every selectable row must be mapped to a content line")
+	assert.Equal(t, without.rowLines, with.rowLines,
+		"a summary appended after the selectable sections must not shift their content lines")
+
+	// The mapping drives EnsureLineVisible: walking down to the last attached
+	// file must scroll its (initially off-screen) row into the viewport.
+	require.NotContains(t, with.View(), "deleted.txt", "the last attached row must start off screen")
+	for range 5 {
+		with.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	}
+	require.Equal(t, 5, with.selected)
+	assert.Contains(t, with.View(), "deleted.txt",
+		"navigating onto the row must bring it into view through rowLines")
+}
+
+func TestContextDialogPlainTextCompactionSummary(t *testing.T) {
+	t.Parallel()
+
+	b := testBreakdown()
+	b.LatestCompactionSummary = "Line one of the summary.\nLine two, kept verbatim."
+
+	d := &contextDialog{breakdown: b}
+	text := d.renderPlainText()
+
+	assert.Contains(t, text, "Latest compaction summary")
+	assert.Contains(t, text, "Line one of the summary.\nLine two, kept verbatim.")
+	assert.NotContains(t, text, "\x1b[", "plain text must carry no ANSI escapes")
+}
+
+func TestContextDialogPlainTextNoCompactionSummary(t *testing.T) {
+	t.Parallel()
+
+	d := &contextDialog{breakdown: testBreakdown()}
+	assert.NotContains(t, d.renderPlainText(), "Latest compaction summary")
+}


### PR DESCRIPTION
## Summary

- expose the latest compaction summary through the context breakdown
- display the full summary in the scrollable `/context` dialog
- include the verbatim summary in `/context` clipboard output
- derive the displayed summary and prompt messages from the same session-history snapshot

Closes #3870.

## Preview

Approximate plain-text rendering of `/context` after a compaction. The actual TUI applies the existing category colors, border, usage bar, and scrollbar styles.

```text
╭────────────────────────────────────────────────────────────────────╮
│ Context Window                                                     │
│ openai/gpt-4o  •  limit: 128.0K tokens                             │
├────────────────────────────────────────────────────────────────────┤
│ █████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ │
│ ~25.4K of 128.0K tokens (20%)                                      │
│                                                                    │
│ ■ System prompt          1.2K    <1%  (3 messages)                 │
│ ■ Tool definitions       8.4K     7%  (23 tools)                   │
│ ■ Prompt files            600    <1%  (1 file)                     │
│ ■ Messages               6.1K     5%  (12 messages)                │
│ ■ Tool results           8.2K     6%  (18 results)                 │
│ ■ Compaction summary      900    <1%  (1 summary)                  │
│ ■ Free space           102.6K    80%                               │
│                                                                    │
│ Latest compaction summary                                          │
│ The user is implementing issue #3870. The chosen UX is to expose   │
│ the latest compaction summary from the /context dialog. The        │
│ implementation must preserve scrolling and clipboard support.      │
│ Tests and linting currently pass.                                  │
│                                                                    │
│ Token counts are estimates; the provider's tokenizer may count     │
│ differently.                                                       │
│                                                                    │
│ ↑↓ scroll                         c copy                  Esc close │
╰────────────────────────────────────────────────────────────────────╯
```

When live sessions or file inventories exist, the summary is placed after those selectable sections so their navigation mapping remains unchanged:

```text
Live sessions
▶ root       a81c04f2  25.4K of 128.0K (20%)  (current)
  developer  531cb912  12.1K of 128.0K (9%)

Attached files
  main.go     2.1K   2%  /project/main.go

Latest compaction summary
The latest summary wraps to the dialog width and remains scrollable.
```

The section is omitted when the session has never been compacted. Pressing `c` copies the same summary verbatim as plain text.

## Issue expectations

| Expectation | Implementation |
|---|---|
| View a compaction result summary | `/context` renders the latest stored compaction summary |
| Understand what the model retained | The exact summary injected into subsequent model context is shown verbatim |
| Preserve usability for long summaries | Text wraps to the dialog width and remains inside the existing scroll view |
| Work after session persistence/resume | The view reads the already persisted session summary |

A semantic retained-versus-dropped diff and agent-level persistent compaction instructions are intentionally excluded. `FirstKeptEntry` identifies the verbatim retained message boundary, but it cannot prove which facts a summarizing model preserved semantically.

## Validation

- `task test`
- `go test -race ./pkg/session ./pkg/runtime ./pkg/tui/dialog`
- `./scripts/build.sh`
- `golangci-lint run`
- `go run ./lint .`
- `go mod tidy --diff`
- `gofmt -l .`
