### PR TITLE
fix(runtime): guard nested agent delegation

### DIFF
--- a/docs/tools/background-agents/index.md
+++ b/docs/tools/background-agents/index.md
@@ -32,6 +32,8 @@ The background agents tool lets an orchestrator dispatch work to sub-agents conc
 
 `run_background_agent` returns a **task ID** string. Tools run by the sub-agent inherit the parent session's permissions. Because background tasks run non-interactively, any tool call that would normally prompt the user for approval will be automatically denied. To allow background agents to run mutating tools, you must explicitly approve them in the parent session (e.g. via YOLO mode or explicit allow rules).
 
+Background delegation shares the same runtime guards as `transfer_task`: delegation cycles are rejected and chains are capped at 10 nested delegations. See [Delegation Limits](../transfer-task/index.md#delegation-limits).
+
 ### `view_background_agent` and `stop_background_agent` parameters
 
 | Parameter | Type   | Required | Description                                                    |

--- a/docs/tools/transfer-task/index.md
+++ b/docs/tools/transfer-task/index.md
@@ -58,6 +58,15 @@ The `transfer_task` tool takes three parameters:
 
 The call blocks until the sub-agent returns its result, which becomes the tool's response. For non-blocking parallel delegation, use [`background_agents`](../background-agents/index.md) instead.
 
+## Delegation Limits
+
+Sub-agents can have `sub_agents` of their own, so multi-level delegation chains are supported. Two runtime guards keep chains sane, applied to both `transfer_task` and `run_background_agent`:
+
+- **Cycles are rejected.** A delegation targeting an agent that is already part of the active delegation chain (for example `a -> b -> a`) fails with an error naming the cycle.
+- **Depth is capped at 10 nested delegations.** The root agent delegating to its first sub-agent counts as depth 1; a call that would exceed the cap fails with an error stating the attempted depth.
+
+A rejected delegation returns a tool error to the calling agent and never starts the sub-agent.
+
 > [!TIP]
 > **See also**
 >

--- a/pkg/runtime/agent_delegation.go
+++ b/pkg/runtime/agent_delegation.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -47,6 +48,40 @@ func validateAgentInList(currentAgent, targetAgent, action, listDesc string, age
 		"Agent %s cannot %s %s: target agent not in %s. No agents are configured in this list.",
 		currentAgent, action, targetAgent, listDesc,
 	))
+}
+
+// maxDelegationDepth caps the number of chained agent-delegation edges
+// (transfer_task and run_background_agent) below a root session. The root
+// agent delegating to its first child is depth 1; a delegation is allowed at
+// exactly this depth and rejected beyond it. Handoffs and skill sub-sessions
+// are not delegation edges and do not count. This is a fixed runtime guard
+// against runaway recursion, not user configuration: legitimate teams stay
+// well below it.
+const maxDelegationDepth = 10
+
+// validateDelegation guards one agent-delegation edge from caller to target
+// against the parent session's recorded delegation lineage. On success it
+// returns the child session's lineage (parent lineage plus caller, freshly
+// allocated so concurrent fan-out from one parent never shares backing
+// arrays). On a direct or indirect cycle, or when the chain would exceed
+// maxDelegationDepth, it returns a non-empty actionable error message and
+// the caller must not spawn the child session.
+func validateDelegation(parent *session.Session, caller, target string) ([]string, string) {
+	childLineage := append(parent.DelegationLineageSnapshot(), caller)
+	if slices.Contains(childLineage, target) {
+		path := strings.Join(append(slices.Clone(childLineage), target), " -> ")
+		return nil, fmt.Sprintf(
+			"delegation cycle detected: %s. Agent %s is already part of the active delegation chain; complete the task directly or delegate to a different agent.",
+			path, target,
+		)
+	}
+	if len(childLineage) > maxDelegationDepth {
+		return nil, fmt.Sprintf(
+			"delegation depth limit exceeded: agent %s is at delegation depth %d and delegating to %s would reach depth %d, exceeding the maximum of %d. Complete the task directly instead of delegating further.",
+			caller, len(childLineage)-1, target, len(childLineage), maxDelegationDepth,
+		)
+	}
+	return childLineage, ""
 }
 
 // buildTaskSystemMessage constructs the system message for a delegated task.
@@ -126,6 +161,13 @@ type SubSessionConfig struct {
 	// top of the agent's own toolsets. Used by fork-mode skills that declare
 	// assistive toolsets.
 	ExtraToolSets []tools.ToolSet
+	// DelegationLineage is the chain of agents that delegated to produce this
+	// child session (parent lineage plus the delegating caller), as computed
+	// by validateDelegation. Set only for true delegation edges
+	// (transfer_task, run_background_agent); when nil the child inherits the
+	// parent session's lineage unchanged, so non-delegation sub-sessions
+	// (e.g. skills) preserve ancestry without adding an edge.
+	DelegationLineage []string
 }
 
 // delegationRequest bundles a [SubSessionConfig] with the single
@@ -152,6 +194,12 @@ type delegationRequest struct {
 	// sub-sessions that must NOT share the runtime's mutable
 	// currentAgent, while switching is for sequential delegations where
 	// the parent loop is blocked anyway.
+	//
+	// When the parent session is itself pinned (a background agent's
+	// session), runForwarding downgrades the switch to pinning the child
+	// to AgentName instead: the shared current agent belongs to the
+	// concurrent foreground loop and must not be mutated from a
+	// background task (#3886).
 	SwitchCurrentAgent bool
 }
 
@@ -176,6 +224,11 @@ func newSubSession(parent *session.Session, cfg SubSessionConfig, childAgent *ag
 		userMsg = "Please proceed."
 	}
 
+	lineage := cfg.DelegationLineage
+	if lineage == nil {
+		lineage = parent.DelegationLineageSnapshot()
+	}
+
 	opts := []session.Opt{
 		session.WithSystemMessage(sysMsg),
 		session.WithImplicitUserMessage(userMsg),
@@ -193,6 +246,9 @@ func newSubSession(parent *session.Session, cfg SubSessionConfig, childAgent *ag
 	}
 	if cfg.PinAgent {
 		opts = append(opts, session.WithAgentName(cfg.AgentName))
+	}
+	if len(lineage) > 0 {
+		opts = append(opts, session.WithDelegationLineage(lineage))
 	}
 	opts = append(opts, session.WithPermissions(cfg.Permissions))
 	// Merge parent's excluded tools with config's excluded tools so that
@@ -270,15 +326,20 @@ func (r *LocalRuntime) swapCurrentAgent(ctx context.Context, sessionID string, f
 // on whatever span is attached to ctx — a no-op if none.
 //
 // runForwarding handles every concern the callers used to duplicate:
-// swapping the current agent (if requested), resolving the child agent,
-// building the sub-session, driving RunStream, and recording the
-// sub-session on the parent.
+// resolving the caller from the parent session, swapping the current agent
+// (if requested; downgraded to pinning the child when the parent session is
+// itself pinned), resolving the child agent, building the sub-session,
+// driving RunStream, and recording the sub-session on the parent.
 func (r *LocalRuntime) runForwarding(ctx context.Context, parent *session.Session, evts EventSink, req delegationRequest) (*tools.ToolCallResult, error) {
 	span := trace.SpanFromContext(ctx)
 
-	callerAgent, err := r.team.Agent(r.currentAgentName())
-	if err != nil {
-		return nil, fmt.Errorf("current agent not found: %w", err)
+	// The caller resolves from the parent session, not the shared current
+	// agent: a nested transfer from a pinned background session must
+	// attribute events, hooks, and completion to the pinned agent, no
+	// matter where the concurrent foreground loop points (#3886).
+	callerAgent := r.resolveSessionAgent(parent)
+	if callerAgent == nil {
+		return nil, errors.New("no agent resolved for the parent session")
 	}
 	child, err := r.team.Agent(req.AgentName)
 	if err != nil {
@@ -286,7 +347,16 @@ func (r *LocalRuntime) runForwarding(ctx context.Context, parent *session.Sessio
 	}
 
 	if req.SwitchCurrentAgent {
-		defer r.swapCurrentAgent(ctx, parent.ID, callerAgent, child, evts)()
+		if parent.AgentName == "" {
+			defer r.swapCurrentAgent(ctx, parent.ID, callerAgent, child, evts)()
+		} else {
+			// Pinned parent (background delegation): the shared current
+			// agent belongs to the concurrent foreground loop and must not
+			// be mutated. Pin the child to the target instead — RunStream
+			// resolves pinned sessions directly, so the child still
+			// executes as the target agent, without switch events/hooks.
+			req.PinAgent = true
+		}
 	}
 
 	s := newSubSession(parent, req.SubSessionConfig, child)
@@ -344,6 +414,16 @@ func (r *LocalRuntime) runForwarding(ctx context.Context, parent *session.Sessio
 // callers like background agents PinAgent the child session so the
 // runtime never mutates the shared currentAgent state.
 func (r *LocalRuntime) runCollecting(ctx context.Context, parent *session.Session, cfg SubSessionConfig, onContent func(string)) *agenttool.RunResult {
+	// The caller resolves from the parent session, not the shared current
+	// agent: a nested background dispatch from a pinned session must
+	// attribute the child's completion to the pinned agent, no matter
+	// where the concurrent foreground loop points (#3886). Resolved once
+	// up front so the subagent_stop defer below can't drift to a
+	// different agent if the shared current changes mid-run.
+	callerAgent := r.resolveSessionAgent(parent)
+	if callerAgent == nil {
+		return &agenttool.RunResult{ErrMsg: "no agent resolved for the parent session"}
+	}
 	child, err := r.team.Agent(cfg.AgentName)
 	if err != nil {
 		return &agenttool.RunResult{ErrMsg: fmt.Sprintf("agent %q not found: %s", cfg.AgentName, err)}
@@ -352,14 +432,12 @@ func (r *LocalRuntime) runCollecting(ctx context.Context, parent *session.Sessio
 	s := newSubSession(parent, cfg, child)
 
 	// subagent_stop fires after the background sub-session has fully
-	// drained — success or failure. The parent agent at the time of
-	// dispatch (whoever called run_background_agent) owns the executor;
-	// we resolve it via CurrentAgent because the background path doesn't
-	// carry the parent agent name. dispatchHook silently no-ops when
-	// CurrentAgent is nil. The deferred call ensures the hook fires even
-	// when an ErrorEvent or ctx cancellation breaks us out of the loop.
+	// drained — success or failure. The caller agent (whoever dispatched
+	// run_background_agent) owns the executor. The deferred call ensures
+	// the hook fires even when an ErrorEvent or ctx cancellation breaks
+	// us out of the loop.
 	defer func() {
-		r.executeSubagentStopHooks(ctx, parent, s, r.CurrentAgent(), cfg.AgentName, s.GetLastAssistantMessageContent())
+		r.executeSubagentStopHooks(ctx, parent, s, callerAgent, cfg.AgentName, s.GetLastAssistantMessageContent())
 	}()
 
 	var errMsg string
@@ -517,7 +595,28 @@ func (r *LocalRuntime) persistBackgroundSubSession(ctx context.Context, parentID
 	}
 }
 
-// CurrentAgentSubAgentNames implements agenttool.Runner.
+// SubAgentNames implements agenttool.SessionSubAgentResolver, which
+// HandleRun prefers over the legacy CurrentAgentSubAgentNames. The
+// sub-agent list resolves from the calling session — a pinned background
+// session yields its pinned agent — so a nested run_background_agent
+// dispatched from a detached background task is validated against the
+// actual caller, not whatever the concurrent foreground loop's shared
+// current agent points at (#3886).
+func (r *LocalRuntime) SubAgentNames(sess *session.Session) []string {
+	if sess == nil {
+		return nil
+	}
+	a := r.resolveSessionAgent(sess)
+	if a == nil {
+		return nil
+	}
+	return agentNames(a.SubAgents())
+}
+
+// CurrentAgentSubAgentNames implements agenttool.Runner. It is the legacy
+// shared current-agent resolver, kept so the Runner contract stays
+// source-compatible; HandleRun never takes this path for LocalRuntime
+// because the session-aware SubAgentNames above is preferred.
 func (r *LocalRuntime) CurrentAgentSubAgentNames() []string {
 	a := r.CurrentAgent()
 	if a == nil {
@@ -534,16 +633,28 @@ func (r *LocalRuntime) CurrentAgentSubAgentNames() []string {
 // Tool calls that result in an "Ask" outcome will be auto-denied by the dispatcher
 // due to the non-interactive context.
 func (r *LocalRuntime) RunAgent(ctx context.Context, params agenttool.RunParams) *agenttool.RunResult {
+	// Caller identity must come from the parent session, not the shared
+	// current agent: nested background delegation runs on pinned sessions
+	// whose agent can differ from whatever the foreground loop points at.
+	caller := r.resolveSessionAgent(params.ParentSession)
+	if caller == nil {
+		return &agenttool.RunResult{ErrMsg: "no agent resolved for the parent session"}
+	}
+	childLineage, guardErr := validateDelegation(params.ParentSession, caller.Name(), params.AgentName)
+	if guardErr != "" {
+		return &agenttool.RunResult{ErrMsg: guardErr}
+	}
 	return r.runCollecting(ctx, params.ParentSession, SubSessionConfig{
-		Task:           params.Task,
-		ExpectedOutput: params.ExpectedOutput,
-		AgentName:      params.AgentName,
-		Title:          "Background agent task",
-		ToolsApproved:  params.ParentSession.IsToolsApproved(),
-		SafetyPolicy:   params.ParentSession.GetSafetyPolicy(),
-		Permissions:    params.ParentSession.ClonePermissions(),
-		NonInteractive: true,
-		PinAgent:       true,
+		Task:              params.Task,
+		ExpectedOutput:    params.ExpectedOutput,
+		AgentName:         params.AgentName,
+		Title:             "Background agent task",
+		ToolsApproved:     params.ParentSession.IsToolsApproved(),
+		SafetyPolicy:      params.ParentSession.GetSafetyPolicy(),
+		Permissions:       params.ParentSession.ClonePermissions(),
+		NonInteractive:    true,
+		PinAgent:          true,
+		DelegationLineage: childLineage,
 	}, params.OnContent)
 }
 
@@ -557,9 +668,20 @@ func (r *LocalRuntime) handleTaskTransfer(ctx context.Context, sess *session.Ses
 		return nil, fmt.Errorf("invalid arguments: %w", err)
 	}
 
-	a := r.CurrentAgent()
+	// Resolve the caller session-aware: nested transfer_task from a pinned
+	// background session must attribute the call to the pinned agent, not
+	// the shared current agent (#3886).
+	a := r.resolveSessionAgent(sess)
+	if a == nil {
+		return nil, errors.New("no agent resolved for the calling session")
+	}
 	if errResult := validateAgentInList(a.Name(), params.Agent, "transfer task to", "sub-agents list", a.SubAgents()); errResult != nil {
 		return errResult, nil
+	}
+
+	childLineage, guardErr := validateDelegation(sess, a.Name(), params.Agent)
+	if guardErr != "" {
+		return tools.ResultError(guardErr), nil
 	}
 
 	slog.DebugContext(ctx, "Transferring task to agent", "from_agent", a.Name(), "to_agent", params.Agent, "task", params.Task)
@@ -596,14 +718,15 @@ func (r *LocalRuntime) handleTaskTransfer(ctx context.Context, sess *session.Ses
 
 	return r.runForwarding(ctx, sess, evts, delegationRequest{
 		SubSessionConfig: SubSessionConfig{
-			Task:           params.Task,
-			ExpectedOutput: params.ExpectedOutput,
-			AgentName:      params.Agent,
-			Title:          "Transferred task",
-			ToolsApproved:  sess.IsToolsApproved(),
-			SafetyPolicy:   sess.GetSafetyPolicy(),
-			Permissions:    sess.ClonePermissions(),
-			NonInteractive: sess.NonInteractive,
+			Task:              params.Task,
+			ExpectedOutput:    params.ExpectedOutput,
+			AgentName:         params.Agent,
+			Title:             "Transferred task",
+			ToolsApproved:     sess.IsToolsApproved(),
+			SafetyPolicy:      sess.GetSafetyPolicy(),
+			Permissions:       sess.ClonePermissions(),
+			NonInteractive:    sess.NonInteractive,
+			DelegationLineage: childLineage,
 		},
 		SwitchCurrentAgent: true,
 	})

--- a/pkg/runtime/agent_delegation_test.go
+++ b/pkg/runtime/agent_delegation_test.go
@@ -2,15 +2,20 @@ package runtime
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
 	"github.com/docker/docker-agent/pkg/config/latest"
+	"github.com/docker/docker-agent/pkg/hooks"
 	"github.com/docker/docker-agent/pkg/permissions"
 	"github.com/docker/docker-agent/pkg/runtime/toolexec"
 	"github.com/docker/docker-agent/pkg/safety"
@@ -642,4 +647,1041 @@ func TestTransferTask_PropagatesPermissions(t *testing.T) {
 	parentClone := sess.ClonePermissions()
 	assert.Equal(t, []string{"safe_tool"}, parentClone.Allow,
 		"parent permissions must remain isolated from child mutations after transfer_task")
+}
+
+// firstSubSession returns the first sub-session attached to s, or nil.
+func firstSubSession(s *session.Session) *session.Session {
+	for _, item := range s.MessagesSnapshot() {
+		if item.IsSubSession() {
+			return item.SubSession
+		}
+	}
+	return nil
+}
+
+// transferToolCall builds a transfer_task tool call targeting the given agent.
+func transferToolCall(target string) tools.ToolCall {
+	return tools.ToolCall{
+		ID:   "call_1",
+		Type: "function",
+		Function: tools.FunctionCall{
+			Name:      "transfer_task",
+			Arguments: fmt.Sprintf(`{"agent":%q,"task":"do work","expected_output":"result"}`, target),
+		},
+	}
+}
+
+// ancestorNames returns n distinct agent names for crafting delegation lineages.
+func ancestorNames(n int) []string {
+	names := make([]string, n)
+	for i := range names {
+		names[i] = fmt.Sprintf("ancestor%d", i)
+	}
+	return names
+}
+
+func TestValidateDelegation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("first delegation from a root session", func(t *testing.T) {
+		parent := session.New()
+		lineage, errMsg := validateDelegation(parent, "root", "worker")
+		assert.Empty(t, errMsg)
+		assert.Equal(t, []string{"root"}, lineage)
+	})
+
+	t.Run("direct cycle", func(t *testing.T) {
+		parent := session.New()
+		lineage, errMsg := validateDelegation(parent, "a", "a")
+		assert.Nil(t, lineage)
+		assert.Contains(t, errMsg, "delegation cycle detected: a -> a")
+	})
+
+	t.Run("indirect cycle", func(t *testing.T) {
+		parent := session.New(session.WithDelegationLineage([]string{"a"}))
+		lineage, errMsg := validateDelegation(parent, "b", "a")
+		assert.Nil(t, lineage)
+		assert.Contains(t, errMsg, "delegation cycle detected: a -> b -> a")
+	})
+
+	t.Run("deep indirect cycle names the full attempted path", func(t *testing.T) {
+		parent := session.New(session.WithDelegationLineage([]string{"root", "a"}))
+		_, errMsg := validateDelegation(parent, "b", "root")
+		assert.Contains(t, errMsg, "root -> a -> b -> root")
+	})
+
+	t.Run("allows exactly the maximum depth", func(t *testing.T) {
+		parent := session.New(session.WithDelegationLineage(ancestorNames(maxDelegationDepth - 1)))
+		lineage, errMsg := validateDelegation(parent, "caller", "target")
+		assert.Empty(t, errMsg)
+		assert.Len(t, lineage, maxDelegationDepth)
+	})
+
+	t.Run("rejects one edge past the maximum", func(t *testing.T) {
+		parent := session.New(session.WithDelegationLineage(ancestorNames(maxDelegationDepth)))
+		lineage, errMsg := validateDelegation(parent, "caller", "target")
+		assert.Nil(t, lineage)
+		assert.Contains(t, errMsg, "delegation depth limit exceeded")
+		assert.Contains(t, errMsg, fmt.Sprintf("at delegation depth %d", maxDelegationDepth))
+		assert.Contains(t, errMsg, fmt.Sprintf("reach depth %d", maxDelegationDepth+1))
+		assert.Contains(t, errMsg, fmt.Sprintf("maximum of %d", maxDelegationDepth))
+	})
+
+	t.Run("sibling delegations never share lineage storage", func(t *testing.T) {
+		parent := session.New(session.WithDelegationLineage([]string{"root"}))
+		first, errMsg := validateDelegation(parent, "a", "b")
+		require.Empty(t, errMsg)
+		second, errMsg := validateDelegation(parent, "c", "d")
+		require.Empty(t, errMsg)
+
+		first[0] = "mutated"
+		assert.Equal(t, []string{"root", "c"}, second)
+		assert.Equal(t, []string{"root"}, parent.DelegationLineageSnapshot())
+	})
+}
+
+func TestNewSubSession_DelegationLineage(t *testing.T) {
+	t.Parallel()
+
+	childAgent := agent.New("worker", "")
+
+	t.Run("delegation edge sets and isolates the lineage", func(t *testing.T) {
+		parent := session.New(session.WithDelegationLineage([]string{"root"}))
+		lineage := []string{"root", "coordinator"}
+		s := newSubSession(parent, SubSessionConfig{
+			Task:              "work",
+			AgentName:         "worker",
+			Title:             "Task",
+			DelegationLineage: lineage,
+		}, childAgent)
+
+		assert.Equal(t, []string{"root", "coordinator"}, s.DelegationLineage)
+		lineage[1] = "mutated"
+		assert.Equal(t, []string{"root", "coordinator"}, s.DelegationLineage)
+	})
+
+	t.Run("nil lineage inherits the parent's unchanged", func(t *testing.T) {
+		// Skill sub-sessions leave DelegationLineage nil: they are not
+		// delegation edges but must keep ancestry so nested delegations
+		// from within a skill are still guarded.
+		parent := session.New(session.WithDelegationLineage([]string{"root", "coordinator"}))
+		s := newSubSession(parent, SubSessionConfig{
+			Task:      "work",
+			AgentName: "worker",
+			Title:     "Task",
+		}, childAgent)
+
+		assert.Equal(t, []string{"root", "coordinator"}, s.DelegationLineage)
+	})
+
+	t.Run("root parent yields no lineage", func(t *testing.T) {
+		parent := session.New()
+		s := newSubSession(parent, SubSessionConfig{
+			Task:      "work",
+			AgentName: "worker",
+			Title:     "Task",
+		}, childAgent)
+
+		assert.Empty(t, s.DelegationLineage)
+	})
+}
+
+func TestTransferTask_RejectsDirectCycle(t *testing.T) {
+	t.Parallel()
+
+	prov := &mockProvider{id: "test/mock-model", stream: &mockStream{}}
+	root := agent.New("root", "Root agent", agent.WithModel(prov))
+	// Self-delegation is structurally possible in config; the runtime
+	// guard must reject it before a child session is spawned.
+	agent.WithSubAgents(root)(root)
+
+	tm := team.New(team.WithAgents(root))
+	rt, err := NewLocalRuntime(t.Context(), tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStore{}),
+	)
+	require.NoError(t, err)
+
+	sess := session.New(session.WithUserMessage("Test"))
+	evts := make(chan Event, 128)
+
+	result, err := rt.handleTaskTransfer(t.Context(), sess, transferToolCall("root"), NewChannelSink(evts))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Output, "delegation cycle detected: root -> root")
+	assert.Nil(t, firstSubSession(sess), "rejected delegation must not attach a child session")
+}
+
+// TestTransferTask_NestedFromPinnedBackgroundSession covers the #3886 nested
+// scenario: a background agent (pinned session) calling transfer_task. The
+// caller must resolve from the session, so acyclic multi-level delegation
+// stays supported while delegating back to an ancestor is rejected.
+func TestTransferTask_NestedFromPinnedBackgroundSession(t *testing.T) {
+	t.Parallel()
+
+	workerStream := newStreamBuilder().AddContent("worker done").AddStopWithUsage(10, 5).Build()
+	helperStream := newStreamBuilder().AddContent("helper done").AddStopWithUsage(10, 5).Build()
+
+	root := agent.New("root", "Root agent", agent.WithModel(&mockProvider{id: "test/mock-model", stream: &mockStream{}}))
+	worker := agent.New("worker", "Worker agent", agent.WithModel(&mockProvider{id: "test/mock-model", stream: workerStream}))
+	helper := agent.New("helper", "Helper agent", agent.WithModel(&mockProvider{id: "test/mock-model", stream: helperStream}))
+	agent.WithSubAgents(worker)(root)
+	// helper is only reachable from worker; root also stays in worker's
+	// sub-agents so the cycle rejection below is the delegation guard's
+	// doing, not the sub-agent list check.
+	agent.WithSubAgents(helper, root)(worker)
+
+	tm := team.New(team.WithAgents(root, worker, helper))
+	rt, err := NewLocalRuntime(t.Context(), tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStore{}),
+	)
+	require.NoError(t, err)
+
+	parent := session.New(session.WithUserMessage("Test"))
+	res := rt.RunAgent(t.Context(), agenttool.RunParams{
+		AgentName:     "worker",
+		Task:          "background work",
+		ParentSession: parent,
+	})
+	require.Empty(t, res.ErrMsg)
+
+	child := firstSubSession(parent)
+	require.NotNil(t, child)
+	assert.Equal(t, "worker", child.AgentName)
+	assert.Equal(t, []string{"root"}, child.DelegationLineage)
+
+	evts := make(chan Event, 128)
+
+	// Delegating back to an ancestor from the pinned child is an indirect cycle.
+	result, err := rt.handleTaskTransfer(t.Context(), child, transferToolCall("root"), NewChannelSink(evts))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Output, "root -> worker -> root")
+	assert.Nil(t, firstSubSession(child), "rejected delegation must not attach a child session")
+
+	// Acyclic delegation from the same pinned child is allowed. helper is
+	// not in root's sub-agents, so success also proves the caller resolved
+	// from the pinned session (worker), not the shared current agent (root).
+	result, err = rt.handleTaskTransfer(t.Context(), child, transferToolCall("helper"), NewChannelSink(evts))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.IsError, "acyclic multi-level delegation must stay supported: %s", result.Output)
+
+	grandchild := firstSubSession(child)
+	require.NotNil(t, grandchild)
+	assert.Equal(t, "helper", grandchild.AgentName,
+		"nested transfer children from a pinned parent are pinned to the target")
+	assert.Equal(t, []string{"root", "worker"}, grandchild.DelegationLineage)
+	assert.Equal(t, []string{"root"}, child.DelegationLineage,
+		"sibling delegations must not mutate the parent's lineage")
+}
+
+// probeTool returns a single-tool list whose handler invokes record at
+// execution time. Tests use it to observe the runtime's shared current
+// agent from inside a running sub-session.
+func probeTool(record func()) []tools.Tool {
+	return []tools.Tool{{
+		Name:       "probe",
+		Parameters: map[string]any{},
+		Handler: func(context.Context, tools.ToolCall, tools.Runtime) (*tools.ToolCallResult, error) {
+			record()
+			return tools.ResultSuccess("probed"), nil
+		},
+	}}
+}
+
+// probeAgent builds an agent that makes one "probe" tool call (invoking
+// record mid-run) and then replies with content.
+func probeAgent(name, content string, record func()) *agent.Agent {
+	prov := &queueProvider{id: "test/mock-model", streams: []chat.MessageStream{
+		newStreamBuilder().AddToolCallWithStop("call_probe", "probe", "{}").Build(),
+		newStreamBuilder().AddContent(content).AddStopWithUsage(10, 5).Build(),
+	}}
+	return agent.New(name, name+" agent",
+		agent.WithModel(prov),
+		agent.WithToolSets(newStubToolSet(nil, probeTool(record), nil)),
+	)
+}
+
+// collectTransferEvents closes evts and returns the AgentSwitching events and
+// the SubSessionCompleted event it carried.
+func collectTransferEvents(evts chan Event) (switches []*AgentSwitchingEvent, completed *SubSessionCompletedEvent) {
+	close(evts)
+	for ev := range evts {
+		switch e := ev.(type) {
+		case *AgentSwitchingEvent:
+			switches = append(switches, e)
+		case *SubSessionCompletedEvent:
+			completed = e
+		}
+	}
+	return switches, completed
+}
+
+// TestTransferTask_PinnedParentDoesNotMutateSharedCurrentAgent reproduces the
+// #3886 nested misattribution: transfer_task from a pinned background session
+// used to enter the shared switch path, so runForwarding re-resolved the
+// caller to the foreground agent (root), swapCurrentAgent mutated the shared
+// current agent mid-flight, and SubSessionCompleted plus subagent_stop were
+// attributed to root. The child must instead be pinned to the target, run as
+// the target, and be attributed to the actual pinned caller (worker).
+func TestTransferTask_PinnedParentDoesNotMutateSharedCurrentAgent(t *testing.T) {
+	t.Parallel()
+
+	var rt *LocalRuntime
+	var mu sync.Mutex
+	var observed []string
+	record := func() {
+		mu.Lock()
+		defer mu.Unlock()
+		observed = append(observed, rt.CurrentAgent().Name())
+	}
+
+	workerStream := newStreamBuilder().AddContent("worker done").AddStopWithUsage(10, 5).Build()
+	root := agent.New("root", "Root agent", agent.WithModel(&mockProvider{id: "test/mock-model", stream: &mockStream{}}))
+	worker := agent.New("worker", "Worker agent",
+		agent.WithModel(&mockProvider{id: "test/mock-model", stream: workerStream}),
+		// The recording subagent_stop hook lives on worker: it only fires
+		// when the runtime attributes the nested transfer to the pinned
+		// caller rather than the shared current agent (root).
+		agent.WithHooks(&hooks.Config{
+			SubagentStop: []hooks.Hook{{Type: hooks.HookTypeBuiltin, Command: "test_record_subagent_stop"}},
+		}),
+	)
+	helper := probeAgent("helper", "helper done", record)
+	agent.WithSubAgents(worker)(root)
+	agent.WithSubAgents(helper)(worker)
+
+	tm := team.New(team.WithAgents(root, worker, helper))
+	var err error
+	rt, err = NewLocalRuntime(t.Context(), tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStore{}),
+	)
+	require.NoError(t, err)
+
+	rb := &recordingBuiltin{}
+	require.NoError(t, rt.hooksRegistry.RegisterBuiltin("test_record_subagent_stop", rb.hook))
+	rt.buildHooksExecutors()
+
+	parent := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))
+	res := rt.RunAgent(t.Context(), agenttool.RunParams{
+		AgentName:     "worker",
+		Task:          "background work",
+		ParentSession: parent,
+	})
+	require.Empty(t, res.ErrMsg)
+
+	child := firstSubSession(parent)
+	require.NotNil(t, child)
+	require.Equal(t, "worker", child.AgentName, "background child session must be pinned")
+
+	evts := make(chan Event, 128)
+	result, err := rt.handleTaskTransfer(t.Context(), child, transferToolCall("helper"), NewChannelSink(evts))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.IsError, "nested transfer must succeed: %s", result.Output)
+	assert.Equal(t, "helper done", result.Output, "the child must run as the target agent")
+
+	mu.Lock()
+	assert.Equal(t, []string{"root"}, observed,
+		"shared current agent must stay untouched while the pinned child's transfer runs")
+	mu.Unlock()
+	assert.Equal(t, "root", rt.CurrentAgent().Name())
+
+	grandchild := firstSubSession(child)
+	require.NotNil(t, grandchild)
+	assert.Equal(t, "helper", grandchild.AgentName, "grandchild must be pinned to the target agent")
+
+	switches, completed := collectTransferEvents(evts)
+	assert.Empty(t, switches, "a pinned-parent transfer must not emit AgentSwitching events")
+	require.NotNil(t, completed, "SubSessionCompleted must still be emitted")
+	assert.Equal(t, "worker", completed.GetAgentName(),
+		"SubSessionCompleted must be attributed to the pinned caller")
+
+	stops := rb.snapshot()
+	require.Len(t, stops, 1, "worker's subagent_stop hook must fire exactly once")
+	assert.Equal(t, "helper", stops[0].AgentName)
+	assert.Equal(t, child.ID, stops[0].ParentSessionID)
+	assert.Equal(t, grandchild.ID, stops[0].SessionID)
+	assert.Equal(t, "helper done", stops[0].StopResponse)
+}
+
+// TestTransferTask_ForegroundSwitchesAndRestoresCurrentAgent pins the
+// sequential semantics for ordinary foreground transfers: the shared current
+// agent is switched to the target while the child runs (the child session
+// stays unpinned and resolves through it), then restored, with entry and
+// return AgentSwitching events around the run.
+func TestTransferTask_ForegroundSwitchesAndRestoresCurrentAgent(t *testing.T) {
+	t.Parallel()
+
+	var rt *LocalRuntime
+	var mu sync.Mutex
+	var observed []string
+	record := func() {
+		mu.Lock()
+		defer mu.Unlock()
+		observed = append(observed, rt.CurrentAgent().Name())
+	}
+
+	librarian := probeAgent("librarian", "found it", record)
+	root := agent.New("root", "Root agent", agent.WithModel(&mockProvider{id: "test/mock-model", stream: &mockStream{}}))
+	agent.WithSubAgents(librarian)(root)
+
+	tm := team.New(team.WithAgents(root, librarian))
+	var err error
+	rt, err = NewLocalRuntime(t.Context(), tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStore{}),
+	)
+	require.NoError(t, err)
+
+	sess := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))
+	evts := make(chan Event, 128)
+
+	result, err := rt.handleTaskTransfer(t.Context(), sess, transferToolCall("librarian"), NewChannelSink(evts))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.IsError, "transfer must succeed: %s", result.Output)
+	assert.Equal(t, "found it", result.Output)
+
+	mu.Lock()
+	assert.Equal(t, []string{"librarian"}, observed,
+		"the shared current agent must point at the target while the child runs")
+	mu.Unlock()
+	assert.Equal(t, "root", rt.CurrentAgent().Name(), "the shared current agent must be restored afterwards")
+
+	child := firstSubSession(sess)
+	require.NotNil(t, child)
+	assert.Empty(t, child.AgentName, "foreground transfer children stay unpinned")
+
+	switches, completed := collectTransferEvents(evts)
+	require.Len(t, switches, 2, "entry and return AgentSwitching events must be emitted")
+	assert.True(t, switches[0].Switching)
+	assert.Equal(t, "root", switches[0].FromAgent)
+	assert.Equal(t, "librarian", switches[0].ToAgent)
+	assert.False(t, switches[1].Switching)
+	assert.Equal(t, "librarian", switches[1].FromAgent)
+	assert.Equal(t, "root", switches[1].ToAgent)
+	require.NotNil(t, completed)
+	assert.Equal(t, "root", completed.GetAgentName())
+}
+
+// TestTransferTask_ConcurrentPinnedNestedTransfersStayIsolated runs two
+// nested transfers from two pinned background sessions concurrently. Each
+// child must execute as its own target via session pinning, with the shared
+// current agent never leaving root — the corruption mode before the fix,
+// where each transfer swapped the shared field and could misroute the other
+// (and any foreground) session's agent resolution.
+func TestTransferTask_ConcurrentPinnedNestedTransfersStayIsolated(t *testing.T) {
+	t.Parallel()
+
+	var rt *LocalRuntime
+	var mu sync.Mutex
+	var observed []string
+	record := func() {
+		mu.Lock()
+		defer mu.Unlock()
+		observed = append(observed, rt.CurrentAgent().Name())
+	}
+
+	root := agent.New("root", "Root agent", agent.WithModel(&mockProvider{id: "test/mock-model", stream: &mockStream{}}))
+	newWorker := func(name string, helper *agent.Agent) *agent.Agent {
+		stream := newStreamBuilder().AddContent(name+" done").AddStopWithUsage(10, 5).Build()
+		w := agent.New(name, "Worker agent", agent.WithModel(&mockProvider{id: "test/mock-model", stream: stream}))
+		agent.WithSubAgents(helper)(w)
+		return w
+	}
+	helperA := probeAgent("helperA", "helperA done", record)
+	helperB := probeAgent("helperB", "helperB done", record)
+	workerA := newWorker("workerA", helperA)
+	workerB := newWorker("workerB", helperB)
+	agent.WithSubAgents(workerA, workerB)(root)
+
+	tm := team.New(team.WithAgents(root, workerA, workerB, helperA, helperB))
+	var err error
+	rt, err = NewLocalRuntime(t.Context(), tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStore{}),
+	)
+	require.NoError(t, err)
+
+	spawn := func(workerName string) *session.Session {
+		p := session.New(session.WithUserMessage("Test"), session.WithToolsApproved(true))
+		res := rt.RunAgent(t.Context(), agenttool.RunParams{
+			AgentName:     workerName,
+			Task:          "background work",
+			ParentSession: p,
+		})
+		require.Empty(t, res.ErrMsg)
+		child := firstSubSession(p)
+		require.NotNil(t, child)
+		return child
+	}
+	childA := spawn("workerA")
+	childB := spawn("workerB")
+
+	type transferOutcome struct {
+		result *tools.ToolCallResult
+		err    error
+		evts   chan Event
+	}
+	run := func(child *session.Session, target string) chan transferOutcome {
+		out := make(chan transferOutcome, 1)
+		go func() {
+			evts := make(chan Event, 128)
+			result, err := rt.handleTaskTransfer(t.Context(), child, transferToolCall(target), NewChannelSink(evts))
+			out <- transferOutcome{result: result, err: err, evts: evts}
+		}()
+		return out
+	}
+	outA := run(childA, "helperA")
+	outB := run(childB, "helperB")
+	a := <-outA
+	b := <-outB
+
+	require.NoError(t, a.err)
+	require.NotNil(t, a.result)
+	require.False(t, a.result.IsError, "workerA's transfer must succeed: %s", a.result.Output)
+	assert.Equal(t, "helperA done", a.result.Output)
+	require.NoError(t, b.err)
+	require.NotNil(t, b.result)
+	require.False(t, b.result.IsError, "workerB's transfer must succeed: %s", b.result.Output)
+	assert.Equal(t, "helperB done", b.result.Output)
+
+	mu.Lock()
+	assert.Equal(t, []string{"root", "root"}, observed,
+		"neither concurrent pinned transfer may mutate the shared current agent")
+	mu.Unlock()
+	assert.Equal(t, "root", rt.CurrentAgent().Name())
+
+	grandA := firstSubSession(childA)
+	require.NotNil(t, grandA)
+	assert.Equal(t, "helperA", grandA.AgentName)
+	grandB := firstSubSession(childB)
+	require.NotNil(t, grandB)
+	assert.Equal(t, "helperB", grandB.AgentName)
+
+	switchesA, completedA := collectTransferEvents(a.evts)
+	assert.Empty(t, switchesA, "pinned transfers must not emit AgentSwitching events")
+	require.NotNil(t, completedA)
+	assert.Equal(t, "workerA", completedA.GetAgentName())
+	switchesB, completedB := collectTransferEvents(b.evts)
+	assert.Empty(t, switchesB, "pinned transfers must not emit AgentSwitching events")
+	require.NotNil(t, completedB)
+	assert.Equal(t, "workerB", completedB.GetAgentName())
+}
+
+func TestTransferTask_DepthBoundary(t *testing.T) {
+	t.Parallel()
+
+	childStream := newStreamBuilder().AddContent("done").AddStopWithUsage(10, 5).Build()
+	librarian := agent.New("librarian", "Library agent", agent.WithModel(&mockProvider{id: "test/mock-model", stream: childStream}))
+	root := agent.New("root", "Root agent", agent.WithModel(&mockProvider{id: "test/mock-model", stream: &mockStream{}}))
+	agent.WithSubAgents(librarian)(root)
+
+	tm := team.New(team.WithAgents(root, librarian))
+	rt, err := NewLocalRuntime(t.Context(), tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStore{}),
+	)
+	require.NoError(t, err)
+
+	t.Run("allows exactly the maximum depth", func(t *testing.T) {
+		sess := session.New(
+			session.WithUserMessage("Test"),
+			session.WithDelegationLineage(ancestorNames(maxDelegationDepth-1)),
+		)
+		evts := make(chan Event, 128)
+
+		result, err := rt.handleTaskTransfer(t.Context(), sess, transferToolCall("librarian"), NewChannelSink(evts))
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.False(t, result.IsError, "delegation at the maximum depth must be allowed: %s", result.Output)
+
+		child := firstSubSession(sess)
+		require.NotNil(t, child)
+		assert.Len(t, child.DelegationLineage, maxDelegationDepth)
+	})
+
+	t.Run("rejects one edge past the maximum", func(t *testing.T) {
+		sess := session.New(
+			session.WithUserMessage("Test"),
+			session.WithDelegationLineage(ancestorNames(maxDelegationDepth)),
+		)
+		evts := make(chan Event, 128)
+
+		result, err := rt.handleTaskTransfer(t.Context(), sess, transferToolCall("librarian"), NewChannelSink(evts))
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.True(t, result.IsError)
+		assert.Contains(t, result.Output, "delegation depth limit exceeded")
+		assert.Contains(t, result.Output, fmt.Sprintf("reach depth %d", maxDelegationDepth+1))
+		assert.Contains(t, result.Output, fmt.Sprintf("maximum of %d", maxDelegationDepth))
+		assert.Nil(t, firstSubSession(sess), "rejected delegation must not attach a child session")
+	})
+}
+
+func TestRunAgent_RejectsDelegationCycle(t *testing.T) {
+	t.Parallel()
+
+	workerStream := newStreamBuilder().AddContent("done").AddStopWithUsage(10, 5).Build()
+	worker := agent.New("worker", "Worker agent", agent.WithModel(&mockProvider{id: "test/mock-model", stream: workerStream}))
+	root := agent.New("root", "Root agent", agent.WithModel(&mockProvider{id: "test/mock-model", stream: &mockStream{}}))
+	agent.WithSubAgents(worker)(root)
+	agent.WithSubAgents(root)(worker)
+
+	tm := team.New(team.WithAgents(root, worker))
+	rt, err := NewLocalRuntime(t.Context(), tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStore{}),
+	)
+	require.NoError(t, err)
+
+	parent := session.New(session.WithUserMessage("Test"))
+	res := rt.RunAgent(t.Context(), agenttool.RunParams{
+		AgentName:     "worker",
+		Task:          "background work",
+		ParentSession: parent,
+	})
+	require.Empty(t, res.ErrMsg)
+
+	child := firstSubSession(parent)
+	require.NotNil(t, child)
+	assert.Equal(t, []string{"root"}, child.DelegationLineage)
+
+	// Delegating back to an ancestor from the background child must fail
+	// before any child session is spawned.
+	res = rt.RunAgent(t.Context(), agenttool.RunParams{
+		AgentName:     "root",
+		Task:          "loop back",
+		ParentSession: child,
+	})
+	assert.Contains(t, res.ErrMsg, "delegation cycle detected")
+	assert.Contains(t, res.ErrMsg, "root -> worker -> root")
+	assert.Nil(t, firstSubSession(child), "rejected delegation must not attach a child session")
+}
+
+// TestRunAgent_NestedAcyclicDelegation verifies that a background agent can
+// itself dispatch a background agent, and that the caller resolves from the
+// pinned parent session: with the shared current agent (root) the grandchild
+// lineage would be [root root] instead of [root worker].
+func TestRunAgent_NestedAcyclicDelegation(t *testing.T) {
+	t.Parallel()
+
+	workerStream := newStreamBuilder().AddContent("worker done").AddStopWithUsage(10, 5).Build()
+	helperStream := newStreamBuilder().AddContent("helper done").AddStopWithUsage(10, 5).Build()
+
+	root := agent.New("root", "Root agent", agent.WithModel(&mockProvider{id: "test/mock-model", stream: &mockStream{}}))
+	worker := agent.New("worker", "Worker agent", agent.WithModel(&mockProvider{id: "test/mock-model", stream: workerStream}))
+	helper := agent.New("helper", "Helper agent", agent.WithModel(&mockProvider{id: "test/mock-model", stream: helperStream}))
+	agent.WithSubAgents(worker)(root)
+	agent.WithSubAgents(helper)(worker)
+
+	tm := team.New(team.WithAgents(root, worker, helper))
+	rt, err := NewLocalRuntime(t.Context(), tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStore{}),
+	)
+	require.NoError(t, err)
+
+	parent := session.New(session.WithUserMessage("Test"))
+	res := rt.RunAgent(t.Context(), agenttool.RunParams{
+		AgentName:     "worker",
+		Task:          "background work",
+		ParentSession: parent,
+	})
+	require.Empty(t, res.ErrMsg)
+
+	child := firstSubSession(parent)
+	require.NotNil(t, child)
+
+	res = rt.RunAgent(t.Context(), agenttool.RunParams{
+		AgentName:     "helper",
+		Task:          "nested background work",
+		ParentSession: child,
+	})
+	require.Empty(t, res.ErrMsg, "acyclic nested background delegation must stay supported")
+
+	grandchild := firstSubSession(child)
+	require.NotNil(t, grandchild)
+	assert.Equal(t, "helper", grandchild.AgentName)
+	assert.Equal(t, []string{"root", "worker"}, grandchild.DelegationLineage,
+		"caller must resolve from the pinned parent session, not the shared current agent")
+	assert.Equal(t, []string{"root"}, child.DelegationLineage)
+}
+
+// TestRunAgent_NestedBackgroundSubagentStopFiresOnPinnedCaller covers hook
+// attribution for nested background → background delegation: when a pinned
+// worker session dispatches run_background_agent to helper, the subagent_stop
+// hook belongs to the pinned caller (worker), not to whatever the shared
+// current agent points at (root). Before the fix, runCollecting's deferred
+// hook used r.CurrentAgent(), so root's hook received the helper completion
+// and worker's never fired.
+//
+// In production the nested dispatch reaches the Runner entry (RunAgent) on a
+// detached goroutine owned by the run_background_agent handler; calling
+// rt.RunAgent synchronously here drives the exact same entry point and hook
+// path without the goroutine indirection.
+func TestRunAgent_NestedBackgroundSubagentStopFiresOnPinnedCaller(t *testing.T) {
+	t.Parallel()
+
+	workerStream := newStreamBuilder().AddContent("worker done").AddStopWithUsage(10, 5).Build()
+	helperStream := newStreamBuilder().AddContent("helper done").AddStopWithUsage(10, 5).Build()
+
+	root := agent.New("root", "Root agent",
+		agent.WithModel(&mockProvider{id: "test/mock-model", stream: &mockStream{}}),
+		agent.WithHooks(&hooks.Config{
+			SubagentStop: []hooks.Hook{{Type: hooks.HookTypeBuiltin, Command: "test_record_subagent_stop_root"}},
+		}),
+	)
+	worker := agent.New("worker", "Worker agent",
+		agent.WithModel(&mockProvider{id: "test/mock-model", stream: workerStream}),
+		agent.WithHooks(&hooks.Config{
+			SubagentStop: []hooks.Hook{{Type: hooks.HookTypeBuiltin, Command: "test_record_subagent_stop_worker"}},
+		}),
+	)
+	helper := agent.New("helper", "Helper agent", agent.WithModel(&mockProvider{id: "test/mock-model", stream: helperStream}))
+	agent.WithSubAgents(worker)(root)
+	agent.WithSubAgents(helper)(worker)
+
+	tm := team.New(team.WithAgents(root, worker, helper))
+	rt, err := NewLocalRuntime(t.Context(), tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStore{}),
+	)
+	require.NoError(t, err)
+
+	rbRoot := &recordingBuiltin{}
+	rbWorker := &recordingBuiltin{}
+	require.NoError(t, rt.hooksRegistry.RegisterBuiltin("test_record_subagent_stop_root", rbRoot.hook))
+	require.NoError(t, rt.hooksRegistry.RegisterBuiltin("test_record_subagent_stop_worker", rbWorker.hook))
+	rt.buildHooksExecutors()
+
+	parent := session.New(session.WithUserMessage("Test"))
+	res := rt.RunAgent(t.Context(), agenttool.RunParams{
+		AgentName:     "worker",
+		Task:          "background work",
+		ParentSession: parent,
+	})
+	require.Empty(t, res.ErrMsg)
+
+	child := firstSubSession(parent)
+	require.NotNil(t, child)
+	require.Equal(t, "worker", child.AgentName, "background child session must be pinned")
+
+	res = rt.RunAgent(t.Context(), agenttool.RunParams{
+		AgentName:     "helper",
+		Task:          "nested background work",
+		ParentSession: child,
+	})
+	require.Empty(t, res.ErrMsg)
+
+	grandchild := firstSubSession(child)
+	require.NotNil(t, grandchild)
+
+	workerStops := rbWorker.snapshot()
+	require.Len(t, workerStops, 1, "worker's subagent_stop hook must fire exactly once for the nested completion")
+	assert.Equal(t, "helper", workerStops[0].AgentName)
+	assert.Equal(t, child.ID, workerStops[0].ParentSessionID)
+	assert.Equal(t, grandchild.ID, workerStops[0].SessionID)
+	assert.Equal(t, "helper done", workerStops[0].StopResponse)
+
+	// Root's hook sees only its own direct child (the first, unpinned
+	// dispatch resolves to the shared current agent, root); the nested
+	// helper completion must not reach it.
+	rootStops := rbRoot.snapshot()
+	require.Len(t, rootStops, 1, "root's subagent_stop hook must not receive the nested helper completion")
+	assert.Equal(t, "worker", rootStops[0].AgentName)
+	assert.Equal(t, parent.ID, rootStops[0].ParentSessionID)
+	assert.Equal(t, child.ID, rootStops[0].SessionID)
+	assert.Equal(t, "worker done", rootStops[0].StopResponse)
+}
+
+func TestRunAgent_DepthBoundary(t *testing.T) {
+	t.Parallel()
+
+	workerStream := newStreamBuilder().AddContent("done").AddStopWithUsage(10, 5).Build()
+	worker := agent.New("worker", "Worker agent", agent.WithModel(&mockProvider{id: "test/mock-model", stream: workerStream}))
+	root := agent.New("root", "Root agent", agent.WithModel(&mockProvider{id: "test/mock-model", stream: &mockStream{}}))
+	agent.WithSubAgents(worker)(root)
+
+	tm := team.New(team.WithAgents(root, worker))
+	rt, err := NewLocalRuntime(t.Context(), tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStore{}),
+	)
+	require.NoError(t, err)
+
+	t.Run("allows exactly the maximum depth", func(t *testing.T) {
+		parent := session.New(
+			session.WithUserMessage("Test"),
+			session.WithDelegationLineage(ancestorNames(maxDelegationDepth-1)),
+		)
+		res := rt.RunAgent(t.Context(), agenttool.RunParams{
+			AgentName:     "worker",
+			Task:          "deep work",
+			ParentSession: parent,
+		})
+		require.Empty(t, res.ErrMsg, "delegation at the maximum depth must be allowed")
+
+		child := firstSubSession(parent)
+		require.NotNil(t, child)
+		assert.Len(t, child.DelegationLineage, maxDelegationDepth)
+	})
+
+	t.Run("rejects one edge past the maximum", func(t *testing.T) {
+		parent := session.New(
+			session.WithUserMessage("Test"),
+			session.WithDelegationLineage(ancestorNames(maxDelegationDepth)),
+		)
+		res := rt.RunAgent(t.Context(), agenttool.RunParams{
+			AgentName:     "worker",
+			Task:          "too deep",
+			ParentSession: parent,
+		})
+		assert.Contains(t, res.ErrMsg, "delegation depth limit exceeded")
+		assert.Contains(t, res.ErrMsg, fmt.Sprintf("reach depth %d", maxDelegationDepth+1))
+		assert.Contains(t, res.ErrMsg, fmt.Sprintf("maximum of %d", maxDelegationDepth))
+		assert.Nil(t, firstSubSession(parent), "rejected delegation must not attach a child session")
+	})
+}
+
+// enqueue appends scripted streams to the provider after construction. Used
+// when a later turn's arguments are only known mid-test (e.g. a dynamic
+// background task ID parsed from an earlier tool result). Safe to call
+// concurrently with CreateChatCompletionStream.
+func (p *queueProvider) enqueue(streams ...chat.MessageStream) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.streams = append(p.streams, streams...)
+}
+
+// toolResultContent returns the recorded tool result for the given tool call
+// ID from the session's own messages, failing the test when absent.
+func toolResultContent(t *testing.T, sess *session.Session, toolCallID string) string {
+	t.Helper()
+	for _, m := range sess.OwnMessages() {
+		if m.Message.Role == chat.MessageRoleTool && m.Message.ToolCallID == toolCallID {
+			return m.Message.Content
+		}
+	}
+	t.Fatalf("no tool result recorded for tool call %q", toolCallID)
+	return ""
+}
+
+// parseBackgroundTaskID extracts the dynamic task ID from a
+// run_background_agent tool result.
+func parseBackgroundTaskID(t *testing.T, dispatchOutput string) string {
+	t.Helper()
+	const marker = "Background agent task started with ID: "
+	_, rest, ok := strings.Cut(dispatchOutput, marker)
+	require.True(t, ok, "dispatch result must announce the task ID, got: %s", dispatchOutput)
+	id, _, _ := strings.Cut(rest, "\n")
+	id = strings.TrimSpace(id)
+	require.NotEmpty(t, id, "task ID must not be empty")
+	return id
+}
+
+// TestRunStream_NestedBackgroundAgents_EndToEnd is the true asynchronous
+// end-to-end regression test for #3904/#3886. Unlike the tests above, it
+// never calls RunAgent or handleTaskTransfer directly: root is driven
+// through rt.Run, so its model's run_background_agent tool call dispatches
+// through r.toolMap into the real agenttool.Handler.HandleRun, which returns
+// a task ID immediately and runs the worker on the real detached goroutine.
+// Inside that detached RunStream the worker's model again calls
+// run_background_agent (nested background → background), and root later
+// inspects completion through the real list/view handlers via further model
+// tool calls.
+//
+// This runtime integration test qualifies as end-to-end because it executes
+// the entire production async path — model stream → tool dispatch →
+// HandleRun → detached goroutine → nested HandleRun → task bookkeeping →
+// polling handlers — in one process with no external network; only the model
+// providers are scripted.
+//
+// Synchronisation is deterministic: subagent_stop hook channels gate the
+// worker's final turn and the test's own progress, and task completion is
+// awaited by polling the real registered list_background_agents handler
+// under a bounded deadline. No arbitrary sleeps.
+func TestRunStream_NestedBackgroundAgents_EndToEnd(t *testing.T) {
+	t.Parallel()
+
+	// helperDrained closes when worker's subagent_stop hook fires (the
+	// nested helper sub-session fully drained); it gates worker's final
+	// turn. workerDrained closes when root's subagent_stop hook fires (the
+	// worker sub-session fully drained); it gates the test's progress.
+	helperDrained := make(chan struct{})
+	workerDrained := make(chan struct{})
+
+	rootProv := &queueProvider{id: "test/mock-model", streams: []chat.MessageStream{
+		newStreamBuilder().
+			AddToolCallName("call_run_worker", agenttool.ToolNameRunBackgroundAgent).
+			AddToolCallArguments("call_run_worker", `{"agent":"worker","task":"do the background work"}`).
+			AddToolCallStopWithUsage(10, 5).
+			Build(),
+		newStreamBuilder().AddContent("dispatched worker").AddStopWithUsage(10, 5).Build(),
+	}}
+	// The release gate makes worker's final turn wait until the nested
+	// helper task has drained — a deterministic stand-in for the "poll
+	// until done" turns a real model would issue.
+	workerProv := &stepProvider{id: "test/mock-model", steps: []providerStep{
+		{stream: newStreamBuilder().
+			AddToolCallName("call_run_helper", agenttool.ToolNameRunBackgroundAgent).
+			AddToolCallArguments("call_run_helper", `{"agent":"helper","task":"do the nested work"}`).
+			AddToolCallStopWithUsage(10, 5).
+			Build()},
+		{release: helperDrained, stream: newStreamBuilder().AddContent("worker done").AddStopWithUsage(10, 5).Build()},
+	}}
+	helperProv := &mockProvider{
+		id:     "test/mock-model",
+		stream: newStreamBuilder().AddContent("nested helper done").AddStopWithUsage(10, 5).Build(),
+	}
+
+	helper := agent.New("helper", "Helper agent", agent.WithModel(helperProv))
+	// helper is reachable only from worker: the nested dispatch can only
+	// succeed when HandleRun validates the target against the pinned
+	// caller (worker), not the shared current agent (root) — #3886.
+	worker := agent.New("worker", "Worker agent",
+		agent.WithModel(workerProv),
+		agent.WithSubAgents(helper),
+		agent.WithToolSets(agenttool.New()),
+		agent.WithHooks(&hooks.Config{
+			SubagentStop: []hooks.Hook{{Type: hooks.HookTypeBuiltin, Command: "test_signal_worker_subagent_stop"}},
+		}),
+	)
+	root := agent.New("root", "Root agent",
+		agent.WithModel(rootProv),
+		agent.WithSubAgents(worker),
+		agent.WithToolSets(agenttool.New()),
+		agent.WithHooks(&hooks.Config{
+			SubagentStop: []hooks.Hook{{Type: hooks.HookTypeBuiltin, Command: "test_signal_root_subagent_stop"}},
+		}),
+	)
+
+	tm := team.New(team.WithAgents(root, worker, helper))
+	rt, err := NewLocalRuntime(t.Context(), tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStore{}),
+	)
+	require.NoError(t, err)
+	// StopAll cancels and waits for detached task goroutines, so they
+	// cannot leak past the test even on a failure path.
+	t.Cleanup(func() { _ = rt.Close() })
+
+	rbRoot := &recordingBuiltin{}
+	rbWorker := &recordingBuiltin{}
+	var rootOnce, workerOnce sync.Once
+	require.NoError(t, rt.hooksRegistry.RegisterBuiltin("test_signal_root_subagent_stop",
+		func(ctx context.Context, in *hooks.Input, args []string) (*hooks.Output, error) {
+			out, err := rbRoot.hook(ctx, in, args)
+			rootOnce.Do(func() { close(workerDrained) })
+			return out, err
+		}))
+	require.NoError(t, rt.hooksRegistry.RegisterBuiltin("test_signal_worker_subagent_stop",
+		func(ctx context.Context, in *hooks.Input, args []string) (*hooks.Output, error) {
+			out, err := rbWorker.hook(ctx, in, args)
+			workerOnce.Do(func() { close(helperDrained) })
+			return out, err
+		}))
+	rt.buildHooksExecutors()
+
+	sess := session.New(session.WithUserMessage("dispatch the worker"), session.WithToolsApproved(true))
+
+	// Turn 1: root's model dispatches the worker. HandleRun must return a
+	// task ID immediately while the worker runs detached.
+	_, err = rt.Run(t.Context(), sess)
+	require.NoError(t, err)
+
+	dispatchOut := toolResultContent(t, sess, "call_run_worker")
+	require.Contains(t, dispatchOut, "Background agent task started with ID: ",
+		"run_background_agent must return a task ID immediately (async dispatch)")
+	taskID := parseBackgroundTaskID(t, dispatchOut)
+
+	// The whole nested chain runs on detached goroutines that never touch
+	// the runtime's shared current agent.
+	waitClosed(t, workerDrained, "worker background task to drain")
+	assert.Equal(t, "root", rt.CurrentAgent().Name(),
+		"shared current agent must remain root while background tasks run")
+
+	// The subagent_stop hooks fire just before HandleRun's goroutines mark
+	// their tasks completed, so await both terminal statuses through the
+	// real registered list handler (bounded, no fixed sleep budget).
+	listHandler := rt.toolMap[agenttool.ToolNameListBackgroundAgents]
+	require.NotNil(t, listHandler, "list_background_agents must be registered on the runtime tool map")
+	listCall := tools.ToolCall{
+		ID:       "call_list_poll",
+		Type:     "function",
+		Function: tools.FunctionCall{Name: agenttool.ToolNameListBackgroundAgents},
+	}
+	var listOut string
+	require.Eventually(t, func() bool {
+		res, err := listHandler(t.Context(), sess, listCall, NewChannelSink(make(chan Event, 4)))
+		if err != nil {
+			return false
+		}
+		listOut = res.Output
+		return strings.Count(listOut, "Status:  completed") == 2
+	}, 20*time.Second, time.Millisecond,
+		"both background tasks must reach completed status via the real list handler")
+	// Both the root-dispatched worker task and the worker-dispatched helper
+	// task live in the same real handler.
+	assert.Contains(t, listOut, "Agent:   worker")
+	assert.Contains(t, listOut, "Agent:   helper")
+	assert.Contains(t, listOut, taskID)
+
+	// Turn 2: root's model inspects the finished task through the real
+	// view handler; the task ID is dynamic, parsed from turn 1's result.
+	rootProv.enqueue(
+		newStreamBuilder().
+			AddToolCallName("call_view_worker", agenttool.ToolNameViewBackgroundAgent).
+			AddToolCallArguments("call_view_worker", fmt.Sprintf(`{"task_id":%q}`, taskID)).
+			AddToolCallStopWithUsage(10, 5).
+			Build(),
+		newStreamBuilder().AddContent("background check complete").AddStopWithUsage(10, 5).Build(),
+	)
+	sess.AddMessage(session.UserMessage("check on the background task"))
+	_, err = rt.Run(t.Context(), sess)
+	require.NoError(t, err)
+
+	viewOut := toolResultContent(t, sess, "call_view_worker")
+	assert.Contains(t, viewOut, taskID)
+	assert.Contains(t, viewOut, "Status:  completed", "the worker task must be completed")
+	assert.Contains(t, viewOut, "worker done", "the worker's final output must be visible through view_background_agent")
+
+	// Session structure: root → worker (pinned child) → helper (pinned
+	// grandchild), with delegation lineage recorded per edge.
+	child := firstSubSession(sess)
+	require.NotNil(t, child, "root session must carry the worker sub-session")
+	assert.Equal(t, "worker", child.AgentName, "background child session must be pinned to worker")
+	assert.Equal(t, []string{"root"}, child.DelegationLineage)
+	assert.Equal(t, "worker done", child.GetLastAssistantMessageContent())
+
+	grandchild := firstSubSession(child)
+	require.NotNil(t, grandchild, "worker session must carry the nested helper sub-session")
+	assert.Equal(t, "helper", grandchild.AgentName, "nested background grandchild must be pinned to helper")
+	assert.Equal(t, []string{"root", "worker"}, grandchild.DelegationLineage)
+	assert.Equal(t, "nested helper done", grandchild.GetLastAssistantMessageContent())
+
+	// Hook attribution: the nested helper completion belongs to worker (the
+	// pinned caller), the worker completion to root.
+	workerStops := rbWorker.snapshot()
+	require.Len(t, workerStops, 1, "worker's subagent_stop hook must fire exactly once")
+	assert.Equal(t, "helper", workerStops[0].AgentName)
+	assert.Equal(t, child.ID, workerStops[0].ParentSessionID)
+	assert.Equal(t, grandchild.ID, workerStops[0].SessionID)
+	assert.Equal(t, "nested helper done", workerStops[0].StopResponse)
+
+	rootStops := rbRoot.snapshot()
+	require.Len(t, rootStops, 1, "root's subagent_stop hook must fire exactly once")
+	assert.Equal(t, "worker", rootStops[0].AgentName)
+	assert.Equal(t, sess.ID, rootStops[0].ParentSessionID)
+	assert.Equal(t, child.ID, rootStops[0].SessionID)
+	assert.Equal(t, "worker done", rootStops[0].StopResponse)
+
+	assert.Equal(t, "root", rt.CurrentAgent().Name(),
+		"the shared current agent must still be root after the whole chain")
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1296,7 +1296,14 @@ func (r *LocalRuntime) resolveSessionAgent(sess *session.Session) *agent.Agent {
 
 // CurrentAgentSkillsToolset returns the skills toolset for the current agent, or nil if not enabled.
 func (r *LocalRuntime) CurrentAgentSkillsToolset() *skills.ToolSet {
-	a := r.CurrentAgent()
+	return agentSkillsToolset(r.CurrentAgent())
+}
+
+// agentSkillsToolset returns the skills toolset configured on a, or nil if
+// a is nil or has none. Session-aware callers (e.g. RunSkillFork) use it
+// directly so a pinned session's agent is honoured instead of the shared
+// current agent.
+func agentSkillsToolset(a *agent.Agent) *skills.ToolSet {
 	if a == nil {
 		return nil
 	}

--- a/pkg/runtime/skill_runner.go
+++ b/pkg/runtime/skill_runner.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -30,17 +31,25 @@ func (r *LocalRuntime) handleRunSkill(ctx context.Context, sess *session.Session
 // agent's own system prompt is preserved. Shared by the run_skill tool
 // and the App's slash-command path.
 func (r *LocalRuntime) RunSkillFork(ctx context.Context, sess *session.Session, args skills.RunSkillArgs, evts EventSink) (*tools.ToolCallResult, error) {
-	st := r.CurrentAgentSkillsToolset()
+	// The caller resolves from the session, not the shared current agent:
+	// a fork skill invoked from a pinned background session must use the
+	// pinned agent's skills, identity, and model override, no matter where
+	// the concurrent foreground loop points (#3886).
+	caller := r.resolveSessionAgent(sess)
+	if caller == nil {
+		return nil, errors.New("no agent resolved for the calling session")
+	}
+	ca := caller.Name()
+
+	st := agentSkillsToolset(caller)
 	if st == nil {
-		return tools.ResultError("no skills are available for the current agent"), nil
+		return tools.ResultError("no skills are available for agent " + ca), nil
 	}
 
 	prepared, errResult := st.PrepareForkSubSession(ctx, args)
 	if errResult != nil {
 		return errResult, nil
 	}
-
-	ca := r.currentAgentName()
 
 	// Open the span before any pre-delegation work so model resolution
 	// (inside WithAgentModel) is recorded under runtime.run_skill rather
@@ -101,7 +110,11 @@ func (r *LocalRuntime) RunSkillFork(ctx context.Context, sess *session.Session, 
 	}
 
 	// Skills are sub-sessions of the caller, not delegations, so the
-	// runtime's currentAgent stays put.
+	// runtime's currentAgent stays put and the delegation lineage is
+	// inherited unchanged (no DelegationLineage: not a delegation edge).
+	// When the caller session is itself pinned (a background agent's
+	// session), pin the child to the same agent so RunStream resolves it
+	// as the pinned caller instead of the shared current agent.
 	return r.runForwarding(ctx, sess, evts, delegationRequest{
 		SubSessionConfig: SubSessionConfig{
 			Task:                prepared.Task,
@@ -113,6 +126,7 @@ func (r *LocalRuntime) RunSkillFork(ctx context.Context, sess *session.Session, 
 			SafetyPolicy:        sess.GetSafetyPolicy(),
 			Permissions:         sess.ClonePermissions(),
 			NonInteractive:      sess.NonInteractive,
+			PinAgent:            sess.AgentName != "",
 			ExcludedTools:       []string{skills.ToolNameRunSkill},
 			AllowedTools:        prepared.AllowedTools,
 			ExtraToolSets:       prepared.ToolSets,

--- a/pkg/runtime/skill_runner_test.go
+++ b/pkg/runtime/skill_runner_test.go
@@ -1,0 +1,105 @@
+package runtime
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/docker/docker-agent/pkg/agent"
+	"github.com/docker/docker-agent/pkg/chat"
+	"github.com/docker/docker-agent/pkg/session"
+	"github.com/docker/docker-agent/pkg/skills"
+	"github.com/docker/docker-agent/pkg/team"
+	skillstool "github.com/docker/docker-agent/pkg/tools/builtin/skills"
+)
+
+// TestRunSkillFork_PinnedSessionRunsAsPinnedAgent covers fork-mode skills
+// invoked from a pinned background session (#3886): the skill lookup, the
+// child's identity, and its execution must all resolve from the session's
+// pinned agent (worker), never from the shared current agent (root), and
+// the shared current agent must stay untouched while the skill child runs.
+//
+// The pinned session mirrors what RunAgent produces for a background
+// delegation root -> worker (pinned to worker, lineage [root]); it is
+// constructed directly so worker's scripted provider streams are consumed
+// by the skill child alone.
+func TestRunSkillFork_PinnedSessionRunsAsPinnedAgent(t *testing.T) {
+	t.Parallel()
+
+	var rt *LocalRuntime
+	var mu sync.Mutex
+	var observed []string
+	record := func() {
+		mu.Lock()
+		defer mu.Unlock()
+		observed = append(observed, rt.CurrentAgent().Name())
+	}
+
+	// The fork skill is inline (body served from memory), so the test
+	// needs no filesystem or command expansion.
+	skillTS := skillstool.New([]skills.Skill{{
+		Name:          "greet",
+		Description:   "Greets the user",
+		Context:       "fork",
+		InlineContent: "# Greet\nSay the greeting.",
+	}}, "")
+
+	// Only worker has the skills toolset. Its provider first makes a
+	// probe tool call (recording the shared current agent mid-run), then
+	// answers: receiving that answer proves the skill child executed on
+	// worker's provider, i.e. as the pinned agent.
+	workerProv := &queueProvider{id: "test/mock-model", streams: []chat.MessageStream{
+		newStreamBuilder().AddToolCallWithStop("call_probe", "probe", "{}").Build(),
+		newStreamBuilder().AddContent("worker skill done").AddStopWithUsage(10, 5).Build(),
+	}}
+	worker := agent.New("worker", "Worker agent",
+		agent.WithModel(workerProv),
+		agent.WithToolSets(skillTS, newStubToolSet(nil, probeTool(record), nil)),
+	)
+	root := agent.New("root", "Root agent", agent.WithModel(&mockProvider{id: "test/mock-model", stream: &mockStream{}}))
+	agent.WithSubAgents(worker)(root)
+
+	tm := team.New(team.WithAgents(root, worker))
+	var err error
+	rt, err = NewLocalRuntime(t.Context(), tm,
+		WithSessionCompaction(false),
+		WithModelStore(mockModelStore{}),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "root", rt.CurrentAgent().Name(), "shared current agent starts at root")
+
+	sess := session.New(
+		session.WithUserMessage("Test"),
+		session.WithToolsApproved(true),
+		session.WithAgentName("worker"),
+		session.WithDelegationLineage([]string{"root"}),
+	)
+
+	evts := make(chan Event, 128)
+	result, err := rt.RunSkillFork(t.Context(), sess,
+		skillstool.RunSkillArgs{Name: "greet", Task: "greet the user"}, NewChannelSink(evts))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.IsError, "fork skill from a pinned session must succeed: %s", result.Output)
+	assert.Equal(t, "worker skill done", result.Output, "the skill child must execute as the pinned caller")
+
+	mu.Lock()
+	assert.Equal(t, []string{"root"}, observed,
+		"the shared current agent must stay root while the pinned skill child runs")
+	mu.Unlock()
+	assert.Equal(t, "root", rt.CurrentAgent().Name(), "the shared current agent must remain root afterwards")
+
+	child := firstSubSession(sess)
+	require.NotNil(t, child)
+	assert.Equal(t, "worker", child.AgentName, "the skill child must be pinned to the pinned caller")
+	assert.Equal(t, []string{"root"}, child.DelegationLineage,
+		"skills are not delegation edges: lineage must be inherited unchanged, not incremented")
+
+	switches, completed := collectTransferEvents(evts)
+	assert.Empty(t, switches, "a pinned skill fork must not emit AgentSwitching events")
+	require.NotNil(t, completed)
+	assert.Equal(t, "worker", completed.GetAgentName(),
+		"SubSessionCompleted must be attributed to the pinned caller")
+}

--- a/pkg/session/branch.go
+++ b/pkg/session/branch.go
@@ -108,6 +108,7 @@ func (s *Session) Clone() *Session {
 		ExtraToolSets:           slices.Clone(s.ExtraToolSets),
 		AgentName:               s.AgentName,
 		ParentID:                s.ParentID,
+		DelegationLineage:       cloneStringSlice(s.DelegationLineage),
 		InstructionContext:      cloneInstructionContext(s.InstructionContext),
 		MessageUsageHistory:     slices.Clone(s.MessageUsageHistory),
 	}
@@ -204,6 +205,10 @@ func copySessionMetadata(dst, src *Session, title string) {
 	if src == nil || dst == nil {
 		return
 	}
+	// AgentName, ParentID, and DelegationLineage are deliberately not
+	// copied: a branch/fork is a fresh top-level session, not a pinned
+	// sub-session, so transient delegation state must not carry over.
+	// Clone() keeps them because it reproduces the session verbatim.
 	dst.SetTitle(title)
 	dst.ToolsApproved = src.ToolsApproved
 	dst.SafetyPolicy = src.SafetyPolicy

--- a/pkg/session/clone_test.go
+++ b/pkg/session/clone_test.go
@@ -41,6 +41,7 @@ func TestClone_CopiesScalarFields(t *testing.T) {
 		ExcludedTools:           []string{"run_skill"},
 		AgentName:               "root",
 		ParentID:                "parent",
+		DelegationLineage:       []string{"coordinator"},
 	}
 	orig.AddMessage(UserMessage("hello"))
 
@@ -64,6 +65,9 @@ func TestClone_CopiesScalarFields(t *testing.T) {
 	assert.InEpsilon(t, 1.5, clone.Cost, 1e-9)
 	assert.Equal(t, "root", clone.AgentName)
 	assert.Equal(t, "parent", clone.ParentID)
+	assert.Equal(t, []string{"coordinator"}, clone.DelegationLineage)
+	clone.DelegationLineage[0] = "mutated"
+	assert.Equal(t, []string{"coordinator"}, orig.DelegationLineage)
 	assert.Equal(t, "hello", clone.GetLastUserMessageContent())
 	require.NotNil(t, clone.Permissions)
 	assert.Equal(t, []string{"a"}, clone.Permissions.Allow)

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -369,6 +369,14 @@ type Session struct {
 	// within the parent session's Messages array.
 	ParentID string `json:"-"`
 
+	// DelegationLineage records the names of the agents that delegated,
+	// transitively, to produce this sub-session (root caller first), not
+	// including the agent running the session itself. The runtime uses it to
+	// reject delegation cycles and excessive nesting across transfer_task and
+	// run_background_agent. Not persisted: a restored session starts as a
+	// fresh delegation root.
+	DelegationLineage []string `json:"-"`
+
 	// InstructionContext keeps the cache-stable snapshot and chronological
 	// updates for dynamic system context.
 	InstructionContext *InstructionContextState `json:"instruction_context,omitempty"`
@@ -1237,6 +1245,15 @@ func (s *Session) AttachedFilesSnapshot() []string {
 	return slices.Clone(s.AttachedFiles)
 }
 
+// DelegationLineageSnapshot returns a copy of the session's delegation
+// lineage. Callers may freely mutate the returned slice without affecting
+// the session.
+func (s *Session) DelegationLineageSnapshot() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return slices.Clone(s.DelegationLineage)
+}
+
 type Opt func(s *Session)
 
 func WithUserMessage(content string) Opt {
@@ -1376,6 +1393,16 @@ func WithAgentName(name string) Opt {
 func WithParentID(parentID string) Opt {
 	return func(s *Session) {
 		s.ParentID = parentID
+	}
+}
+
+// WithDelegationLineage records the chain of agents that delegated to produce
+// this sub-session (root caller first, excluding the session's own agent).
+// The slice is cloned so the session never shares backing storage with the
+// caller — required for concurrent delegation fan-out from one parent.
+func WithDelegationLineage(names []string) Opt {
+	return func(s *Session) {
+		s.DelegationLineage = slices.Clone(names)
 	}
 }
 

--- a/pkg/tools/builtin/agent/agent.go
+++ b/pkg/tools/builtin/agent/agent.go
@@ -77,11 +77,29 @@ type RunResult struct {
 }
 
 // Runner abstracts the runtime dependency for background agent execution.
+//
+// Runners may additionally implement [SessionSubAgentResolver]; HandleRun
+// prefers it for target validation. The legacy CurrentAgentSubAgentNames
+// method stays required so existing out-of-tree Runner implementations
+// remain source-compatible.
 type Runner interface {
 	// CurrentAgentSubAgentNames returns the names of the current agent's sub-agents.
 	CurrentAgentSubAgentNames() []string
 	// RunAgent starts a sub-agent and blocks until completion or cancellation.
 	RunAgent(ctx context.Context, params RunParams) *RunResult
+}
+
+// SessionSubAgentResolver is an optional interface a [Runner] may implement
+// to resolve dispatchable sub-agents from the calling session instead of
+// shared current-agent state. A pinned background session resolves to its
+// pinned agent, so a nested run_background_agent dispatched from a detached
+// background task validates against the actual caller, not whatever the
+// concurrent foreground loop's current agent points at (#3886).
+// LocalRuntime implements it.
+type SessionSubAgentResolver interface {
+	// SubAgentNames returns the names of the sub-agents the given session's
+	// agent may dispatch to.
+	SubAgentNames(sess *session.Session) []string
 }
 
 // taskStatus represents the lifecycle state of a background agent task.
@@ -262,6 +280,19 @@ func (h *Handler) pruneCompleted() {
 	}
 }
 
+// subAgentNames resolves the sub-agents the calling session's agent may
+// dispatch to. The session-aware resolver is preferred when the Runner
+// implements it (LocalRuntime does, so nested background dispatch validates
+// against the pinned caller — #3886); the legacy shared current-agent method
+// is the compatibility fallback for Runners that predate
+// SessionSubAgentResolver.
+func (h *Handler) subAgentNames(sess *session.Session) []string {
+	if resolver, ok := h.runner.(SessionSubAgentResolver); ok {
+		return resolver.SubAgentNames(sess)
+	}
+	return h.runner.CurrentAgentSubAgentNames()
+}
+
 // HandleRun starts a sub-agent task asynchronously and returns a task ID immediately.
 func (h *Handler) HandleRun(ctx context.Context, sess *session.Session, toolCall tools.ToolCall) (*tools.ToolCallResult, error) {
 	var params RunBackgroundAgentArgs
@@ -276,7 +307,7 @@ func (h *Handler) HandleRun(ctx context.Context, sess *session.Session, toolCall
 		return tools.ResultError("task must not be empty"), nil
 	}
 
-	subAgentNames := h.runner.CurrentAgentSubAgentNames()
+	subAgentNames := h.subAgentNames(sess)
 	if !slices.Contains(subAgentNames, params.Agent) {
 		if len(subAgentNames) > 0 {
 			return tools.ResultError(fmt.Sprintf("agent %q is not in the sub-agents list. Available: %s", params.Agent, strings.Join(subAgentNames, ", "))), nil

--- a/pkg/tools/builtin/agent/agent_test.go
+++ b/pkg/tools/builtin/agent/agent_test.go
@@ -18,14 +18,32 @@ import (
 	"github.com/docker/docker-agent/pkg/tools"
 )
 
-// mockRunner implements Runner for testing.
+// mockRunner implements Runner plus the optional SessionSubAgentResolver,
+// mirroring production LocalRuntime which implements both.
 type mockRunner struct {
 	subAgentNames []string
 	runResult     *RunResult
 	runDelay      time.Duration // optional delay to simulate work
+
+	mu            sync.Mutex
+	validatedSess *session.Session // session SubAgentNames resolved against
+	legacyCalls   int              // CurrentAgentSubAgentNames invocations
 }
 
-func (m *mockRunner) CurrentAgentSubAgentNames() []string { return m.subAgentNames }
+func (m *mockRunner) CurrentAgentSubAgentNames() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.legacyCalls++
+	return m.subAgentNames
+}
+
+func (m *mockRunner) SubAgentNames(sess *session.Session) []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.validatedSess = sess
+	return m.subAgentNames
+}
+
 func (m *mockRunner) RunAgent(ctx context.Context, params RunParams) *RunResult {
 	if m.runDelay > 0 {
 		select {
@@ -38,6 +56,25 @@ func (m *mockRunner) RunAgent(ctx context.Context, params RunParams) *RunResult 
 	if m.runResult != nil && m.runResult.Result != "" && params.OnContent != nil {
 		params.OnContent(m.runResult.Result)
 	}
+	if m.runResult != nil {
+		return m.runResult
+	}
+	return &RunResult{}
+}
+
+// legacyRunner implements only the base Runner contract — no
+// SessionSubAgentResolver — standing in for out-of-tree Runner
+// implementations that predate the session-aware resolver.
+type legacyRunner struct {
+	subAgentNames []string
+	runResult     *RunResult
+}
+
+func (m *legacyRunner) CurrentAgentSubAgentNames() []string {
+	return m.subAgentNames
+}
+
+func (m *legacyRunner) RunAgent(context.Context, RunParams) *RunResult {
 	if m.runResult != nil {
 		return m.runResult
 	}
@@ -541,6 +578,62 @@ func TestHandleRun_WithExpectedOutput(t *testing.T) {
 	result, err := h.HandleRun(t.Context(), session.New(), tc)
 	require.NoError(t, err)
 	assert.False(t, result.IsError)
+
+	h.wg.Wait()
+
+	h.tasks.Range(func(_ string, tk *task) bool {
+		assert.Equal(t, taskCompleted, tk.loadStatus())
+		return true
+	})
+}
+
+// TestHandleRun_ValidatesAgainstCallingSession pins the #3886 contract:
+// target validation receives the calling session, so the Runner can resolve
+// a pinned background caller instead of shared current-agent state.
+func TestHandleRun_ValidatesAgainstCallingSession(t *testing.T) {
+	t.Parallel()
+	m := &mockRunner{subAgentNames: []string{"sub"}, runResult: &RunResult{Result: "done"}}
+	h := newTestHandlerWithRunner(m)
+
+	sess := session.New()
+	tc := makeToolCall(t, RunBackgroundAgentArgs{Agent: "sub", Task: "do something"})
+	result, err := h.HandleRun(t.Context(), sess, tc)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	h.wg.Wait()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	assert.Same(t, sess, m.validatedSess,
+		"HandleRun must validate the target against the calling session")
+	assert.Zero(t, m.legacyCalls,
+		"the session-aware resolver must be preferred over the legacy method")
+}
+
+// TestHandleRun_LegacyRunnerFallback pins source compatibility: a Runner
+// without SessionSubAgentResolver still validates and dispatches through
+// the legacy CurrentAgentSubAgentNames fallback.
+func TestHandleRun_LegacyRunnerFallback(t *testing.T) {
+	t.Parallel()
+	h := newTestHandlerWithRunner(&legacyRunner{
+		subAgentNames: []string{"sub"},
+		runResult:     &RunResult{Result: "done"},
+	})
+
+	// The fallback is the only source of names, so a rejected unknown
+	// target proves validation flowed through it.
+	bad := makeToolCall(t, RunBackgroundAgentArgs{Agent: "nonexistent", Task: "do something"})
+	result, err := h.HandleRun(t.Context(), session.New(), bad)
+	require.NoError(t, err)
+	assert.True(t, result.IsError)
+	assert.Contains(t, result.Output, "not in the sub-agents list")
+
+	good := makeToolCall(t, RunBackgroundAgentArgs{Agent: "sub", Task: "do something"})
+	result, err = h.HandleRun(t.Context(), session.New(), good)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Output, "agent_task_")
 
 	h.wg.Wait()
 


### PR DESCRIPTION
## Summary

- reject direct and indirect nested agent-delegation cycles with the attempted path
- cap `transfer_task` and `run_background_agent` chains at 10 delegation edges
- preserve valid multi-level foreground and background delegation with session-aware caller resolution
- keep pinned background sessions isolated from the shared foreground agent
- document the delegation limit and add deterministic async end-to-end coverage

## Context

This follows #3886, which establishes that agents started with `run_background_agent` may delegate to their own sub-agents. Supporting that pattern requires both termination guards and session-aware routing: a pinned background session must validate, attribute, and execute nested work as its pinned agent rather than the runtime's shared foreground agent.

## Issue expectations

| Expectation | Implementation |
| --- | --- |
| Direct cycles are rejected | `validateDelegation` rejects self-delegation before a child session starts |
| Indirect cycles are rejected | Per-session lineage detects an ancestor target and reports paths such as `a -> b -> a` |
| Acyclic multi-level delegation remains supported | Lineage propagates through foreground, background, and mixed nested paths |
| Excessive nesting stops with an actionable error | A fixed runtime maximum of 10 edges is documented; depth 10 is accepted and depth 11 is rejected |
| Foreground and background paths are covered | Tests cover `transfer_task`, `RunAgent`, pinned sessions, concurrent nested transfers, and real async background handlers |
| Background delegation from #3886 remains safe | Handler target validation resolves from the calling session; pinned children do not mutate shared foreground state |

## Test coverage

- direct and indirect cycles
- exact maximum-depth boundary
- foreground transfer switching and restoration
- nested transfers from pinned background sessions
- concurrent pinned nested transfers
- nested background-agent hook attribution
- forked skills from pinned sessions without adding a delegation edge
- legacy `Runner` compatibility fallback
- end-to-end `root -> run_background_agent(worker) -> run_background_agent(helper) -> list/view` through the real dispatcher and detached goroutines

## Validation

- `task test`
- `task lint`
- `task build`
- focused runtime tests with `-race`, including repeated async end-to-end runs

Closes #3904
Related to #3886
