### PR TITLE
feat(filesystem): say when list_directory finds an empty directory

### DIFF
--- a/pkg/tools/builtin/filesystem/filesystem.go
+++ b/pkg/tools/builtin/filesystem/filesystem.go
@@ -1052,6 +1052,18 @@ func (t *ToolSet) handleListDirectory(ctx context.Context, args ListDirectoryArg
 		}
 	}
 
+	// An empty Output is rendered as a generic "(no output)" placeholder
+	// upstream, which the model cannot distinguish from a tool failure and
+	// typically retries with a shell command. Say explicitly that the
+	// listing succeeded and the directory is empty.
+	if count == 0 {
+		if len(entries) == 0 {
+			fmt.Fprintf(&result, "Directory is empty: %s\n", resolvedPath)
+		} else {
+			fmt.Fprintf(&result, "Directory has no visible entries (%d hidden by ignore patterns): %s\n", len(entries), resolvedPath)
+		}
+	}
+
 	return &tools.ToolCallResult{
 		Output: result.String(),
 		Meta:   meta,

--- a/pkg/tools/builtin/filesystem/filesystem_test.go
+++ b/pkg/tools/builtin/filesystem/filesystem_test.go
@@ -465,6 +465,37 @@ func TestFilesystemTool_ListDirectory(t *testing.T) {
 	assert.Contains(t, result.Output, "not found")
 }
 
+// TestFilesystemTool_ListDirectoryEmpty pins the empty-directory message:
+// with an empty Output the runtime substitutes a generic "(no output)"
+// placeholder, which models read as a tool failure and retry via shell.
+func TestFilesystemTool_ListDirectoryEmpty(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	tool := New(tmpDir)
+
+	result, err := tool.handleListDirectory(t.Context(), ListDirectoryArgs{
+		Path: ".",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Output, "Directory is empty: "+tmpDir)
+}
+
+func TestFilesystemTool_ListDirectoryAllEntriesIgnored(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(tmpDir, ".git"), 0o755))
+	tool := New(tmpDir, WithIgnoreVCS(true))
+
+	result, err := tool.handleListDirectory(t.Context(), ListDirectoryArgs{
+		Path: ".",
+	})
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+	assert.Contains(t, result.Output, "no visible entries (1 hidden by ignore patterns)")
+	assert.Contains(t, result.Output, tmpDir)
+}
+
 func TestFilesystemTool_EditFile(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Why

`list_directory` returns an empty `Output` for an empty directory, and the runtime substitutes a generic `(no output)` placeholder (`pkg/runtime/toolexec/dispatcher.go`). The model cannot tell "the listing succeeded and the directory is empty" from "the tool broke".

In a real session the working directory was an empty scratch dir: the model called `list_directory`, got `(no output)`, distrusted it, and re-listed the same directory through the shell — a wasted turn, and it *still* concluded "your directory is empty or I don't have access to it".

## What

When the listing produces no entries, say so explicitly instead of returning nothing:

- `Directory is empty: <resolved path>` — nothing there at all
- `Directory has no visible entries (N hidden by ignore patterns): <resolved path>` — entries exist but are all VCS/agents-ignore filtered, so the model doesn't go looking for files that are deliberately hidden

Including the resolved path doubles as a resolution hint, same as #3908 did for not-found errors.