### PR TITLE
fix(ci): grant PR reviewer actions write permission

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -26,6 +26,6 @@ jobs:
       issues: write # Create security incident issues if secrets detected
       checks: write # (Optional) Show review progress as a check run
       id-token: write # Required for OIDC authentication to AWS Secrets Manager
-      actions: read # Download artifacts from trigger workflow
+      actions: write # Download trigger artifacts; review-lock cache and feedback artifact cleanup
     with:
       trigger-run-id: ${{ github.event_name == 'workflow_run' && format('{0}', github.event.workflow_run.id) || '' }}


### PR DESCRIPTION
## Summary

- grant the reusable PR review workflow the `actions: write` permission required by docker-agent-action v2.0.3
- restore PR review runs that currently fail during workflow validation

## Root cause

The caller grants `actions: read`, while the nested `review` job in docker-agent-action v2.0.3 requests `actions: write` for review-lock cache and feedback artifact cleanup. GitHub rejects the workflow before any job starts.

## Validation

- `actionlint .github/workflows/pr-review.yml`
- `./scripts/workflow-lint.sh`
- `git diff --check`
