### PR TITLE
feat(tui): configurable interrupt confirmation for Esc key

### DIFF
--- a/pkg/tui/dialog/interrupt_confirmation.go
+++ b/pkg/tui/dialog/interrupt_confirmation.go
@@ -1,0 +1,102 @@
+package dialog
+
+import (
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/docker/docker-agent/pkg/tui/core"
+	"github.com/docker/docker-agent/pkg/tui/core/layout"
+	"github.com/docker/docker-agent/pkg/tui/styles"
+)
+
+// InterruptConfirmedMsg is sent when the user confirms they want to
+// interrupt the current stream.
+type InterruptConfirmedMsg struct{}
+
+type interruptConfirmationKeyMap struct {
+	Yes key.Binding
+	No  key.Binding
+	Esc key.Binding
+}
+
+func defaultInterruptConfirmationKeyMap() interruptConfirmationKeyMap {
+	return interruptConfirmationKeyMap{
+		Yes: key.NewBinding(
+			key.WithKeys("y", "Y"),
+			key.WithHelp("Y", "yes"),
+		),
+		No: key.NewBinding(
+			key.WithKeys("n", "N"),
+			key.WithHelp("N", "no"),
+		),
+		Esc: key.NewBinding(
+			key.WithKeys("esc"),
+			key.WithHelp("Esc", "cancel"),
+		),
+	}
+}
+
+type interruptConfirmationDialog struct {
+	BaseDialog
+
+	keyMap interruptConfirmationKeyMap
+}
+
+// NewInterruptConfirmationDialog creates a new interrupt confirmation dialog.
+func NewInterruptConfirmationDialog() Dialog {
+	return &interruptConfirmationDialog{
+		keyMap: defaultInterruptConfirmationKeyMap(),
+	}
+}
+
+// Init initializes the interrupt confirmation dialog.
+func (d *interruptConfirmationDialog) Init() tea.Cmd {
+	return nil
+}
+
+// Update handles messages for the interrupt confirmation dialog.
+func (d *interruptConfirmationDialog) Update(msg tea.Msg) (layout.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		cmd := d.SetSize(msg.Width, msg.Height)
+		return d, cmd
+
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, d.keyMap.Yes):
+			return d, tea.Sequence(
+				core.CmdHandler(CloseDialogMsg{}),
+				core.CmdHandler(InterruptConfirmedMsg{}),
+			)
+		case key.Matches(msg, d.keyMap.No), key.Matches(msg, d.keyMap.Esc):
+			return d, core.CmdHandler(CloseDialogMsg{})
+		}
+	}
+
+	return d, nil
+}
+
+// Position returns the dialog position (centered).
+func (d *interruptConfirmationDialog) Position() (row, col int) {
+	return d.CenterDialog(d.View())
+}
+
+// View renders the interrupt confirmation dialog.
+func (d *interruptConfirmationDialog) View() string {
+	dialogWidth := d.ComputeDialogWidth(50, 30, 50)
+	contentWidth := d.ContentWidth(dialogWidth, 2)
+
+	content := NewContent(contentWidth).
+		AddTitle("Interrupt").
+		AddSeparator().
+		AddSpace().
+		AddQuestion("Stop the current response?").
+		AddSpace().
+		AddHelpKeys("Y", "yes", "N", "no").
+		Build()
+
+	return styles.DialogStyle.
+		Padding(1, 2).
+		Width(dialogWidth).
+		Render(content)
+}

--- a/pkg/tui/dialog/settings.go
+++ b/pkg/tui/dialog/settings.go
@@ -57,6 +57,7 @@ const (
 	rowCacheStablePrompts
 	rowLean
 	rowTabTitleLength
+	rowInterruptConfirmation
 	behaviorRowCount
 )
 
@@ -105,6 +106,16 @@ var sendModeOptions = []sendModeOption{
 	{messages.SendModeQueue, "Queue", "hold until the current turn ends"},
 }
 
+var interruptConfirmationModes = []messages.InterruptMode{
+	messages.InterruptModeAlways, messages.InterruptModeDoubleTap, messages.InterruptModeNone,
+}
+
+var interruptConfirmationLabels = map[messages.InterruptMode]string{
+	messages.InterruptModeAlways:    "Always (confirm dialog)",
+	messages.InterruptModeDoubleTap: "Double-tap (press Esc twice)",
+	messages.InterruptModeNone:      "None (immediate)",
+}
+
 type settingsDialog struct {
 	BaseDialog
 
@@ -126,6 +137,9 @@ func NewSettingsDialog(preferences messages.Preferences, showVisuals bool) Dialo
 	}
 	if preferences.SoundThreshold <= 0 {
 		preferences.SoundThreshold = 10
+	}
+	if preferences.InterruptConfirmation == "" {
+		preferences.InterruptConfirmation = messages.InterruptModeAlways
 	}
 	return &settingsDialog{original: preferences, current: preferences, showVisuals: showVisuals}
 }
@@ -284,6 +298,8 @@ func (d *settingsDialog) changeValue(delta int) tea.Cmd {
 			d.current.Lean = !d.current.Lean
 		case rowTabTitleLength:
 			d.current.TabTitleMaxLength = stepValue(d.current.TabTitleMaxLength, delta, 1, 5, 100)
+		case rowInterruptConfirmation:
+			d.current.InterruptConfirmation = cycleValue(interruptConfirmationModes, d.current.InterruptConfirmation, delta)
 		}
 	case tabNotifications:
 		switch d.selected[d.tab] {
@@ -402,6 +418,7 @@ func (d *settingsDialog) renderBehaviorTab(content *Content, inner int) {
 		AddContent(d.renderToggleRow(rowCacheStablePrompts, "Cache-stable dynamic prompts", d.current.CacheStablePrompts)).
 		AddContent(d.renderToggleRow(rowLean, "Lean UI by default", d.current.Lean)).
 		AddContent(d.renderStepperRow(rowTabTitleLength, "Tab title max length", d.current.TabTitleMaxLength, "chars", inner, false))
+	content.AddContent(d.renderSelectorRow(rowInterruptConfirmation, "Interrupt confirmation", interruptConfirmationLabels[d.current.InterruptConfirmation], inner))
 	if d.confirmYOLO {
 		content.AddSpace().AddContent(styles.MutedStyle.Render("Auto-approve can run tools without confirmation. Press again to enable."))
 	}

--- a/pkg/tui/handlers.go
+++ b/pkg/tui/handlers.go
@@ -892,21 +892,22 @@ func (m *appModel) handleThemeFileChanged(themeRef string) (tea.Model, tea.Cmd) 
 func (m *appModel) handleOpenSettingsDialog() (tea.Model, tea.Cmd) {
 	settings := userconfig.Get()
 	preferences := messages.Preferences{
-		Layout:             m.layoutSettings,
-		SendMode:           m.sendMode,
-		SplitDiffView:      settings.GetSplitDiffView(),
-		ExpandThinking:     settings.GetExpandThinking(),
-		HideToolResults:    settings.HideToolResults,
-		RenderImages:       settings.GetRenderImages(),
-		YOLO:               settings.YOLO,
-		RestoreTabs:        settings.GetRestoreTabs(),
-		Snapshot:           settings.SnapshotsEnabled(),
-		CacheStablePrompts: settings.CacheStablePromptsEnabled(),
-		WarnOnCacheMiss:    settings.CacheMissWarningsEnabled(),
-		Lean:               settings.Lean,
-		TabTitleMaxLength:  settings.GetTabTitleMaxLength(),
-		Sound:              settings.GetSound(),
-		SoundThreshold:     settings.GetSoundThreshold(),
+		Layout:                m.layoutSettings,
+		SendMode:              m.sendMode,
+		SplitDiffView:         settings.GetSplitDiffView(),
+		ExpandThinking:        settings.GetExpandThinking(),
+		HideToolResults:       settings.HideToolResults,
+		RenderImages:          settings.GetRenderImages(),
+		YOLO:                  settings.YOLO,
+		RestoreTabs:           settings.GetRestoreTabs(),
+		Snapshot:              settings.SnapshotsEnabled(),
+		CacheStablePrompts:    settings.CacheStablePromptsEnabled(),
+		WarnOnCacheMiss:       settings.CacheMissWarningsEnabled(),
+		Lean:                  settings.Lean,
+		TabTitleMaxLength:     settings.GetTabTitleMaxLength(),
+		Sound:                 settings.GetSound(),
+		SoundThreshold:        settings.GetSoundThreshold(),
+		InterruptConfirmation: messages.ParseInterruptMode(settings.GetInterruptConfirmation()),
 	}
 	return m, core.CmdHandler(dialog.OpenDialogMsg{
 		Model: dialog.NewSettingsDialog(preferences, !m.hideSidebar),
@@ -922,6 +923,7 @@ func (m *appModel) handleApplySettings(msg messages.ApplySettingsMsg) (tea.Model
 	m.sendMode = messages.ParseSendMode(string(preferences.SendMode))
 	for _, page := range m.chatPages {
 		page.SetSendMode(m.sendMode)
+		page.SetInterruptMode(preferences.InterruptConfirmation)
 	}
 	if m.sessionState.SplitDiffView() != preferences.SplitDiffView {
 		m.sessionState.SetSplitDiffView(preferences.SplitDiffView)
@@ -1001,6 +1003,7 @@ func savePreferences(p messages.Preferences) error {
 		s.YOLO = p.YOLO
 		s.Lean = p.Lean
 		s.Sound = p.Sound
+		s.InterruptConfirmation = string(p.InterruptConfirmation)
 		if p.SoundThreshold == userconfig.DefaultSoundThreshold {
 			s.SoundThreshold = 0
 		} else {
@@ -1061,6 +1064,7 @@ func saveSettingsToUserConfig(layout messages.LayoutSettings, mode messages.Send
 		WarnOnCacheMiss:    settings.CacheMissWarningsEnabled(),
 		Lean:               settings.Lean, TabTitleMaxLength: settings.GetTabTitleMaxLength(),
 		Sound: settings.GetSound(), SoundThreshold: settings.GetSoundThreshold(),
+		InterruptConfirmation: messages.ParseInterruptMode(settings.GetInterruptConfirmation()),
 	})
 }
 

--- a/pkg/tui/messages/settings.go
+++ b/pkg/tui/messages/settings.go
@@ -129,23 +129,48 @@ func ParseSendMode(raw string) SendMode {
 	return SendModeSteer
 }
 
+// InterruptMode identifies how Esc interrupts a running stream.
+type InterruptMode string
+
+const (
+	// InterruptModeAlways shows a confirmation dialog on Esc.
+	InterruptModeAlways InterruptMode = "always"
+	// InterruptModeDoubleTap requires pressing Esc twice within 1 second.
+	InterruptModeDoubleTap InterruptMode = "double-tap"
+	// InterruptModeNone interrupts immediately on Esc.
+	InterruptModeNone InterruptMode = "none"
+)
+
+// ParseInterruptMode normalizes a raw interrupt mode string, falling back to
+// InterruptModeAlways for empty or unknown values so persisted configs can
+// never break the interrupt behavior.
+func ParseInterruptMode(raw string) InterruptMode {
+	switch InterruptMode(raw) {
+	case InterruptModeDoubleTap, InterruptModeNone:
+		return InterruptMode(raw)
+	default:
+		return InterruptModeAlways
+	}
+}
+
 // Preferences contains the persistent values managed by the settings dialog.
 type Preferences struct {
-	Layout             LayoutSettings
-	SendMode           SendMode
-	SplitDiffView      bool
-	ExpandThinking     bool
-	HideToolResults    bool
-	RenderImages       bool
-	YOLO               bool
-	RestoreTabs        bool
-	Snapshot           bool
-	CacheStablePrompts bool
-	WarnOnCacheMiss    bool
-	Lean               bool
-	TabTitleMaxLength  int
-	Sound              bool
-	SoundThreshold     int
+	Layout                LayoutSettings
+	SendMode              SendMode
+	SplitDiffView         bool
+	ExpandThinking        bool
+	HideToolResults       bool
+	RenderImages          bool
+	YOLO                  bool
+	RestoreTabs           bool
+	Snapshot              bool
+	CacheStablePrompts    bool
+	WarnOnCacheMiss       bool
+	Lean                  bool
+	TabTitleMaxLength     int
+	Sound                 bool
+	SoundThreshold        int
+	InterruptConfirmation InterruptMode
 }
 
 // Settings dialog messages.

--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/docker-agent/pkg/tui/components/sidebar"
 	"github.com/docker/docker-agent/pkg/tui/core"
 	"github.com/docker/docker-agent/pkg/tui/core/layout"
+	"github.com/docker/docker-agent/pkg/tui/dialog"
 	msgtypes "github.com/docker/docker-agent/pkg/tui/messages"
 	"github.com/docker/docker-agent/pkg/tui/service"
 	"github.com/docker/docker-agent/pkg/tui/styles"
@@ -157,6 +158,8 @@ type Page interface {
 	// SetSendMode sets what happens to messages sent while the agent is
 	// working: steer into the ongoing stream or queue until the turn ends.
 	SetSendMode(mode msgtypes.SendMode)
+	// SetInterruptMode sets how Esc interrupts a running stream.
+	SetInterruptMode(mode msgtypes.InterruptMode)
 	// SetRoutingID records the tab identity used to address this page's
 	// one-shot UI timers back to it (messages.RoutedMsg.SessionID). The
 	// appModel keys its chat pages — and the supervisor its event routing —
@@ -235,6 +238,14 @@ type chatPage struct {
 
 	// Key map
 	keyMap KeyMap
+
+	// interruptMode controls how Esc interrupts a running stream.
+	interruptMode msgtypes.InterruptMode
+	// lastInterruptTime tracks when the last Esc was pressed for double-tap mode.
+	lastInterruptTime time.Time
+	// waitingForDoubleTap indicates the user pressed Esc once and is waiting
+	// for a second press to confirm the interrupt.
+	waitingForDoubleTap bool
 
 	ctx func() context.Context
 
@@ -423,6 +434,12 @@ func WithSendMode(mode msgtypes.SendMode) PageOption {
 	}
 }
 
+func WithInterruptMode(mode msgtypes.InterruptMode) PageOption {
+	return func(p *chatPage) {
+		p.interruptMode = mode
+	}
+}
+
 // sectionVisibility maps layout settings to the sidebar's visibility config.
 func sectionVisibility(settings msgtypes.LayoutSettings) sidebar.SectionVisibility {
 	return sidebar.SectionVisibility{
@@ -590,6 +607,10 @@ func (p *chatPage) update(msg tea.Msg) (layout.Model, tea.Cmd) {
 		cmds = append(cmds, sidebarCmd)
 
 		return p, tea.Batch(cmds...)
+
+	case dialog.InterruptConfirmedMsg:
+		cmd := p.cancelStream(true)
+		return p, cmd
 
 	default:
 		// Try to handle as a runtime event
@@ -837,6 +858,7 @@ func (p *chatPage) cancelStream(showCancelMessage bool) tea.Cmd {
 	p.streamCancelled = true
 	p.streamDepth = 0
 	p.agentStack = nil
+	p.waitingForDoubleTap = false
 	p.setPendingResponse(false)
 	// Send StreamCancelledMsg to all components to handle cleanup
 	return tea.Batch(
@@ -847,6 +869,32 @@ func (p *chatPage) cancelStream(showCancelMessage bool) tea.Cmd {
 
 func isBangCommand(content string) bool {
 	return strings.HasPrefix(content, "!")
+}
+
+// handleInterrupt processes an Esc key press during a running stream.
+// The behavior depends on interruptMode:
+//   - "always": opens a confirmation dialog
+//   - "double-tap": requires two Esc presses within 500ms
+//   - "none": cancels immediately
+func (p *chatPage) handleInterrupt() tea.Cmd {
+	switch p.interruptMode {
+	case "double-tap":
+		now := time.Now()
+		if !p.lastInterruptTime.IsZero() && now.Sub(p.lastInterruptTime) <= time.Second {
+			p.lastInterruptTime = time.Time{}
+			p.waitingForDoubleTap = false
+			return p.cancelStream(true)
+		}
+		p.lastInterruptTime = now
+		p.waitingForDoubleTap = true
+		return nil
+	case "none":
+		return p.cancelStream(true)
+	default:
+		return func() tea.Msg {
+			return dialog.OpenDialogMsg{Model: dialog.NewInterruptConfirmationDialog()}
+		}
+	}
 }
 
 func (p *chatPage) parseImmediateCommand(content string) tea.Cmd {
@@ -1292,6 +1340,10 @@ func (p *chatPage) SetLayoutSettings(settings msgtypes.LayoutSettings) tea.Cmd {
 // SetSendMode sets the behavior of messages sent while the agent is working.
 func (p *chatPage) SetSendMode(mode msgtypes.SendMode) {
 	p.sendMode = mode
+}
+
+func (p *chatPage) SetInterruptMode(mode msgtypes.InterruptMode) {
+	p.interruptMode = mode
 }
 
 // SetRoutingID records the tab identity this page's routed UI timers are

--- a/pkg/tui/page/chat/input_handlers.go
+++ b/pkg/tui/page/chat/input_handlers.go
@@ -48,7 +48,7 @@ func (p *chatPage) handleKeyPress(msg tea.KeyPressMsg) (layout.Model, tea.Cmd) {
 		}
 		// Otherwise cancel the stream (only if something is running)
 		if p.working || p.msgCancel != nil {
-			cmd := p.cancelStream(true)
+			cmd := p.handleInterrupt()
 			return p, cmd
 		}
 		// Forward to messages for other uses (e.g., clear selection)

--- a/pkg/tui/tui_exit_test.go
+++ b/pkg/tui/tui_exit_test.go
@@ -58,12 +58,13 @@ func (m *mockChatPage) SetSidebarSettings(chat.SidebarSettings)  {}
 func (m *mockChatPage) SetLayoutSettings(messages.LayoutSettings) tea.Cmd {
 	return nil
 }
-func (m *mockChatPage) SetSendMode(messages.SendMode) {}
-func (m *mockChatPage) SetRoutingID(string)           {}
-func (m *mockChatPage) TakeRoutedTimers() tea.Cmd     { return nil }
-func (m *mockChatPage) VisualGeneration() uint64      { return 0 }
-func (m *mockChatPage) Bindings() []key.Binding       { return nil }
-func (m *mockChatPage) Help() help.KeyMap             { return nil }
+func (m *mockChatPage) SetSendMode(messages.SendMode)           {}
+func (m *mockChatPage) SetInterruptMode(messages.InterruptMode) {}
+func (m *mockChatPage) SetRoutingID(string)                     {}
+func (m *mockChatPage) TakeRoutedTimers() tea.Cmd               { return nil }
+func (m *mockChatPage) VisualGeneration() uint64                { return 0 }
+func (m *mockChatPage) Bindings() []key.Binding                 { return nil }
+func (m *mockChatPage) Help() help.KeyMap                       { return nil }
 
 type countingChatPage struct {
 	mockChatPage

--- a/pkg/userconfig/userconfig.go
+++ b/pkg/userconfig/userconfig.go
@@ -133,6 +133,10 @@ type Settings struct {
 	// working: "steer" (default) injects them into the ongoing stream,
 	// "queue" holds them until the current turn ends. Managed via /settings.
 	BusySendMode string `yaml:"busy_send_mode,omitempty"`
+	// InterruptConfirmation controls how Esc interrupts a running stream:
+	// "always" (default) shows a confirmation dialog, "double-tap" requires
+	// pressing Esc twice within 1 second, "none" interrupts immediately.
+	InterruptConfirmation string `yaml:"interrupt_confirmation,omitempty"`
 	// Extra preserves settings keys this version does not know about (e.g.
 	// written by a newer docker-agent) across a load/save round trip.
 	Extra map[string]any `yaml:",inline"`
@@ -255,6 +259,15 @@ func (s *Settings) GetRestoreTabs() bool {
 		return false
 	}
 	return *s.RestoreTabs
+}
+
+// GetInterruptConfirmation returns the configured interrupt confirmation mode.
+// Returns "always" if unset.
+func (s *Settings) GetInterruptConfirmation() string {
+	if s == nil || s.InterruptConfirmation == "" {
+		return "always"
+	}
+	return s.InterruptConfirmation
 }
 
 // SnapshotsEnabled returns whether global snapshot auto-injection is enabled.


### PR DESCRIPTION
> *Disclaimer:* This is the first time I am touching a *Go* codebase with zero prior knowledge of Go. I have relied heavily on the `dogfooding agent` mentioned in the Contributing guidelines and ran it against my self-hosted Laguna S 2.1 118B. All feedbacks, good or bad, are welcome

Add a configurable interrupt confirmation feature that allows users to choose how Esc interrupts a running stream:

- "always" (default): Shows a confirmation dialog
- "double-tap": Requires pressing Esc twice within 1 second
- "none": Single Esc interrupts immediately

The setting is configurable via YAML config file and the /settings dialog in the Behavior tab.

Changes:
- Add InterruptConfirmation field to Settings struct and getter method
- Add InterruptMode type with constants and ParseInterruptMode function
- Create InterruptConfirmationDialog with Yes/No/Esc key bindings
- Add interrupt mode handling to chat page with handleInterrupt method
- Wire up interrupt mode from settings to chat pages
- Add interrupt confirmation row to Behavior tab in settings dialog
- Update test mocks for interface compliance