### PR TITLE
feat(shell): name the resolved interpreter in the shell tool description

### DIFF
--- a/pkg/tools/builtin/shell/shell.go
+++ b/pkg/tools/builtin/shell/shell.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	goruntime "runtime"
 	"strings"
 	"sync"
 	"time"
@@ -359,13 +360,15 @@ func formatCommandOutput(timeoutCtx, ctx context.Context, err error, rawOutput s
 }
 
 func (t *ToolSet) Instructions() string {
-	return `## Shell Tools
+	return fmt.Sprintf(`## Shell Tools
 
+- Commands are executed by %s on %s — write them in that shell's syntax
 - Each call runs in a fresh shell session — no state persists between calls
 - Default timeout: 30s. Set "timeout" for longer operations (builds, tests)
 - Use "cwd" parameter instead of cd within commands
 - Combine operations with pipes, redirections, and heredocs
-- Non-zero exit codes return error info with output; timed-out commands are terminated`
+- Non-zero exit codes return error info with output; timed-out commands are terminated`,
+		shellBaseName(t.handler.shell), displayOS())
 }
 
 func (t *ToolSet) Tools(context.Context) ([]tools.Tool, error) {
@@ -373,7 +376,7 @@ func (t *ToolSet) Tools(context.Context) ([]tools.Tool, error) {
 		{
 			Name:                    ToolNameShell,
 			Category:                "shell",
-			Description:             `Executes the given shell command in the user's default shell.`,
+			Description:             shellToolDescription(t.handler.shell),
 			Parameters:              tools.MustSchemaFor[RunShellArgs](),
 			OutputSchema:            tools.MustSchemaFor[string](),
 			Handler:                 tools.NewRuntimeHandler(t.handler.RunShell),
@@ -398,4 +401,63 @@ func (t *ToolSet) Start(context.Context) error {
 func (t *ToolSet) Stop(context.Context) error {
 	t.handler.stopAskpass()
 	return nil
+}
+
+// shellToolDescription names the interpreter that will run the command.
+// Models default to POSIX syntax when the description only says "the
+// user's default shell", which wastes turns on Windows where the
+// resolved shell is PowerShell or cmd.exe (e.g. "pwd && ls -la" is a
+// parse error under Windows PowerShell 5.1).
+func shellToolDescription(shellPath string) string {
+	name := shellBaseName(shellPath)
+	desc := fmt.Sprintf("Executes the given shell command with %s on %s.", name, displayOS())
+	if hint := shellSyntaxHint(name); hint != "" {
+		desc += " " + hint
+	}
+	return desc
+}
+
+// shellSyntaxHint returns a dialect warning for shells that models
+// commonly mistake for a POSIX shell. Empty for shells where the name
+// alone is enough of a cue.
+func shellSyntaxHint(name string) string {
+	switch name {
+	case "powershell":
+		// Windows PowerShell 5.1: '&&' / '||' are parse errors and
+		// POSIX flags don't exist ('ls -la' fails on the alias).
+		return `Use Windows PowerShell 5.1 syntax: chain commands with ";" (not "&&"), and avoid POSIX commands/flags like "ls -la".`
+	case "pwsh":
+		return `Use PowerShell syntax; POSIX commands/flags like "ls -la" are not available.`
+	case "cmd":
+		return `Use cmd.exe syntax, not POSIX shell syntax.`
+	default:
+		return ""
+	}
+}
+
+// shellBaseName reduces a resolved shell path to a lowercase name the
+// model can recognize (C:\...\powershell.exe -> powershell, /bin/zsh -> zsh).
+// Splits on both separators instead of filepath.Base so the result is
+// deterministic regardless of the host OS the path came from.
+func shellBaseName(shellPath string) string {
+	base := shellPath
+	if i := strings.LastIndexAny(base, `/\`); i >= 0 {
+		base = base[i+1:]
+	}
+	return strings.ToLower(strings.TrimSuffix(base, filepath.Ext(base)))
+}
+
+// displayOS returns a friendlier label for the common values of
+// runtime.GOOS, falling back to GOOS itself for anything exotic.
+func displayOS() string {
+	switch goruntime.GOOS {
+	case "darwin":
+		return "macOS"
+	case "windows":
+		return "Windows"
+	case "linux":
+		return "Linux"
+	default:
+		return goruntime.GOOS
+	}
 }

--- a/pkg/tools/builtin/shell/shell_test.go
+++ b/pkg/tools/builtin/shell/shell_test.go
@@ -200,7 +200,49 @@ func TestShellTool_Instructions(t *testing.T) {
 	instructions := tool.Instructions()
 
 	assert.Contains(t, instructions, "Shell Tools")
+	assert.Contains(t, instructions, shellBaseName(tool.handler.shell),
+		"instructions must name the resolved shell so the model uses its syntax")
+	assert.Contains(t, instructions, displayOS())
 	assert.NotContains(t, instructions, "run_background_job")
+}
+
+// TestShellTool_DescriptionNamesInterpreter guards against regressing to a
+// generic "the user's default shell" description: without the resolved shell
+// name, models assume POSIX and emit commands that fail under PowerShell/cmd.
+func TestShellTool_DescriptionNamesInterpreter(t *testing.T) {
+	t.Parallel()
+
+	tool := New(nil, &config.RuntimeConfig{Config: config.Config{WorkingDir: t.TempDir()}})
+
+	allTools, err := tool.Tools(t.Context())
+	require.NoError(t, err)
+	require.Len(t, allTools, 1)
+
+	description := allTools[0].Description
+	assert.Contains(t, description, shellBaseName(tool.handler.shell))
+	assert.Contains(t, description, displayOS())
+}
+
+func TestShellBaseName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path     string
+		expected string
+	}{
+		{path: "/bin/zsh", expected: "zsh"},
+		{path: "/usr/local/bin/fish", expected: "fish"},
+		{path: `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, expected: "powershell"},
+		{path: `C:\Program Files\PowerShell\7\pwsh.exe`, expected: "pwsh"},
+		{path: `C:\Windows\System32\cmd.exe`, expected: "cmd"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, shellBaseName(tt.path))
+		})
+	}
 }
 
 func TestResolveWorkDir(t *testing.T) {


### PR DESCRIPTION
## Why

The shell tool describes itself as *"Executes the given shell command in the user's default shell."* That tells the model nothing about which shell — or even which OS — will interpret the command, so models default to POSIX syntax.

On Windows the toolset actually resolves PowerShell (pwsh/powershell.exe, cmd.exe fallback), and in a real session on a Windows host this cost two wasted turns before the model found its footing:

```
turn 1:  pwd && ls -la   → parse error ('&&' is not valid in Windows PowerShell 5.1)
turn 2:  ls -la          → error (ls is a Get-ChildItem alias; -la is not a parameter)
turn 3:  dir             → finally works
```

The toolset already knows the exact resolved shell binary at construction time; it just never told the model.

## What

- The tool description now names the resolved interpreter and OS, e.g.
  - `Executes the given shell command with powershell on Windows. Use Windows PowerShell 5.1 syntax: chain commands with ";" (not "&&"), and avoid POSIX commands/flags like "ls -la".`
  - `Executes the given shell command with zsh on macOS.`
- Toolset instructions gain a matching first bullet: *Commands are executed by `<shell>` on `<OS>` — write them in that shell's syntax.*
- Shells commonly mistaken for POSIX (powershell, pwsh, cmd) carry an explicit dialect warning; Unix shells need only the name.

Same spirit as #3908: give the model the one machine fact it cannot guess, so it self-corrects in zero turns instead of two.