### PR TITLE
fix(runtime): resolve transfer_task caller from pinned session agent

### DIFF
--- a/pkg/runtime/agent_delegation.go
+++ b/pkg/runtime/agent_delegation.go
@@ -557,7 +557,7 @@ func (r *LocalRuntime) handleTaskTransfer(ctx context.Context, sess *session.Ses
 		return nil, fmt.Errorf("invalid arguments: %w", err)
 	}
 
-	a := r.CurrentAgent()
+	a := r.resolveSessionAgent(sess)
 	if errResult := validateAgentInList(a.Name(), params.Agent, "transfer task to", "sub-agents list", a.SubAgents()); errResult != nil {
 		return errResult, nil
 	}

--- a/pkg/runtime/agent_delegation_test.go
+++ b/pkg/runtime/agent_delegation_test.go
@@ -643,3 +643,53 @@ func TestTransferTask_PropagatesPermissions(t *testing.T) {
 	assert.Equal(t, []string{"safe_tool"}, parentClone.Allow,
 		"parent permissions must remain isolated from child mutations after transfer_task")
 }
+
+// TestHandleTaskTransfer_UsesPinnedSessionAgent verifies that transfer_task
+// inside a background sub-session resolves the caller from the session's
+// pinned agent, not the runtime's shared current-agent. Regression test for
+// the bug where a pipeline agent dispatched via run_background_agent could
+// not transfer_task to its own sub-agents because current-agent remained
+// the root coordinator.
+func TestHandleTaskTransfer_UsesPinnedSessionAgent(t *testing.T) {
+	t.Parallel()
+
+	childStream := newStreamBuilder().AddContent("done").AddStopWithUsage(10, 5).Build()
+	prov := &mockProvider{id: "test/mock-model", stream: childStream}
+
+	// root only knows pipeline; pipeline knows director.
+	director := agent.New("director", "Director agent", agent.WithModel(prov))
+	pipeline := agent.New("pipeline", "Pipeline agent", agent.WithModel(prov))
+	agent.WithSubAgents(director)(pipeline)
+	root := agent.New("root", "Root agent", agent.WithModel(prov))
+	agent.WithSubAgents(pipeline)(root)
+
+	tm := team.New(team.WithAgents(root, pipeline, director))
+	rt, err := NewLocalRuntime(t.Context(), tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStore{}),
+	)
+	require.NoError(t, err)
+
+	// background sub-session pinned to pipeline (as run_background_agent does).
+	sess := session.New(
+		session.WithUserMessage("Please proceed."),
+		session.WithAgentName("pipeline"),
+		session.WithToolsApproved(true),
+	)
+	evts := make(chan Event, 128)
+
+	toolCall := tools.ToolCall{
+		ID:   "call_1",
+		Type: "function",
+		Function: tools.FunctionCall{
+			Name:      "transfer_task",
+			Arguments: `{"agent":"director","task":"write a prompt","expected_output":"prompt text"}`,
+		},
+	}
+
+	result, err := rt.handleTaskTransfer(t.Context(), sess, toolCall, NewChannelSink(evts))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.IsError,
+		"pipeline (pinned session) should be able to transfer to its sub-agent director; got: %s", result.Output)
+}


### PR DESCRIPTION
## What

Fixes `transfer_task` failing inside a `run_background_agent` sub-session. See issue #3886.

## Problem

A coordinator (`root`) fans out work via `run_background_agent` to a composite agent (`pipeline`) that has its own `sub_agents` (e.g. `director`). When `pipeline` calls `transfer_task(agent="director")`, it fails with:

```
Agent root cannot transfer task to director: target agent not in sub-agents list. Available agent IDs are: pipeline
```

The error names **root** as the caller even though the call originates from `pipeline`, whose sub-agents do include `director`.

## Root cause

`handleTaskTransfer` resolves the calling agent via `r.CurrentAgent()`, which returns the runtime's **shared** current-agent field. Background sub-sessions are created with `PinAgent: true` + `WithAgentName(cfg.AgentName)` (`RunAgent` → `runCollecting`), which pins the **session** to `pipeline` but deliberately does not mutate `currentAgent` (it stays `root`). So validation runs against `root.SubAgents() = [pipeline]` and rejects `director`.

`agentRouter.ResolveSession` already handles pinned sessions ("when sess pins a specific agent (e.g. background agent tasks), that agent is returned directly"), but `handleTaskTransfer` wasn't using it.

## Fix

Resolve the caller via `resolveSessionAgent(sess)` instead of `CurrentAgent()`. This returns the pinned agent when the session pins one, and falls back to `CurrentAgent()` otherwise — so ordinary `transfer_task` behavior is unchanged.

## Tests

Adds `TestHandleTaskTransfer_UsesPinnedSessionAgent`: a session pinned to `pipeline` (as `run_background_agent` does) transfers to `director` while the runtime's current-agent is `root`.

- Without fix: fails with the exact error above
- With fix: passes

`go test ./pkg/runtime/` passes.

Closes #3886
