### PR TITLE
fix(tui): preserve stream cancellation after compaction

### DIFF
--- a/pkg/tui/page/chat/chat.go
+++ b/pkg/tui/page/chat/chat.go
@@ -211,7 +211,10 @@ type chatPage struct {
 
 	msgCancel       context.CancelFunc
 	streamCancelled bool
-	streamDepth     int      // nesting depth of active streams (incremented on StreamStarted, decremented on StreamStopped)
+	// streamDepth is the nesting depth of active streams (StreamStarted++,
+	// StreamStopped--). >0 during a root compaction marks it as automatic
+	// (nested mid-run); standalone /compact emits no StreamStarted.
+	streamDepth     int
 	agentStack      []string // agent per active stream level; len(agentStack)==streamDepth
 	streamStartTime time.Time
 

--- a/pkg/tui/page/chat/compaction_events_test.go
+++ b/pkg/tui/page/chat/compaction_events_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -11,11 +12,12 @@ import (
 	"github.com/docker/docker-agent/pkg/runtime"
 	"github.com/docker/docker-agent/pkg/session"
 	"github.com/docker/docker-agent/pkg/tui/animation"
+	msgtypes "github.com/docker/docker-agent/pkg/tui/messages"
 	"github.com/docker/docker-agent/pkg/tui/service"
 )
 
-// subCompactionEvent builds a completed compaction event for the given session.
-func subCompactionEvent(sessionID, outcome string) *runtime.SessionCompactionEvent {
+// compactionEvent builds a completed compaction event for the given session.
+func compactionEvent(sessionID, outcome string) *runtime.SessionCompactionEvent {
 	return &runtime.SessionCompactionEvent{
 		Type:         "session_compaction",
 		SessionID:    sessionID,
@@ -40,7 +42,7 @@ func TestSubSessionCompactionKeepsRootWorkState(t *testing.T) {
 	p.working = true
 	p.messageQueue = []queuedMessage{{content: "queued while working"}}
 
-	handled, _ := p.handleRuntimeEvent(subCompactionEvent("sub-session-1", runtime.CompactionOutcomeApplied))
+	handled, _ := p.handleRuntimeEvent(compactionEvent("sub-session-1", runtime.CompactionOutcomeApplied))
 	require.True(t, handled)
 
 	assert.True(t, p.working, "a sub-session compaction must not mark the root chat idle")
@@ -48,9 +50,11 @@ func TestSubSessionCompactionKeepsRootWorkState(t *testing.T) {
 	assert.Len(t, p.messageQueue, 1, "root queued messages must not be processed")
 }
 
-// TestRootSessionCompactionResetsWorkState pins the complementary root path:
-// the root session's own compaction completion still cleans up.
-func TestRootSessionCompactionResetsWorkState(t *testing.T) {
+// TestStandaloneRootCompactionResetsWorkState pins the explicit /compact
+// path: it runs without a surrounding stream (Summarize emits no
+// StreamStarted), so its completion event is the terminal signal that
+// cleans up the work state.
+func TestStandaloneRootCompactionResetsWorkState(t *testing.T) {
 	t.Parallel()
 
 	sess := session.New()
@@ -60,12 +64,144 @@ func TestRootSessionCompactionResetsWorkState(t *testing.T) {
 	defer cancel()
 	p.msgCancel = cancel
 	p.working = true
+	require.Zero(t, p.streamDepth, "explicit /compact runs outside any stream")
 
-	handled, _ := p.handleRuntimeEvent(subCompactionEvent(sess.ID, runtime.CompactionOutcomeApplied))
+	handled, _ := p.handleRuntimeEvent(compactionEvent(sess.ID, runtime.CompactionOutcomeApplied))
 	require.True(t, handled)
 
-	assert.False(t, p.working, "the root compaction completion marks the chat idle")
+	assert.False(t, p.working, "the standalone compaction completion marks the chat idle")
 	assert.Nil(t, p.msgCancel)
+}
+
+// TestAutoRootCompactionMidStreamKeepsWorkState pins the #3872 contract: an
+// automatic (threshold-triggered) root compaction completes inside an active
+// RunStream, so whatever the outcome it only updates presentation — the
+// outer stream's cancel func, working flag, depth and queued messages stay
+// intact until StreamStopped.
+func TestAutoRootCompactionMidStreamKeepsWorkState(t *testing.T) {
+	t.Parallel()
+
+	outcomes := []string{
+		runtime.CompactionOutcomeApplied,
+		runtime.CompactionOutcomeSkipped,
+		runtime.CompactionOutcomeFailed,
+	}
+	for _, outcome := range outcomes {
+		t.Run(outcome, func(t *testing.T) {
+			t.Parallel()
+
+			sess := session.New()
+			p := New(animation.NewRuntime(), t.Context(), app.New(t.Context(), queueTestRuntime{}, sess), service.NewSessionState(sess)).(*chatPage)
+
+			_, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			p.msgCancel = cancel
+			p.messageQueue = []queuedMessage{{content: "queued while working"}}
+
+			handled, _ := p.handleRuntimeEvent(runtime.StreamStarted(sess.ID, "root"))
+			require.True(t, handled)
+			require.Equal(t, 1, p.streamDepth)
+			require.True(t, p.working)
+
+			handled, _ = p.handleRuntimeEvent(compactionEvent(sess.ID, outcome))
+			require.True(t, handled)
+
+			assert.True(t, p.working, "a mid-stream compaction must not mark the chat idle")
+			assert.NotNil(t, p.msgCancel, "the outer stream's cancel func must stay intact")
+			assert.Equal(t, 1, p.streamDepth, "a compaction event is not a stream boundary")
+			assert.Len(t, p.messageQueue, 1, "queued messages must wait for the stream to stop")
+		})
+	}
+}
+
+// TestStreamStoppedAfterMidStreamCompactionCleansUp proves the cleanup the
+// mid-stream compaction deferred actually happens at the outer
+// StreamStopped: the chat goes idle and the cancel func is released.
+func TestStreamStoppedAfterMidStreamCompactionCleansUp(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	p := New(animation.NewRuntime(), t.Context(), app.New(t.Context(), queueTestRuntime{}, sess), service.NewSessionState(sess)).(*chatPage)
+
+	_, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	p.msgCancel = cancel
+
+	handled, _ := p.handleRuntimeEvent(runtime.StreamStarted(sess.ID, "root"))
+	require.True(t, handled)
+	handled, _ = p.handleRuntimeEvent(compactionEvent(sess.ID, runtime.CompactionOutcomeApplied))
+	require.True(t, handled)
+	require.True(t, p.working)
+
+	handled, cmd := p.handleRuntimeEvent(runtime.StreamStopped(sess.ID, "root", "normal"))
+	require.True(t, handled)
+	require.NotNil(t, cmd)
+
+	assert.Zero(t, p.streamDepth)
+	assert.False(t, p.working, "the outermost StreamStopped marks the chat idle")
+	assert.Nil(t, p.msgCancel, "the outermost StreamStopped releases the cancel func")
+}
+
+// TestStreamStoppedAfterMidStreamCompactionProcessesQueue proves messages
+// held back during a mid-stream compaction are released at the outer
+// StreamStopped: the queued message is popped and starts processing
+// synchronously (working again, fresh cancel func armed).
+func TestStreamStoppedAfterMidStreamCompactionProcessesQueue(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	p := New(animation.NewRuntime(), t.Context(), app.New(t.Context(), queueTestRuntime{}, sess), service.NewSessionState(sess)).(*chatPage)
+
+	_, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	p.msgCancel = cancel
+	p.messageQueue = []queuedMessage{{content: "queued while working"}}
+
+	handled, _ := p.handleRuntimeEvent(runtime.StreamStarted(sess.ID, "root"))
+	require.True(t, handled)
+	handled, _ = p.handleRuntimeEvent(compactionEvent(sess.ID, runtime.CompactionOutcomeApplied))
+	require.True(t, handled)
+	require.Len(t, p.messageQueue, 1, "the compaction must leave the queue to StreamStopped")
+
+	handled, cmd := p.handleRuntimeEvent(runtime.StreamStopped(sess.ID, "root", "normal"))
+	require.True(t, handled)
+	require.NotNil(t, cmd)
+
+	assert.Empty(t, p.messageQueue, "StreamStopped pops the queued message")
+	assert.True(t, p.working, "the popped message starts processing immediately")
+	assert.NotNil(t, p.msgCancel, "the new turn arms a fresh cancel func")
+	assert.Zero(t, p.streamDepth, "depth resets for the new turn")
+}
+
+// TestEscCancelsStreamAfterMidStreamCompaction proves Esc stays wired after
+// an automatic mid-stream compaction: the page still reads as working and
+// the preserved cancel func cancels the outer stream. InterruptModeNone
+// skips the confirmation dialog, making the cancellation synchronous.
+func TestEscCancelsStreamAfterMidStreamCompaction(t *testing.T) {
+	t.Parallel()
+
+	sess := session.New()
+	p := New(animation.NewRuntime(), t.Context(), app.New(t.Context(), queueTestRuntime{}, sess), service.NewSessionState(sess),
+		WithInterruptMode(msgtypes.InterruptModeNone)).(*chatPage)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	p.msgCancel = cancel
+
+	handled, _ := p.handleRuntimeEvent(runtime.StreamStarted(sess.ID, "root"))
+	require.True(t, handled)
+	handled, _ = p.handleRuntimeEvent(compactionEvent(sess.ID, runtime.CompactionOutcomeApplied))
+	require.True(t, handled)
+
+	_, cmd := p.handleKeyPress(tea.KeyPressMsg{Code: tea.KeyEscape})
+	require.NotNil(t, cmd)
+
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("Esc after a mid-stream compaction must cancel the outer stream")
+	}
+	assert.Nil(t, p.msgCancel, "cancelStream clears the cancel func after invoking it")
 }
 
 // TestSubSessionCompactionNotice verifies the agent-scoped feedback for each
@@ -77,7 +213,7 @@ func TestSubSessionCompactionNotice(t *testing.T) {
 		"the request was already announced; started stays silent")
 
 	for _, outcome := range []string{"", runtime.CompactionOutcomeApplied, runtime.CompactionOutcomeSkipped, runtime.CompactionOutcomeFailed} {
-		assert.NotNil(t, subSessionCompactionNotice(subCompactionEvent("sub-1", outcome)),
+		assert.NotNil(t, subSessionCompactionNotice(compactionEvent("sub-1", outcome)),
 			"outcome %q must produce user feedback", outcome)
 	}
 }

--- a/pkg/tui/page/chat/runtime_events.go
+++ b/pkg/tui/page/chat/runtime_events.go
@@ -147,26 +147,26 @@ func (p *chatPage) handleRuntimeEvent(msg tea.Msg) (bool, tea.Cmd) {
 			return true, tea.Batch(sidebarCmd, subSessionCompactionNotice(msg))
 		}
 		if msg.Status == "completed" {
+			noticeCmd := rootCompactionNotice(msg)
+			if p.streamDepth > 0 {
+				// Automatic compaction nested in a live stream (the threshold
+				// fires after StreamStarted): update presentation only.
+				// Clearing msgCancel/working/queue here would break Esc and
+				// start queued messages against the live run (#3872);
+				// StreamStopped owns the cleanup.
+				return true, tea.Batch(sidebarCmd, noticeCmd)
+			}
+			// Standalone /compact runs outside any stream (Summarize emits no
+			// StreamStarted): this terminal event cleans up the work state.
 			p.msgCancel = nil
-			cmds := []tea.Cmd{
+			return true, tea.Batch(
 				sidebarCmd,
 				p.setWorking(false),
 				p.setPendingResponse(false),
 				p.processNextQueuedMessage(),
 				p.messages.ScrollToBottom(),
-			}
-			// Only announce success when a summary was actually applied.
-			// "failed" already surfaced an ErrorEvent; "skipped" means the
-			// compaction was a no-op (nothing to compact, hook veto, empty
-			// model output). Empty outcome (older servers) keeps the legacy
-			// success toast.
-			switch msg.Outcome {
-			case "", runtime.CompactionOutcomeApplied:
-				cmds = append(cmds, notification.SuccessCmd("Session compacted successfully."))
-			case runtime.CompactionOutcomeSkipped:
-				cmds = append(cmds, notification.InfoCmd("Session compaction skipped."))
-			}
-			return true, tea.Batch(cmds...)
+				noticeCmd,
+			)
 		}
 		return true, sidebarCmd
 
@@ -215,6 +215,21 @@ func (p *chatPage) isSubSessionEvent(sessionID string) bool {
 	}
 	sess := p.app.Session()
 	return sess != nil && sessionID != sess.ID
+}
+
+// rootCompactionNotice builds the root session's terminal compaction
+// feedback. Success is only announced when a summary was actually applied:
+// "failed" already surfaced an ErrorEvent; "skipped" means the compaction
+// was a no-op (nothing to compact, hook veto, empty model output). Empty
+// outcome (older servers) keeps the legacy success toast.
+func rootCompactionNotice(msg *runtime.SessionCompactionEvent) tea.Cmd {
+	switch msg.Outcome {
+	case "", runtime.CompactionOutcomeApplied:
+		return notification.SuccessCmd("Session compacted successfully.")
+	case runtime.CompactionOutcomeSkipped:
+		return notification.InfoCmd("Session compaction skipped.")
+	}
+	return nil
 }
 
 // subSessionCompactionNotice builds the agent-scoped feedback for a


### PR DESCRIPTION
## Summary

- preserve root-stream cancellation state when automatic compaction completes mid-run
- defer stream cleanup and queued-message processing to the outer `StreamStopped` event
- retain the existing cleanup behavior for standalone `/compact`
- add regression coverage for cancellation, compaction outcomes and queue processing

## Root cause

A completed root `SessionCompactionEvent` was always treated as the terminal event of a standalone `/compact`.

Automatic compaction also emits this event while the enclosing `RunStream` is still active. Clearing `msgCancel` and the working state at that point left the model stream running but made Esc ineffective.

## Issue expectations

| Expectation | Implementation |
|---|---|
| Esc interrupts an ongoing stream | The active stream cancel function is preserved across automatic compaction |
| Interruption remains available after repeated compactions | Applied, skipped and failed compaction outcomes preserve stream state |
| Queued messages do not start against the active stream | Queue processing is deferred to the outer `StreamStopped` event |
| Manual `/compact` keeps its existing behavior | Standalone compaction at stream depth zero still performs terminal cleanup |

## Validation

- `task build`
- `task lint`
- `task test`
- `go test -race -count=1 ./pkg/tui/page/chat`

The reported vLLM thinking-loop scenario is non-deterministic and was not reproduced manually. The failing lifecycle sequence is covered deterministically by regression tests.

Fixes #3872
