### PR TITLE
fix(skills): expire cache entries at deadline

### DIFF
--- a/pkg/skills/cache.go
+++ b/pkg/skills/cache.go
@@ -87,7 +87,12 @@ func (c *diskCache) Get(baseURL, skillName, filePath string) (string, bool) {
 		return "", false
 	}
 
-	if time.Now().After(meta.ExpiresAt) {
+	// Stale at ExpiresAt itself (now >= ExpiresAt): zero-freshness entries
+	// (max-age=0, no-store, no-cache) set ExpiresAt to the store time, and
+	// coarse wall clocks (e.g. Windows; the JSON round-trip drops the
+	// monotonic reading) can make Now equal ExpiresAt. Strict After() would
+	// wrongly treat that instant as fresh.
+	if !time.Now().Before(meta.ExpiresAt) {
 		return "", false
 	}
 


### PR DESCRIPTION
## Summary

- treat cache entries as stale when the current time equals their expiry deadline
- prevent zero-freshness entries from being reused on coarse-resolution clocks such as Windows
- preserve existing behavior for entries whose expiry remains in the future

## Context

The Windows test in [Actions run 30802380958, job 91649724192](https://github.com/docker/docker-agent/actions/runs/30802380958/job/91649724192?pr=3891) failed because `TestDiskCache_Get_Expired` received a cache hit for `max-age=0`.

Cache metadata is serialized to JSON, which removes Go's monotonic clock reading. On Windows, a subsequent wall-clock read can equal `ExpiresAt`. The previous strict `After` comparison treated that boundary instant as fresh. Using an inclusive expiry check implements `now >= ExpiresAt` semantics.

## Validation

- `go test -count=100 -run '^(TestDiskCache_Get_Expired|TestDiskCache_No(Store|Cache)StoresButExpiresImmediately)$' ./pkg/skills`
- `go test ./pkg/skills`
- `task test`
- `task lint`
- `task build`
- `task check-plan-cross`
- Windows cross-compilation of the `pkg/skills` test binary
