### PR TITLE
fix(filesystem): repair malformed inner JSON in double-serialized edits

### DIFF
--- a/pkg/tools/builtin/filesystem/filesystem.go
+++ b/pkg/tools/builtin/filesystem/filesystem.go
@@ -397,10 +397,10 @@ func ParseEditFileArgs(data []byte) (EditFileArgs, error) {
 		if err := json.Unmarshal(repaired, &args.Edits); err != nil {
 			return EditFileArgs{}, fmt.Errorf("failed to parse double-serialized edits string after repair: %w", err)
 		}
+		slog.Debug("Repaired malformed double-serialized edits payload")
 		if err := validateRepairedEdits(args.Edits); err != nil {
 			return EditFileArgs{}, err
 		}
-		slog.Debug("Repaired malformed double-serialized edits payload")
 	}
 
 	return args, nil

--- a/pkg/tools/builtin/filesystem/filesystem.go
+++ b/pkg/tools/builtin/filesystem/filesystem.go
@@ -397,10 +397,27 @@ func ParseEditFileArgs(data []byte) (EditFileArgs, error) {
 		if err := json.Unmarshal(repaired, &args.Edits); err != nil {
 			return EditFileArgs{}, fmt.Errorf("failed to parse double-serialized edits string after repair: %w", err)
 		}
+		if err := validateRepairedEdits(args.Edits); err != nil {
+			return EditFileArgs{}, err
+		}
 		slog.Debug("Repaired malformed double-serialized edits payload")
 	}
 
 	return args, nil
+}
+
+// validateRepairedEdits guards against repair output that is structurally
+// valid but semantically corrupted. An empty oldText is never a meaningful
+// edit (handleEditFile's strings.Replace would silently insert newText at
+// the start of the file), so its presence after a repair means the repair
+// removed a load-bearing character rather than a spurious one.
+func validateRepairedEdits(edits []Edit) error {
+	for i, edit := range edits {
+		if edit.OldText == "" {
+			return fmt.Errorf("repaired edits payload is invalid: edit %d has empty oldText", i+1)
+		}
+	}
+	return nil
 }
 
 // tryRepairEditFileJSON attempts to fix common LLM JSON malformations by

--- a/pkg/tools/builtin/filesystem/filesystem.go
+++ b/pkg/tools/builtin/filesystem/filesystem.go
@@ -388,7 +388,16 @@ func ParseEditFileArgs(data []byte) (EditFileArgs, error) {
 		return EditFileArgs{}, fmt.Errorf("edits field is neither an array nor a JSON string: %w", err)
 	}
 	if err := json.Unmarshal([]byte(editsStr), &args.Edits); err != nil {
-		return EditFileArgs{}, fmt.Errorf("failed to parse double-serialized edits string: %w", err)
+		// The inner payload can carry the same brace/bracket-counting
+		// mistakes as the outer JSON, so give it the same repair pass.
+		repaired, ok := tryRepairEditFileJSON([]byte(editsStr))
+		if !ok {
+			return EditFileArgs{}, fmt.Errorf("failed to parse double-serialized edits string: %w", err)
+		}
+		if err := json.Unmarshal(repaired, &args.Edits); err != nil {
+			return EditFileArgs{}, fmt.Errorf("failed to parse double-serialized edits string after repair: %w", err)
+		}
+		slog.Debug("Repaired malformed double-serialized edits payload")
 	}
 
 	return args, nil

--- a/pkg/tools/builtin/filesystem/filesystem_test.go
+++ b/pkg/tools/builtin/filesystem/filesystem_test.go
@@ -587,6 +587,22 @@ func TestParseEditFileArgs(t *testing.T) {
 			wantErrMsg: "failed to parse double-serialized edits string",
 		},
 		{
+			name:     "repair: double-serialized with extra closing brace in inner payload",
+			input:    `{"edits": "[{\"oldText\": \"a\", \"newText\": \"b\"}}]", "path": "docker-compose.yml"}`,
+			wantPath: "docker-compose.yml",
+			wantEdits: []Edit{
+				{OldText: "a", NewText: "b"},
+			},
+		},
+		{
+			name:     "repair: double-serialized with extra closing bracket in inner payload",
+			input:    `{"path": "f.go", "edits": "[{\"oldText\": \"a\", \"newText\": \"b\"}]]"}`,
+			wantPath: "f.go",
+			wantEdits: []Edit{
+				{OldText: "a", NewText: "b"},
+			},
+		},
+		{
 			name:     "missing edits field (partial/streaming args)",
 			input:    `{"path": "/tmp/test.txt"}`,
 			wantPath: "/tmp/test.txt",

--- a/pkg/tools/builtin/filesystem/filesystem_test.go
+++ b/pkg/tools/builtin/filesystem/filesystem_test.go
@@ -603,6 +603,21 @@ func TestParseEditFileArgs(t *testing.T) {
 			},
 		},
 		{
+			name:     "repair: double-serialized with extra closing brace between inner array elements",
+			input:    `{"path": "f.go", "edits": "[{\"oldText\": \"a\", \"newText\": \"b\"}}, {\"oldText\": \"c\", \"newText\": \"d\"}]"}`,
+			wantPath: "f.go",
+			wantEdits: []Edit{
+				{OldText: "a", NewText: "b"},
+				{OldText: "c", NewText: "d"},
+			},
+		},
+		{
+			name:       "repair: rejected when inner repair yields an edit with empty oldText",
+			input:      `{"path": "f.go", "edits": "[{\"oldText\": \"a\"}}, {\"newText\": \"b\"}]"}`,
+			wantErr:    true,
+			wantErrMsg: "empty oldText",
+		},
+		{
 			name:     "missing edits field (partial/streaming args)",
 			input:    `{"path": "/tmp/test.txt"}`,
 			wantPath: "/tmp/test.txt",


### PR DESCRIPTION
## Why

`ParseEditFileArgs` already handles two model failure modes independently: a double-serialized `edits` field (#2144), and brace/bracket-counting mistakes in the outer JSON (repaired via `tryRepairEditFileJSON`). But when both happen at once, parsing fails.

A production session hit exactly that combination — the model sent `edits` as a JSON string *and* miscounted braces inside it:

```json
{"edits": "[{\"oldText\": \"...\", \"newText\": \"...\"}}]", "path": "docker-compose.yml"}
```

The unwrap succeeded, but the inner payload (`...}}]` — extra closing brace) failed with:

```
Error calling tool: failed to parse double-serialized edits string: invalid character '}' after array element
```

The model then recovered by reading the whole file and rewriting it — a full extra round-trip that the existing repair logic was designed to avoid.

## What

Give the unwrapped inner payload the same repair pass as the outer JSON. Genuinely unparseable payloads still error as before.